### PR TITLE
fix(table): pass filteredData to onDownloadCsv

### DIFF
--- a/src/components/BarChartCard/BarChartCard.jsx
+++ b/src/components/BarChartCard/BarChartCard.jsx
@@ -192,7 +192,7 @@ const BarChartCard = ({
               }}
               actions={{
                 toolbar: {
-                  onDownloadCSV: () => csvDownloadHandler(tableData, title),
+                  onDownloadCSV: filteredData => csvDownloadHandler(filteredData, title),
                 },
               }}
               view={{

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -446,6 +446,7 @@ const Table = props => {
               'rowEditBarButtons'
             ),
           }}
+          data={data}
         />
       ) : null}
       <div className="addons-iot-table-container">

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -621,7 +621,7 @@ storiesOf('Watson IoT/Table', module)
             ...actions,
             toolbar: {
               ...actions.toolbar,
-              onDownloadCSV: () => csvDownloadHandler(initialState.data, 'my table data'),
+              onDownloadCSV: filteredData => csvDownloadHandler(filteredData, 'my table data'),
             },
           }}
           isSortable

--- a/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -9,6 +9,7 @@ import {
   TableSearchPropTypes,
   defaultI18NPropTypes,
   ActiveTableToolbarPropType,
+  TableRowPropTypes,
 } from '../TablePropTypes';
 import { tableTranslateWithId } from '../../../utils/componentUtilityFunctions';
 import { settings } from '../../../constants/Settings';
@@ -98,6 +99,8 @@ const propTypes = {
     /** buttons to be shown with when activeBar is 'rowEdit' */
     rowEditBarButtons: PropTypes.node,
   }).isRequired,
