### PR TITLE
feat(list): added simple reordering

### DIFF
--- a/src/components/List/HierarchyList/HierarchyList.story.jsx
+++ b/src/components/List/HierarchyList/HierarchyList.story.jsx
@@ -175,7 +175,7 @@ storiesOf('Watson IoT Experimental/HierarchyList', module)
         isLoading={boolean('isLoading', false)}
       />
     </div>
-  ));
+  ))
   .add('With Nested Reorder', () => {
     const HierarchyListWithReorder = () => {
       const [items, setItems] = useState([
@@ -209,6 +209,8 @@ storiesOf('Watson IoT Experimental/HierarchyList', module)
         })),
       ]);
 
+      const allowsEdit = boolean('Allow Item Movement', true);
+
       return (
         <div style={{ width: 400, height: 400 }}>
           <HierarchyList
@@ -224,6 +226,9 @@ storiesOf('Watson IoT Experimental/HierarchyList', module)
             isLoading={boolean('isLoading', false)}
             onListUpdated={updatedItems => {
               setItems(updatedItems);
+            }}
+            itemWillMove={() => {
+              return allowsEdit;
             }}
           />
         </div>

--- a/src/components/List/HierarchyList/HierarchyList.story.jsx
+++ b/src/components/List/HierarchyList/HierarchyList.story.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { text, select, boolean } from '@storybook/addon-knobs';
@@ -6,6 +6,7 @@ import { Add16 } from '@carbon/icons-react';
 import { OverflowMenu, OverflowMenuItem } from 'carbon-components-react';
 
 import { Button } from '../../..';
+import { EditingStyle } from '../../../utils/DragAndDropUtils';
 import { sampleHierarchy } from '../List.story';
 
 import HierarchyList from './HierarchyList';
@@ -175,3 +176,59 @@ storiesOf('Watson IoT Experimental/HierarchyList', module)
       />
     </div>
   ));
+  .add('With Nested Reorder', () => {
+    const HierarchyListWithReorder = () => {
+      const [items, setItems] = useState([
+        ...Object.keys(sampleHierarchy.MLB['American League']).map(team => ({
+          id: team,
+          isCategory: true,
+          content: {
+            value: team,
+          },
+          children: Object.keys(sampleHierarchy.MLB['American League'][team]).map(player => ({
+            id: `${team}_${player}`,
+            content: {
+              value: player,
+            },
+            isSelectable: true,
+          })),
+        })),
+        ...Object.keys(sampleHierarchy.MLB['National League']).map(team => ({
+          id: team,
+          isCategory: true,
+          content: {
+            value: team,
+          },
+          children: Object.keys(sampleHierarchy.MLB['National League'][team]).map(player => ({
+            id: `${team}_${player}`,
+            content: {
+              value: player,
+            },
+            isSelectable: true,
+          })),
+        })),
+      ]);
+
+      return (
+        <div style={{ width: 400, height: 400 }}>
+          <HierarchyList
+            title={text('Title', 'MLB Expanded List')}
+            defaultSelectedId={text('Default Selected Id', 'New York Mets_Pete Alonso')}
+            items={items}
+            editingStyle={select(
+              'Editing Style',
+              [EditingStyle.SingleNesting, EditingStyle.MultipleNesting],
+              EditingStyle.SingleNesting
+            )}
+            pageSize={select('Page Size', ['sm', 'lg', 'xl'], 'lg')}
+            isLoading={boolean('isLoading', false)}
+            onListUpdated={updatedItems => {
+              setItems(updatedItems);
+            }}
+          />
+        </div>
+      );
+    };
+
+    return <HierarchyListWithReorder />;
+  });

