### PR TITLE
feat(TimeSeriesCard/BarChartCard): add zoomBar functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,8 +113,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.10.2",
-    "@carbon/charts": "^0.34.5",
-    "@carbon/charts-react": "^0.34.5",
+    "@carbon/charts": "^0.34.8",
+    "@carbon/charts-react": "^0.34.8",
     "@carbon/colors": "10.8.0",
     "@carbon/icons-react": "10.11.0",
     "@carbon/layout": "10.7.1",

--- a/src/components/BarChartCard/BarChartCard.jsx
+++ b/src/components/BarChartCard/BarChartCard.jsx
@@ -7,7 +7,12 @@ import isEmpty from 'lodash/isEmpty';
 import memoize from 'lodash/memoize';
 
 import { BarChartCardPropTypes, CardPropTypes } from '../../constants/CardPropTypes';
-import { CARD_SIZES, BAR_CHART_TYPES, BAR_CHART_LAYOUTS } from '../../constants/LayoutConstants';
+import {
+  CARD_SIZES,
+  BAR_CHART_TYPES,
+  BAR_CHART_LAYOUTS,
+  ZOOM_BAR_ENABLED_CARD_SIZES,
+} from '../../constants/LayoutConstants';
 import Card from '../Card/Card';
 import { settings } from '../../constants/Settings';
 import { chartValueFormatter, handleCardVariables } from '../../utils/cardUtilityFunctions';
@@ -56,6 +61,7 @@ const BarChartCard = ({
       yLabel,
       unit,
       type = BAR_CHART_TYPES.SIMPLE,
+      zoomBar,
     },
     values: valuesProp,
   } = handleCardVariables(titleProp, content, initialValues, others);
@@ -176,6 +182,17 @@ const BarChartCard = ({
                   chartValueFormatter(tooltipValue, size, unit, locale),
                 customHTML: (...args) => handleTooltip(...args, timeDataSourceId, colors, locale),
               },
+              ...(zoomBar?.enabled && ZOOM_BAR_ENABLED_CARD_SIZES.includes(size)
+                ? {
+                    zoomBar: {
+                      // [zoomBar.axes]: {    TODO: the top axes is the only one support at the moment so default to top
+                      top: {
+                        enabled: zoomBar.enabled,
+                        initialZoomDomain: zoomBar.initialZoomDomain,
+                      },
+                    },
+                  }
+                : {}),
             }}
             width="100%"
             height="100%"

--- a/src/components/BarChartCard/BarChartCard.story.jsx
+++ b/src/components/BarChartCard/BarChartCard.story.jsx
@@ -350,6 +350,42 @@ storiesOf('Watson IoT/BarChartCard', module)
       </div>
     );
   })
