### PR TITLE
fix(imagecard): story doesn't use hotspot icon config

### DIFF
--- a/src/components/ImageCard/ImageCard.story.jsx
+++ b/src/components/ImageCard/ImageCard.story.jsx
@@ -17,10 +17,30 @@ const content = {
 
 const values = {
   hotspots: [
-    { x: 35, y: 65, content: <span style={{ padding: '10px' }}>Elevators</span> },
-    { x: 45, y: 25, content: <span style={{ padding: '10px' }}>Stairs</span> },
-    { x: 45, y: 50, content: <span style={{ padding: '10px' }}>Stairs</span> },
-    { x: 45, y: 75, content: <span style={{ padding: '10px' }}>Stairs</span> },
+    {
+      x: 35,
+      y: 65,
+      icon: 'icon--arrow--down',
+      content: <span style={{ padding: '10px' }}>Elevators</span>,
+    },
+    {
+      x: 45,
+      y: 25,
+      icon: 'icon--arrow--left',
+      content: <span style={{ padding: '10px' }}>Stairs</span>,
+    },
+    {
+      x: 45,
+      y: 50,
+      icon: 'icon--arrow--right',
+      content: <span style={{ padding: '10px' }}>Vent Fan</span>,
+    },
+    {
+      x: 45,
+      y: 75,
+      icon: 'icon--arrow--up',
+      content: <span style={{ padding: '10px' }}>Humidity Sensor</span>,
+    },
   ],
 };
 


### PR DESCRIPTION
**Summary**

- Minor update to ImageCard story to add icons for hotspots (mostly as an excuse to build a new release)