+  /** Row value data for the body of the table */
+  data: TableRowPropTypes.isRequired,
 };
 
 const defaultProps = {
@@ -143,6 +146,7 @@ const TableToolbar = ({
     totalItemsCount,
     rowEditBarButtons,
   },
+  data,
 }) => (
   <CarbonTableToolbar className={classnames(`${iotPrefix}--table-toolbar`, className)}>
     <TableBatchActions
@@ -208,7 +212,10 @@ const TableToolbar = ({
         ) : null}
         {onDownloadCSV ? (
           <TableToolbarSVGButton
-            onClick={onDownloadCSV}
+            onClick={() => {
+              // hand back the filtered data
+              onDownloadCSV(data);
+            }}
             description={i18n.downloadIconDescription}
             testId="download-button"
             renderIcon={Download20}

--- a/src/components/TableCard/TableCard.jsx
+++ b/src/components/TableCard/TableCard.jsx
@@ -781,7 +781,7 @@ const TableCard = ({
               toolbar: {
                 onClearAllFilters: () => {},
                 onToggleFilter: () => {},
-                onDownloadCSV: () => csvDownloadHandler(tableDataWithTimestamp, title),
+                onDownloadCSV: filteredData => csvDownloadHandler(filteredData, title),
               },
             }}
             view={{

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -546,7 +546,7 @@ const TimeSeriesCard = ({
               }}
               actions={{
                 toolbar: {
-                  onDownloadCSV: () => csvDownloadHandler(tableData, title),
+                  onDownloadCSV: filteredData => csvDownloadHandler(filteredData, title),
                 },
               }}
               view={{

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -2430,6 +2430,134 @@ Map {
         "isRequired": true,
         "type": "shape",
       },
+      "data": Object {
+        "args": Array [
+          Object {
+            "args": Array [
+              Object {
+                "children": Object {
+                  "args": Array [
+                    Array [
+                      Object {
+                        "type": "array",
+                      },
+                    ],
+                  ],
+                  "type": "oneOfType",
+                },
+                "id": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+                "isSelectable": Object {
+                  "type": "bool",
+                },
+                "rowActions": Object {
+                  "args": Array [
+                    Object {
+                      "args": Array [
+                        Object {
+                          "disabled": Object {
+                            "type": "bool",
+                          },
+                          "hasDivider": Object {
+                            "type": "bool",
+                          },
+                          "id": Object {
+                            "isRequired": true,
+                            "type": "string",
+                          },
+                          "isDelete": Object {
+                            "type": "bool",
+                          },
+                          "isEdit": Object {
+                            "type": "bool",
+                          },
+                          "isOverflow": Object {
+                            "type": "bool",
+                          },
+                          "labelText": Object {
+                            "type": "string",
+                          },
+                          "renderIcon": Object {
+                            "args": Array [
+                              Array [
+                                Object {
+                                  "args": Array [
+                                    Object {
+                                      "height": Object {
+                                        "type": "string",
+                                      },
+                                      "svgData": Object {
+                                        "isRequired": true,
+                                        "type": "object",
+                                      },
+                                      "viewBox": Object {
+                                        "isRequired": true,
+                                        "type": "string",
+                                      },
+                                      "width": Object {
+                                        "type": "string",
+                                      },
+                                    },
+                                  ],
+                                  "type": "shape",
+                                },
+                                Object {
+                                  "args": Array [
+                                    Array [
+                                      "caretUp",
+                                      "caretDown",
+                                      "edit",
+                                      "close",
+                                      "checkmark",
+                                      "warning",
+                                      "arrowUp",
+                                      "arrowDown",
+                                      "user",
+                                      "info",
+                                      "help",
+                                    ],
+                                  ],
+                                  "type": "oneOf",
+                                },
+                                Object {
+                                  "type": "node",
+                                },
+                                Object {
+                                  "type": "object",
+                                },
+                                Object {
+                                  "type": "func",
+                                },
+                              ],
+                            ],
+                            "type": "oneOfType",
+                          },
+                        },
+                      ],
+                      "type": "shape",
+                    },
+                  ],
+                  "type": "arrayOf",
+                },
+                "values": Object {
+                  "args": Array [
+                    Object {
+                      "type": "any",
+                    },
+                  ],
+                  "isRequired": true,
+                  "type": "objectOf",
+                },
+              },
+            ],
+            "type": "shape",
+          },
+        ],
+        "isRequired": true,
+        "type": "arrayOf",
+      },
       "i18n": Object {
         "args": Array [
           Object {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2088,7 +2088,7 @@
     levenary "^1.1.1"
     semver "^5.5.0"
 
-"@babel/preset-env@^7.4.5", "@babel/preset-env@^7.8.7":
+"@babel/preset-env@^7.4.5":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.10.4.tgz#fbf57f9a803afd97f4f32e4f798bb62e4b2bef5f"
   integrity sha512-tcmuQ6vupfMZPrLrc38d0sF2OjLT3/bZ0dry5HchNCQbrokoQi4reXqclvkkAT5b+gWc23meVWpve5P/7+w/zw==
@@ -13271,11 +13271,6 @@ lodash@4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
 lodash@^4.0.0, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@~4.17.10:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
-
-lodash@^4.17.19:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==


### PR DESCRIPTION
Closes #1448 

**Summary**

- Passed the filteredData back to the `onDownloadCsv` callback so the CSV will be generated with the active filtered data

**Change List (commits, features, bugs, etc)**

- Pass `data` prop to TableToolbar
- Added `data` propType to TableToolbar
- Updated the publicAPI snapshot to reflect the new prop
- Changed `onClick` prop of TableToolbarSVGButton to call the `onDownloadCsv` callback with the filtered `data` prop
- Changed all cards that use `onDownloadCsv` to use the new callback `data` argument
- I didn't do anything but `yarn install` from the master branch so I'm not sure where the yarn.lock change came from

**Acceptance Test (how to verify the PR)**

1. Go to any story that implements `onDownloadCsv` (I was using TableCard)
2. Click the CSV download toolbar button
3. See that the output is correct
4. Filter the table with any of the filters or by searching
5. Click the CSV download button again and see that it only shows data that has been filtered