--- a/src/components/List/HierarchyList/HierarchyList.test.jsx
+++ b/src/components/List/HierarchyList/HierarchyList.test.jsx
@@ -318,8 +318,8 @@ describe('HierarchyList', () => {
     const itemSelectedText = screen.queryByText('1 item selected');
     const moveText = screen.queryByText('Move');
 
-    expect(itemSelectedText).toBeInTheDOM();
-    expect(moveText).toBeInTheDOM();
+    expect(itemSelectedText).toBeDefined();
+    expect(moveText).toBeDefined();
 
     fireEvent.click(checkbox);
 
@@ -352,8 +352,8 @@ describe('HierarchyList', () => {
     const itemSelectedText = screen.queryByText('2 items selected');
     const moveText = screen.queryByText('Move');
 
-    expect(itemSelectedText).toBeInTheDOM();
-    expect(moveText).toBeInTheDOM();
+    expect(itemSelectedText).toBeDefined();
+    expect(moveText).toBeDefined();
 
     fireEvent.click(moveText);
 

--- a/src/components/List/HierarchyList/HierarchyListReorderModal.jsx
+++ b/src/components/List/HierarchyList/HierarchyListReorderModal.jsx
@@ -1,0 +1,216 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { BreadcrumbItem, RadioButton } from 'carbon-components-react';
+
+import { Button } from '../../..';
+import ComposedModal from '../../ComposedModal/ComposedModal';
+import BreadCrumb from '../../Breadcrumb/Breadcrumb';
+import { settings } from '../../../constants/Settings';
+
+const { iotPrefix } = settings;
+
+const propTypes = {
+  /** ListItems to be displayed */
+  items: PropTypes.arrayOf(PropTypes.any).isRequired,
+  selectedIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+  /** Internationalization text */
+  i18n: PropTypes.shape({
+    allRows: PropTypes.string,
+    modalTitle: PropTypes.string,
+    modalDescription: PropTypes.string,
+  }),
+  /**   Close the dialog */
+  onClose: PropTypes.func.isRequired,
+  /** Callback to submit the dialog/form */
+  onSubmit: PropTypes.func,
+  /**  Is data currently being sent to the backend */
+  sendingData: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  /** Should the dialog be open or not */
+  open: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+};
+
+const defaultProps = {
+  i18n: {
+    itemsSelected: '%d items selected',
+    itemSelected: '%d item selected',
+    itemTitle: 'Move %d item underneath',
+    itemsTitle: 'Move %d items underneath',
+    cancel: 'Cancel',
+    allRows: 'All rows',
+  },
+  sendingData: null,
+  onSubmit: () => {},
+  open: false,
+};
+
+const HierarchyListReorderModal = ({
+  i18n,
+  items,
+  sendingData,
+  selectedIds,
+  open,
+  onClose,
+  onSubmit,
+}) => {
+  const [selectedParentPath, setSelectedParentPath] = useState([]);
+  const [selectedItem, setSelectedItem] = useState(null);
+
+  const onLineItemClicked = item => {
+    if (item.children && item.children.length > 0) {
+      setSelectedParentPath([...selectedParentPath, item.id]);
+      setSelectedItem(null);
+    } else {
+      setSelectedItem(item.id);
+    }
+  };
+
+  const renderRadioTile = item => {
+    return selectedIds.find(id => id === item.id) ? null : (
+      <div
+        className={`${iotPrefix}--hierarchy-list-bulk-modal--list-item`}
+        key={`${item.id}-bulk-reorder-list-item-${item.content.value}`}
+      >
+        <RadioButton
+          className={`${iotPrefix}--hierarchy-list-bulk-modal--radio`}
+          name={item.id}
+          key={`radio-${item.content.value}`}
+          value={item.content.value}
+          hideLabel
+          labelText={item.content.value}
+          onChange={() => {
+            setSelectedItem(item.id);
+          }}
+          tabIndex={0}
+          checked={item.id === selectedItem}
+        />
+
+        <div
+          role="button"
+          className={`${iotPrefix}--hierarchy-list-bulk-modal--list-item-button`}
+          tabIndex={0}
+          onClick={() => onLineItemClicked(item)}
+          onKeyPress={({ key }) => key === 'Enter' && onLineItemClicked(item)}
+        >
+          <div className={`${iotPrefix}--hierarchy-list-bulk-modal--list-item-value`}>
+            {item.content.value}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  const renderRadioButtonGroup = selectedItems => {
+    return (
+      <div className={`${iotPrefix}--hierarchy-list-bulk-modal--list`}>
+        {selectedItems?.map(item => {
+          return renderRadioTile(item);
+        })}
+      </div>
+    );
+  };
+
+  const renderBreadCrumbItem = (item, isCurrent) => {
+    const title = item === null ? i18n.allRows : item.content.value;
+    const id = item === null ? 'all' : item.id;
+
+    return (
+      <BreadcrumbItem
+        className={`${iotPrefix}--hierarchy-list-bulk-modal--breadcrumb`}
+        title={title}
+        key={`breadcrumb-${id}-${title}`}
+        isCurrentPage={isCurrent}
+      >
+        <Button
+          className={`${iotPrefix}--hierarchy-list-bulk-modal-- breadcrumb-button`}
+          kind="ghost"
+          onClick={() => {
+            if (isCurrent) {
+              return;
+            }
+
+            const index = selectedParentPath.findIndex(pathItem => pathItem === item?.id);
+
+            if (item !== null && index >= 0) {
+              setSelectedParentPath(selectedParentPath.slice(0, index + 1));
+            } else {
+              setSelectedParentPath([]);
+            }
+          }}
+        >
+          {title}
+        </Button>
+      </BreadcrumbItem>
+    );
+  };
+
+  const getBreadCrumbData = (breadcrumbs, selectedItems, path, pathIndex) => {
+    if (pathIndex < path.length) {
+      const breadCrumbItem = selectedItems.find(item => item.id === path[pathIndex]);
+
+      return getBreadCrumbData(
+        [...breadcrumbs, breadCrumbItem],
+        breadCrumbItem.children,
+        path,
+        pathIndex + 1
+      );
+    }
+
+    return breadcrumbs;
+  };
+
+  const renderContent = () => {
+    const breadcrumbData = getBreadCrumbData([], items, selectedParentPath, 0);
+    const group =
+      breadcrumbData.length > 0 ? breadcrumbData[breadcrumbData.length - 1].children : items;
+
+    const renderedCrumbs = [];
+
+    renderedCrumbs.push(renderBreadCrumbItem(null, selectedParentPath.length === 0));
+
+    breadcrumbData.forEach((crumb, index) => {
+      renderedCrumbs.push(renderBreadCrumbItem(crumb, index === breadcrumbData.length - 1));
+    });
+
+    return (
+      <>
+        <BreadCrumb data-testid="modal-breadcrumb">{renderedCrumbs}</BreadCrumb>
+        {renderRadioButtonGroup(group)}
+      </>
+    );
+  };
+
+  return (
+    <ComposedModal
+      className={`${iotPrefix}--hierarchy-list-bulk-modal`}
+      open={open}
+      header={{
+        title:
+          selectedIds.length > 1
+            ? `${i18n.itemsTitle.replace('%d', selectedIds?.length ?? '')}`
+            : `${i18n.itemTitle.replace('%d', selectedIds?.length ?? '')}`,
+      }}
+      onClose={() => {
+        setSelectedParentPath([]);
+        setSelectedItem(null);
+        onClose();
+      }}
+      onSubmit={() => {
+        onSubmit(selectedItem);
+
+        setSelectedParentPath([]);
+        setSelectedItem(null);
+      }}
+      sendingData={sendingData}
+    >
+      <div className={`${iotPrefix}--hierarchy-list-bulk-modal--title`}>
+        {i18n.modalDescription}
+      </div>
+      {renderContent()}
+    </ComposedModal>
+  );
+};
+
+HierarchyListReorderModal.propTypes = propTypes;
+HierarchyListReorderModal.defaultProps = defaultProps;
+
+export default HierarchyListReorderModal;

--- a/src/components/List/HierarchyList/HierarchyListReorderModal.test.jsx
+++ b/src/components/List/HierarchyList/HierarchyListReorderModal.test.jsx
@@ -1,0 +1,255 @@
+import React from 'react';
+import { render, fireEvent, screen, within } from '@testing-library/react';
+
+import { sampleHierarchy } from '../List.story';
+import { DropLocation, EditingStyle, moveItemsInList } from '../../../utils/DragAndDropUtils';
+
+import HierarchyListReorderModal from './HierarchyListReorderModal';
+
+describe('HierarchyListReorderModal', () => {
+  const items = [
+    ...Object.keys(sampleHierarchy.MLB['American League']).map(team => ({
+      id: team,
+      isCategory: true,
+      content: {
+        value: team,
+      },
+      children: Object.keys(sampleHierarchy.MLB['American League'][team]).map(player => ({
+        id: `${team}_${player}`,
+        content: {
+          value: player,
+          secondaryValue: sampleHierarchy.MLB['American League'][team][player],
+        },
+        isSelectable: true,
+      })),
+    })),
+    ...Object.keys(sampleHierarchy.MLB['National League']).map(team => ({
+      id: team,
+      isCategory: true,
+      content: {
+        value: team,
+      },
+      children: Object.keys(sampleHierarchy.MLB['National League'][team]).map(player => ({
+        id: `${team}_${player}`,
+        content: {
+          value: player,
+          secondaryValue: sampleHierarchy.MLB['National League'][team][player],
+        },
+        isSelectable: true,
+      })),
+    })),
+  ];
+
+  it('modal hides selected items', () => {
+    const selectedIds = [items[0].id, items[2].id];
+
+    render(
+      <HierarchyListReorderModal
+        items={items}
+        title="Hierarchy List Reorder Modal"
+        editingStyle={EditingStyle.MultipleNesting}
+        selectedIds={selectedIds}
+        open
+      />
+    );
+
+    const itemSelectedText = screen.queryByText(items[0].content.value);
+    const itemSelectedTwoText = screen.queryByText(items[2].content.value);
+
+    const breadcrumbs = screen.queryByTestId('modal-breadcrumb');
+
+    expect(within(breadcrumbs).queryByText('All rows')).toBeInTheDOM();
+
+    expect(itemSelectedText).toBeNull();
+    expect(itemSelectedTwoText).toBeNull();
+  });
+
+  it('clicking text updates breadcrumbs', () => {
+    const selectedIds = [items[0].id];
+
+    render(
+      <HierarchyListReorderModal
+        items={items}
+        title="Hierarchy List Reorder Modal"
+        editingStyle={EditingStyle.MultipleNesting}
+        selectedIds={selectedIds}
+        open
+      />
+    );
+
+    // Clicks the top item in the radio button group
+    const itemToSelect = screen.queryAllByRole('button')[2];
+    fireEvent.click(itemToSelect);
+
+    const breadcrumbs = screen.queryByTestId('modal-breadcrumb');
+
+    expect(within(breadcrumbs).queryByText('All rows')).toBeInTheDOM();
+    expect(within(breadcrumbs).queryByText(items[1].content.value)).toBeInTheDOM();
+  });
+
+  it('clicking current breadcrumb does not update the view', () => {
+    const selectedIds = [items[0].id];
+
+    render(
+      <HierarchyListReorderModal
+        items={items}
+        title="Hierarchy List Reorder Modal"
+        editingStyle={EditingStyle.MultipleNesting}
+        selectedIds={selectedIds}
+        open
+      />
+    );
+
+    // Clicks the top item in the radio button group
+    const itemToSelect = screen.queryAllByRole('button')[2];
+    fireEvent.click(itemToSelect);
+
+    const breadcrumbs = screen.queryByTestId('modal-breadcrumb');
+
+    expect(within(breadcrumbs).queryByText('All rows')).toBeInTheDOM();
+    expect(within(breadcrumbs).queryByText(items[1].content.value)).toBeInTheDOM();
+
+    // Selects the current breadcrumb
+    const thirdBreadCrumb = screen.queryAllByRole('button')[3];
+    fireEvent.click(thirdBreadCrumb);
+
+    const updatedBreadCrumbs = screen.queryByTestId('modal-breadcrumb');
+    expect(within(updatedBreadCrumbs).queryByText('All rows')).toBeInTheDOM();
+    expect(within(updatedBreadCrumbs).queryByText(items[1].content.value)).toBeInTheDOM();
+  });
+
+  it('clicking parent breadcrumb updates the view', () => {
+    const newList = moveItemsInList(items, [items[1].id], items[0].id, DropLocation.Nested);
+
+    const selectedIds = [newList[1].id];
+
+    render(
+      <HierarchyListReorderModal
+        items={newList}
+        title="Hierarchy List Reorder Modal"
+        editingStyle={EditingStyle.MultipleNesting}
+        selectedIds={selectedIds}
+        open
+      />
+    );
+
+    // Clicks the top item in the radio button group
+    const itemToSelect = screen.queryAllByRole('button')[2];
+    fireEvent.click(itemToSelect);
+
+    // Clicks the top item in the radio button group again
+    const secondItemToSelect = screen.queryAllByRole('button')[3];
+    fireEvent.click(secondItemToSelect);
+
+    const breadcrumbs = screen.queryByTestId('modal-breadcrumb');
+
+    expect(within(breadcrumbs).queryByText('All rows')).toBeInTheDOM();
+    expect(within(breadcrumbs).queryByText(newList[0].content.value)).toBeInTheDOM();
+    expect(within(breadcrumbs).queryByText(newList[0].children[0].content.value)).toBeInTheDOM();
+
+    fireEvent.click(within(breadcrumbs).queryAllByRole('button')[1]);
+
+    const updatedBreadCrumbs = screen.queryByTestId('modal-breadcrumb');
+
+    expect(within(updatedBreadCrumbs).queryByText('All rows')).toBeInTheDOM();
+    expect(within(updatedBreadCrumbs).queryByText(newList[0].content.value)).toBeInTheDOM();
+    expect(within(updatedBreadCrumbs).queryByText(newList[0].children[0].content.value)).toBeNull();
+  });
+
+  it('clicking all rows updates resets view', () => {
+    const selectedIds = [items[0].id];
+
+    render(
+      <HierarchyListReorderModal
+        items={items}
+        title="Hierarchy List Reorder Modal"
+        editingStyle={EditingStyle.MultipleNesting}
+        selectedIds={selectedIds}
+        open
+      />
+    );
+
+    // Clicks the top item in the radio button group
+    const itemToSelect = screen.queryAllByRole('button')[2];
+    fireEvent.click(itemToSelect);
+
+    const breadcrumbs = screen.queryByTestId('modal-breadcrumb');
+
+    expect(within(breadcrumbs).queryByText('All rows')).toBeInTheDOM();
+    expect(within(breadcrumbs).queryByText(items[1].content.value)).toBeInTheDOM();
+
+    const allItemsButton = screen.queryAllByRole('button')[1];
+
+    fireEvent.click(allItemsButton);
+
+    const breadcrumbsRerender = screen.queryByTestId('modal-breadcrumb');
+    expect(within(breadcrumbsRerender).queryByText('All rows')).toBeInTheDOM();
+    expect(within(breadcrumbsRerender).queryByText(items[1].content.value)).toBeNull();
+  });
+
+  it('clicking radio button returns correct drop id', () => {
+    const selectedIds = [items[0].id];
+    let dropId = null;
+
+    render(
+      <HierarchyListReorderModal
+        items={items}
+        title="Hierarchy List Reorder Modal"
+        editingStyle={EditingStyle.MultipleNesting}
+        selectedIds={selectedIds}
+        open
+        onSubmit={id => {
+          dropId = id;
+        }}
+      />
+    );
+
+    const saveButton = screen.queryAllByRole('button')[8];
+
+    const radioButtons = screen.queryAllByRole('radio');
+
+    fireEvent.click(radioButtons[0]);
+
+    fireEvent.click(saveButton);
+
+    expect(dropId).toEqual(items[1].id);
+  });
+
+  it('clicking row without child selects row instead', () => {
+    const selectedIds = [items[0].id];
+    let dropId = null;
+
+    render(
+      <HierarchyListReorderModal
+        items={items}
+        title="Hierarchy List Reorder Modal"
+        editingStyle={EditingStyle.MultipleNesting}
+        selectedIds={selectedIds}
+        open
+        onSubmit={id => {
+          dropId = id;
+        }}
+      />
+    );
+
+    const saveButton = screen.queryAllByRole('button')[8];
+
+    // Clicks the top item in the radio button group
+    const itemToSelect = screen.queryAllByRole('button')[2];
+    fireEvent.click(itemToSelect);
+
+    // Clicks the top item in the radio button group again
+    const secondItemToSelect = screen.queryAllByRole('button')[3];
+    fireEvent.click(secondItemToSelect);
+
+    const breadcrumbs = screen.queryByTestId('modal-breadcrumb');
+
+    expect(within(breadcrumbs).queryByText('All rows')).toBeInTheDOM();
+    expect(within(breadcrumbs).queryByText(items[1].content.value)).toBeInTheDOM();
+    expect(within(breadcrumbs).queryByText(items[2].content.value)).toBeNull();
+
+    fireEvent.click(saveButton);
+
+    expect(dropId).toEqual(items[1].children[0].id);
+  });
+});

--- a/src/components/List/HierarchyList/HierarchyListReorderModal.test.jsx
+++ b/src/components/List/HierarchyList/HierarchyListReorderModal.test.jsx
@@ -58,7 +58,7 @@ describe('HierarchyListReorderModal', () => {
 
     const breadcrumbs = screen.queryByTestId('modal-breadcrumb');
 
-    expect(within(breadcrumbs).queryByText('All rows')).toBeInTheDOM();
+    expect(within(breadcrumbs).queryByText('All rows')).toBeDefined();
 
     expect(itemSelectedText).toBeNull();
     expect(itemSelectedTwoText).toBeNull();
@@ -83,8 +83,8 @@ describe('HierarchyListReorderModal', () => {
 
     const breadcrumbs = screen.queryByTestId('modal-breadcrumb');
 
-    expect(within(breadcrumbs).queryByText('All rows')).toBeInTheDOM();
-    expect(within(breadcrumbs).queryByText(items[1].content.value)).toBeInTheDOM();
+    expect(within(breadcrumbs).queryByText('All rows')).toBeDefined();
+    expect(within(breadcrumbs).queryByText(items[1].content.value)).toBeDefined();
   });
 
   it('clicking current breadcrumb does not update the view', () => {
@@ -106,16 +106,16 @@ describe('HierarchyListReorderModal', () => {
 
     const breadcrumbs = screen.queryByTestId('modal-breadcrumb');
 
-    expect(within(breadcrumbs).queryByText('All rows')).toBeInTheDOM();
-    expect(within(breadcrumbs).queryByText(items[1].content.value)).toBeInTheDOM();
+    expect(within(breadcrumbs).queryByText('All rows')).toBeDefined();
+    expect(within(breadcrumbs).queryByText(items[1].content.value)).toBeDefined();
 
     // Selects the current breadcrumb
     const thirdBreadCrumb = screen.queryAllByRole('button')[3];
     fireEvent.click(thirdBreadCrumb);
 
     const updatedBreadCrumbs = screen.queryByTestId('modal-breadcrumb');
-    expect(within(updatedBreadCrumbs).queryByText('All rows')).toBeInTheDOM();
-    expect(within(updatedBreadCrumbs).queryByText(items[1].content.value)).toBeInTheDOM();
+    expect(within(updatedBreadCrumbs).queryByText('All rows')).toBeDefined();
+    expect(within(updatedBreadCrumbs).queryByText(items[1].content.value)).toBeDefined();
   });
 
   it('clicking parent breadcrumb updates the view', () => {
@@ -143,16 +143,16 @@ describe('HierarchyListReorderModal', () => {
 
     const breadcrumbs = screen.queryByTestId('modal-breadcrumb');
 
-    expect(within(breadcrumbs).queryByText('All rows')).toBeInTheDOM();
-    expect(within(breadcrumbs).queryByText(newList[0].content.value)).toBeInTheDOM();
-    expect(within(breadcrumbs).queryByText(newList[0].children[0].content.value)).toBeInTheDOM();
+    expect(within(breadcrumbs).queryByText('All rows')).toBeDefined();
+    expect(within(breadcrumbs).queryByText(newList[0].content.value)).toBeDefined();
+    expect(within(breadcrumbs).queryByText(newList[0].children[0].content.value)).toBeDefined();
 
     fireEvent.click(within(breadcrumbs).queryAllByRole('button')[1]);
 
     const updatedBreadCrumbs = screen.queryByTestId('modal-breadcrumb');
 
-    expect(within(updatedBreadCrumbs).queryByText('All rows')).toBeInTheDOM();
-    expect(within(updatedBreadCrumbs).queryByText(newList[0].content.value)).toBeInTheDOM();
+    expect(within(updatedBreadCrumbs).queryByText('All rows')).toBeDefined();
+    expect(within(updatedBreadCrumbs).queryByText(newList[0].content.value)).toBeDefined();
     expect(within(updatedBreadCrumbs).queryByText(newList[0].children[0].content.value)).toBeNull();
   });
 
@@ -175,15 +175,15 @@ describe('HierarchyListReorderModal', () => {
 
     const breadcrumbs = screen.queryByTestId('modal-breadcrumb');
 
-    expect(within(breadcrumbs).queryByText('All rows')).toBeInTheDOM();
-    expect(within(breadcrumbs).queryByText(items[1].content.value)).toBeInTheDOM();
+    expect(within(breadcrumbs).queryByText('All rows')).toBeDefined();
+    expect(within(breadcrumbs).queryByText(items[1].content.value)).toBeDefined();
 
     const allItemsButton = screen.queryAllByRole('button')[1];
 
     fireEvent.click(allItemsButton);
 
     const breadcrumbsRerender = screen.queryByTestId('modal-breadcrumb');
-    expect(within(breadcrumbsRerender).queryByText('All rows')).toBeInTheDOM();
+    expect(within(breadcrumbsRerender).queryByText('All rows')).toBeDefined();
     expect(within(breadcrumbsRerender).queryByText(items[1].content.value)).toBeNull();
   });
 
@@ -244,8 +244,8 @@ describe('HierarchyListReorderModal', () => {
 
     const breadcrumbs = screen.queryByTestId('modal-breadcrumb');
 
-    expect(within(breadcrumbs).queryByText('All rows')).toBeInTheDOM();
-    expect(within(breadcrumbs).queryByText(items[1].content.value)).toBeInTheDOM();
+    expect(within(breadcrumbs).queryByText('All rows')).toBeDefined();
+    expect(within(breadcrumbs).queryByText(items[1].content.value)).toBeDefined();
     expect(within(breadcrumbs).queryByText(items[2].content.value)).toBeNull();
 
     fireEvent.click(saveButton);

--- a/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
+++ b/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
@@ -21,6 +21,399 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
       }
     >
       <div
+        className="bx--modal iot--hierarchy-list-bulk-modal iot--composed-modal"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onClose={[Function]}
+        onKeyDown={[Function]}
+        open={false}
+        role="presentation"
+      >
+        <span
+          className="bx--visually-hidden"
+          role="link"
+          tabIndex="0"
+        >
+          Focus sentinel
+        </span>
+        <div
+          className="bx--modal-container"
+          tabIndex={-1}
+        >
+          <div
+            className="bx--modal-header"
+          >
+            <p
+              className="bx--modal-header__heading bx--type-beta"
+            >
+              Move 0 item underneath
+            </p>
+            <button
+              aria-label="Close"
+              className="bx--modal-close"
+              onClick={[Function]}
+              title="Close"
+              type="button"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--modal-close__icon"
+                focusable="false"
+                height={20}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            className="bx--modal-content"
+          >
+            <div
+              className="iot--hierarchy-list-bulk-modal--title"
+            >
+              Select a destination
+            </div>
+            <div
+              className="breadcrumb--container"
+              data-testid="overflow"
+            >
+              <nav
+                aria-label="Breadcrumb"
+                className={null}
+                data-testid="modal-breadcrumb"
+              >
+                <ol
+                  className="bx--breadcrumb"
+                >
+                  <li
+                    className="bx--breadcrumb-item bx--breadcrumb-item--current iot--hierarchy-list-bulk-modal--breadcrumb"
+                    title="All rows"
+                  >
+                    <button
+                      className="bx--link iot--btn bx--btn bx--btn--ghost"
+                      disabled={false}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      All rows
+                    </button>
+                  </li>
+                </ol>
+              </nav>
+            </div>
+            <div
+              className="iot--hierarchy-list-bulk-modal--list"
+            >
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id3"
+                    name="Chicago White Sox"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="Chicago White Sox"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id3"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      Chicago White Sox
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    Chicago White Sox
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id4"
+                    name="New York Yankees"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="New York Yankees"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id4"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      New York Yankees
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    New York Yankees
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id5"
+                    name="Houston Astros"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="Houston Astros"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id5"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      Houston Astros
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    Houston Astros
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id6"
+                    name="Atlanta Braves"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="Atlanta Braves"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id6"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      Atlanta Braves
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    Atlanta Braves
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id7"
+                    name="New York Mets"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="New York Mets"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id7"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      New York Mets
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    New York Mets
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id8"
+                    name="Washington Nationals"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="Washington Nationals"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id8"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      Washington Nationals
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    Washington Nationals
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="bx--modal-footer iot--composed-modal-footer"
+            inputref={
+              Object {
+                "current": null,
+              }
+            }
+          >
+            <button
+              className="iot--btn bx--btn bx--btn--secondary"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Cancel
+            </button>
+            <button
+              className="iot--btn bx--btn bx--btn--primary"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+        <span
+          className="bx--visually-hidden"
+          role="link"
+          tabIndex="0"
+        >
+          Focus sentinel
+        </span>
+      </div>
+      <div
         className="iot--list iot--list__full-height"
       >
         <div
@@ -142,6 +535,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -191,6 +585,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -240,6 +635,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -289,6 +685,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -338,6 +735,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -468,6 +866,1940 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/HierarchyList With Nested Reorder 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "height": 400,
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="bx--modal iot--hierarchy-list-bulk-modal iot--composed-modal"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onClose={[Function]}
+        onKeyDown={[Function]}
+        open={false}
+        role="presentation"
+      >
+        <span
+          className="bx--visually-hidden"
+          role="link"
+          tabIndex="0"
+        >
+          Focus sentinel
+        </span>
+        <div
+          className="bx--modal-container"
+          tabIndex={-1}
+        >
+          <div
+            className="bx--modal-header"
+          >
+            <p
+              className="bx--modal-header__heading bx--type-beta"
+            >
+              Move 1 item underneath
+            </p>
+            <button
+              aria-label="Close"
+              className="bx--modal-close"
+              onClick={[Function]}
+              title="Close"
+              type="button"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--modal-close__icon"
+                focusable="false"
+                height={20}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            className="bx--modal-content"
+          >
+            <div
+              className="iot--hierarchy-list-bulk-modal--title"
+            >
+              Select a destination
+            </div>
+            <div
+              className="breadcrumb--container"
+              data-testid="overflow"
+            >
+              <nav
+                aria-label="Breadcrumb"
+                className={null}
+                data-testid="modal-breadcrumb"
+              >
+                <ol
+                  className="bx--breadcrumb"
+                >
+                  <li
+                    className="bx--breadcrumb-item bx--breadcrumb-item--current iot--hierarchy-list-bulk-modal--breadcrumb"
+                    title="All rows"
+                  >
+                    <button
+                      className="bx--link iot--btn bx--btn bx--btn--ghost"
+                      disabled={false}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      All rows
+                    </button>
+                  </li>
+                </ol>
+              </nav>
+            </div>
+            <div
+              className="iot--hierarchy-list-bulk-modal--list"
+            >
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id21"
+                    name="Chicago White Sox"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="Chicago White Sox"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id21"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      Chicago White Sox
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    Chicago White Sox
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id22"
+                    name="New York Yankees"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="New York Yankees"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id22"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      New York Yankees
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    New York Yankees
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id23"
+                    name="Houston Astros"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="Houston Astros"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id23"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      Houston Astros
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    Houston Astros
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id24"
+                    name="Atlanta Braves"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="Atlanta Braves"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id24"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      Atlanta Braves
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    Atlanta Braves
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id25"
+                    name="New York Mets"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="New York Mets"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id25"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      New York Mets
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    New York Mets
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id26"
+                    name="Washington Nationals"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="Washington Nationals"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id26"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      Washington Nationals
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    Washington Nationals
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="bx--modal-footer iot--composed-modal-footer"
+            inputref={
+              Object {
+                "current": null,
+              }
+            }
+          >
+            <button
+              className="iot--btn bx--btn bx--btn--secondary"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Cancel
+            </button>
+            <button
+              className="iot--btn bx--btn bx--btn--primary"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+        <span
+          className="bx--visually-hidden"
+          role="link"
+          tabIndex="0"
+        >
+          Focus sentinel
+        </span>
+      </div>
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              MLB Expanded List
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            />
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item-editable--drag-container"
+              role="listitem"
+            >
+              <div
+                className="iot--list-item-editable--drop-targets"
+              >
+                <div
+                  className="iot--list-item-editable--drop-target-nested"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "100%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-above"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-below"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+              </div>
+              <div
+                className="iot--list-item iot--list-item-editable"
+              >
+                <div
+                  className="iot--list-item-editable--drag-preview"
+                >
+                  Chicago White Sox
+                </div>
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--expand-icon"
+                  data-testid="expand-icon"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-label="Close"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--list-item--content"
+                >
+                  <div
+                    className="iot--list-item--content--values"
+                  >
+                    <div
+                      className="iot--list-item--content--values--main"
+                    >
+                      <div
+                        className="iot--list-item--content--values--value iot--list-item--category"
+                        title="Chicago White Sox"
+                      >
+                        Chicago White Sox
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item-editable--drag-container"
+              role="listitem"
+            >
+              <div
+                className="iot--list-item-editable--drop-targets"
+              >
+                <div
+                  className="iot--list-item-editable--drop-target-nested"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "100%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-above"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-below"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+              </div>
+              <div
+                className="iot--list-item iot--list-item-editable"
+              >
+                <div
+                  className="iot--list-item-editable--drag-preview"
+                >
+                  New York Yankees
+                </div>
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--expand-icon"
+                  data-testid="expand-icon"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-label="Close"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--list-item--content"
+                >
+                  <div
+                    className="iot--list-item--content--values"
+                  >
+                    <div
+                      className="iot--list-item--content--values--main"
+                    >
+                      <div
+                        className="iot--list-item--content--values--value iot--list-item--category"
+                        title="New York Yankees"
+                      >
+                        New York Yankees
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item-editable--drag-container"
+              role="listitem"
+            >
+              <div
+                className="iot--list-item-editable--drop-targets"
+              >
+                <div
+                  className="iot--list-item-editable--drop-target-nested"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "100%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-above"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-below"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+              </div>
+              <div
+                className="iot--list-item iot--list-item-editable"
+              >
+                <div
+                  className="iot--list-item-editable--drag-preview"
+                >
+                  Houston Astros
+                </div>
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--expand-icon"
+                  data-testid="expand-icon"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-label="Close"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--list-item--content"
+                >
+                  <div
+                    className="iot--list-item--content--values"
+                  >
+                    <div
+                      className="iot--list-item--content--values--main"
+                    >
+                      <div
+                        className="iot--list-item--content--values--value iot--list-item--category"
+                        title="Houston Astros"
+                      >
+                        Houston Astros
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item-editable--drag-container"
+              role="listitem"
+            >
+              <div
+                className="iot--list-item-editable--drop-targets"
+              >
+                <div
+                  className="iot--list-item-editable--drop-target-nested"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "100%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-above"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-below"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+              </div>
+              <div
+                className="iot--list-item iot--list-item-editable"
+              >
+                <div
+                  className="iot--list-item-editable--drag-preview"
+                >
+                  Atlanta Braves
+                </div>
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--expand-icon"
+                  data-testid="expand-icon"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-label="Close"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--list-item--content"
+                >
+                  <div
+                    className="iot--list-item--content--values"
+                  >
+                    <div
+                      className="iot--list-item--content--values--main"
+                    >
+                      <div
+                        className="iot--list-item--content--values--value iot--list-item--category"
+                        title="Atlanta Braves"
+                      >
+                        Atlanta Braves
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item-editable--drag-container"
+              role="listitem"
+            >
+              <div
+                className="iot--list-item-editable--drop-targets"
+              >
+                <div
+                  className="iot--list-item-editable--drop-target-nested"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "100%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-above"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-below"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+              </div>
+              <div
+                className="iot--list-item iot--list-item-editable"
+              >
+                <div
+                  className="iot--list-item-editable--drag-preview"
+                >
+                  New York Mets
+                </div>
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--expand-icon"
+                  data-testid="expand-icon"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-label="Expand"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--list-item--content"
+                >
+                  <div
+                    className="iot--list-item--content--values"
+                  >
+                    <div
+                      className="iot--list-item--content--values--main"
+                    >
+                      <div
+                        className="iot--list-item--content--values--value iot--list-item--category"
+                        title="New York Mets"
+                      >
+                        New York Mets
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item-editable--drag-container"
+              role="listitem"
+            >
+              <div
+                className="iot--list-item-editable--drop-targets"
+              >
+                <div
+                  className="iot--list-item-editable--drop-target-nested"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "100%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-above"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-below"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+              </div>
+              <div
+                className="iot--list-item iot--list-item-editable"
+              >
+                <div
+                  className="iot--list-item-editable--drag-preview"
+                >
+                  Jeff McNeil
+                </div>
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--nesting-offset"
+                  style={
+                    Object {
+                      "width": "30px",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item--content"
+                >
+                  <div
+                    className="iot--list-item--content--values"
+                  >
+                    <div
+                      className="iot--list-item--content--values--main"
+                    >
+                      <div
+                        className="iot--list-item--content--values--value"
+                        title="Jeff McNeil"
+                      >
+                        Jeff McNeil
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item-editable--drag-container"
+              role="listitem"
+            >
+              <div
+                className="iot--list-item-editable--drop-targets"
+              >
+                <div
+                  className="iot--list-item-editable--drop-target-nested"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "100%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-above"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-below"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+              </div>
+              <div
+                className="iot--list-item iot--list-item-editable"
+              >
+                <div
+                  className="iot--list-item-editable--drag-preview"
+                >
+                  Amed Rosario
+                </div>
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--nesting-offset"
+                  style={
+                    Object {
+                      "width": "30px",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item--content"
+                >
+                  <div
+                    className="iot--list-item--content--values"
+                  >
+                    <div
+                      className="iot--list-item--content--values--main"
+                    >
+                      <div
+                        className="iot--list-item--content--values--value"
+                        title="Amed Rosario"
+                      >
+                        Amed Rosario
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item-editable--drag-container"
+              role="listitem"
+            >
+              <div
+                className="iot--list-item-editable--drop-targets"
+              >
+                <div
+                  className="iot--list-item-editable--drop-target-nested"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "100%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-above"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-below"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+              </div>
+              <div
+                className="iot--list-item iot--list-item-editable"
+              >
+                <div
+                  className="iot--list-item-editable--drag-preview"
+                >
+                  Michael Conforto
+                </div>
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--nesting-offset"
+                  style={
+                    Object {
+                      "width": "30px",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item--content"
+                >
+                  <div
+                    className="iot--list-item--content--values"
+                  >
+                    <div
+                      className="iot--list-item--content--values--main"
+                    >
+                      <div
+                        className="iot--list-item--content--values--value"
+                        title="Michael Conforto"
+                      >
+                        Michael Conforto
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item-editable--drag-container"
+              role="listitem"
+            >
+              <div
+                className="iot--list-item-editable--drop-targets"
+              >
+                <div
+                  className="iot--list-item-editable--drop-target-nested"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "100%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-above"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-below"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+              </div>
+              <div
+                className="iot--list-item iot--list-item-editable"
+              >
+                <div
+                  className="iot--list-item-editable--drag-preview"
+                >
+                  Pete Alonso
+                </div>
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--nesting-offset"
+                  style={
+                    Object {
+                      "width": "30px",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item--content"
+                >
+                  <div
+                    className="iot--list-item--content--values"
+                  >
+                    <div
+                      className="iot--list-item--content--values--main"
+                    >
+                      <div
+                        className="iot--list-item--content--values--value"
+                        title="Pete Alonso"
+                      >
+                        Pete Alonso
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item-editable--drag-container"
+              role="listitem"
+            >
+              <div
+                className="iot--list-item-editable--drop-targets"
+              >
+                <div
+                  className="iot--list-item-editable--drop-target-nested"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "100%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-above"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-below"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+              </div>
+              <div
+                className="iot--list-item iot--list-item-editable"
+              >
+                <div
+                  className="iot--list-item-editable--drag-preview"
+                >
+                  Wilson Ramos
+                </div>
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--nesting-offset"
+                  style={
+                    Object {
+                      "width": "30px",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item--content"
+                >
+                  <div
+                    className="iot--list-item--content--values"
+                  >
+                    <div
+                      className="iot--list-item--content--values--main"
+                    >
+                      <div
+                        className="iot--list-item--content--values--value"
+                        title="Wilson Ramos"
+                      >
+                        Wilson Ramos
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item-editable--drag-container"
+              role="listitem"
+            >
+              <div
+                className="iot--list-item-editable--drop-targets"
+              >
+                <div
+                  className="iot--list-item-editable--drop-target-nested"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "100%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-above"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-below"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+              </div>
+              <div
+                className="iot--list-item iot--list-item-editable"
+              >
+                <div
+                  className="iot--list-item-editable--drag-preview"
+                >
+                  Robinson Cano
+                </div>
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--nesting-offset"
+                  style={
+                    Object {
+                      "width": "30px",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item--content"
+                >
+                  <div
+                    className="iot--list-item--content--values"
+                  >
+                    <div
+                      className="iot--list-item--content--values--main"
+                    >
+                      <div
+                        className="iot--list-item--content--values--value"
+                        title="Robinson Cano"
+                      >
+                        Robinson Cano
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item-editable--drag-container"
+              role="listitem"
+            >
+              <div
+                className="iot--list-item-editable--drop-targets"
+              >
+                <div
+                  className="iot--list-item-editable--drop-target-nested"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "100%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-above"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-below"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+              </div>
+              <div
+                className="iot--list-item iot--list-item-editable"
+              >
+                <div
+                  className="iot--list-item-editable--drag-preview"
+                >
+                  JD Davis
+                </div>
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--nesting-offset"
+                  style={
+                    Object {
+                      "width": "30px",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item--content"
+                >
+                  <div
+                    className="iot--list-item--content--values"
+                  >
+                    <div
+                      className="iot--list-item--content--values--main"
+                    >
+                      <div
+                        className="iot--list-item--content--values--value"
+                        title="JD Davis"
+                      >
+                        JD Davis
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item-editable--drag-container"
+              role="listitem"
+            >
+              <div
+                className="iot--list-item-editable--drop-targets"
+              >
+                <div
+                  className="iot--list-item-editable--drop-target-nested"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "100%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-above"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-below"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+              </div>
+              <div
+                className="iot--list-item iot--list-item-editable"
+              >
+                <div
+                  className="iot--list-item-editable--drag-preview"
+                >
+                  Brandon Nimmo
+                </div>
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--nesting-offset"
+                  style={
+                    Object {
+                      "width": "30px",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item--content"
+                >
+                  <div
+                    className="iot--list-item--content--values"
+                  >
+                    <div
+                      className="iot--list-item--content--values--main"
+                    >
+                      <div
+                        className="iot--list-item--content--values--value"
+                        title="Brandon Nimmo"
+                      >
+                        Brandon Nimmo
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item-editable--drag-container"
+              role="listitem"
+            >
+              <div
+                className="iot--list-item-editable--drop-targets"
+              >
+                <div
+                  className="iot--list-item-editable--drop-target-nested"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "100%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-above"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-below"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+              </div>
+              <div
+                className="iot--list-item iot--list-item-editable"
+              >
+                <div
+                  className="iot--list-item-editable--drag-preview"
+                >
+                  Jacob Degrom
+                </div>
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--nesting-offset"
+                  style={
+                    Object {
+                      "width": "30px",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item--content"
+                >
+                  <div
+                    className="iot--list-item--content--values"
+                  >
+                    <div
+                      className="iot--list-item--content--values--main"
+                    >
+                      <div
+                        className="iot--list-item--content--values--value"
+                        title="Jacob Degrom"
+                      >
+                        Jacob Degrom
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item-editable--drag-container"
+              role="listitem"
+            >
+              <div
+                className="iot--list-item-editable--drop-targets"
+              >
+                <div
+                  className="iot--list-item-editable--drop-target-nested"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "100%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-above"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+                <div
+                  className="iot--list-item-editable--drop-target-below"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "33%",
+                    }
+                  }
+                />
+              </div>
+              <div
+                className="iot--list-item iot--list-item-editable"
+              >
+                <div
+                  className="iot--list-item-editable--drag-preview"
+                >
+                  Washington Nationals
+                </div>
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--expand-icon"
+                  data-testid="expand-icon"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-label="Close"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--list-item--content"
+                >
+                  <div
+                    className="iot--list-item--content--values"
+                  >
+                    <div
+                      className="iot--list-item--content--values--main"
+                    >
+                      <div
+                        className="iot--list-item--content--values--value iot--list-item--category"
+                        title="Washington Nationals"
+                      >
+                        Washington Nationals
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--page"
+        >
+          <div
+            className="iot-simple-pagination-container"
+          >
+            <span
+              className="iot-simple-pagination-page-label"
+              maxpage={1}
+            >
+              Page 1
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/HierarchyList With OverflowMenu 1`] = `
 <div
   className="storybook-container"
@@ -488,6 +2820,399 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         }
       }
     >
+      <div
+        className="bx--modal iot--hierarchy-list-bulk-modal iot--composed-modal"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onClose={[Function]}
+        onKeyDown={[Function]}
+        open={false}
+        role="presentation"
+      >
+        <span
+          className="bx--visually-hidden"
+          role="link"
+          tabIndex="0"
+        >
+          Focus sentinel
+        </span>
+        <div
+          className="bx--modal-container"
+          tabIndex={-1}
+        >
+          <div
+            className="bx--modal-header"
+          >
+            <p
+              className="bx--modal-header__heading bx--type-beta"
+            >
+              Move 0 item underneath
+            </p>
+            <button
+              aria-label="Close"
+              className="bx--modal-close"
+              onClick={[Function]}
+              title="Close"
+              type="button"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--modal-close__icon"
+                focusable="false"
+                height={20}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            className="bx--modal-content"
+          >
+            <div
+              className="iot--hierarchy-list-bulk-modal--title"
+            >
+              Select a destination
+            </div>
+            <div
+              className="breadcrumb--container"
+              data-testid="overflow"
+            >
+              <nav
+                aria-label="Breadcrumb"
+                className={null}
+                data-testid="modal-breadcrumb"
+              >
+                <ol
+                  className="bx--breadcrumb"
+                >
+                  <li
+                    className="bx--breadcrumb-item bx--breadcrumb-item--current iot--hierarchy-list-bulk-modal--breadcrumb"
+                    title="All rows"
+                  >
+                    <button
+                      className="bx--link iot--btn bx--btn bx--btn--ghost"
+                      disabled={false}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      All rows
+                    </button>
+                  </li>
+                </ol>
+              </nav>
+            </div>
+            <div
+              className="iot--hierarchy-list-bulk-modal--list"
+            >
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id15"
+                    name="Chicago White Sox"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="Chicago White Sox"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id15"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      Chicago White Sox
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    Chicago White Sox
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id16"
+                    name="New York Yankees"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="New York Yankees"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id16"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      New York Yankees
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    New York Yankees
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id17"
+                    name="Houston Astros"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="Houston Astros"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id17"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      Houston Astros
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    Houston Astros
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id18"
+                    name="Atlanta Braves"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="Atlanta Braves"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id18"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      Atlanta Braves
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    Atlanta Braves
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id19"
+                    name="New York Mets"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="New York Mets"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id19"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      New York Mets
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    New York Mets
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id20"
+                    name="Washington Nationals"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="Washington Nationals"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id20"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      Washington Nationals
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    Washington Nationals
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="bx--modal-footer iot--composed-modal-footer"
+            inputref={
+              Object {
+                "current": null,
+              }
+            }
+          >
+            <button
+              className="iot--btn bx--btn bx--btn--secondary"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Cancel
+            </button>
+            <button
+              className="iot--btn bx--btn bx--btn--primary"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+        <span
+          className="bx--visually-hidden"
+          role="link"
+          tabIndex="0"
+        >
+          Focus sentinel
+        </span>
+      </div>
       <div
         className="iot--list"
       >
@@ -580,6 +3305,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -629,6 +3355,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -678,6 +3405,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -727,6 +3455,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -776,6 +3505,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -825,6 +3555,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -930,6 +3661,399 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
       }
     >
       <div
+        className="bx--modal iot--hierarchy-list-bulk-modal iot--composed-modal"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onClose={[Function]}
+        onKeyDown={[Function]}
+        open={false}
+        role="presentation"
+      >
+        <span
+          className="bx--visually-hidden"
+          role="link"
+          tabIndex="0"
+        >
+          Focus sentinel
+        </span>
+        <div
+          className="bx--modal-container"
+          tabIndex={-1}
+        >
+          <div
+            className="bx--modal-header"
+          >
+            <p
+              className="bx--modal-header__heading bx--type-beta"
+            >
+              Move 0 item underneath
+            </p>
+            <button
+              aria-label="Close"
+              className="bx--modal-close"
+              onClick={[Function]}
+              title="Close"
+              type="button"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--modal-close__icon"
+                focusable="false"
+                height={20}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            className="bx--modal-content"
+          >
+            <div
+              className="iot--hierarchy-list-bulk-modal--title"
+            >
+              Select a destination
+            </div>
+            <div
+              className="breadcrumb--container"
+              data-testid="overflow"
+            >
+              <nav
+                aria-label="Breadcrumb"
+                className={null}
+                data-testid="modal-breadcrumb"
+              >
+                <ol
+                  className="bx--breadcrumb"
+                >
+                  <li
+                    className="bx--breadcrumb-item bx--breadcrumb-item--current iot--hierarchy-list-bulk-modal--breadcrumb"
+                    title="All rows"
+                  >
+                    <button
+                      className="bx--link iot--btn bx--btn bx--btn--ghost"
+                      disabled={false}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      All rows
+                    </button>
+                  </li>
+                </ol>
+              </nav>
+            </div>
+            <div
+              className="iot--hierarchy-list-bulk-modal--list"
+            >
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id9"
+                    name="Chicago White Sox"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="Chicago White Sox"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id9"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      Chicago White Sox
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    Chicago White Sox
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id10"
+                    name="New York Yankees"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="New York Yankees"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id10"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      New York Yankees
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    New York Yankees
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id11"
+                    name="Houston Astros"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="Houston Astros"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id11"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      Houston Astros
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    Houston Astros
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id12"
+                    name="Atlanta Braves"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="Atlanta Braves"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id12"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      Atlanta Braves
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    Atlanta Braves
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id13"
+                    name="New York Mets"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="New York Mets"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id13"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      New York Mets
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    New York Mets
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id14"
+                    name="Washington Nationals"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="Washington Nationals"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id14"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      Washington Nationals
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    Washington Nationals
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="bx--modal-footer iot--composed-modal-footer"
+            inputref={
+              Object {
+                "current": null,
+              }
+            }
+          >
+            <button
+              className="iot--btn bx--btn bx--btn--secondary"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Cancel
+            </button>
+            <button
+              className="iot--btn bx--btn bx--btn--primary"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+        <span
+          className="bx--visually-hidden"
+          role="link"
+          tabIndex="0"
+        >
+          Focus sentinel
+        </span>
+      </div>
+      <div
         className="iot--list"
       >
         <div
@@ -1021,6 +4145,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -1066,22 +4191,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -1127,22 +4241,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -1188,22 +4291,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -1249,22 +4341,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content iot--list-item--content__selected"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -1310,23 +4391,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item iot--list-item__selectable"
+              data_testid={null}
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
               tabIndex={0}
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1335,9 +4405,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -1363,23 +4431,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item iot--list-item__selectable"
+              data_testid={null}
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
               tabIndex={0}
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1388,9 +4445,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -1416,8 +4471,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item iot--list-item__selectable"
+              data_testid={null}
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
@@ -1430,9 +4485,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -1444,9 +4497,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   >
                     <div
                       className="iot--list-item--content--values--value"
-                      title="Michael ConfortoMichael ConfortoMichael ConfortoMichael Conforto"
+                      title="Michael Conforto"
                     >
-                      Michael ConfortoMichael ConfortoMichael ConfortoMichael Conforto
+                      Michael Conforto
                     </div>
                   </div>
                 </div>
@@ -1457,17 +4510,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             className="iot--list-item-parent"
             data-floating-menu-container={true}
           >
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
->>>>>>> feat(list): updated drag style
             <div
               className="iot--list-item iot--list-item__selectable iot--list-item__selected"
+              data_testid="list-item__selected"
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
@@ -1480,9 +4525,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content iot--list-item--content__selected"
               >
@@ -1508,8 +4551,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item iot--list-item__selectable"
+              data_testid={null}
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
@@ -1522,9 +4565,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -1549,17 +4590,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             className="iot--list-item-parent"
             data-floating-menu-container={true}
           >
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
->>>>>>> feat(list): updated drag style
             <div
               className="iot--list-item iot--list-item__selectable"
+              data_testid={null}
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
@@ -1572,9 +4605,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -1600,8 +4631,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item iot--list-item__selectable"
+              data_testid={null}
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
@@ -1614,9 +4645,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -1641,17 +4670,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             className="iot--list-item-parent"
             data-floating-menu-container={true}
           >
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
->>>>>>> feat(list): updated drag style
             <div
               className="iot--list-item iot--list-item__selectable"
+              data_testid={null}
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
@@ -1664,9 +4685,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -1693,6 +4712,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           >
             <div
               className="iot--list-item iot--list-item__selectable"
+              data_testid={null}
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
@@ -1705,9 +4725,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -1737,6 +4755,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"

--- a/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
+++ b/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
@@ -1066,7 +1066,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--expand-icon"
@@ -1115,7 +1127,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--expand-icon"
@@ -1164,7 +1188,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--expand-icon"
@@ -1213,7 +1249,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content iot--list-item--content__selected"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--expand-icon"
@@ -1262,11 +1310,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
               tabIndex={0}
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1303,11 +1363,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
               tabIndex={0}
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1344,6 +1416,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
               onKeyPress={[Function]}
@@ -1384,6 +1457,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             className="iot--list-item-parent"
             data-floating-menu-container={true}
           >
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+>>>>>>> feat(list): updated drag style
             <div
               className="iot--list-item iot--list-item__selectable iot--list-item__selected"
               onClick={[Function]}
@@ -1426,6 +1508,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
               onKeyPress={[Function]}
@@ -1466,6 +1549,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             className="iot--list-item-parent"
             data-floating-menu-container={true}
           >
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+>>>>>>> feat(list): updated drag style
             <div
               className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
@@ -1508,6 +1600,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
               onKeyPress={[Function]}
@@ -1548,6 +1641,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             className="iot--list-item-parent"
             data-floating-menu-container={true}
           >
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+>>>>>>> feat(list): updated drag style
             <div
               className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}

--- a/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
+++ b/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
@@ -2058,7 +2058,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 <div
                   className="iot--list-item-editable--drag-preview"
                 >
-                  Michael Conforto
+                  Michael ConfortoMichael ConfortoMichael ConfortoMichael Conforto
                 </div>
                 <svg
                   aria-hidden={true}
@@ -2094,9 +2094,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     >
                       <div
                         className="iot--list-item--content--values--value"
-                        title="Michael Conforto"
+                        title="Michael ConfortoMichael ConfortoMichael ConfortoMichael Conforto"
                       >
-                        Michael Conforto
+                        Michael ConfortoMichael ConfortoMichael ConfortoMichael Conforto
                       </div>
                     </div>
                   </div>
@@ -4497,9 +4497,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   >
                     <div
                       className="iot--list-item--content--values--value"
-                      title="Michael Conforto"
+                      title="Michael ConfortoMichael ConfortoMichael ConfortoMichael Conforto"
                     >
-                      Michael Conforto
+                      Michael ConfortoMichael ConfortoMichael ConfortoMichael Conforto
                     </div>
                   </div>
                 </div>

--- a/src/components/List/HierarchyList/_hierarchy-list.scss
+++ b/src/components/List/HierarchyList/_hierarchy-list.scss
@@ -1,0 +1,101 @@
+@import '../../../globals/vars';
+
+.#{$iot-prefix}--hierarchy-list-bulk {
+  &-header {
+    width: 100%;
+    background-color: $focus;
+
+    display: flex;
+
+    &--title {
+      padding-left: $spacing-05;
+      margin: auto;
+
+      flex-grow: 1;
+      color: $ui-background;
+    }
+
+    &--button-container {
+      display: flex;
+      flex-direction: row;
+    }
+
+    &--divider {
+      height: $spacing-04;
+      padding-right: $spacing-02;
+      margin: auto 0 auto $spacing-02;
+      border-left: 1px solid $ui-background;
+    }
+
+    &--button {
+      padding: 0 $spacing-08 0 $spacing-05 !important;
+
+      &-no-icon {
+        padding: 0 $spacing-05;
+      }
+    }
+  }
+
+  &-modal {
+    &--breadcrumb {
+      overflow-y: scroll;
+
+      > button {
+        padding: 0 !important;
+      }
+    }
+
+    .#{prefix}--modal-content {
+      padding-right: 0 !important;
+    }
+
+    &--list {
+      display: flex;
+
+      width: 100%;
+
+      align-items: flex-start;
+      margin-top: rem(6px);
+      flex-direction: column;
+
+      &-item {
+        display: flex;
+        position: relative;
+        width: 100%;
+        background-color: $ui-background;
+
+        &:hover {
+          background-color: $hover-ui;
+        }
+
+        &::after {
+          height: 1px;
+
+          content: '';
+          background: $ui-03;
+          position: absolute;
+          bottom: 0px;
+          right: $spacing-08;
+          left: 0;
+        }
+
+        &-button {
+          display: flex;
+          align-content: flex-start;
+          padding: auto 0;
+          padding-right: $spacing-04;
+          flex-grow: 1;
+        }
+
+        &-value {
+          margin: auto 0;
+        }
+      }
+    }
+
+    &--radio {
+      padding: $spacing-05;
+      margin: 0 !important;
+    }
+  }
+}

--- a/src/components/List/HierarchyList/_hierarchy-list.scss
+++ b/src/components/List/HierarchyList/_hierarchy-list.scss
@@ -28,7 +28,7 @@
     }
 
     &--button {
-      padding: 0 $spacing-08 0 $spacing-05 !important;
+      padding: 0 $spacing-08 0 $spacing-05;
 
       &-no-icon {
         padding: 0 $spacing-05;
@@ -41,12 +41,8 @@
       overflow-y: scroll;
 
       > button {
-        padding: 0 !important;
+        padding: 0;
       }
-    }
-
-    .#{prefix}--modal-content {
-      padding-right: 0 !important;
     }
 
     &--list {
@@ -95,7 +91,7 @@
 
     &--radio {
       padding: $spacing-05;
-      margin: 0 !important;
+      margin-right: 0 !important;
     }
   }
 }

--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -1,6 +1,8 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { DragDropContext } from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
 
 import { settings } from '../../constants/Settings';
 import SimplePagination, { SimplePaginationPropTypes } from '../SimplePagination/SimplePagination';
@@ -37,6 +39,8 @@ const propTypes = {
   buttons: PropTypes.arrayOf(PropTypes.node),
   /** data source of list items */
   items: PropTypes.arrayOf(PropTypes.shape(itemPropTypes)).isRequired,
+  /** list can be rearranged */
+  isEditing: PropTypes.bool,
   /** use full height in list */
   isFullHeight: PropTypes.bool,
   /** use large/fat row in list */
@@ -63,6 +67,8 @@ const propTypes = {
   handleSelect: PropTypes.func,
   /** call back function of expansion */
   toggleExpansion: PropTypes.func,
+  /** callback function for reorder */
+  onItemMoved: PropTypes.func,
 };
 
 const defaultProps = {
@@ -70,6 +76,7 @@ const defaultProps = {
   title: null,
   search: null,
   buttons: [],
+  isEditing: false,
   isFullHeight: false,
   isLargeRow: false,
   isLoading: false,
@@ -85,6 +92,7 @@ const defaultProps = {
   expandedIds: [],
   handleSelect: () => {},
   toggleExpansion: () => {},
+  onItemMoved: () => {},
 };
 
 const List = forwardRef((props, ref) => {
@@ -104,11 +112,13 @@ const List = forwardRef((props, ref) => {
     handleSelect,
     toggleExpansion,
     iconPosition,
+    isEditing,
     isLargeRow,
     isLoading,
+    onItemMoved,
   } = props;
   const selectedItemRef = ref;
-  const renderItemAndChildren = (item, level) => {
+  const renderItemAndChildren = (item, index, depth) => {
     const hasChildren = item.children && item.children.length > 0;
     const isSelected = item.id === selectedId || selectedIds.some(id => item.id === id);
     const isExpanded = expandedIds.filter(rowId => rowId === item.id).length > 0;
@@ -128,15 +138,18 @@ const List = forwardRef((props, ref) => {
       >
         <ListItem
           id={item.id}
+          index={index}
           key={`${item.id}-list-item-${level}-${value}`}
           nestingLevel={level}
           value={value}
           icon={icon}
           iconPosition={iconPosition}
+          isEditing={isEditing}
           secondaryValue={secondaryValue}
           rowActions={rowActions}
           onSelect={handleSelect}
           onExpand={toggleExpansion}
+          onItemMoved={onItemMoved}
           selected={isSelected}
           expanded={isExpanded}
           isExpandable={hasChildren}
@@ -148,14 +161,17 @@ const List = forwardRef((props, ref) => {
           tags={tags}
         />
       </div>,
-
       ...(hasChildren && isExpanded
-        ? item.children.map(child => renderItemAndChildren(child, level + 1))
+        ? item.children.map((child, nestedIndex) => {
+            const newDepth = [...depth, index];
+
+            return renderItemAndChildren(child, nestedIndex, newDepth);
+          })
         : []),
     ];
   };
 
-  const listItems = items.map(item => renderItemAndChildren(item, 0));
+  const listItems = items.map((item, index) => renderItemAndChildren(item, index, []));
 
   return (
     <div
@@ -198,4 +214,5 @@ const List = forwardRef((props, ref) => {
 List.propTypes = propTypes;
 List.defaultProps = defaultProps;
 
-export default List;
+export { List as UnconnectedList };
+export default DragDropContext(HTML5Backend)(List);

--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -80,7 +80,6 @@ const propTypes = {
   itemWillMove: PropTypes.func,
 };
 
-/* istanbul ignore next */
 const defaultProps = {
   className: null,
   title: null,

--- a/src/components/List/List.story.jsx
+++ b/src/components/List/List.story.jsx
@@ -69,7 +69,7 @@ export const sampleHierarchy = {
       'New York Mets': {
         'Jeff McNeil': '3B',
         'Amed Rosario': 'SS',
-        'Michael ConfortoMichael ConfortoMichael ConfortoMichael Conforto': 'RF',
+        'Michael Conforto': 'RF',
         'Pete Alonso': '1B',
         'Wilson Ramos': 'C',
         'Robinson Cano': '2B',
@@ -487,7 +487,7 @@ storiesOf('Watson IoT Experimental/List', module)
         isLoading={boolean('isLoading', false)}
       />
     </div>
-  ));
+  ))
   .add('basic (single column) with reorder', () => {
     const SingleColumnReorder = () => {
       const startData = Object.entries(

--- a/src/components/List/List.story.jsx
+++ b/src/components/List/List.story.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { text, boolean } from '@storybook/addon-knobs';
-import { Add16, Edit16, Star16, Close16, Checkmark16, NumberSmall_132 } from '@carbon/icons-react';
+import { Add16, Edit16, Star16, Close16, Checkmark16 } from '@carbon/icons-react';
 import cloneDeep from 'lodash/cloneDeep';
 import someDeep from 'deepdash/someDeep';
 
@@ -496,15 +496,9 @@ storiesOf('Watson IoT Experimental/List', module)
       const editing = boolean('isEditing,', true);
 
       const onItemMoved = (dragProps, hoverProps) => {
-        console.log(`raw drag: ${dragProps} raw hover: ${hoverProps}`);
-
         const dragCard = listItems[dragProps.index];
         listItems.splice(dragProps.index, 1);
         listItems.splice(hoverProps.index, 0, dragCard);
-
-        console.log(
-          `drag: ${dragProps.index} hover: ${hoverProps.index} items: ${JSON.stringify(listItems)}`
-        );
 
         setListItems([...listItems]);
       };
@@ -584,7 +578,7 @@ storiesOf('Watson IoT Experimental/List', module)
 
         cloneDeep(items).forEach(item => {
           if (item.children) {
-            item.children = searchNestedItems(item.children, draggedItem, hoverProps);
+            item.children = searchNestedItems(item.children, draggedItem, hoverProps); // eslint-disable-line no-param-reassign
           }
 
           if (item.id === hoverProps.id && isAbove) {
@@ -625,12 +619,7 @@ storiesOf('Watson IoT Experimental/List', module)
         }
 
         const draggedItem = searchDraggedItem(listItems, dragProps.id);
-
-        console.log(`before ${dragProps.id}  ${hoverProps.id} above? ${isAbove}`);
-
         const newList = searchNestedItems(listItems, draggedItem, hoverProps, isAbove);
-
-        // console.log(`after ${JSON.stringify(newList)}`);
 
         setListItems(newList);
 

--- a/src/components/List/List.story.jsx
+++ b/src/components/List/List.story.jsx
@@ -69,7 +69,7 @@ export const sampleHierarchy = {
       'New York Mets': {
         'Jeff McNeil': '3B',
         'Amed Rosario': 'SS',
-        'Michael Conforto': 'RF',
+        'Michael ConfortoMichael ConfortoMichael ConfortoMichael Conforto': 'RF',
         'Pete Alonso': '1B',
         'Wilson Ramos': 'C',
         'Robinson Cano': '2B',

--- a/src/components/List/List.story.jsx
+++ b/src/components/List/List.story.jsx
@@ -6,7 +6,6 @@ import { Add16, Edit16, Star16, Close16, Checkmark16 } from '@carbon/icons-react
 import cloneDeep from 'lodash/cloneDeep';
 import someDeep from 'deepdash/someDeep';
 
-import { DropLocation } from '../../utils/DragAndDropUtils';
 import { Button, OverflowMenu, OverflowMenuItem, Checkbox } from '../..';
 import { Tag } from '../Tag';
 
@@ -608,7 +607,7 @@ storiesOf('Watson IoT Experimental/List', module)
             buttons={editing ? [cancelButton, saveButton] : []}
             title={text('title', 'NY Yankees')}
             items={listItems}
-            editMode="multiple"
+            editingStyle="multiple"
             // editMode={editing ? 'multiple' : null}
             isLoading={boolean('isLoading', false)}
             expandedIds={expandedIds}

--- a/src/components/List/List.story.jsx
+++ b/src/components/List/List.story.jsx
@@ -1,15 +1,21 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { text, boolean } from '@storybook/addon-knobs';
+import { boolean, select, text } from '@storybook/addon-knobs';
 import { Add16, Edit16, Star16, Close16, Checkmark16 } from '@carbon/icons-react';
 import cloneDeep from 'lodash/cloneDeep';
 import someDeep from 'deepdash/someDeep';
 
+import { DropLocation } from '../../utils/DragAndDropUtils';
 import { Button, OverflowMenu, OverflowMenuItem, Checkbox } from '../..';
 import { Tag } from '../Tag';
 
 import List from './List';
+
+const EditMode = {
+  Single: 'single',
+  Multiple: 'multiple',
+};
 
 export const sampleHierarchy = {
   MLB: {
@@ -532,7 +538,7 @@ storiesOf('Watson IoT Experimental/List', module)
             buttons={editing ? [cancelButton, saveButton] : []}
             title={text('title', 'NY Yankees')}
             items={listItems}
-            isEditing={editing}
+            editMode={select('Edit Mode', EditMode, EditMode.Single)}
             isLoading={boolean('isLoading', false)}
             onItemMoved={onItemMoved}
           />
@@ -573,59 +579,6 @@ storiesOf('Watson IoT Experimental/List', module)
       const [listItems, setListItems] = useState(startData);
       const editing = boolean('isEditing,', true);
 
-      const searchNestedItems = (items, draggedItem, hoverProps, isAbove) => {
-        const finalList = [];
-
-        cloneDeep(items).forEach(item => {
-          if (item.children) {
-            item.children = searchNestedItems(item.children, draggedItem, hoverProps); // eslint-disable-line no-param-reassign
-          }
-
-          if (item.id === hoverProps.id && isAbove) {
-            finalList.push(draggedItem);
-          }
-
-          if (item.id !== draggedItem.id) {
-            finalList.push(item);
-          }
-
-          if (item.id === hoverProps.id && !isAbove) {
-            finalList.push(draggedItem);
-          }
-        });
-
-        return finalList;
-      };
-
-      const searchDraggedItem = (items, id) => {
-        let draggedItem = null;
-
-        cloneDeep(items).forEach(item => {
-          if (draggedItem === null) {
-            if (item.id === id) {
-              draggedItem = item;
-            } else if (item.children) {
-              draggedItem = searchDraggedItem(item.children, id);
-            }
-          }
-        });
-
-        return draggedItem;
-      };
-
-      const onItemMoved = (dragProps, hoverProps, isAbove) => {
-        if (dragProps.id === hoverProps.id) {
-          return false;
-        }
-
-        const draggedItem = searchDraggedItem(listItems, dragProps.id);
-        const newList = searchNestedItems(listItems, draggedItem, hoverProps, isAbove);
-
-        setListItems(newList);
-
-        return true;
-      };
-
       const saveButton = (
         <Button
           renderIcon={Checkmark16}
@@ -655,9 +608,9 @@ storiesOf('Watson IoT Experimental/List', module)
             buttons={editing ? [cancelButton, saveButton] : []}
             title={text('title', 'NY Yankees')}
             items={listItems}
-            isEditing={editing}
+            editMode="multiple"
+            // editMode={editing ? 'multiple' : null}
             isLoading={boolean('isLoading', false)}
-            onItemMoved={onItemMoved}
             expandedIds={expandedIds}
             toggleExpansion={id => {
               if (expandedIds.filter(rowId => rowId === id).length > 0) {

--- a/src/components/List/List.test.jsx
+++ b/src/components/List/List.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-import List from './List';
+import List, { UnconnectedList } from './List';
 import { sampleHierarchy } from './List.story';
 
 describe('List', () => {
@@ -15,23 +15,23 @@ describe('List', () => {
       }));
 
   it('List when pagination is null', () => {
-    const renderedElement = render(<List title="list" items={getListItems(5)} />);
+    const renderedElement = render(<UnconnectedList title="list" items={getListItems(5)} />);
     expect(renderedElement.container.innerHTML).toBeTruthy();
   });
 
   it('List to have default handleSelect', () => {
-    expect(List.defaultProps.handleSelect).toBeDefined();
-    List.defaultProps.handleSelect();
+    expect(UnconnectedList.defaultProps.handleSelect).toBeDefined();
+    UnconnectedList.defaultProps.handleSelect();
   });
 
   it('List to have default toggleExpansion', () => {
-    expect(List.defaultProps.toggleExpansion).toBeDefined();
-    List.defaultProps.toggleExpansion();
+    expect(UnconnectedList.defaultProps.toggleExpansion).toBeDefined();
+    UnconnectedList.defaultProps.toggleExpansion();
   });
 
   it('List when selectedIds is set', () => {
     const renderedElement = render(
-      <List title="list" items={getListItems(5)} selectedIds={['1', '2']} />
+      <UnconnectedList title="list" items={getListItems(5)} selectedIds={['1', '2']} />
     );
     expect(renderedElement.container.innerHTML).toBeTruthy();
   });

--- a/src/components/List/List.test.jsx
+++ b/src/components/List/List.test.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
+import { Checkbox } from '../..';
+
 import List, { UnconnectedList } from './List';
 import { sampleHierarchy } from './List.story';
 
@@ -75,5 +77,24 @@ describe('List', () => {
       />
     );
     expect(screen.getByTitle('Chicago White Sox')).toBeTruthy();
+  });
+
+  it('List renders icons', () => {
+    render(
+      <List
+        title="list"
+        items={[
+          ...Object.keys(sampleHierarchy.MLB['American League']).map(team => ({
+            id: team,
+            isCategory: true,
+            content: {
+              value: team,
+              icon: <Checkbox id={`${team}-checkbox`} name={team} labelText={`${team}`} checked />,
+            },
+          })),
+        ]}
+      />
+    );
+    expect(screen.getByLabelText('Chicago White Sox')).toBeTruthy();
   });
 });

--- a/src/components/List/ListHeader/_list-header.scss
+++ b/src/components/List/ListHeader/_list-header.scss
@@ -17,7 +17,7 @@
     padding: $spacing-03;
     align-items: center;
     & > * {
-      margin-left: $spacing-03;
+      margin-left: $spacing-05;
     }
   }
 

--- a/src/components/List/ListItem/ListItem.jsx
+++ b/src/components/List/ListItem/ListItem.jsx
@@ -10,13 +10,14 @@ import { settings } from '../../../constants/Settings';
 
 import ListTarget, { TargetSize } from './ListTarget';
 
-const { iotPrefix, prefix } = settings;
+const { iotPrefix } = settings;
 
 export const ItemType = 'ListItem';
 
 const ListItemWrapper = ({
   id,
   editingStyle,
+  expanded,
   isSelectable,
   itemWillMove,
   onItemMoved,
@@ -38,6 +39,7 @@ const ListItemWrapper = ({
         { [`${iotPrefix}--list-item__large`]: isLargeRow },
         { [`${iotPrefix}--list-item-editable`]: editingStyle }
       )}
+      data_testid={selected ? 'list-item__selected' : null}
       onKeyPress={({ key }) => key === 'Enter' && onSelect(id)}
       onClick={() => {
         onSelect(id);
@@ -62,6 +64,7 @@ const ListItemWrapper = ({
 
     return (
       <div
+        role="listitem"
         className={classnames(`${iotPrefix}--list-item-editable--drag-container`, {
           [`${iotPrefix}--list-item-editable-dragging`]: isDragging,
         })}
@@ -81,6 +84,7 @@ const ListItemWrapper = ({
           canNest ? (
             <ListTarget
               id={id}
+              isDragging={isDragging}
               targetPosition={DropLocation.Nested}
               targetSize={TargetSize.Full}
               itemWillMove={itemWillMove}
@@ -90,15 +94,19 @@ const ListItemWrapper = ({
 
           <ListTarget
             id={id}
+            isDragging={isDragging}
             targetPosition={DropLocation.Above}
             itemWillMove={itemWillMove}
             targetSize={canNest ? TargetSize.Third : TargetSize.Half}
             onItemMoved={onItemMoved}
           />
+
           <ListTarget
             id={id}
+            isDragging={isDragging}
             targetPosition={DropLocation.Below}
             itemWillMove={itemWillMove}
+            targetOverride={expanded ? DropLocation.Nested : null} // If item is expanded then the bottom target will nest
             targetSize={canNest ? TargetSize.Third : TargetSize.Half}
             onItemMoved={onItemMoved}
           />
@@ -121,6 +129,7 @@ const ListItemWrapperProps = {
     EditingStyle.SingleNesting,
     EditingStyle.MultipleNesting,
   ]),
+  expanded: PropTypes.bool.isRequired,
   isLargeRow: PropTypes.bool.isRequired,
   isSelectable: PropTypes.bool.isRequired,
   isDragging: PropTypes.bool.isRequired,
@@ -171,7 +180,7 @@ const ListItemPropTypes = {
   connectDragPreview: PropTypes.func.isRequired,
   index: PropTypes.number.isRequired,
   dragPreviewText: PropTypes.string,
-  nestedIndex: PropTypes.arrayOf(PropTypes.number),
+  nestingLevel: PropTypes.number,
   isDragging: PropTypes.bool.isRequired,
   onItemMoved: PropTypes.func.isRequired,
   itemWillMove: PropTypes.func.isRequired,
@@ -191,7 +200,7 @@ const ListItemDefaultProps = {
   rowActions: [],
   icon: null,
   iconPosition: 'left',
-  nestingLevel: [],
+  nestingLevel: 0,
   isCategory: false,
   i18n: {
     expand: 'Expand',
@@ -221,7 +230,6 @@ const ListItem = ({
   isCategory,
   i18n,
   isDragging,
-  isOver,
   selectedItemRef,
   tags,
   connectDragSource,
@@ -231,13 +239,14 @@ const ListItem = ({
 }) => {
   const handleExpansionClick = () => isExpandable && onExpand(id);
 
-  const renderNestingOffset = () =>
-    nestingLevel.length > 0 ? (
+  const renderNestingOffset = () => {
+    return nestingLevel > 0 ? (
       <div
-        className={`${prefix}--assistive-text ${iotPrefix}--list-item--nesting-offset`}
-        style={{ width: `${nestingLevel.length * 30}px` }}
+        className={`${iotPrefix}--list-item--nesting-offset`}
+        style={{ width: `${nestingLevel * 30}px` }}
       />
     ) : null;
+  };
 
   const renderExpander = () =>
     isExpandable ? (
@@ -246,6 +255,7 @@ const ListItem = ({
         tabIndex={0}
         className={`${iotPrefix}--list-item--expand-icon`}
         onClick={handleExpansionClick}
+        data-testid="expand-icon"
         onKeyPress={({ key }) => key === 'Enter' && handleExpansionClick()}
       >
         {expanded ? (
@@ -298,10 +308,10 @@ const ListItem = ({
       {...{
         id,
         isSelectable,
-        isOver,
         selected,
         isDragging,
         editingStyle,
+        expanded,
         isLargeRow,
         onSelect,
         connectDragSource,
@@ -310,8 +320,8 @@ const ListItem = ({
       }}
     >
       {renderDragPreview()}
-      {renderNestingOffset()}
       {dragIcon()}
+      {renderNestingOffset()}
       {renderExpander()}
       <div
         className={classnames(

--- a/src/components/List/ListItem/ListItem.test.jsx
+++ b/src/components/List/ListItem/ListItem.test.jsx
@@ -1,26 +1,39 @@
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
 import { Add16, Edit16 } from '@carbon/icons-react';
+import TestBackend from 'react-dnd-test-backend';
+import { DragDropContext } from 'react-dnd';
 
 import { Tag } from '../../Tag';
 
 import { UnconnectedListItem } from './ListItem';
 
+const wrapInTestContext = (DecoratedComponent, props) =>
+  DragDropContext(TestBackend)(() => <DecoratedComponent {...props} />);
+
 describe('ListItem', () => {
   it('test ListItem gets rendered', () => {
-    render(<UnconnectedListItem id="1" value="some content" />);
+    render(<UnconnectedListItem id="1" value="some content" index="0" />);
     expect(screen.getByText('some content')).toBeTruthy();
   });
 
   it('ListItem with large row and secondary value', () => {
-    render(<UnconnectedListItem id="1" value="some content" secondaryValue="second" isLargeRow />);
+    render(
+      <UnconnectedListItem
+        id="1"
+        value="some content"
+        secondaryValue="second"
+        index="0"
+        isLargeRow
+      />
+    );
     expect(screen.getByText('some content')).toBeTruthy();
     expect(screen.getByText('second')).toBeTruthy();
   });
 
   it('ListItem when isSelectable set to true', () => {
     const onSelect = jest.fn();
-    render(<UnconnectedListItem id="1" value="test" isSelectable onSelect={onSelect} />);
+    render(<UnconnectedListItem id="1" value="test" isSelectable onSelect={onSelect} index="0" />);
     fireEvent.keyPress(screen.getAllByRole('button')[0], { key: 'Enter', charCode: 13 });
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
@@ -34,14 +47,14 @@ describe('ListItem', () => {
 
   it('ListItem when is Expandable set to true', () => {
     const onExpand = jest.fn();
-    render(<UnconnectedListItem id="1" value="" isExpandable onExpand={onExpand} />);
+    render(<UnconnectedListItem id="1" value="" isExpandable onExpand={onExpand} index="0" />);
     fireEvent.keyPress(screen.getAllByRole('button')[0], { key: 'Enter', charCode: 13 });
     expect(onExpand).toHaveBeenCalledTimes(1);
   });
 
   it('ListItem when is Expandable set to true and onClick will trigger onExpand', () => {
     const onExpand = jest.fn();
-    render(<UnconnectedListItem id="1" value="" isExpandable onExpand={onExpand} />);
+    render(<UnconnectedListItem id="1" value="" isExpandable onExpand={onExpand} index="0" />);
     fireEvent.click(screen.getAllByRole('button')[0]);
     expect(onExpand).toHaveBeenCalledTimes(1);
   });
@@ -54,6 +67,7 @@ describe('ListItem', () => {
         value="test"
         icon={<Add16 title="iconTitle" onClick={onClick} />}
         iconPosition="left"
+        index="0"
       />
     );
     fireEvent.click(screen.getByTitle('iconTitle'));
@@ -63,7 +77,7 @@ describe('ListItem', () => {
   it('ListItem with rowActions', () => {
     const rowActionOnClick = jest.fn();
     const rowActions = [<Edit16 title="iconTitle" onClick={rowActionOnClick} />];
-    render(<UnconnectedListItem id="1" value="test" rowActions={rowActions} />);
+    render(<UnconnectedListItem id="1" value="test" rowActions={rowActions} index="0" />);
     fireEvent.click(screen.getByTitle('iconTitle'));
     expect(rowActionOnClick).toHaveBeenCalledTimes(1);
   });
@@ -76,6 +90,7 @@ describe('ListItem', () => {
         id="1"
         value="test value with a really long string to ensure that it stretches the length of the ListItem"
         rowActions={rowActions}
+        index="0"
       />
     );
     fireEvent.click(screen.getByTitle('iconTitle'));
@@ -90,7 +105,7 @@ describe('ListItem', () => {
     };
     const i18nDefaults = UnconnectedListItem.defaultProps.i18n;
     const { rerender } = render(
-      <UnconnectedListItem i18n={i18nTest} id="1" value="" isExpandable />
+      <UnconnectedListItem i18n={i18nTest} id="1" value="" isExpandable index="0" />
     );
     expect(screen.getByLabelText(i18nTest.close)).toBeInTheDocument();
     expect(screen.queryByLabelText(i18nDefaults.close)).not.toBeInTheDocument();
@@ -109,7 +124,7 @@ describe('ListItem', () => {
         my tag 2
       </Tag>,
     ];
-    const { rerender } = render(<UnconnectedListItem id="1" value="test" />);
+    const { rerender } = render(<UnconnectedListItem id="1" value="test" index="0" />);
     expect(screen.queryByText('my tag 1')).not.toBeInTheDocument();
     expect(screen.queryByText('my tag 2')).not.toBeInTheDocument();
 
@@ -119,7 +134,40 @@ describe('ListItem', () => {
   });
 
   it('ListItem in edit mode', () => {
-    render(<UnconnectedListItem id="1" value="test" isEditing />);
+    render(<UnconnectedListItem id="1" value="test" editingStyle="multiple" index="0" />);
     expect(screen.getByTestId('list-item-editable')).toBeTruthy();
+  });
+
+  it('ListItem has three targets in nesting mode', () => {
+    const listItemProps = {
+      id: '1',
+      value: 'test',
+      editingStyle: 'single-nesting',
+    };
+
+    const Wrapped = wrapInTestContext(UnconnectedListItem, listItemProps);
+
+    render(<Wrapped />);
+
+    const targets = screen.getAllByTestId('list-target');
+
+    expect(targets.length).toEqual(3);
+  });
+
+  it('ListItem has two targets in outside of nesting mode', () => {
+    const listItemProps = {
+      id: '1',
+      value: 'test',
+      editingStyle: 'single',
+      index: '0',
+    };
+
+    const Wrapped = wrapInTestContext(UnconnectedListItem, listItemProps);
+
+    render(<Wrapped />);
+
+    const targets = screen.getAllByTestId('list-target');
+
+    expect(targets.length).toEqual(2);
   });
 });

--- a/src/components/List/ListItem/ListItem.test.jsx
+++ b/src/components/List/ListItem/ListItem.test.jsx
@@ -8,13 +8,13 @@ import { UnconnectedListItem } from './ListItem';
 
 describe('ListItem', () => {
   it('test ListItem gets rendered', () => {
-    render(<UnconnectedListItem id="1" value="test" />);
-    expect(screen.getByText('test')).toBeTruthy();
+    render(<UnconnectedListItem id="1" value="some content" />);
+    expect(screen.getByText('some content')).toBeTruthy();
   });
 
   it('ListItem with large row and secondary value', () => {
-    render(<UnconnectedListItem id="1" value="test" secondaryValue="second" isLargeRow />);
-    expect(screen.getByText('test')).toBeTruthy();
+    render(<UnconnectedListItem id="1" value="some content" secondaryValue="second" isLargeRow />);
+    expect(screen.getByText('some content')).toBeTruthy();
     expect(screen.getByText('second')).toBeTruthy();
   });
 

--- a/src/components/List/ListItem/ListItem.test.jsx
+++ b/src/components/List/ListItem/ListItem.test.jsx
@@ -4,44 +4,44 @@ import { Add16, Edit16 } from '@carbon/icons-react';
 
 import { Tag } from '../../Tag';
 
-import ListItem from './ListItem';
+import { UnconnectedListItem } from './ListItem';
 
 describe('ListItem', () => {
   it('test ListItem gets rendered', () => {
-    render(<ListItem id="1" value="test" />);
+    render(<UnconnectedListItem id="1" value="test" />);
     expect(screen.getByText('test')).toBeTruthy();
   });
 
   it('ListItem with large row and secondary value', () => {
-    render(<ListItem id="1" value="test" secondaryValue="second" isLargeRow />);
+    render(<UnconnectedListItem id="1" value="test" secondaryValue="second" isLargeRow />);
     expect(screen.getByText('test')).toBeTruthy();
     expect(screen.getByText('second')).toBeTruthy();
   });
 
   it('ListItem when isSelectable set to true', () => {
     const onSelect = jest.fn();
-    render(<ListItem id="1" value="test" isSelectable onSelect={onSelect} />);
+    render(<UnconnectedListItem id="1" value="test" isSelectable onSelect={onSelect} />);
     fireEvent.keyPress(screen.getAllByRole('button')[0], { key: 'Enter', charCode: 13 });
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
 
   it('ListItem when isSelectable is set to true and onClick will trigger onSelect', () => {
     const onSelect = jest.fn();
-    render(<ListItem id="1" value="" isSelectable onSelect={onSelect} />);
+    render(<UnconnectedListItem id="1" value="" isSelectable onSelect={onSelect} />);
     fireEvent.click(screen.getAllByRole('button')[0]);
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
 
   it('ListItem when is Expandable set to true', () => {
     const onExpand = jest.fn();
-    render(<ListItem id="1" value="" isExpandable onExpand={onExpand} />);
+    render(<UnconnectedListItem id="1" value="" isExpandable onExpand={onExpand} />);
     fireEvent.keyPress(screen.getAllByRole('button')[0], { key: 'Enter', charCode: 13 });
     expect(onExpand).toHaveBeenCalledTimes(1);
   });
 
   it('ListItem when is Expandable set to true and onClick will trigger onExpand', () => {
     const onExpand = jest.fn();
-    render(<ListItem id="1" value="" isExpandable onExpand={onExpand} />);
+    render(<UnconnectedListItem id="1" value="" isExpandable onExpand={onExpand} />);
     fireEvent.click(screen.getAllByRole('button')[0]);
     expect(onExpand).toHaveBeenCalledTimes(1);
   });
@@ -49,7 +49,7 @@ describe('ListItem', () => {
   it('ListItem with Icon', () => {
     const onClick = jest.fn();
     render(
-      <ListItem
+      <UnconnectedListItem
         id="1"
         value="test"
         icon={<Add16 title="iconTitle" onClick={onClick} />}
@@ -63,7 +63,7 @@ describe('ListItem', () => {
   it('ListItem with rowActions', () => {
     const rowActionOnClick = jest.fn();
     const rowActions = [<Edit16 title="iconTitle" onClick={rowActionOnClick} />];
-    render(<ListItem id="1" value="test" rowActions={rowActions} />);
+    render(<UnconnectedListItem id="1" value="test" rowActions={rowActions} />);
     fireEvent.click(screen.getByTitle('iconTitle'));
     expect(rowActionOnClick).toHaveBeenCalledTimes(1);
   });
@@ -72,7 +72,7 @@ describe('ListItem', () => {
     const rowActionOnClick = jest.fn();
     const rowActions = [<Edit16 title="iconTitle" onClick={rowActionOnClick} />];
     render(
-      <ListItem
+      <UnconnectedListItem
         id="1"
         value="test value with a really long string to ensure that it stretches the length of the ListItem"
         rowActions={rowActions}
@@ -88,12 +88,14 @@ describe('ListItem', () => {
       expand: 'expand',
       close: 'close',
     };
-    const i18nDefaults = ListItem.defaultProps.i18n;
-    const { rerender } = render(<ListItem i18n={i18nTest} id="1" value="" isExpandable />);
+    const i18nDefaults = UnconnectedListItem.defaultProps.i18n;
+    const { rerender } = render(
+      <UnconnectedListItem i18n={i18nTest} id="1" value="" isExpandable />
+    );
     expect(screen.getByLabelText(i18nTest.close)).toBeInTheDocument();
     expect(screen.queryByLabelText(i18nDefaults.close)).not.toBeInTheDocument();
 
-    rerender(<ListItem i18n={i18nTest} id="1" value="" isExpandable expanded />);
+    rerender(<UnconnectedListItem i18n={i18nTest} id="1" value="" isExpandable expanded />);
     expect(screen.getByLabelText(i18nTest.expand)).toBeInTheDocument();
     expect(screen.queryByLabelText(i18nDefaults.expand)).not.toBeInTheDocument();
   });
@@ -107,12 +109,17 @@ describe('ListItem', () => {
         my tag 2
       </Tag>,
     ];
-    const { rerender } = render(<ListItem id="1" value="test" />);
+    const { rerender } = render(<UnconnectedListItem id="1" value="test" />);
     expect(screen.queryByText('my tag 1')).not.toBeInTheDocument();
     expect(screen.queryByText('my tag 2')).not.toBeInTheDocument();
 
-    rerender(<ListItem id="1" value="test" tags={tags} />);
+    rerender(<UnconnectedListItem id="1" value="test" tags={tags} />);
     expect(screen.getByText('my tag 1')).toBeVisible();
     expect(screen.getByText('my tag 2')).toBeVisible();
+  });
+
+  it('ListItem in edit mode', () => {
+    render(<UnconnectedListItem id="1" value="test" isEditing />);
+    expect(screen.getByTestId('list-item-editable')).toBeTruthy();
   });
 });

--- a/src/components/List/ListItem/ListTarget.jsx
+++ b/src/components/List/ListItem/ListTarget.jsx
@@ -17,12 +17,15 @@ const ListTargetPropTypes = {
   connectDropTarget: PropTypes.func.isRequired,
   isOver: PropTypes.bool,
   targetPosition: PropTypes.string.isRequired,
-  targetSize: PropTypes.oneOf[(TargetSize.Third, TargetSize.Half, TargetSize.Full)],
+  targetSize: PropTypes.oneOf([TargetSize.Third, TargetSize.Half, TargetSize.Full]),
+  // eslint-disable-next-line react/no-unused-prop-types
+  targetOverride: PropTypes.string,
 };
 
 const ListTargetDefaultProps = {
   isOver: false,
   targetSize: TargetSize.Third,
+  targetOverride: null,
 };
 
 const ListTarget = ({ connectDropTarget, targetPosition, targetSize, isOver }) => {
@@ -36,6 +39,7 @@ const ListTarget = ({ connectDropTarget, targetPosition, targetSize, isOver }) =
 
   return (
     <div
+      data-testid="list-target"
       className={classnames(`${iotPrefix}--list-item-editable--drop-target-${targetPosition}`, {
         [`${iotPrefix}--list-item-editable--drop-target-${targetPosition}__over`]: isOver,
       })}
@@ -51,11 +55,12 @@ const ListTarget = ({ connectDropTarget, targetPosition, targetSize, isOver }) =
   );
 };
 
+/* istanbul ignore next */
 const rowTarget = {
   drop(hoverProps, monitor) {
     const hoverId = hoverProps.id;
     const dragId = monitor.getItem().props.id;
-    const target = hoverProps.targetPosition;
+    const target = hoverProps.targetOverride ?? hoverProps.targetPosition;
 
     // Check if drop is allowed
     if (hoverProps.itemWillMove(dragId, hoverId, target)) {
@@ -64,6 +69,7 @@ const rowTarget = {
   },
 };
 
+/* istanbul ignore next */
 const dt = DropTarget('ListItem', rowTarget, (connect, monitor) => ({
   connectDropTarget: connect.dropTarget(),
   isOver: monitor.isOver({ shallow: true }),

--- a/src/components/List/ListItem/ListTarget.jsx
+++ b/src/components/List/ListItem/ListTarget.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { DropTarget } from 'react-dnd';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+
+import { settings } from '../../../constants/Settings';
+
+import { ItemType } from './ListItem';
+
+const { iotPrefix } = settings;
+
+const ListTargetPropTypes = {
+  id: PropTypes.string.isRequired,
+  targetPosition: PropTypes.string.isRequired,
+  onItemMoved: PropTypes.func.isRequired,
+  itemWillMove: PropTypes.func.isRequired,
+  isOver: PropTypes.bool.isRequired,
+  connectDropTarget: PropTypes.func.isRequired,
+};
+
+const ListTarget = ({ connectDropTarget, targetPosition, isOver }) => {
+  return (
+    <div
+      className={classnames(`${iotPrefix}--list-item-editable--drop-target-${targetPosition}`, {
+        [`${iotPrefix}--list-item-editable--drop-target-${targetPosition}__over`]: isOver,
+      })}
+      ref={instance => {
+        if (connectDropTarget) {
+          connectDropTarget(instance);
+        }
+      }}
+    />
+  );
+};
+
+const rowTarget = {
+  drop(hoverProps, monitor) {
+    const hoverId = hoverProps.id;
+    const dragId = monitor.getItem().props.id;
+    const target = hoverProps.targetPosition;
+
+    // Check if drop is allowed
+    if (hoverProps.itemWillMove(dragId, hoverId, target)) {
+      hoverProps.onItemMoved(dragId, hoverId, target);
+    }
+  },
+};
+
+const dt = DropTarget('ListItem', rowTarget, (connect, monitor) => ({
+  connectDropTarget: connect.dropTarget(),
+  isOver: monitor.isOver({ shallow: true }),
+  isMovingUp: monitor.getDifferenceFromInitialOffset()?.y <= 0,
+}));
+
+ListTarget.propTypes = ListTargetPropTypes;
+
+export default dt(ListTarget);

--- a/src/components/List/ListItem/ListTarget.jsx
+++ b/src/components/List/ListItem/ListTarget.jsx
@@ -55,7 +55,6 @@ const ListTarget = ({ connectDropTarget, targetPosition, targetSize, isOver }) =
   );
 };
 
-/* istanbul ignore next */
 const rowTarget = {
   drop(hoverProps, monitor) {
     const hoverId = hoverProps.id;
@@ -69,11 +68,9 @@ const rowTarget = {
   },
 };
 
-/* istanbul ignore next */
 const dt = DropTarget('ListItem', rowTarget, (connect, monitor) => ({
   connectDropTarget: connect.dropTarget(),
   isOver: monitor.isOver({ shallow: true }),
-  isMovingUp: monitor.getDifferenceFromInitialOffset()?.y <= 0,
 }));
 
 ListTarget.propTypes = ListTargetPropTypes;

--- a/src/components/List/ListItem/ListTarget.jsx
+++ b/src/components/List/ListItem/ListTarget.jsx
@@ -5,25 +5,43 @@ import PropTypes from 'prop-types';
 
 import { settings } from '../../../constants/Settings';
 
-import { ItemType } from './ListItem';
-
 const { iotPrefix } = settings;
 
-const ListTargetPropTypes = {
-  id: PropTypes.string.isRequired,
-  targetPosition: PropTypes.string.isRequired,
-  onItemMoved: PropTypes.func.isRequired,
-  itemWillMove: PropTypes.func.isRequired,
-  isOver: PropTypes.bool.isRequired,
-  connectDropTarget: PropTypes.func.isRequired,
+export const TargetSize = {
+  Third: 'third',
+  Half: 'half',
+  Full: 'full',
 };
 
-const ListTarget = ({ connectDropTarget, targetPosition, isOver }) => {
+const ListTargetPropTypes = {
+  connectDropTarget: PropTypes.func.isRequired,
+  isOver: PropTypes.bool,
+  targetPosition: PropTypes.string.isRequired,
+  targetSize: PropTypes.oneOf[(TargetSize.Third, TargetSize.Half, TargetSize.Full)],
+};
+
+const ListTargetDefaultProps = {
+  isOver: false,
+  targetSize: TargetSize.Third,
+};
+
+const ListTarget = ({ connectDropTarget, targetPosition, targetSize, isOver }) => {
+  let height = 33; // defaults to TargetSize.Third
+
+  if (targetSize === TargetSize.Full) {
+    height = 100;
+  } else if (targetSize === TargetSize.Half) {
+    height = 50;
+  }
+
   return (
     <div
       className={classnames(`${iotPrefix}--list-item-editable--drop-target-${targetPosition}`, {
         [`${iotPrefix}--list-item-editable--drop-target-${targetPosition}__over`]: isOver,
       })}
+      style={{
+        height: `${height}%`,
+      }}
       ref={instance => {
         if (connectDropTarget) {
           connectDropTarget(instance);
@@ -53,5 +71,6 @@ const dt = DropTarget('ListItem', rowTarget, (connect, monitor) => ({
 }));
 
 ListTarget.propTypes = ListTargetPropTypes;
+ListTarget.defaultProps = ListTargetDefaultProps;
 
 export default dt(ListTarget);

--- a/src/components/List/ListItem/_list-item.scss
+++ b/src/components/List/ListItem/_list-item.scss
@@ -19,6 +19,7 @@
     flex-direction: column;
     position: absolute;
     align-items: stretch;
+    // pointer-events: none;
   }
 
   &--drop-target-above {
@@ -86,6 +87,7 @@
   overflow-x: hidden;
 
   &--handle {
+    flex-shrink: 0;
     fill: $inverse-02;
     margin-right: $spacing-03;
   }

--- a/src/components/List/ListItem/_list-item.scss
+++ b/src/components/List/ListItem/_list-item.scss
@@ -23,10 +23,7 @@
 
   &--drop-target-above {
     position: relative;
-
     width: 100%;
-    height: 33%;
-
     bottom: 0;
 
     &__over {
@@ -50,7 +47,6 @@
     position: absolute;
 
     width: 100%;
-    height: 33%;
     bottom: 0;
 
     &__over {

--- a/src/components/List/ListItem/_list-item.scss
+++ b/src/components/List/ListItem/_list-item.scss
@@ -13,6 +13,21 @@
     border-bottom: solid 2px $focus;
   }
 
+  &--drag-preview {
+    position: absolute;
+    background: $inverse-02;
+    color: $text-04;
+    padding: $spacing-02 $spacing-04;
+    border-radius: 0.125rem;
+    opacity: 1;
+
+    z-index: -100;
+  }
+
+  &-dragging {
+    background: $hover-ui;
+  }
+
   &:hover {
     background: $hover-ui;
     cursor: grab;
@@ -25,12 +40,13 @@
   display: flex;
   height: rem(40px);
   color: $text-02;
-  padding: $spacing-03 $spacing-03 $spacing-03 $spacing-05;
+  padding: $spacing-03;
   align-items: center;
   overflow-x: hidden;
 
   &--handle {
-    fill: $ibm-color__gray-100;
+    fill: $inverse-02;
+    margin-right: $spacing-03;
   }
 
   &__large {
@@ -61,7 +77,7 @@
 
   &--expand-icon {
     cursor: pointer;
-    padding: $spacing-01;
+    padding: $spacing-01 $spacing-01 $spacing-01 $spacing-03;
     margin-right: $spacing-04;
     transform: rotate(180deg);
   }

--- a/src/components/List/ListItem/_list-item.scss
+++ b/src/components/List/ListItem/_list-item.scss
@@ -19,7 +19,6 @@
     flex-direction: column;
     position: absolute;
     align-items: stretch;
-    // pointer-events: none;
   }
 
   &--drop-target-above {

--- a/src/components/List/ListItem/_list-item.scss
+++ b/src/components/List/ListItem/_list-item.scss
@@ -4,6 +4,21 @@
   position: relative;
 }
 
+.#{$iot-prefix}--list-item-editable {
+  &-drag-above {
+    border-top: solid 2px $focus;
+  }
+
+  &-drag-below {
+    border-bottom: solid 2px $focus;
+  }
+
+  &:hover {
+    background: $hover-ui;
+    cursor: grab;
+  }
+}
+
 .#{$iot-prefix}--list-item {
   background: $ui-01;
   border-bottom: 1px solid $ui-03;
@@ -13,6 +28,10 @@
   padding: $spacing-03 $spacing-03 $spacing-03 $spacing-05;
   align-items: center;
   overflow-x: hidden;
+
+  &--handle {
+    fill: $ibm-color__gray-100;
+  }
 
   &__large {
     height: rem(96px);

--- a/src/components/List/ListItem/_list-item.scss
+++ b/src/components/List/ListItem/_list-item.scss
@@ -5,12 +5,57 @@
 }
 
 .#{$iot-prefix}--list-item-editable {
-  &-drag-above {
-    border-top: solid 2px $focus;
+  &--drag-container {
+    position: relative;
+    overflow: hidden;
+    align-items: stretch;
+    justify-content: space-between;
   }
 
-  &-drag-below {
-    border-bottom: solid 2px $focus;
+  &--drop-targets {
+    width: 100%;
+    height: rem(40px);
+    display: flex;
+    flex-direction: column;
+    position: absolute;
+    align-items: stretch;
+  }
+
+  &--drop-target-above {
+    position: relative;
+
+    width: 100%;
+    height: 33%;
+
+    bottom: 0;
+
+    &__over {
+      border-top: solid 2px $focus;
+    }
+  }
+
+  &--drop-target-nested {
+    position: absolute;
+    width: 100%;
+
+    top: 0;
+    bottom: 0;
+
+    &__over {
+      border: solid 2px $focus;
+    }
+  }
+
+  &--drop-target-below {
+    position: absolute;
+
+    width: 100%;
+    height: 33%;
+    bottom: 0;
+
+    &__over {
+      border-bottom: solid 2px $focus;
+    }
   }
 
   &--drag-preview {

--- a/src/components/List/SimpleList/SimpleList.jsx
+++ b/src/components/List/SimpleList/SimpleList.jsx
@@ -6,7 +6,6 @@ import {
   handleEditModeSelect,
   moveItemsInList,
 } from '../../../utils/DragAndDropUtils';
-
 import List from '../List';
 
 const itemPropTypes = {
@@ -133,6 +132,23 @@ const SimpleList = ({
     pageOfPagesText: page => i18n.pageOfPagesText(page),
   };
 
+  /* istanbul ignore next */
+  const onItemMoved = (dragId, hoverId, target) => {
+    let updatedList;
+
+    if (
+      editModeSelectedIds.length > 0 &&
+      editModeSelectedIds.find(selectionId => selectionId === dragId)
+    ) {
+      updatedList = moveItemsInList(items, editModeSelectedIds, hoverId, target);
+    } else {
+      updatedList = moveItemsInList(items, [dragId], hoverId, target);
+    }
+
+    onListUpdated(updatedList);
+    setFilteredItems(updatedList);
+  };
+
   return (
     <List
       title={title}
@@ -179,21 +195,7 @@ const SimpleList = ({
       isLargeRow={isLargeRow}
       isLoading={isLoading}
       editingStyle={editingStyle}
-      onItemMoved={(dragId, hoverId, target) => {
-        let updatedList;
-
-        if (
-          editModeSelectedIds.length > 0 &&
-          editModeSelectedIds.find(selectionId => selectionId === dragId)
-        ) {
-          updatedList = moveItemsInList(items, editModeSelectedIds, hoverId, target);
-        } else {
-          updatedList = moveItemsInList(items, [dragId], hoverId, target);
-        }
-
-        onListUpdated(updatedList);
-        setFilteredItems(updatedList);
-      }}
+      onItemMoved={onItemMoved}
     />
   );
 };

--- a/src/components/List/SimpleList/SimpleList.jsx
+++ b/src/components/List/SimpleList/SimpleList.jsx
@@ -132,7 +132,6 @@ const SimpleList = ({
     pageOfPagesText: page => i18n.pageOfPagesText(page),
   };
 
-  /* istanbul ignore next */
   const onItemMoved = (dragId, hoverId, target) => {
     let updatedList;
 

--- a/src/components/List/SimpleList/SimpleList.story.jsx
+++ b/src/components/List/SimpleList/SimpleList.story.jsx
@@ -12,7 +12,7 @@ import { EditingStyle } from '../../../utils/DragAndDropUtils';
 import SimpleList from './SimpleList';
 import SimpleListREADME from './README.md';
 
-const getListItems = num =>
+export const getListItems = num =>
   Array(num)
     .fill(0)
     .map((i, idx) => ({

--- a/src/components/List/SimpleList/SimpleList.story.jsx
+++ b/src/components/List/SimpleList/SimpleList.story.jsx
@@ -1,11 +1,13 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Add16, Close16, Edit16 } from '@carbon/icons-react';
 import { storiesOf } from '@storybook/react';
-import { text, boolean } from '@storybook/addon-knobs';
+import { boolean, select, text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { spacing03 } from '@carbon/layout';
 import { Button, OverflowMenu, OverflowMenuItem } from 'carbon-components-react';
 import { withReadme } from 'storybook-readme';
+
+import { EditingStyle } from '../../../utils/DragAndDropUtils';
 
 import SimpleList from './SimpleList';
 import SimpleListREADME from './README.md';
@@ -338,4 +340,36 @@ storiesOf('Watson IoT Experimental/SimpleList', module)
       </div>
     )),
     { info: { text: `` } }
-  );
+  )
+  .add('basic - SimpleList with reorder', () => {
+    const SimpleListWithReorder = () => {
+      const [items, setItems] = useState(getListItems(5));
+
+      return (
+        <div style={{ width: 500 }}>
+          <SimpleList
+            title={text('Text', 'Simple List')}
+            hasSearch
+            i18n={{
+              searchPlaceHolderText: 'Enter a search',
+              pageOfPagesText: pageNumber => `Page ${pageNumber}`,
+              items: '%d items',
+            }}
+            buttons={buttonsToRender}
+            items={items}
+            isLoading={boolean('isLoading', false)}
+            editingStyle={select(
+              'Editing Style',
+              [EditingStyle.Single, EditingStyle.Multiple],
+              EditingStyle.Single
+            )}
+            onListUpdated={updatedItems => {
+              setItems(updatedItems);
+            }}
+          />
+        </div>
+      );
+    };
+
+    return <SimpleListWithReorder />;
+  });

--- a/src/components/List/SimpleList/SimpleList.story.jsx
+++ b/src/components/List/SimpleList/SimpleList.story.jsx
@@ -341,9 +341,9 @@ storiesOf('Watson IoT Experimental/SimpleList', module)
     )),
     { info: { text: `` } }
   )
-  .add('basic - SimpleList with reorder', () => {
+  .add('list with reorder', () => {
     const SimpleListWithReorder = () => {
-      const [items, setItems] = useState(getListItems(5));
+      const [items, setItems] = useState(getListItems(15));
 
       return (
         <div style={{ width: 500 }}>

--- a/src/components/List/__snapshots__/List.story.storyshot
+++ b/src/components/List/__snapshots__/List.story.storyshot
@@ -442,31 +442,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           className="iot--list--content"
         >
           <div
-            className=""
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item iot--list-item-editable"
+              className="iot--list-item"
             >
-              <div
-                className="iot--list-item-editable--drag-preview"
-              >
-                DJ LeMahieu
-              </div>
-              <svg
-                aria-hidden={true}
-                className="iot--list-item--handle"
-                data-testid="list-item-editable"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
-                />
-              </svg>
               <div
                 className="iot--list-item--content"
               >
@@ -488,31 +469,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            className=""
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item iot--list-item-editable"
+              className="iot--list-item"
             >
-              <div
-                className="iot--list-item-editable--drag-preview"
-              >
-                Luke Voit
-              </div>
-              <svg
-                aria-hidden={true}
-                className="iot--list-item--handle"
-                data-testid="list-item-editable"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
-                />
-              </svg>
               <div
                 className="iot--list-item--content"
               >
@@ -534,31 +496,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            className=""
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item iot--list-item-editable"
+              className="iot--list-item"
             >
-              <div
-                className="iot--list-item-editable--drag-preview"
-              >
-                Gary Sanchez
-              </div>
-              <svg
-                aria-hidden={true}
-                className="iot--list-item--handle"
-                data-testid="list-item-editable"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
-                />
-              </svg>
               <div
                 className="iot--list-item--content"
               >
@@ -580,31 +523,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            className=""
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item iot--list-item-editable"
+              className="iot--list-item"
             >
-              <div
-                className="iot--list-item-editable--drag-preview"
-              >
-                Kendrys Morales
-              </div>
-              <svg
-                aria-hidden={true}
-                className="iot--list-item--handle"
-                data-testid="list-item-editable"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
-                />
-              </svg>
               <div
                 className="iot--list-item--content"
               >
@@ -626,31 +550,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            className=""
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item iot--list-item-editable"
+              className="iot--list-item"
             >
-              <div
-                className="iot--list-item-editable--drag-preview"
-              >
-                Gleyber Torres
-              </div>
-              <svg
-                aria-hidden={true}
-                className="iot--list-item--handle"
-                data-testid="list-item-editable"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
-                />
-              </svg>
               <div
                 className="iot--list-item--content"
               >
@@ -672,31 +577,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            className=""
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item iot--list-item-editable"
+              className="iot--list-item"
             >
-              <div
-                className="iot--list-item-editable--drag-preview"
-              >
-                Clint Frazier
-              </div>
-              <svg
-                aria-hidden={true}
-                className="iot--list-item--handle"
-                data-testid="list-item-editable"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
-                />
-              </svg>
               <div
                 className="iot--list-item--content"
               >
@@ -718,31 +604,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            className=""
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item iot--list-item-editable"
+              className="iot--list-item"
             >
-              <div
-                className="iot--list-item-editable--drag-preview"
-              >
-                Brett Gardner
-              </div>
-              <svg
-                aria-hidden={true}
-                className="iot--list-item--handle"
-                data-testid="list-item-editable"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
-                />
-              </svg>
               <div
                 className="iot--list-item--content"
               >
@@ -764,31 +631,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            className=""
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item iot--list-item-editable"
+              className="iot--list-item"
             >
-              <div
-                className="iot--list-item-editable--drag-preview"
-              >
-                Gio Urshela
-              </div>
-              <svg
-                aria-hidden={true}
-                className="iot--list-item--handle"
-                data-testid="list-item-editable"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
-                />
-              </svg>
               <div
                 className="iot--list-item--content"
               >
@@ -810,31 +658,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            className=""
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item iot--list-item-editable"
+              className="iot--list-item"
             >
-              <div
-                className="iot--list-item-editable--drag-preview"
-              >
-                Cameron Maybin
-              </div>
-              <svg
-                aria-hidden={true}
-                className="iot--list-item--handle"
-                data-testid="list-item-editable"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
-                />
-              </svg>
               <div
                 className="iot--list-item--content"
               >
@@ -856,31 +685,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            className=""
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item iot--list-item-editable"
+              className="iot--list-item"
             >
-              <div
-                className="iot--list-item-editable--drag-preview"
-              >
-                Robinson Cano
-              </div>
-              <svg
-                aria-hidden={true}
-                className="iot--list-item--handle"
-                data-testid="list-item-editable"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
-                />
-              </svg>
               <div
                 className="iot--list-item--content"
               >
@@ -1032,71 +842,124 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           className="iot--list--content"
         >
           <div
-            className=""
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item iot--list-item__selectable iot--list-item-editable"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
+              className="iot--list-item-editable--drag-container"
+              role="listitem"
             >
               <div
-                className="iot--list-item-editable--drag-preview"
+                className="iot--list-item-editable--drop-targets"
               >
-                Chicago White Sox
-              </div>
-              <svg
-                aria-hidden={true}
-                className="iot--list-item--handle"
-                data-testid="list-item-editable"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                <div
+                  className="iot--list-item-editable--drop-target-above"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "50%",
+                    }
+                  }
                 />
-              </svg>
+                <div
+                  className="iot--list-item-editable--drop-target-below"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "50%",
+                    }
+                  }
+                />
+              </div>
               <div
-                className="iot--list-item--expand-icon"
-                onClick={[Function]}
-                onKeyPress={[Function]}
-                role="button"
-                tabIndex={0}
+                className="iot--list-item iot--list-item-editable"
               >
+                <div
+                  className="iot--list-item-editable--drag-preview"
+                >
+                  Chicago White Sox
+                </div>
                 <svg
-                  aria-label="Close"
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
                   focusable="false"
                   height={16}
                   preserveAspectRatio="xMidYMid meet"
-                  role="img"
-                  viewBox="0 0 16 16"
+                  viewBox="0 0 32 32"
                   width={16}
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
-                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
                   />
                 </svg>
-              </div>
-              <div
-                className="iot--list-item--content"
-              >
                 <div
-                  className="iot--list-item--content--values"
+                  className="iot--list-item--expand-icon"
+                  data-testid="expand-icon"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-label="Close"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--list-item--content"
                 >
                   <div
-                    className="iot--list-item--content--values--main"
+                    className="iot--list-item--content--icon iot--list-item--content--icon__left"
                   >
                     <div
-                      className="iot--list-item--content--values--value iot--list-item--category"
-                      title="Chicago White Sox"
+                      className="bx--form-item bx--checkbox-wrapper"
                     >
-                      Chicago White Sox
+                      <input
+                        checked={false}
+                        className="bx--checkbox"
+                        data-testid="Chicago White Sox-checkbox"
+                        id="Chicago White Sox-checkbox"
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        type="checkbox"
+                      />
+                      <label
+                        className="bx--checkbox-label"
+                        htmlFor="Chicago White Sox-checkbox"
+                        title={null}
+                      >
+                        <span
+                          className="bx--checkbox-label-text"
+                        >
+                          
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    className="iot--list-item--content--values"
+                  >
+                    <div
+                      className="iot--list-item--content--values--main"
+                    >
+                      <div
+                        className="iot--list-item--content--values--value iot--list-item--category"
+                        title="Chicago White Sox"
+                      >
+                        Chicago White Sox
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1104,71 +967,124 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            className=""
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item iot--list-item__selectable iot--list-item-editable"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
+              className="iot--list-item-editable--drag-container"
+              role="listitem"
             >
               <div
-                className="iot--list-item-editable--drag-preview"
+                className="iot--list-item-editable--drop-targets"
               >
-                New York Yankees
-              </div>
-              <svg
-                aria-hidden={true}
-                className="iot--list-item--handle"
-                data-testid="list-item-editable"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                <div
+                  className="iot--list-item-editable--drop-target-above"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "50%",
+                    }
+                  }
                 />
-              </svg>
+                <div
+                  className="iot--list-item-editable--drop-target-below"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "50%",
+                    }
+                  }
+                />
+              </div>
               <div
-                className="iot--list-item--expand-icon"
-                onClick={[Function]}
-                onKeyPress={[Function]}
-                role="button"
-                tabIndex={0}
+                className="iot--list-item iot--list-item-editable"
               >
+                <div
+                  className="iot--list-item-editable--drag-preview"
+                >
+                  New York Yankees
+                </div>
                 <svg
-                  aria-label="Close"
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
                   focusable="false"
                   height={16}
                   preserveAspectRatio="xMidYMid meet"
-                  role="img"
-                  viewBox="0 0 16 16"
+                  viewBox="0 0 32 32"
                   width={16}
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
-                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
                   />
                 </svg>
-              </div>
-              <div
-                className="iot--list-item--content"
-              >
                 <div
-                  className="iot--list-item--content--values"
+                  className="iot--list-item--expand-icon"
+                  data-testid="expand-icon"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-label="Close"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--list-item--content"
                 >
                   <div
-                    className="iot--list-item--content--values--main"
+                    className="iot--list-item--content--icon iot--list-item--content--icon__left"
                   >
                     <div
-                      className="iot--list-item--content--values--value iot--list-item--category"
-                      title="New York Yankees"
+                      className="bx--form-item bx--checkbox-wrapper"
                     >
-                      New York Yankees
+                      <input
+                        checked={false}
+                        className="bx--checkbox"
+                        data-testid="New York Yankees-checkbox"
+                        id="New York Yankees-checkbox"
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        type="checkbox"
+                      />
+                      <label
+                        className="bx--checkbox-label"
+                        htmlFor="New York Yankees-checkbox"
+                        title={null}
+                      >
+                        <span
+                          className="bx--checkbox-label-text"
+                        >
+                          
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    className="iot--list-item--content--values"
+                  >
+                    <div
+                      className="iot--list-item--content--values--main"
+                    >
+                      <div
+                        className="iot--list-item--content--values--value iot--list-item--category"
+                        title="New York Yankees"
+                      >
+                        New York Yankees
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1176,71 +1092,124 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            className=""
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item iot--list-item__selectable iot--list-item-editable"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
+              className="iot--list-item-editable--drag-container"
+              role="listitem"
             >
               <div
-                className="iot--list-item-editable--drag-preview"
+                className="iot--list-item-editable--drop-targets"
               >
-                Houston Astros
-              </div>
-              <svg
-                aria-hidden={true}
-                className="iot--list-item--handle"
-                data-testid="list-item-editable"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                <div
+                  className="iot--list-item-editable--drop-target-above"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "50%",
+                    }
+                  }
                 />
-              </svg>
+                <div
+                  className="iot--list-item-editable--drop-target-below"
+                  data-testid="list-target"
+                  style={
+                    Object {
+                      "height": "50%",
+                    }
+                  }
+                />
+              </div>
               <div
-                className="iot--list-item--expand-icon"
-                onClick={[Function]}
-                onKeyPress={[Function]}
-                role="button"
-                tabIndex={0}
+                className="iot--list-item iot--list-item-editable"
               >
+                <div
+                  className="iot--list-item-editable--drag-preview"
+                >
+                  Houston Astros
+                </div>
                 <svg
-                  aria-label="Close"
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
                   focusable="false"
                   height={16}
                   preserveAspectRatio="xMidYMid meet"
-                  role="img"
-                  viewBox="0 0 16 16"
+                  viewBox="0 0 32 32"
                   width={16}
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
-                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
                   />
                 </svg>
-              </div>
-              <div
-                className="iot--list-item--content"
-              >
                 <div
-                  className="iot--list-item--content--values"
+                  className="iot--list-item--expand-icon"
+                  data-testid="expand-icon"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-label="Close"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--list-item--content"
                 >
                   <div
-                    className="iot--list-item--content--values--main"
+                    className="iot--list-item--content--icon iot--list-item--content--icon__left"
                   >
                     <div
-                      className="iot--list-item--content--values--value iot--list-item--category"
-                      title="Houston Astros"
+                      className="bx--form-item bx--checkbox-wrapper"
                     >
-                      Houston Astros
+                      <input
+                        checked={false}
+                        className="bx--checkbox"
+                        data-testid="Houston Astros-checkbox"
+                        id="Houston Astros-checkbox"
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        type="checkbox"
+                      />
+                      <label
+                        className="bx--checkbox-label"
+                        htmlFor="Houston Astros-checkbox"
+                        title={null}
+                      >
+                        <span
+                          className="bx--checkbox-label-text"
+                        >
+                          
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    className="iot--list-item--content--values"
+                  >
+                    <div
+                      className="iot--list-item--content--values--main"
+                    >
+                      <div
+                        className="iot--list-item--content--values--value iot--list-item--category"
+                        title="Houston Astros"
+                      >
+                        Houston Astros
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1358,6 +1327,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -1407,6 +1377,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -1452,19 +1423,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1473,9 +1432,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -1507,19 +1464,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1528,9 +1473,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -1562,19 +1505,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1583,9 +1514,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -1617,19 +1546,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1638,9 +1555,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -1672,19 +1587,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1693,9 +1596,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -1727,19 +1628,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1748,9 +1637,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -1782,19 +1669,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1803,9 +1678,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -1837,19 +1710,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1858,9 +1719,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -1892,19 +1751,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1913,9 +1760,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -1947,19 +1792,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1968,9 +1801,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -2006,6 +1837,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -2055,6 +1887,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -2100,19 +1933,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -2121,9 +1942,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -2155,19 +1974,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -2176,9 +1983,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -2210,19 +2015,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -2231,9 +2024,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -2265,19 +2056,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -2286,9 +2065,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -2320,19 +2097,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -2341,9 +2106,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -2375,19 +2138,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -2396,9 +2147,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -2430,19 +2179,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -2451,9 +2188,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -2485,19 +2220,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -2506,9 +2229,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -2540,19 +2261,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -2561,9 +2270,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -2599,6 +2306,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -2648,6 +2356,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -2795,6 +2504,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           >
             <div
               className="iot--list-item iot--list-item__selectable"
+              data_testid={null}
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
@@ -2802,6 +2512,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -2876,6 +2587,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           >
             <div
               className="iot--list-item iot--list-item__selectable"
+              data_testid={null}
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
@@ -2883,6 +2595,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -2957,6 +2670,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           >
             <div
               className="iot--list-item iot--list-item__selectable"
+              data_testid={null}
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
@@ -2964,6 +2678,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -3038,6 +2753,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           >
             <div
               className="iot--list-item iot--list-item__selectable"
+              data_testid={null}
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
@@ -3045,6 +2761,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -3119,6 +2836,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           >
             <div
               className="iot--list-item iot--list-item__selectable"
+              data_testid={null}
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
@@ -3126,6 +2844,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -3200,6 +2919,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           >
             <div
               className="iot--list-item iot--list-item__selectable"
+              data_testid={null}
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
@@ -3207,6 +2927,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -3385,6 +3106,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -3430,7 +3152,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
             >
               <div
@@ -3440,36 +3161,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Expand"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
->>>>>>> feat(list): updated drag style
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -3490,47 +3185,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   />
                 </svg>
               </div>
-<<<<<<< HEAD
-=======
-            </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
-            <div
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "60px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
->>>>>>> feat(list): updated drag style
               <div
                 className="iot--list-item--content"
               >
@@ -3594,41 +3248,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "60px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Expand"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -3637,30 +3257,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "60px",
                   }
                 }
-              >
-                 
-              </div>
-<<<<<<< HEAD
-=======
-            </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
-            <div
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "90px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
-            >
->>>>>>> feat(list): updated drag style
+              />
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -3754,19 +3354,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "90px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -3775,11 +3363,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "60px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -3873,19 +3460,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "90px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -3894,9 +3469,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "90px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -3945,19 +3518,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "90px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -3966,9 +3527,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "90px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -4017,19 +3576,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "90px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -4038,9 +3585,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "90px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -4089,19 +3634,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "90px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -4110,9 +3643,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "90px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -4161,19 +3692,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "90px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -4182,9 +3701,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "90px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -4233,19 +3750,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "90px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -4254,9 +3759,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "90px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -4305,19 +3808,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "90px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -4326,9 +3817,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "90px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -4377,19 +3866,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "90px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -4398,9 +3875,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "90px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -4449,23 +3924,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "60px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -4474,9 +3933,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "90px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -4525,41 +3982,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Expand"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -4568,9 +3991,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "90px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -4628,11 +4049,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "60px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -4726,23 +4146,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "60px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -4751,11 +4155,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -4848,11 +4251,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "60px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -4946,23 +4348,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "60px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -4971,11 +4357,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "60px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -5069,23 +4454,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
-<<<<<<< HEAD
               className="iot--list-item"
-=======
-              className="bx--assistive-text iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "60px",
-                }
-              }
-            />
-            <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
->>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -5094,11 +4463,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "60px",
                   }
                 }
-              >
-                 
-              </div>
+              />
               <div
                 className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"

--- a/src/components/List/__snapshots__/List.story.storyshot
+++ b/src/components/List/__snapshots__/List.story.storyshot
@@ -442,33 +442,34 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           className="iot--list--content"
         >
           <div
-            style={
-              Object {
-                "opacity": 1,
-              }
-            }
+            className=""
           >
             <div
               className="iot--list-item iot--list-item-editable"
             >
               <div
+                className="iot--list-item-editable--drag-preview"
+              >
+                DJ LeMahieu
+              </div>
+              <svg
+                aria-hidden={true}
+                className="iot--list-item--handle"
+                data-testid="list-item-editable"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                />
+              </svg>
+              <div
                 className="iot--list-item--content"
               >
-                <svg
-                  aria-hidden={true}
-                  className="iot--list-item--handle"
-                  data-testid="list-item-editable"
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 32 32"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
-                  />
-                </svg>
                 <div
                   className="iot--list-item--content--values"
                 >
@@ -487,33 +488,34 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            style={
-              Object {
-                "opacity": 1,
-              }
-            }
+            className=""
           >
             <div
               className="iot--list-item iot--list-item-editable"
             >
               <div
+                className="iot--list-item-editable--drag-preview"
+              >
+                Luke Voit
+              </div>
+              <svg
+                aria-hidden={true}
+                className="iot--list-item--handle"
+                data-testid="list-item-editable"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                />
+              </svg>
+              <div
                 className="iot--list-item--content"
               >
-                <svg
-                  aria-hidden={true}
-                  className="iot--list-item--handle"
-                  data-testid="list-item-editable"
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 32 32"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
-                  />
-                </svg>
                 <div
                   className="iot--list-item--content--values"
                 >
@@ -532,33 +534,34 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            style={
-              Object {
-                "opacity": 1,
-              }
-            }
+            className=""
           >
             <div
               className="iot--list-item iot--list-item-editable"
             >
               <div
+                className="iot--list-item-editable--drag-preview"
+              >
+                Gary Sanchez
+              </div>
+              <svg
+                aria-hidden={true}
+                className="iot--list-item--handle"
+                data-testid="list-item-editable"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                />
+              </svg>
+              <div
                 className="iot--list-item--content"
               >
-                <svg
-                  aria-hidden={true}
-                  className="iot--list-item--handle"
-                  data-testid="list-item-editable"
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 32 32"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
-                  />
-                </svg>
                 <div
                   className="iot--list-item--content--values"
                 >
@@ -577,33 +580,34 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            style={
-              Object {
-                "opacity": 1,
-              }
-            }
+            className=""
           >
             <div
               className="iot--list-item iot--list-item-editable"
             >
               <div
+                className="iot--list-item-editable--drag-preview"
+              >
+                Kendrys Morales
+              </div>
+              <svg
+                aria-hidden={true}
+                className="iot--list-item--handle"
+                data-testid="list-item-editable"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                />
+              </svg>
+              <div
                 className="iot--list-item--content"
               >
-                <svg
-                  aria-hidden={true}
-                  className="iot--list-item--handle"
-                  data-testid="list-item-editable"
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 32 32"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
-                  />
-                </svg>
                 <div
                   className="iot--list-item--content--values"
                 >
@@ -622,33 +626,34 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            style={
-              Object {
-                "opacity": 1,
-              }
-            }
+            className=""
           >
             <div
               className="iot--list-item iot--list-item-editable"
             >
               <div
+                className="iot--list-item-editable--drag-preview"
+              >
+                Gleyber Torres
+              </div>
+              <svg
+                aria-hidden={true}
+                className="iot--list-item--handle"
+                data-testid="list-item-editable"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                />
+              </svg>
+              <div
                 className="iot--list-item--content"
               >
-                <svg
-                  aria-hidden={true}
-                  className="iot--list-item--handle"
-                  data-testid="list-item-editable"
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 32 32"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
-                  />
-                </svg>
                 <div
                   className="iot--list-item--content--values"
                 >
@@ -667,33 +672,34 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            style={
-              Object {
-                "opacity": 1,
-              }
-            }
+            className=""
           >
             <div
               className="iot--list-item iot--list-item-editable"
             >
               <div
+                className="iot--list-item-editable--drag-preview"
+              >
+                Clint Frazier
+              </div>
+              <svg
+                aria-hidden={true}
+                className="iot--list-item--handle"
+                data-testid="list-item-editable"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                />
+              </svg>
+              <div
                 className="iot--list-item--content"
               >
-                <svg
-                  aria-hidden={true}
-                  className="iot--list-item--handle"
-                  data-testid="list-item-editable"
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 32 32"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
-                  />
-                </svg>
                 <div
                   className="iot--list-item--content--values"
                 >
@@ -712,33 +718,34 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            style={
-              Object {
-                "opacity": 1,
-              }
-            }
+            className=""
           >
             <div
               className="iot--list-item iot--list-item-editable"
             >
               <div
+                className="iot--list-item-editable--drag-preview"
+              >
+                Brett Gardner
+              </div>
+              <svg
+                aria-hidden={true}
+                className="iot--list-item--handle"
+                data-testid="list-item-editable"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                />
+              </svg>
+              <div
                 className="iot--list-item--content"
               >
-                <svg
-                  aria-hidden={true}
-                  className="iot--list-item--handle"
-                  data-testid="list-item-editable"
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 32 32"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
-                  />
-                </svg>
                 <div
                   className="iot--list-item--content--values"
                 >
@@ -757,33 +764,34 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            style={
-              Object {
-                "opacity": 1,
-              }
-            }
+            className=""
           >
             <div
               className="iot--list-item iot--list-item-editable"
             >
               <div
+                className="iot--list-item-editable--drag-preview"
+              >
+                Gio Urshela
+              </div>
+              <svg
+                aria-hidden={true}
+                className="iot--list-item--handle"
+                data-testid="list-item-editable"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                />
+              </svg>
+              <div
                 className="iot--list-item--content"
               >
-                <svg
-                  aria-hidden={true}
-                  className="iot--list-item--handle"
-                  data-testid="list-item-editable"
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 32 32"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
-                  />
-                </svg>
                 <div
                   className="iot--list-item--content--values"
                 >
@@ -802,33 +810,34 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            style={
-              Object {
-                "opacity": 1,
-              }
-            }
+            className=""
           >
             <div
               className="iot--list-item iot--list-item-editable"
             >
               <div
+                className="iot--list-item-editable--drag-preview"
+              >
+                Cameron Maybin
+              </div>
+              <svg
+                aria-hidden={true}
+                className="iot--list-item--handle"
+                data-testid="list-item-editable"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                />
+              </svg>
+              <div
                 className="iot--list-item--content"
               >
-                <svg
-                  aria-hidden={true}
-                  className="iot--list-item--handle"
-                  data-testid="list-item-editable"
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 32 32"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
-                  />
-                </svg>
                 <div
                   className="iot--list-item--content--values"
                 >
@@ -847,33 +856,34 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            style={
-              Object {
-                "opacity": 1,
-              }
-            }
+            className=""
           >
             <div
               className="iot--list-item iot--list-item-editable"
             >
               <div
+                className="iot--list-item-editable--drag-preview"
+              >
+                Robinson Cano
+              </div>
+              <svg
+                aria-hidden={true}
+                className="iot--list-item--handle"
+                data-testid="list-item-editable"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                />
+              </svg>
+              <div
                 className="iot--list-item--content"
               >
-                <svg
-                  aria-hidden={true}
-                  className="iot--list-item--handle"
-                  data-testid="list-item-editable"
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 32 32"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
-                  />
-                </svg>
                 <div
                   className="iot--list-item--content--values"
                 >
@@ -885,6 +895,352 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                       title="Robinson Cano"
                     >
                       Robinson Cano
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/List reorder hierarchy 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              NY Yankees
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            >
+              <button
+                className="iot--btn bx--btn bx--btn--sm bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Cancel
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Cancel"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="iot--btn bx--btn bx--btn--sm bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Save
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Save"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13 21.2L5.4 13.6 4 15 13 24 28 9 26.6 7.5 13 21.2z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className=""
+          >
+            <div
+              className="iot--list-item iot--list-item__selectable iot--list-item-editable"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <div
+                className="iot--list-item-editable--drag-preview"
+              >
+                Chicago White Sox
+              </div>
+              <svg
+                aria-hidden={true}
+                className="iot--list-item--handle"
+                data-testid="list-item-editable"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                />
+              </svg>
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Chicago White Sox"
+                    >
+                      Chicago White Sox
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className=""
+          >
+            <div
+              className="iot--list-item iot--list-item__selectable iot--list-item-editable"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <div
+                className="iot--list-item-editable--drag-preview"
+              >
+                New York Yankees
+              </div>
+              <svg
+                aria-hidden={true}
+                className="iot--list-item--handle"
+                data-testid="list-item-editable"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                />
+              </svg>
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="New York Yankees"
+                    >
+                      New York Yankees
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className=""
+          >
+            <div
+              className="iot--list-item iot--list-item__selectable iot--list-item-editable"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <div
+                className="iot--list-item-editable--drag-preview"
+              >
+                Houston Astros
+              </div>
+              <svg
+                aria-hidden={true}
+                className="iot--list-item--handle"
+                data-testid="list-item-editable"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                />
+              </svg>
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Houston Astros"
+                    >
+                      Houston Astros
                     </div>
                   </div>
                 </div>
@@ -1096,7 +1452,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1139,7 +1507,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1182,7 +1562,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1225,7 +1617,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1268,7 +1672,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1311,7 +1727,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1354,7 +1782,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1397,7 +1837,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1440,7 +1892,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1483,7 +1947,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1624,7 +2100,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1667,7 +2155,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1710,7 +2210,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1753,7 +2265,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1796,7 +2320,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1839,7 +2375,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1882,7 +2430,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1925,7 +2485,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -1968,7 +2540,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -2846,6 +3430,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
             >
               <div
@@ -2855,6 +3440,31 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     "width": "30px",
                   }
                 }
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Expand"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+>>>>>>> feat(list): updated drag style
               >
                  
               </div>
@@ -2880,6 +3490,47 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   />
                 </svg>
               </div>
+<<<<<<< HEAD
+=======
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "60px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+>>>>>>> feat(list): updated drag style
               <div
                 className="iot--list-item--content"
               >
@@ -2943,7 +3594,41 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "60px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Expand"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -2955,6 +3640,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               >
                  
               </div>
+<<<<<<< HEAD
+=======
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "90px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+            >
+>>>>>>> feat(list): updated drag style
               <div
                 className="iot--list-item--expand-icon"
                 onClick={[Function]}
@@ -3050,7 +3754,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "90px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -3157,7 +3873,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "90px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -3217,7 +3945,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "90px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -3277,7 +4017,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "90px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -3337,7 +4089,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "90px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -3397,7 +4161,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "90px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -3457,7 +4233,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "90px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -3517,7 +4305,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "90px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -3577,7 +4377,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "90px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -3637,7 +4449,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "60px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -3697,7 +4525,41 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Expand"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -3864,7 +4726,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "60px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -4068,7 +4946,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "60px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"
@@ -4175,7 +5069,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             data-floating-menu-container={true}
           >
             <div
+<<<<<<< HEAD
               className="iot--list-item"
+=======
+              className="bx--assistive-text iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "60px",
+                }
+              }
+            />
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+>>>>>>> feat(list): updated drag style
             >
               <div
                 className="iot--list-item--nesting-offset"

--- a/src/components/List/__snapshots__/List.story.storyshot
+++ b/src/components/List/__snapshots__/List.story.storyshot
@@ -341,6 +341,586 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/List basic (single column) with reorder 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              NY Yankees
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            >
+              <button
+                className="iot--btn bx--btn bx--btn--sm bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Cancel
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Cancel"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="iot--btn bx--btn bx--btn--sm bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Save
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Save"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13 21.2L5.4 13.6 4 15 13 24 28 9 26.6 7.5 13 21.2z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <div
+              className="iot--list-item iot--list-item-editable"
+            >
+              <div
+                className="iot--list-item--content"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="DJ LeMahieu"
+                    >
+                      DJ LeMahieu
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <div
+              className="iot--list-item iot--list-item-editable"
+            >
+              <div
+                className="iot--list-item--content"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Luke Voit"
+                    >
+                      Luke Voit
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <div
+              className="iot--list-item iot--list-item-editable"
+            >
+              <div
+                className="iot--list-item--content"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Gary Sanchez"
+                    >
+                      Gary Sanchez
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <div
+              className="iot--list-item iot--list-item-editable"
+            >
+              <div
+                className="iot--list-item--content"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Kendrys Morales"
+                    >
+                      Kendrys Morales
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <div
+              className="iot--list-item iot--list-item-editable"
+            >
+              <div
+                className="iot--list-item--content"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Gleyber Torres"
+                    >
+                      Gleyber Torres
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <div
+              className="iot--list-item iot--list-item-editable"
+            >
+              <div
+                className="iot--list-item--content"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Clint Frazier"
+                    >
+                      Clint Frazier
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <div
+              className="iot--list-item iot--list-item-editable"
+            >
+              <div
+                className="iot--list-item--content"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Brett Gardner"
+                    >
+                      Brett Gardner
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <div
+              className="iot--list-item iot--list-item-editable"
+            >
+              <div
+                className="iot--list-item--content"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Gio Urshela"
+                    >
+                      Gio Urshela
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <div
+              className="iot--list-item iot--list-item-editable"
+            >
+              <div
+                className="iot--list-item--content"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Cameron Maybin"
+                    >
+                      Cameron Maybin
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <div
+              className="iot--list-item iot--list-item-editable"
+            >
+              <div
+                className="iot--list-item--content"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="iot--list-item--handle"
+                  data-testid="list-item-editable"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 6H14V10H10zM18 6H22V10H18zM10 14H14V18H10zM18 14H22V18H18zM10 22H14V26H10zM18 22H22V26H18z"
+                  />
+                </svg>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Robinson Cano"
+                    >
+                      Robinson Cano
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/List with categories, fixed height 1`] = `
 <div
   className="storybook-container"

--- a/src/components/List/_list.scss
+++ b/src/components/List/_list.scss
@@ -10,7 +10,6 @@
   }
   &--content {
     flex: 1 1 0 0;
-    background: $ui-01;
     overflow-y: auto;
 
     &__full-height {

--- a/src/components/List/_list.scss
+++ b/src/components/List/_list.scss
@@ -9,6 +9,7 @@
     flex: 0;
   }
   &--content {
+    background: $ui-01;
     flex: 1 1 0 0;
     overflow-y: auto;
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -149,6 +149,7 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 @import 'components/InlineLoading/inline-loading';
 @import 'components/PaginationNav/pagination-nav';
 @import 'components/FlyoutMenu/flyout-menu';
+@import 'components/List/HierarchyList/hierarchy-list';
 
 //-------------------------------------
 // 🔬 Experimental

--- a/src/utils/DragAndDropUtils.jsx
+++ b/src/utils/DragAndDropUtils.jsx
@@ -13,10 +13,19 @@ export const EditingStyle = {
   MultipleNesting: 'multiple-nesting',
 };
 
+/**
+ * Returns true if a passed in editing style is multiple rather than single
+ * @param {EditingStyle} editingStyle current editing style
+ */
 export const editingStyleIsMultiple = editingStyle => {
   return editingStyle === EditingStyle.MultipleNesting || editingStyle === EditingStyle.Multiple;
 };
 
+/**
+ * Returns a set of items that match the set of ids
+ * @param {Array<ListItem>} items full set of items
+ * @param {Array[string]} ids selected ids from the set of items
+ */
 const searchDraggedItem = (items, ids) => {
   let draggedItems = [];
 
@@ -31,6 +40,14 @@ const searchDraggedItem = (items, ids) => {
   return draggedItems;
 };
 
+/**
+ * Helper function that returns a new list with the dragged items moved to the specified location
+ * @param {Array<ListItem>} items original list of ListItems
+ * @param {Array<ListItem>} draggedItems items to be moved
+ * @param {string} dropId the id of the drop location
+ * @param {DropLocation} location Where the drop will occur, above or below the specified id or as the first child of the specified id
+ * @param {boolean} dropped flag stating if the drop has already occured in case there are duplicate ids in the list
+ */
 const updateList = (items, draggedItems, dropId, location, dropped = false) => {
   let finalList = [];
   let itemDropped = dropped; // Protects against dupe ids and multiple drops
@@ -71,13 +88,23 @@ const updateList = (items, draggedItems, dropId, location, dropped = false) => {
   return finalList;
 };
 
-export const moveItemsInList = (items, dragIds, dropId, target) => {
-  const draggedItems = searchDraggedItem(items, dragIds);
-  const newList = updateList(items, draggedItems, dropId, target);
+/**
+ * Returns a new list with the dragged items moved to the specified location
+ * @param {Array<ListItem>} items original list of ListItems
+ * @param {Array<ListItem>} draggedItems items to be moved
+ * @param {string} dropId the id of the drop location
+ * @param {DropLocation} location Where the drop will occur, above or below the specified id or as the first child of the specified id
+ */
+export const moveItemsInList = (items, dragIds, dropId, location) => {
+  const draggedItems = searchDraggedItem(items, dragIds.filter(id => id !== dropId));
 
-  return newList;
+  return updateList(items, draggedItems, dropId, location);
 };
 
+/**
+ * Returns every child id from the ListItem and their children's ids
+ * @param {ListItem} listItem
+ */
 const getAllChildIds = listItem => {
   let childIds = [];
 
@@ -92,6 +119,13 @@ const getAllChildIds = listItem => {
   return childIds;
 };
 
+/**
+ * Handles adding and removing items to a list to determine which list items are selected or deselected
+ * @param {Array<ListItem>} list original list of ListItems
+ * @param {Array<string>} currentSelection current selection of ListItems as ids
+ * @param {string} id the id of an item that has been selected or deselected
+ * @param {string} parentId the parent id of the selected or deselected item - if unselected, the parent is also unselected
+ */
 export const handleEditModeSelect = (list, currentSelection, id, parentId) => {
   let newSelection = [];
 

--- a/src/utils/DragAndDropUtils.jsx
+++ b/src/utils/DragAndDropUtils.jsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import cloneDeep from 'lodash/cloneDeep';
+
+export const DropLocation = {
+  Above: 'above',
+  Below: 'below',
+  Nested: 'nested',
+};
+
+const searchDraggedItem = (items, ids) => {
+  let draggedItems = [];
+
+  cloneDeep(items).forEach(item => {
+    if (ids.some(id => item.id === id)) {
+      draggedItems.push(item);
+    } else if (item.children) {
+      draggedItems = [...draggedItems, ...searchDraggedItem(item.children, ids)];
+    }
+  });
+
+  return draggedItems;
+};
+
+const updateList = (items, draggedItems, dropId, location, dropped = false) => {
+  let finalList = [];
+  let itemDropped = dropped; // Protects against dupe ids and multiple drops
+
+  if (items) {
+    cloneDeep(items)
+      .filter(item => !draggedItems.find(dragged => dragged.id === item.id)) // filter out dragged items
+      .forEach(item => {
+        // Insert dragged items in before location
+        if (!itemDropped && item.id === dropId && location === DropLocation.Above) {
+          finalList = [...finalList, ...draggedItems];
+          itemDropped = true;
+        }
+
+        let { children = [] } = items;
+
+        // Insert dragged items in nested location
+        if (!itemDropped && item.id === dropId && location === DropLocation.Nested) {
+          itemDropped = true;
+
+          console.log(
+            `dropping in the nest: ${JSON.stringify(draggedItems)} ${JSON.stringify(children)}`
+          );
+
+          children = [
+            ...draggedItems,
+            ...updateList(children, draggedItems, dropId, location, itemDropped),
+          ];
+
+          console.log(`what a drag: ${JSON.stringify(draggedItems)} ${children}`);
+        } else if (children === item.children) {
+          children = updateList(children, draggedItems, dropId, location, itemDropped);
+        }
+
+        item.children = children; // eslint-disable-line no-param-reassign
+        finalList.push(item);
+
+        // Insert dragged items in after location
+        if (!itemDropped && item.id === dropId && location === DropLocation.Below) {
+          finalList = [...finalList, ...draggedItems];
+        }
+      });
+  }
+
+  return finalList;
+};
+
+export const moveItemsInList = (items, dragIds, dropId, target) => {
+  // if (dragId === hoverId) {
+  //   return false;
+  // }
+
+  console.log(
+    `items before: ${JSON.stringify(items)} ${JSON.stringify(dragIds)} ${dropId} ${target}`
+  );
+
+  const draggedItems = searchDraggedItem(items, dragIds);
+
+  // console.log(`dragged items: ${JSON.stringify(draggedItems)}`);
+
+  const newList = updateList(items, draggedItems, dropId, target);
+
+  console.log(`items after: ${JSON.stringify(newList)}`);
+
+  return newList;
+};

--- a/src/utils/DragAndDropUtils.jsx
+++ b/src/utils/DragAndDropUtils.jsx
@@ -7,6 +7,17 @@ export const DropLocation = {
   Nested: 'nested',
 };
 
+export const EditingStyle = {
+  Single: 'single',
+  Multiple: 'multiple',
+  SingleNesting: 'single-nesting',
+  MultipleNesting: 'multiple-nesting',
+};
+
+export const editingStyleIsMultiple = editingStyle => {
+  return editingStyle === EditingStyle.MultipleNesting || editingStyle === EditingStyle.Multiple;
+};
+
 const searchDraggedItem = (items, ids) => {
   let draggedItems = [];
 
@@ -24,10 +35,11 @@ const searchDraggedItem = (items, ids) => {
 const updateList = (items, draggedItems, dropId, location, dropped = false) => {
   let finalList = [];
   let itemDropped = dropped; // Protects against dupe ids and multiple drops
+  const dragContainsDrop = draggedItems.some(dragId => dragId === dropId);
 
   if (items) {
     cloneDeep(items)
-      .filter(item => !draggedItems.find(dragged => dragged.id === item.id)) // filter out dragged items
+      // .filter(item => !draggedItems.find(dragged => dragged.id === item.id)) // filter out dragged items
       .forEach(item => {
         // Insert dragged items in before location
         if (!itemDropped && item.id === dropId && location === DropLocation.Above) {
@@ -35,28 +47,27 @@ const updateList = (items, draggedItems, dropId, location, dropped = false) => {
           itemDropped = true;
         }
 
-        let { children = [] } = items;
+        let { children = [] } = item;
 
         // Insert dragged items in nested location
-        if (!itemDropped && item.id === dropId && location === DropLocation.Nested) {
+        if (!itemDropped && location === DropLocation.Nested && dropId === item.id) {
           itemDropped = true;
 
           console.log(
-            `dropping in the nest: ${JSON.stringify(draggedItems)} ${JSON.stringify(children)}`
+            `dropping in the nest: ${JSON.stringify(draggedItems)} ${JSON.stringify(children)} `
           );
 
-          children = [
-            ...draggedItems,
-            ...updateList(children, draggedItems, dropId, location, itemDropped),
-          ];
+          children = draggedItems.concat(children);
 
-          console.log(`what a drag: ${JSON.stringify(draggedItems)} ${children}`);
-        } else if (children === item.children) {
+          console.log(`what a drag: ${JSON.stringify(draggedItems)} ${JSON.stringify(children)} `);
+        } else if (children?.length) {
           children = updateList(children, draggedItems, dropId, location, itemDropped);
         }
 
-        item.children = children; // eslint-disable-line no-param-reassign
-        finalList.push(item);
+        if (!draggedItems.find(drag => drag.id === item.id)) {
+          item.children = children; // eslint-disable-line no-param-reassign
+          finalList.push(item);
+        }
 
         // Insert dragged items in after location
         if (!itemDropped && item.id === dropId && location === DropLocation.Below) {
@@ -86,4 +97,47 @@ export const moveItemsInList = (items, dragIds, dropId, target) => {
   console.log(`items after: ${JSON.stringify(newList)}`);
 
   return newList;
+};
+
+const getAllChildIds = listItem => {
+  let childIds = [];
+
+  if (listItem.children) {
+    listItem.children.forEach(child => {
+      childIds.push(child.id);
+
+      childIds = [...childIds, ...getAllChildIds(child)];
+    });
+  }
+
+  return childIds;
+};
+
+export const handleEditModeSelect = (list, currentSelection, id, parentId) => {
+  let newSelection = [];
+
+  if (currentSelection.filter(editId => editId === id).length > 0) {
+    newSelection = currentSelection.filter(selected => selected !== id && selected !== parentId);
+  } else {
+    list.forEach(editItem => {
+      if (editItem.id === id) {
+        newSelection.push(id);
+
+        newSelection = [...newSelection, ...getAllChildIds(editItem)];
+      }
+
+      if (editItem.children) {
+        newSelection = [
+          ...newSelection,
+          ...handleEditModeSelect(editItem.children, currentSelection, id, parentId),
+        ];
+      }
+
+      if (currentSelection.some(selectionId => selectionId === editItem.id)) {
+        newSelection.push(editItem.id);
+      }
+    });
+  }
+
+  return newSelection;
 };

--- a/src/utils/__tests__/DragAndDropUtils.test.js
+++ b/src/utils/__tests__/DragAndDropUtils.test.js
@@ -1,0 +1,82 @@
+import { DropLocation, moveItemsInList } from '../DragAndDropUtils';
+import { getListItems } from '../../components/List/SimpleList/SimpleList.story';
+
+const simpleListItems = getListItems(10);
+
+describe('componentUtilityFunctions', () => {
+  it('move first item under the second item', () => {
+    const itemToMove = simpleListItems[0];
+
+    const newList = moveItemsInList(
+      simpleListItems,
+      [itemToMove.id],
+      simpleListItems[1].id,
+      DropLocation.Below
+    );
+
+    expect(newList[1].id).toEqual(itemToMove.id);
+  });
+
+  it('move first item above the second item', () => {
+    const itemToMove = simpleListItems[0];
+
+    const newList = moveItemsInList(
+      simpleListItems,
+      [itemToMove.id],
+      simpleListItems[1].id,
+      DropLocation.Above
+    );
+
+    expect(newList[0].id).toEqual(itemToMove.id);
+  });
+
+  it('move first item nested in second item', () => {
+    const itemToMove = simpleListItems[0];
+
+    const newList = moveItemsInList(
+      simpleListItems,
+      [itemToMove.id],
+      simpleListItems[1].id,
+      DropLocation.Nested
+    );
+
+    expect(newList[0].children[0].id).toEqual(itemToMove.id);
+  });
+
+  it('multiple nesting', () => {
+    const itemToMove = simpleListItems[0];
+
+    let newList = moveItemsInList(
+      simpleListItems,
+      [itemToMove.id],
+      simpleListItems[1].id,
+      DropLocation.Nested
+    );
+
+    newList = moveItemsInList(newList, [newList[0].id], newList[1].id, DropLocation.Nested);
+    newList = moveItemsInList(newList, [newList[0].id], newList[1].id, DropLocation.Nested);
+
+    expect(newList[0].children[0].children[0].children[0].id).toEqual(itemToMove.id);
+  });
+
+  it('move multiple items to top of the list', () => {
+    const itemsToMove = [
+      simpleListItems[0].id,
+      simpleListItems[3].id,
+      simpleListItems[5].id,
+      simpleListItems[9].id,
+    ];
+
+    const newList = moveItemsInList(
+      simpleListItems,
+      itemsToMove,
+      itemsToMove[0],
+      DropLocation.Above
+    );
+
+    expect(newList[0].id).toEqual(itemsToMove[0]);
+    expect(newList[1].id).toEqual(itemsToMove[1]);
+    expect(newList[2].id).toEqual(itemsToMove[2]);
+    expect(newList[3].id).toEqual(itemsToMove[3]);
+  });
+});

--- a/src/utils/__tests__/DragAndDropUtils.test.js
+++ b/src/utils/__tests__/DragAndDropUtils.test.js
@@ -61,7 +61,7 @@ describe('componentUtilityFunctions', () => {
 
   it('move multiple items to top of the list', () => {
     const itemsToMove = [
-      simpleListItems[0].id,
+      simpleListItems[1].id,
       simpleListItems[3].id,
       simpleListItems[5].id,
       simpleListItems[9].id,
@@ -70,7 +70,7 @@ describe('componentUtilityFunctions', () => {
     const newList = moveItemsInList(
       simpleListItems,
       itemsToMove,
-      itemsToMove[0],
+      simpleListItems[0].id,
       DropLocation.Above
     );
 

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -13881,6 +13881,7 @@ Map {
     },
   },
   "List" => Object {
+<<<<<<< HEAD
     "$$typeof": Symbol(react.forward_ref),
     "defaultProps": Object {
       "buttons": Array [],
@@ -13919,65 +13920,169 @@ Map {
         "args": Array [
           Object {
             "type": "string",
+=======
+    "DecoratedComponent": Object {
+      "$$typeof": Symbol(react.forward_ref),
+      "__docgenInfo": Object {
+        "description": "",
+        "methods": Array [],
+        "props": Object {
+          "buttons": Object {
+            "defaultValue": Object {
+              "computed": false,
+              "value": "[]",
+            },
+            "description": "action buttons on right side of list title",
+            "required": false,
+            "type": Object {
+              "name": "arrayOf",
+              "value": Object {
+                "name": "node",
+              },
+            },
           },
-        ],
-        "type": "arrayOf",
-      },
-      "handleSelect": Object {
-        "type": "func",
-      },
-      "i18n": Object {
-        "args": Array [
-          Object {
-            "close": Object {
-              "type": "string",
+          "expandedIds": Object {
+            "defaultValue": Object {
+              "computed": false,
+              "value": "[]",
             },
-            "expand": Object {
-              "type": "string",
+            "description": "ids of row expanded",
+            "required": false,
+            "type": Object {
+              "name": "arrayOf",
+              "value": Object {
+                "name": "string",
+              },
             },
-            "searchPlaceHolderText": Object {
-              "type": "string",
+>>>>>>> feat(list): added simple reordering
+          },
+          "handleSelect": Object {
+            "defaultValue": Object {
+              "computed": false,
+              "value": "() => {}",
+            },
+            "description": "call back function of select",
+            "required": false,
+            "type": Object {
+              "name": "func",
             },
           },
-        ],
-        "type": "shape",
-      },
-      "iconPosition": Object {
-        "args": Array [
-          Array [
-            "left",
-            "right",
-          ],
-        ],
-        "type": "oneOf",
-      },
-      "isFullHeight": Object {
-        "type": "bool",
-      },
-      "isLargeRow": Object {
-        "type": "bool",
-      },
-      "isLoading": Object {
-        "type": "bool",
-      },
-      "items": Object {
-        "args": Array [
-          Object {
-            "args": Array [
-              Object {
-                "children": Object {
-                  "args": Array [
-                    Object {
-                      "type": "object",
-                    },
-                  ],
-                  "type": "arrayOf",
+          "i18n": Object {
+            "defaultValue": Object {
+              "computed": false,
+              "value": "{
+  searchPlaceHolderText: 'Enter a value',
+  expand: 'Expand',
+  close: 'Close',
+}",
+            },
+            "description": "i18n strings",
+            "required": false,
+            "type": Object {
+              "name": "shape",
+              "value": Object {
+                "close": Object {
+                  "name": "string",
+                  "required": false,
                 },
-                "content": Object {
-                  "args": Array [
-                    Object {
+                "expand": Object {
+                  "name": "string",
+                  "required": false,
+                },
+                "searchPlaceHolderText": Object {
+                  "name": "string",
+                  "required": false,
+                },
+              },
+            },
+          },
+          "iconPosition": Object {
+            "defaultValue": Object {
+              "computed": false,
+              "value": "'left'",
+            },
+            "description": "icon can be left or right side of list row primary value",
+            "required": false,
+            "type": Object {
+              "name": "enum",
+              "value": Array [
+                Object {
+                  "computed": false,
+                  "value": "'left'",
+                },
+                Object {
+                  "computed": false,
+                  "value": "'right'",
+                },
+              ],
+            },
+          },
+          "isEditing": Object {
+            "defaultValue": Object {
+              "computed": false,
+              "value": "false",
+            },
+            "description": "list can be rearranged",
+            "required": false,
+            "type": Object {
+              "name": "bool",
+            },
+          },
+          "isFullHeight": Object {
+            "defaultValue": Object {
+              "computed": false,
+              "value": "false",
+            },
+            "description": "use full height in list",
+            "required": false,
+            "type": Object {
+              "name": "bool",
+            },
+          },
+          "isLargeRow": Object {
+            "defaultValue": Object {
+              "computed": false,
+              "value": "false",
+            },
+            "description": "use large/fat row in list",
+            "required": false,
+            "type": Object {
+              "name": "bool",
+            },
+          },
+          "isLoading": Object {
+            "defaultValue": Object {
+              "computed": false,
+              "value": "false",
+            },
+            "description": "optional skeleton to be rendered while loading data",
+            "required": false,
+            "type": Object {
+              "name": "bool",
+            },
+          },
+          "items": Object {
+            "description": "data source of list items",
+            "required": true,
+            "type": Object {
+              "name": "arrayOf",
+              "value": Object {
+                "name": "shape",
+                "value": Object {
+                  "children": Object {
+                    "name": "arrayOf",
+                    "required": false,
+                    "value": Object {
+                      "name": "object",
+                    },
+                  },
+                  "content": Object {
+                    "name": "shape",
+                    "required": false,
+                    "value": Object {
                       "icon": Object {
-                        "type": "node",
+                        "name": "node",
+                        "required": false,
                       },
                       "tags": Object {
                         "args": Array [
@@ -13988,89 +14093,304 @@ Map {
                         "type": "arrayOf",
                       },
                       "value": Object {
-                        "type": "string",
+                        "name": "string",
+                        "required": false,
                       },
                     },
-                  ],
-                  "type": "shape",
-                },
-                "id": Object {
-                  "type": "string",
-                },
-                "isSelectable": Object {
-                  "type": "bool",
+                  },
+                  "id": Object {
+                    "name": "string",
+                    "required": false,
+                  },
+                  "isSelectable": Object {
+                    "name": "bool",
+                    "required": false,
+                  },
                 },
               },
+            },
+          },
+          "onItemMoved": Object {
+            "defaultValue": Object {
+              "computed": false,
+              "value": "() => {}",
+            },
+            "description": "callback function for reorder",
+            "required": false,
+            "type": Object {
+              "name": "func",
+            },
+          },
+          "pagination": Object {
+            "defaultValue": Object {
+              "computed": false,
+              "value": "null",
+            },
+            "description": "pagination at the bottom of list",
+            "required": false,
+            "type": Object {
+              "computed": true,
+              "name": "shape",
+              "value": "import SimplePagination, { SimplePaginationPropTypes } from '../SimplePagination/SimplePagination';",
+            },
+          },
+          "search": Object {
+            "defaultValue": Object {
+              "computed": false,
+              "value": "null",
+            },
+            "description": "search bar call back function and search value",
+            "required": false,
+            "type": Object {
+              "name": "shape",
+              "value": Object {
+                "onChange": Object {
+                  "name": "func",
+                  "required": false,
+                },
+                "value": Object {
+                  "name": "string",
+                  "required": false,
+                },
+              },
+            },
+          },
+          "selectedId": Object {
+            "defaultValue": Object {
+              "computed": false,
+              "value": "null",
+            },
+            "description": "Currently selected item",
+            "required": false,
+            "type": Object {
+              "name": "string",
+            },
+          },
+          "selectedIds": Object {
+            "defaultValue": Object {
+              "computed": false,
+              "value": "[]",
+            },
+            "description": "Multiple currently selected items",
+            "required": false,
+            "type": Object {
+              "name": "arrayOf",
+              "value": Object {
+                "name": "string",
+              },
+            },
+          },
+          "title": Object {
+            "defaultValue": Object {
+              "computed": false,
+              "value": "null",
+            },
+            "description": "list title",
+            "required": false,
+            "type": Object {
+              "name": "string",
+            },
+          },
+          "toggleExpansion": Object {
+            "defaultValue": Object {
+              "computed": false,
+              "value": "() => {}",
+            },
+            "description": "call back function of expansion",
+            "required": false,
+            "type": Object {
+              "name": "func",
+            },
+          },
+        },
+      },
+      "defaultProps": Object {
+        "buttons": Array [],
+        "expandedIds": Array [],
+        "handleSelect": [Function],
+        "i18n": Object {
+          "close": "Close",
+          "expand": "Expand",
+          "searchPlaceHolderText": "Enter a value",
+        },
+        "iconPosition": "left",
+        "isEditing": false,
+        "isFullHeight": false,
+        "isLargeRow": false,
+        "isLoading": false,
+        "onItemMoved": [Function],
+        "pagination": null,
+        "search": null,
+        "selectedId": null,
+        "selectedIds": Array [],
+        "title": null,
+        "toggleExpansion": [Function],
+      },
+      "propTypes": Object {
+        "buttons": Object {
+          "args": Array [
+            Object {
+              "type": "node",
+            },
+          ],
+          "type": "arrayOf",
+        },
+        "expandedIds": Object {
+          "args": Array [
+            Object {
+              "type": "string",
+            },
+          ],
+          "type": "arrayOf",
+        },
+        "handleSelect": Object {
+          "type": "func",
+        },
+        "i18n": Object {
+          "args": Array [
+            Object {
+              "close": Object {
+                "type": "string",
+              },
+              "expand": Object {
+                "type": "string",
+              },
+              "searchPlaceHolderText": Object {
+                "type": "string",
+              },
+            },
+          ],
+          "type": "shape",
+        },
+        "iconPosition": Object {
+          "args": Array [
+            Array [
+              "left",
+              "right",
             ],
-            "type": "shape",
-          },
-        ],
-        "isRequired": true,
-        "type": "arrayOf",
-      },
-      "pagination": Object {
-        "args": Array [
-          Object {
-            "maxPage": Object {
-              "isRequired": true,
-              "type": "number",
+          ],
+          "type": "oneOf",
+        },
+        "isEditing": Object {
+          "type": "bool",
+        },
+        "isFullHeight": Object {
+          "type": "bool",
+        },
+        "isLargeRow": Object {
+          "type": "bool",
+        },
+        "isLoading": Object {
+          "type": "bool",
+        },
+        "items": Object {
+          "args": Array [
+            Object {
+              "args": Array [
+                Object {
+                  "children": Object {
+                    "args": Array [
+                      Object {
+                        "type": "object",
+                      },
+                    ],
+                    "type": "arrayOf",
+                  },
+                  "content": Object {
+                    "args": Array [
+                      Object {
+                        "icon": Object {
+                          "type": "node",
+                        },
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                    ],
+                    "type": "shape",
+                  },
+                  "id": Object {
+                    "type": "string",
+                  },
+                  "isSelectable": Object {
+                    "type": "bool",
+                  },
+                },
+              ],
+              "type": "shape",
             },
-            "nextPageText": Object {
+          ],
+          "isRequired": true,
+          "type": "arrayOf",
+        },
+        "onItemMoved": Object {
+          "type": "func",
+        },
+        "pagination": Object {
+          "args": Array [
+            Object {
+              "maxPage": Object {
+                "isRequired": true,
+                "type": "number",
+              },
+              "nextPageText": Object {
+                "type": "string",
+              },
+              "onPage": Object {
+                "isRequired": true,
+                "type": "func",
+              },
+              "page": Object {
+                "isRequired": true,
+                "type": "number",
+              },
+              "pageOfPagesText": Object {
+                "type": "func",
+              },
+              "pageText": Object {
+                "type": "string",
+              },
+              "prevPageText": Object {
+                "type": "string",
+              },
+            },
+          ],
+          "type": "shape",
+        },
+        "search": Object {
+          "args": Array [
+            Object {
+              "onChange": Object {
+                "type": "func",
+              },
+              "value": Object {
+                "type": "string",
+              },
+            },
+          ],
+          "type": "shape",
+        },
+        "selectedId": Object {
+          "type": "string",
+        },
+        "selectedIds": Object {
+          "args": Array [
+            Object {
               "type": "string",
             },
-            "onPage": Object {
-              "isRequired": true,
-              "type": "func",
-            },
-            "page": Object {
-              "isRequired": true,
-              "type": "number",
-            },
-            "pageOfPagesText": Object {
-              "type": "func",
-            },
-            "pageText": Object {
-              "type": "string",
-            },
-            "prevPageText": Object {
-              "type": "string",
-            },
-          },
-        ],
-        "type": "shape",
+          ],
+          "type": "arrayOf",
+        },
+        "title": Object {
+          "type": "string",
+        },
+        "toggleExpansion": Object {
+          "type": "func",
+        },
       },
-      "search": Object {
-        "args": Array [
-          Object {
-            "onChange": Object {
-              "type": "func",
-            },
-            "value": Object {
-              "type": "string",
-            },
-          },
-        ],
-        "type": "shape",
-      },
-      "selectedId": Object {
-        "type": "string",
-      },
-      "selectedIds": Object {
-        "args": Array [
-          Object {
-            "type": "string",
-          },
-        ],
-        "type": "arrayOf",
-      },
-      "title": Object {
-        "type": "string",
-      },
-      "toggleExpansion": Object {
-        "type": "func",
-      },
+      "render": [Function],
     },
-    "render": [Function],
+    "displayName": "DragDropContext(Component)",
   },
   "SimpleList" => Object {
     "defaultProps": Object {

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -13945,46 +13945,6 @@ Map {
     },
   },
   "List" => Object {
-<<<<<<< HEAD
-    "$$typeof": Symbol(react.forward_ref),
-    "defaultProps": Object {
-      "buttons": Array [],
-      "className": null,
-      "expandedIds": Array [],
-      "handleSelect": [Function],
-      "i18n": Object {
-        "close": "Close",
-        "expand": "Expand",
-        "searchPlaceHolderText": "Enter a value",
-      },
-      "iconPosition": "left",
-      "isFullHeight": false,
-      "isLargeRow": false,
-      "isLoading": false,
-      "pagination": null,
-      "search": null,
-      "selectedId": null,
-      "selectedIds": Array [],
-      "title": null,
-      "toggleExpansion": [Function],
-    },
-    "propTypes": Object {
-      "buttons": Object {
-        "args": Array [
-          Object {
-            "type": "node",
-          },
-        ],
-        "type": "arrayOf",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "expandedIds": Object {
-        "args": Array [
-          Object {
-            "type": "string",
-=======
     "DecoratedComponent": Object {
       "$$typeof": Symbol(react.forward_ref),
       "__docgenInfo": Object {
@@ -14003,6 +13963,17 @@ Map {
               "value": Object {
                 "name": "node",
               },
+            },
+          },
+          "className": Object {
+            "defaultValue": Object {
+              "computed": false,
+              "value": "null",
+            },
+            "description": "Specify an optional className to be applied to the container",
+            "required": false,
+            "type": Object {
+              "name": "string",
             },
           },
           "editingStyle": Object {
@@ -14047,7 +14018,6 @@ Map {
                 "name": "string",
               },
             },
->>>>>>> feat(list): added simple reordering
           },
           "handleSelect": Object {
             "defaultValue": Object {
@@ -14301,6 +14271,7 @@ Map {
       },
       "defaultProps": Object {
         "buttons": Array [],
+        "className": null,
         "editingStyle": null,
         "expandedIds": Array [],
         "handleSelect": [Function],
@@ -14330,6 +14301,9 @@ Map {
             },
           ],
           "type": "arrayOf",
+        },
+        "className": Object {
+          "type": "string",
         },
         "editingStyle": Object {
           "args": Array [

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -4105,19 +4105,32 @@ Map {
   "HierarchyList" => Object {
     "defaultProps": Object {
       "buttons": null,
+      "cancelMoveClicked": [Function],
       "defaultSelectedId": null,
+      "editingStyle": null,
       "hasMultiSelect": false,
       "hasPagination": true,
       "hasSearch": false,
       "i18n": Object {
+        "allRows": "All rows",
+        "cancel": "Cancel",
         "close": "Close",
         "expand": "Expand",
+        "itemSelected": "%d item selected",
+        "itemTitle": "Move %d item underneath",
+        "itemsSelected": "%d items selected",
+        "itemsTitle": "Move %d items underneath",
+        "modalDescription": "Select a destination",
+        "move": "Move",
         "searchPlaceHolderText": "Enter a value",
       },
       "isFullHeight": false,
       "isLoading": false,
+      "itemWillMove": [Function],
+      "onListUpdated": [Function],
       "onSelect": null,
       "pageSize": null,
+      "sendingData": null,
       "title": null,
     },
     "propTypes": Object {
@@ -4129,8 +4142,22 @@ Map {
         ],
         "type": "arrayOf",
       },
+      "cancelMoveClicked": Object {
+        "type": "func",
+      },
       "defaultSelectedId": Object {
         "type": "string",
+      },
+      "editingStyle": Object {
+        "args": Array [
+          Array [
+            "single",
+            "multiple",
+            "single-nesting",
+            "multiple-nesting",
+          ],
+        ],
+        "type": "oneOf",
       },
       "hasMultiSelect": Object {
         "type": "bool",
@@ -4144,10 +4171,28 @@ Map {
       "i18n": Object {
         "args": Array [
           Object {
+            "allRows": Object {
+              "type": "string",
+            },
+            "cancel": Object {
+              "type": "string",
+            },
             "close": Object {
               "type": "string",
             },
             "expand": Object {
+              "type": "string",
+            },
+            "itemsSelected": Object {
+              "type": "string",
+            },
+            "modalDescription": Object {
+              "type": "string",
+            },
+            "modalTitle": Object {
+              "type": "string",
+            },
+            "move": Object {
               "type": "string",
             },
             "searchPlaceHolderText": Object {
@@ -4163,6 +4208,9 @@ Map {
       "isLoading": Object {
         "type": "bool",
       },
+      "itemWillMove": Object {
+        "type": "func",
+      },
       "items": Object {
         "args": Array [
           Object {
@@ -4172,11 +4220,27 @@ Map {
         "isRequired": true,
         "type": "arrayOf",
       },
+      "onListUpdated": Object {
+        "type": "func",
+      },
       "onSelect": Object {
         "type": "func",
       },
       "pageSize": Object {
         "type": "string",
+      },
+      "sendingData": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "bool",
+            },
+            Object {
+              "type": "string",
+            },
+          ],
+        ],
+        "type": "oneOfType",
       },
       "title": Object {
         "type": "string",
@@ -13941,6 +14005,35 @@ Map {
               },
             },
           },
+          "editingStyle": Object {
+            "defaultValue": Object {
+              "computed": false,
+              "value": "null",
+            },
+            "description": "list editing style",
+            "required": false,
+            "type": Object {
+              "name": "enum",
+              "value": Array [
+                Object {
+                  "computed": true,
+                  "value": "EditingStyle.Single",
+                },
+                Object {
+                  "computed": true,
+                  "value": "EditingStyle.Multiple",
+                },
+                Object {
+                  "computed": true,
+                  "value": "EditingStyle.SingleNesting",
+                },
+                Object {
+                  "computed": true,
+                  "value": "EditingStyle.MultipleNesting",
+                },
+              ],
+            },
+          },
           "expandedIds": Object {
             "defaultValue": Object {
               "computed": false,
@@ -13965,6 +14058,17 @@ Map {
             "required": false,
             "type": Object {
               "name": "func",
+            },
+          },
+          "headerOverride": Object {
+            "defaultValue": Object {
+              "computed": false,
+              "value": "null",
+            },
+            "description": "Node to override the default header",
+            "required": false,
+            "type": Object {
+              "name": "node",
             },
           },
           "i18n": Object {
@@ -14017,17 +14121,6 @@ Map {
               ],
             },
           },
-          "isEditing": Object {
-            "defaultValue": Object {
-              "computed": false,
-              "value": "false",
-            },
-            "description": "list can be rearranged",
-            "required": false,
-            "type": Object {
-              "name": "bool",
-            },
-          },
           "isFullHeight": Object {
             "defaultValue": Object {
               "computed": false,
@@ -14059,6 +14152,19 @@ Map {
             "required": false,
             "type": Object {
               "name": "bool",
+            },
+          },
+          "itemWillMove": Object {
+            "defaultValue": Object {
+              "computed": false,
+              "value": "() => {
+  return true;
+}",
+            },
+            "description": "callback function when reorder will occur",
+            "required": false,
+            "type": Object {
+              "name": "func",
             },
           },
           "items": Object {
@@ -14155,17 +14261,6 @@ Map {
               },
             },
           },
-          "selectedId": Object {
-            "defaultValue": Object {
-              "computed": false,
-              "value": "null",
-            },
-            "description": "Currently selected item",
-            "required": false,
-            "type": Object {
-              "name": "string",
-            },
-          },
           "selectedIds": Object {
             "defaultValue": Object {
               "computed": false,
@@ -14206,22 +14301,23 @@ Map {
       },
       "defaultProps": Object {
         "buttons": Array [],
+        "editingStyle": null,
         "expandedIds": Array [],
         "handleSelect": [Function],
+        "headerOverride": null,
         "i18n": Object {
           "close": "Close",
           "expand": "Expand",
           "searchPlaceHolderText": "Enter a value",
         },
         "iconPosition": "left",
-        "isEditing": false,
         "isFullHeight": false,
         "isLargeRow": false,
         "isLoading": false,
+        "itemWillMove": [Function],
         "onItemMoved": [Function],
         "pagination": null,
         "search": null,
-        "selectedId": null,
         "selectedIds": Array [],
         "title": null,
         "toggleExpansion": [Function],
@@ -14235,6 +14331,17 @@ Map {
           ],
           "type": "arrayOf",
         },
+        "editingStyle": Object {
+          "args": Array [
+            Array [
+              "single",
+              "multiple",
+              "single-nesting",
+              "multiple-nesting",
+            ],
+          ],
+          "type": "oneOf",
+        },
         "expandedIds": Object {
           "args": Array [
             Object {
@@ -14245,6 +14352,9 @@ Map {
         },
         "handleSelect": Object {
           "type": "func",
+        },
+        "headerOverride": Object {
+          "type": "node",
         },
         "i18n": Object {
           "args": Array [
@@ -14271,9 +14381,6 @@ Map {
           ],
           "type": "oneOf",
         },
-        "isEditing": Object {
-          "type": "bool",
-        },
         "isFullHeight": Object {
           "type": "bool",
         },
@@ -14282,6 +14389,9 @@ Map {
         },
         "isLoading": Object {
           "type": "bool",
+        },
+        "itemWillMove": Object {
+          "type": "func",
         },
         "items": Object {
           "args": Array [
@@ -14378,9 +14488,6 @@ Map {
           ],
           "type": "shape",
         },
-        "selectedId": Object {
-          "type": "string",
-        },
         "selectedIds": Object {
           "args": Array [
             Object {
@@ -14403,14 +14510,17 @@ Map {
   "SimpleList" => Object {
     "defaultProps": Object {
       "buttons": Array [],
+      "editingStyle": null,
       "hasSearch": false,
       "i18n": Object {
+        "items": "%d items",
         "pageOfPagesText": [Function],
         "searchPlaceHolderText": "Enter a value",
       },
       "isFullHeight": false,
       "isLargeRow": false,
       "isLoading": false,
+      "onListUpdated": [Function],
       "pageSize": null,
     },
     "propTypes": Object {
@@ -14421,6 +14531,17 @@ Map {
           },
         ],
         "type": "arrayOf",
+      },
+      "editingStyle": Object {
+        "args": Array [
+          Array [
+            "single",
+            "multiple",
+            "single-nesting",
+            "multiple-nesting",
+          ],
+        ],
+        "type": "oneOf",
       },
       "hasSearch": Object {
         "type": "bool",
@@ -14492,6 +14613,9 @@ Map {
         ],
         "isRequired": true,
         "type": "arrayOf",
+      },
+      "onListUpdated": Object {
+        "type": "func",
       },
       "pageSize": Object {
         "type": "string",

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -14085,12 +14085,12 @@ Map {
                         "required": false,
                       },
                       "tags": Object {
-                        "args": Array [
-                          Object {
-                            "type": "node",
-                          },
-                        ],
-                        "type": "arrayOf",
+                        "description": "The nodes should be Carbon Tags components",
+                        "name": "arrayOf",
+                        "required": false,
+                        "value": Object {
+                          "name": "node",
+                        },
                       },
                       "value": Object {
                         "name": "string",
@@ -14301,6 +14301,14 @@ Map {
                       Object {
                         "icon": Object {
                           "type": "node",
+                        },
+                        "tags": Object {
+                          "args": Array [
+                            Object {
+                              "type": "node",
+                            },
+                          ],
+                          "type": "arrayOf",
                         },
                         "value": Object {
                           "type": "string",


### PR DESCRIPTION
Closes #

#1344 

Adds the ability for drag and drop for the list component

Single drag and drop for Simple List

Multiple and nested drag and drop for Hierarchy List

Added bulk reorder for Hierarchy List

**Change List (commits, features, bugs, etc)**

React DND for List, with only simple callbacks, Simple List handles single drag and drop, hierarchy list handles nesting and multiple dnd as well

**Acceptance Test (how to verify the PR)**

Simple list basic with reorder, you can drag and drop items into two targets, above and below. When hovering over a list item, a line will show which drop target is highlighted.

In Hierarchy List with reorder it defaults to single drag and drop. In this case there will be three drop targets. Above, below and nesting. The lines for above and below should be the same as the simple drag and drop, but nested will have the whole container highlighted with an outline. Dropping in the nested location will place the dropped item as the first child.

Enable multiple nesting in the editing style here. You can then click the check boxes and drag and drop multiple items.

An option in the header will also appear to handle bulk reorder. When clicked a modal will appear and you will then be able to click a row to view its children, or click the radio button to drop your selection as the first children of that list item. If an item does not contain children, if you click the row, the radio button will select by default.

Added an 'Allow Item Movement' variable to storybook to show what happens when the component does not allow the drag and drop to complete