+  .add('with zoomBar', () => {
+    const size = select('size', acceptableSizes, CARD_SIZES.LARGEWIDE);
+    return (
+      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+        <BarChartCard
+          title={text('title', 'Particles by city over time')}
+          id="stacked-horizontal-sample"
+          isLoading={boolean('isLoading', false)}
+          isEditable={boolean('isEditable', false)}
+          isExpanded={boolean('isExpandable', false)}
+          content={object('content', {
+            type: BAR_CHART_TYPES.STACKED,
+            layout: BAR_CHART_LAYOUTS.VERTICAL,
+            xLabel: 'Dates',
+            yLabel: 'Total',
+            series: [
+              {
+                dataSourceId: 'particles',
+              },
+            ],
+            timeDataSourceId: 'timestamp',
+            categoryDataSourceId: 'city',
+            zoomBar: {
+              enabled: true,
+              axes: 'top',
+              // initialZoomDomain: []
+            },
+          })}
+          values={barChartData.timestamps}
+          size={size}
+          onCardAction={action('onCardAction')}
+          availableActions={{ expand: true, range: true }}
+        />
+      </div>
+    );
+  })
   .add('No data', () => {
     const size = select('size', acceptableSizes, CARD_SIZES.MEDIUMWIDE);
     return (

--- a/src/components/BarChartCard/__snapshots__/BarChartCard.story.storyshot
+++ b/src/components/BarChartCard/__snapshots__/BarChartCard.story.storyshot
@@ -2563,3 +2563,168 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/BarCh
   </button>
 </div>
 `;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/BarChartCard with zoomBar 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "1056px",
+        }
+      }
+    >
+      <div
+        className="iot--card iot--bar-chart-card iot--card--wrapper"
+        data-testid="Card"
+        id="stacked-horizontal-sample"
+        role="presentation"
+        style={
+          Object {
+            "--card-default-height": "624px",
+          }
+        }
+      >
+        <div
+          className="iot--card--header"
+        >
+          <span
+            className="iot--card--title"
+            title="Particles by city over time"
+          >
+            <div
+              className="iot--card--title--text"
+            >
+              Particles by city over time
+            </div>
+          </span>
+          <div
+            className="iot--card--toolbar"
+          >
+            <div
+              className="iot--card--toolbar-date-range-wrapper"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                aria-label="Menu"
+                className="iot--card--toolbar-date-range-action bx--overflow-menu"
+                onClick={[Function]}
+                onClose={[Function]}
+                onKeyDown={[Function]}
+                open={false}
+                tabIndex={0}
+                title="Select time range"
+              >
+                <svg
+                  aria-label="Select time range"
+                  className="bx--overflow-menu__icon"
+                  focusable="false"
+                  height={16}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
+                  />
+                  <path
+                    d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                  />
+                  <path
+                    d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
+                  />
+                  <title>
+                    Select time range
+                  </title>
+                </svg>
+              </button>
+            </div>
+            <button
+              className="iot--card--toolbar-action iot--card--toolbar-svg-wrapper bx--btn--icon-only bx--btn bx--btn--ghost"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              title="Expand to fullscreen"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                aria-label="Expand to fullscreen"
+                className="bx--btn__icon"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M28,4H10A2.0059,2.0059,0,0,0,8,6V20a2.0059,2.0059,0,0,0,2,2H28a2.0059,2.0059,0,0,0,2-2V6A2.0059,2.0059,0,0,0,28,4Zm0,16H10V6H28Z"
+                />
+                <path
+                  d="M18,26H4V16H6V14H4a2.0059,2.0059,0,0,0-2,2V26a2.0059,2.0059,0,0,0,2,2H18a2.0059,2.0059,0,0,0,2-2V24H18Z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          className="iot--card--content"
+          style={
+            Object {
+              "--card-content-height": "576px",
+            }
+          }
+        >
+          <div
+            className="iot--bar-chart-container"
+          >
+            <div
+              className="chart-holder"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -76,7 +76,8 @@ const TimeSeriesCardPropTypes = {
     /** Optionally addes a zoom bar to the chart */
     zoomBar: PropTypes.shape({
       /** Determines which axis to put the zoomBar */
-      axes: PropTypes.string,
+      axes: PropTypes.oneOf(['top']), // top is the only axes supported right now
+      // axes: PropTypes.oneOf(['top', 'bottom', 'left', 'right']), // TODO: When the other axes are supported, swap to this proptype
       /** Determines whether the zoomBar is enabled */
       enabled: PropTypes.bool,
       /** Optional domain to zoom to by default. Can be a timestamp or date string */

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -16,7 +16,12 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 
 import { csvDownloadHandler } from '../../utils/componentUtilityFunctions';
 import { CardPropTypes } from '../../constants/CardPropTypes';
-import { CARD_SIZES, TIME_SERIES_TYPES, DISABLED_COLORS } from '../../constants/LayoutConstants';
+import {
+  CARD_SIZES,
+  TIME_SERIES_TYPES,
+  DISABLED_COLORS,
+  ZOOM_BAR_ENABLED_CARD_SIZES,
+} from '../../constants/LayoutConstants';
 import Card from '../Card/Card';
 import StatefulTable from '../Table/StatefulTable';
 import { settings } from '../../constants/Settings';
@@ -68,6 +73,17 @@ const TimeSeriesCardPropTypes = {
     ),
     /** optional units to put in the legend */
     unit: PropTypes.string,
+    /** Optionally addes a zoom bar to the chart */
+    zoomBar: PropTypes.shape({
+      /** Determines which axis to put the zoomBar */
+      axes: PropTypes.string,
+      /** Determines whether the zoomBar is enabled */
+      enabled: PropTypes.bool,
+      /** Optional domain to zoom to by default. Can be a timestamp or date string */
+      initialZoomDomain: PropTypes.arrayOf(
+        PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+      ),
+    }),
   }).isRequired,
   i18n: PropTypes.shape({
     alertDetected: PropTypes.string,
@@ -274,6 +290,7 @@ const TimeSeriesCard = ({
       includeZeroOnYaxis,
       unit,
       chartType,
+      zoomBar,
     },
     values: valuesProp,
   } = handleCardVariables(titleProp, content, initialValues, others);
@@ -529,6 +546,17 @@ const TimeSeriesCard = ({
                 getFillColor: handleFillColor,
                 getIsFilled: handleIsFilled,
                 color: colors,
+                ...(zoomBar?.enabled && ZOOM_BAR_ENABLED_CARD_SIZES.includes(size)
+                  ? {
+                      zoomBar: {
+                        // [zoomBar.axes]: {    TODO: the top axis is the only axis supported at the moment so default to top
+                        top: {
+                          enabled: zoomBar.enabled,
+                          initialZoomDomain: zoomBar.initialZoomDomain,
+                        },
+                      },
+                    }
+                  : {}),
               }}
               width="100%"
               height="100%"

--- a/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
@@ -390,6 +390,11 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             includeZeroOnXaxis: false,
             includeZeroOnYaxis: false,
             timeDataSourceId: 'timestamp',
+            zoomBar: {
+              enabled: true,
+              axes: 'top',
+              // initialZoomDomain: []
+            },
           })}
           values={getIntervalChartData('minute', 15, { min: 4700000, max: 4800000 }, 100)}
           interval="minute"
@@ -482,6 +487,11 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             includeZeroOnXaxis: true,
             includeZeroOnYaxis: true,
             timeDataSourceId: 'timestamp',
+            zoomBar: {
+              enabled: true,
+              axes: 'top',
+              // initialZoomDomain: []
+            },
           })}
           values={getIntervalChartData('month', 24, { min: 10, max: 100 }, 100)}
           interval="month"
@@ -513,6 +523,11 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             includeZeroOnXaxis: false,
             includeZeroOnYaxis: false,
             timeDataSourceId: 'timestamp',
+            zoomBar: {
+              enabled: true,
+              axes: 'top',
+              // initialZoomDomain: []
+            },
           })}
           values={getIntervalChartData('year', 10, { min: 10, max: 100 }, 100)}
           interval="year"
@@ -547,6 +562,11 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             includeZeroOnXaxis: true,
             includeZeroOnYaxis: true,
             timeDataSourceId: 'timestamp',
+            zoomBar: {
+              enabled: true,
+              axes: 'top',
+              // initialZoomDomain: []
+            },
           })}
           values={getIntervalChartData('day', 12, { min: 10, max: 100 }, 100)}
           breakpoint="lg"
@@ -634,6 +654,42 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
           breakpoint="lg"
           size={size}
           showTimeInGMT={boolean('showTimeInGMT', false)}
+          onCardAction={action('onCardAction')}
+        />
+      </div>
+    );
+  })
+  .add('with zoomBar', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGE);
+    return (
+      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+        <TimeSeriesCard
+          title={text('title', 'Temperature')}
+          id="facility-temperature"
+          isLoading={boolean('isLoading', false)}
+          isExpanded={boolean('isExpandable', false)}
+          content={object('content', {
+            series: [
+              {
+                label: 'Temperature',
+                dataSourceId: 'temperature',
+              },
+            ],
+            xLabel: 'Time',
+            yLabel: 'Temperature (˚F)',
+            includeZeroOnXaxis: true,
+            includeZeroOnYaxis: true,
+            timeDataSourceId: 'timestamp',
+            zoomBar: {
+              enabled: true,
+              axes: 'top',
+              // initialZoomDomain: []
+            },
+          })}
+          values={getIntervalChartData('month', 24, { min: 10, max: 100 }, 100)}
+          interval="month"
+          breakpoint="lg"
+          size={size}
           onCardAction={action('onCardAction')}
         />
       </div>

--- a/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -4157,3 +4157,94 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
   </button>
 </div>
 `;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeSeriesCard with zoomBar 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="iot--card iot--card--wrapper"
+        data-testid="Card"
+        id="facility-temperature"
+        role="presentation"
+        style={
+          Object {
+            "--card-default-height": "624px",
+          }
+        }
+      >
+        <div
+          className="iot--card--header"
+        >
+          <span
+            className="iot--card--title"
+            title="Temperature"
+          >
+            <div
+              className="iot--card--title--text"
+            >
+              Temperature
+            </div>
+          </span>
+        </div>
+        <div
+          className="iot--card--content"
+          style={
+            Object {
+              "--card-content-height": "576px",
+            }
+          }
+        >
+          <div
+            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
+            size="LARGE"
+          >
+            <div
+              className="chart-holder"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/constants/CardPropTypes.js
+++ b/src/constants/CardPropTypes.js
@@ -266,7 +266,8 @@ export const BarChartCardPropTypes = {
     /** Optionally addes a zoom bar to the chart */
     zoomBar: PropTypes.shape({
       /** Determines which axis to put the zoomBar */
-      axes: PropTypes.string,
+      axes: PropTypes.oneOf(['top']), // top is the only axes supported right now
+      // axes: PropTypes.oneOf(['top', 'bottom', 'left', 'right']), // TODO: When the other axes are supported, swap to this proptype
       /** Determines whether the zoomBar is enabled */
       enabled: PropTypes.bool,
       /** Optional domain to zoom to by default. Can be a timestamp or date string */

--- a/src/constants/CardPropTypes.js
+++ b/src/constants/CardPropTypes.js
@@ -263,6 +263,17 @@ export const BarChartCardPropTypes = {
     },
     /** optional units to put in the legend for all datasets */
     unit: PropTypes.string,
+    /** Optionally addes a zoom bar to the chart */
+    zoomBar: PropTypes.shape({
+      /** Determines which axis to put the zoomBar */
+      axes: PropTypes.string,
+      /** Determines whether the zoomBar is enabled */
+      enabled: PropTypes.bool,
+      /** Optional domain to zoom to by default. Can be a timestamp or date string */
+      initialZoomDomain: PropTypes.arrayOf(
+        PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+      ),
+    }),
   }).isRequired,
   /** array of data from the backend for instance [{quarter: '2020-Q1', city: 'Amsterdam', particles: 44700}, ...] */
   values: PropTypes.arrayOf(PropTypes.object),

--- a/src/constants/LayoutConstants.js
+++ b/src/constants/LayoutConstants.js
@@ -233,3 +233,10 @@ export const BAR_CHART_LAYOUTS = {
   HORIZONTAL: 'HORIZONTAL',
   VERTICAL: 'VERTICAL',
 };
+
+// If the card is too small, the chart will be too small when the zoom bar renders
+export const ZOOM_BAR_ENABLED_CARD_SIZES = [
+  CARD_SIZES.MEDIUMWIDE,
+  CARD_SIZES.LARGE,
+  CARD_SIZES.LARGEWIDE,
+];

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -4430,7 +4430,12 @@ Map {
               "args": Array [
                 Object {
                   "axes": Object {
-                    "type": "string",
+                    "args": Array [
+                      Array [
+                        "top",
+                      ],
+                    ],
+                    "type": "oneOf",
                   },
                   "enabled": Object {
                     "type": "bool",
@@ -9302,7 +9307,12 @@ Map {
               "args": Array [
                 Object {
                   "axes": Object {
-                    "type": "string",
+                    "args": Array [
+                      Array [
+                        "top",
+                      ],
+                    ],
+                    "type": "oneOf",
                   },
                   "enabled": Object {
                     "type": "bool",

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -4426,6 +4426,37 @@ Map {
             "yLabel": Object {
               "type": "string",
             },
+            "zoomBar": Object {
+              "args": Array [
+                Object {
+                  "axes": Object {
+                    "type": "string",
+                  },
+                  "enabled": Object {
+                    "type": "bool",
+                  },
+                  "initialZoomDomain": Object {
+                    "args": Array [
+                      Object {
+                        "args": Array [
+                          Array [
+                            Object {
+                              "type": "string",
+                            },
+                            Object {
+                              "type": "number",
+                            },
+                          ],
+                        ],
+                        "type": "oneOfType",
+                      },
+                    ],
+                    "type": "arrayOf",
+                  },
+                },
+              ],
+              "type": "shape",
+            },
           },
         ],
         "isRequired": true,
@@ -9266,6 +9297,37 @@ Map {
             },
             "yLabel": Object {
               "type": "string",
+            },
+            "zoomBar": Object {
+              "args": Array [
+                Object {
+                  "axes": Object {
+                    "type": "string",
+                  },
+                  "enabled": Object {
+                    "type": "bool",
+                  },
+                  "initialZoomDomain": Object {
+                    "args": Array [
+                      Object {
+                        "args": Array [
+                          Array [
+                            Object {
+                              "type": "string",
+                            },
+                            Object {
+                              "type": "number",
+                            },
+                          ],
+                        ],
+                        "type": "oneOfType",
+                      },
+                    ],
+                    "type": "arrayOf",
+                  },
+                },
+              ],
+              "type": "shape",
             },
           },
         ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2513,17 +2513,17 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@carbon/charts-react@^0.34.5":
-  version "0.34.5"
-  resolved "https://registry.yarnpkg.com/@carbon/charts-react/-/charts-react-0.34.5.tgz#ee7f4aa80f2fc158f354eb1fcb3e5a5942fc280b"
-  integrity sha512-+4NErNxR0Xxbawk2GnQArR/y/s1XnoZTdYAwWkTuQVyiJEtlg2eDYGMr5Zk9g9n0pOAVlL1Rr7ZYrnKim5MgNA==
+"@carbon/charts-react@^0.34.8":
+  version "0.34.8"
+  resolved "https://registry.yarnpkg.com/@carbon/charts-react/-/charts-react-0.34.8.tgz#daa4d3f46d215a888cda081ace0d4b903afae264"
+  integrity sha512-+hKQ8Lv1fyM03oCIpWFtNwr4nzhG08PYgxMgsP9HavSTIObvp5fMko8gUgX790XaaqpTT2ntVHOOHw005hkXkg==
   dependencies:
-    "@carbon/charts" "^0.34.5"
+    "@carbon/charts" "^0.34.8"
 
-"@carbon/charts@^0.34.5":
-  version "0.34.5"
-  resolved "https://registry.yarnpkg.com/@carbon/charts/-/charts-0.34.5.tgz#a8e6b4cd030597c6ba992e4b51dac28f5839fb81"
-  integrity sha512-8MlWV2kMovGp94HMsIm4ebiTUwC++vfSTE03RJA5gpDtNzSjpu08Xk/kXYntWFeQwEZIY7ofegJ9qlL62B6mvQ==
+"@carbon/charts@^0.34.8":
+  version "0.34.8"
+  resolved "https://registry.yarnpkg.com/@carbon/charts/-/charts-0.34.8.tgz#f0f512af18dffbc094dfb8a0ec3c726949660361"
+  integrity sha512-FRjdBgnZ3grGxOupCOOPtYmYO/CeoOEAU4pEBdD8ewnbdbCGt/xAmCQMkAKF1iWw4kmAZF7chX8R3G8TnxSQAg==
   dependencies:
     "@carbon/colors" "10.4.0"
     "@carbon/utils-position" "1.1.1"


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-addons-iot-react/issues/1456

**Summary**

- Adds alpha zoomBar functionality to TimeSeriesCard and BarChartCard using the new `zoomBar` prop
- Restricts the zoomBar to cards of size MEDIUMWIDE, LARGE, LARGEWIDE as the other sizes are too small to render both the chart and the zoomBar
- Note: This feature is experimental in carbon charts
```
zoomBar: {
  axes: string,   // defaults to top as thats the only axis supported at the moment
  enabled: boolean,
  initialZoomDomain: array<string|number>    // same as the current `domainRange` prop
}
```

**Change List (commits, features, bugs, etc)**

- Added 2 stories to show the zoomBar feature
- Updated to latest carbon charts to pick up this feature

**Acceptance Test (how to verify the PR)**

- Go to BarChartCard and TimeSeriesCard `with zoomBar` stories and test out the zoom bar
