### PR TITLE
Refactor Image Card to separate "value" content (hotspots) from configuration content

### DIFF
--- a/src/components/Dashboard/Dashboard.story.jsx
+++ b/src/components/Dashboard/Dashboard.story.jsx
@@ -315,6 +315,8 @@ const originalCards = [
       alt: 'Floor Map',
       image: 'firstfloor',
       src: imageFile,
+    },
+    values: {
       hotspots: [
         { x: 35, y: 65, content: <span style={{ padding: '10px' }}>Elevators</span> },
         { x: 45, y: 25, content: <span style={{ padding: '10px' }}>Stairs</span> },

--- a/src/components/ImageCard/ImageCard.jsx
+++ b/src/components/ImageCard/ImageCard.jsx
@@ -14,8 +14,9 @@ const ContentWrapper = styled.div`
   padding: 0 16px 16px 16px;
 `;
 
-const ImageCard = ({ title, content, size, onCardAction, isEditable, ...others }) => {
-  const { src, alt, hotspots, zoomMax } = content;
+const ImageCard = ({ title, content, values, size, onCardAction, isEditable, ...others }) => {
+  const { src } = content;
+  const hotspots = values ? values.hotspots || [] : [];
   const supportedSizes = [CARD_SIZES.MEDIUM, CARD_SIZES.WIDE, CARD_SIZES.LARGE, CARD_SIZES.XLARGE];
   const supportedSize = supportedSizes.includes(size);
   const availableActions = { expand: supportedSize };
@@ -34,7 +35,7 @@ const ImageCard = ({ title, content, size, onCardAction, isEditable, ...others }
             isEditable && !src ? (
               <Image32 width="100%" height="100%" />
             ) : content && src ? (
-              <ImageHotspots src={src} alt={alt} hotspots={hotspots} zoomMax={zoomMax} />
+              <ImageHotspots {...content} hotspots={hotspots} />
             ) : (
               <p>Error retrieving image.</p>
             )

--- a/src/components/ImageCard/ImageCard.story.jsx
+++ b/src/components/ImageCard/ImageCard.story.jsx
@@ -12,13 +12,16 @@ import imageFile from './landscape.jpg';
 const content = {
   src: imageFile,
   alt: 'Sample image',
+  zoomMax: 10,
+};
+
+const values = {
   hotspots: [
     { x: 35, y: 65, content: <span style={{ padding: '10px' }}>Elevators</span> },
     { x: 45, y: 25, content: <span style={{ padding: '10px' }}>Stairs</span> },
     { x: 45, y: 50, content: <span style={{ padding: '10px' }}>Stairs</span> },
     { x: 45, y: 75, content: <span style={{ padding: '10px' }}>Stairs</span> },
   ],
-  zoomMax: 10,
 };
 
 storiesOf('ImageCard (Experimental)', module)
@@ -30,6 +33,7 @@ storiesOf('ImageCard (Experimental)', module)
           title={text('title', 'Image')}
           id="image-hotspots"
           content={object('content', content)}
+          values={object('values', values)}
           breakpoint="lg"
           size={size}
         />
@@ -45,6 +49,7 @@ storiesOf('ImageCard (Experimental)', module)
           isEditable
           id="image-hotspots"
           content={object('content', omit(content, ['src']))}
+          values={object('values', values)}
           breakpoint="lg"
           size={size}
         />

--- a/src/constants/PropTypes.js
+++ b/src/constants/PropTypes.js
@@ -151,13 +151,11 @@ export const DonutCardPropTypes = {
 export const ImageCardPropTypes = {
   content: PropTypes.shape({
     title: PropTypes.string,
-    data: PropTypes.arrayOf(
-      PropTypes.shape({
-        src: PropTypes.string.isRequired,
-        alt: PropTypes.string.isRequired,
-      })
-    ),
+    content: PropTypes.object,
   }).isRequired,
+  values: PropTypes.shape({
+    hotspots: PropTypes.array,
+  }),
 };
 
 export const PieCardPropTypes = DonutCardPropTypes;


### PR DESCRIPTION
**Summary**

- Update to ImageCard props to match other Card types: `content` prop contains configuration, `values` prop contains data rendered by the configuration.  In the case of ImageCard, the `values` is the array of hotspots to show (with values injected)

**Acceptance Test (how to verify the PR)**

- Ensure hotspots in Dashboard story (basic) and ImageCard stories render appropriately
