### PR TITLE
fix(table): column resize fails when adding columns

### DIFF
--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -9,6 +9,8 @@ import Add from '@carbon/icons-react/lib/add/16';
 import Edit from '@carbon/icons-react/lib/edit/16';
 import { spacing03 } from '@carbon/layout';
 import { Add20, TrashCan16, SettingsAdjust16 as SettingsAdjust } from '@carbon/icons-react';
+import cloneDeep from 'lodash/cloneDeep';
+
 import {
   Tooltip,
   TextInput,
@@ -17,9 +19,7 @@ import {
   Button,
   FormGroup,
   Form,
-} from 'carbon-components-react';
-import cloneDeep from 'lodash/cloneDeep';
-
+} from '../../index';
 import { getSortedData, csvDownloadHandler } from '../../utils/componentUtilityFunctions';
 import FullWidthWrapper from '../../internal/FullWidthWrapper';
 import FlyoutMenu, { FlyoutMenuDirection } from '../FlyoutMenu/FlyoutMenu';
@@ -1694,7 +1694,7 @@ storiesOf('Watson IoT/Table', module)
                 <Checkbox
                   labelText="add as hidden column(s)"
                   id="isHiddenCheckbox"
-                  value={isHidden}
+                  defaultChecked={isHidden}
                   onChange={() => setIsHidden(!isHidden)}
                 />
               </FormGroup>
@@ -1753,7 +1753,11 @@ storiesOf('Watson IoT/Table', module)
           const newColumns = [];
           const newOrdering = [];
           colsToAdd.forEach((colToAddId, index) => {
-            newColumns.push({ id: colToAddId, name: colToAddId, width: widths[index] });
+            newColumns.push({
+              id: colToAddId,
+              name: colToAddId,
+              width: widths[index] || undefined,
+            });
             newOrdering.push({ columnId: colToAddId, isHidden });
           });
           setMyColumns([...myColumns, ...newColumns]);

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -9,7 +9,15 @@ import Add from '@carbon/icons-react/lib/add/16';
 import Edit from '@carbon/icons-react/lib/edit/16';
 import { spacing03 } from '@carbon/layout';
 import { Add20, TrashCan16, SettingsAdjust16 as SettingsAdjust } from '@carbon/icons-react';
-import { Tooltip, TextInput, Checkbox, ToastNotification, Button } from 'carbon-components-react';
+import {
+  Tooltip,
+  TextInput,
+  Checkbox,
+  ToastNotification,
+  Button,
+  FormGroup,
+  Form,
+} from 'carbon-components-react';
 import cloneDeep from 'lodash/cloneDeep';
 
 import { getSortedData, csvDownloadHandler } from '../../utils/componentUtilityFunctions';
@@ -1664,21 +1672,126 @@ storiesOf('Watson IoT/Table', module)
     }
   )
   .add(
-    'with resize, onColumnResize callback and no initial column width',
+    'with resize, onColumnResize callback, no initial column width and column management',
     () => {
-      return React.createElement(() => {
-        const [myColumns, setMyColumns] = useState(tableColumns);
-        const onColumnResize = cols => setMyColumns(cols);
+      const ColumnsModifier = ({ onAdd, onRemove, columns, ordering }) => {
+        const [colsToAddField, setColsToAddField] = useState('colX, colY');
+        const [colsToAddWidthField, setColsToAddWidthField] = useState('100px, 150px');
+        const [colsToDeleteField, setColsToDeleteField] = useState('select, status');
+        const [isHidden, setIsHidden] = useState(false);
+
         return (
-          <Table
-            options={{
-              hasResize: true,
-              wrapCellText: select('wrapCellText', selectTextWrapping, 'always'),
-            }}
-            columns={myColumns}
-            data={tableData}
-            actions={{ ...actions, table: { ...actions.table, onColumnResize } }}
-          />
+          <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '2rem' }}>
+            <Form style={{ maxWidth: '300px', marginRight: '2rem' }}>
+              <TextInput
+                labelText="Ids of one or more columns"
+                id="colsToAddInput"
+                value={colsToAddField}
+                type="text"
+                onChange={evt => setColsToAddField(evt.currentTarget.value)}
+              />
+              <FormGroup legendText="" style={{ marginBottom: '1rem' }}>
+                <Checkbox
+                  labelText="add as hidden column(s)"
+                  id="isHiddenCheckbox"
+                  value={isHidden}
+                  onChange={() => setIsHidden(!isHidden)}
+                />
+              </FormGroup>
+              <TextInput
+                labelText="The width of the added columns (if any)"
+                id="colsToAddWidthInput"
+                value={colsToAddWidthField}
+                type="text"
+                onChange={evt => setColsToAddWidthField(evt.currentTarget.value)}
+              />
+              <Button
+                style={{ marginTop: '1rem' }}
+                onClick={() => onAdd(colsToAddField, colsToAddWidthField, isHidden)}
+              >
+                Add
+              </Button>
+            </Form>
+            <div style={{ maxWidth: '50%' }}>
+              <div style={{ margin: '1rem' }}>
+                <p>COLUMNS prop</p>
+                <samp>{JSON.stringify(columns)}</samp>
+              </div>
+              <div style={{ margin: '1rem' }}>
+                <p>ORDERING prop</p>
+                <samp>{JSON.stringify(ordering)}</samp>
+              </div>
+            </div>
+
+            <Form style={{ maxWidth: '300px' }}>
+              <TextInput
+                labelText="One or more IDs of columns to delete"
+                id="removeColInput"
+                value={colsToDeleteField}
+                type="text"
+                onChange={evt => setColsToDeleteField(evt.currentTarget.value)}
+              />
+              <Button
+                style={{ marginTop: '1rem' }}
+                id="removeColInput"
+                onClick={() => onRemove(colsToDeleteField)}
+              >
+                Remove
+              </Button>
+            </Form>
+          </div>
+        );
+      };
+
+      return React.createElement(() => {
+        const [myColumns, setMyColumns] = useState(tableColumns.map(({ filter, ...rest }) => rest));
+        const [myOrdering, setMyOrdering] = useState(defaultOrdering);
+
+        const onAdd = (colIds, colWidths, isHidden) => {
+          const colsToAdd = colIds.split(', ');
+          const widths = colWidths.split(', ');
+          const newColumns = [];
+          const newOrdering = [];
+          colsToAdd.forEach((colToAddId, index) => {
+            newColumns.push({ id: colToAddId, name: colToAddId, width: widths[index] });
+            newOrdering.push({ columnId: colToAddId, isHidden });
+          });
+          setMyColumns([...myColumns, ...newColumns]);
+          setMyOrdering([...myOrdering, ...newOrdering]);
+        };
+
+        const onRemove = colIds => {
+          const colsToDelete = colIds.split(', ');
+          setMyColumns(myColumns.filter(col => !colsToDelete.includes(col.id)));
+          setMyOrdering(myOrdering.filter(col => !colsToDelete.includes(col.columnId)));
+        };
+        const onColumnResize = cols => setMyColumns(cols);
+
+        return (
+          <>
+            <ColumnsModifier
+              onAdd={onAdd}
+              onRemove={onRemove}
+              columns={myColumns}
+              ordering={myOrdering}
+            />
+            <Table
+              options={{
+                hasColumnSelection: true,
+                hasResize: true,
+                wrapCellText: select('wrapCellText', selectTextWrapping, 'always'),
+              }}
+              columns={myColumns}
+              view={{
+                filters: [],
+                table: {
+                  ordering: myOrdering,
+                },
+              }}
+              data={tableData}
+              actions={{ ...actions, table: { ...actions.table, onColumnResize } }}
+            />
+          </>
         );
       });
     },

--- a/src/components/Table/TableHead/TableHead.jsx
+++ b/src/components/Table/TableHead/TableHead.jsx
@@ -25,8 +25,13 @@ import TableHeader from './TableHeader';
 import ColumnResize from './ColumnResize';
 import {
   createNewWidthsMap,
+  calculateWidthOnHide,
   calculateWidthsOnToggle,
   adjustLastColumnWidth,
+  calculateWidthOnShow,
+  visibleColumnsHaveWidth,
+  getIDsOfAddedColumns,
+  getIDsOfRemovedColumns,
 } from './columnWidthUtilityFunctions';
 
 const { iotPrefix } = settings;
@@ -221,10 +226,9 @@ const TableHead = ({
     () => {
       // An initial measuring is needed since there might not be an initial value from the columns prop
       // which means that the layout engine will have to set the widths dynamically
-      // before we know what they are. More importantly, the sum of the inital widths may not match
-      // the available width of the table, e.g. if the user has resized the browser since the
-      // column widths was last saved.
+      // before we know what they are.
       if (hasResize && columns.length && isEmpty(currentColumnWidths)) {
+        console.info('setting currentColumnWidths');
         const measuredWidths = measureColumnWidths();
         const adjustedWidths = adjustLastColumnWidth(ordering, columns, measuredWidths);
         const newWidthsMap = createNewWidthsMap(ordering, currentColumnWidths, adjustedWidths);
@@ -236,10 +240,17 @@ const TableHead = ({
 
   useDeepCompareEffect(
     () => {
-      // We need to update the currentColumnWidths (state) only if the widths
-      // of the column prop is updated after the initial render.
+      // We need to update the currentColumnWidths (state) after the initial render
+      // only if the widths of the column prop is updated or columns are added/removed .
       if (hasResize && columns.length && !isEmpty(currentColumnWidths)) {
-        if (columns.every(col => col.hasOwnProperty('width'))) {
+        const addedColumnIDs = getIDsOfAddedColumns(ordering, currentColumnWidths);
+        const removedColumnIDs = getIDsOfRemovedColumns(ordering, currentColumnWidths);
+
+        if (addedColumnIDs.length > 0 || removedColumnIDs.length > 0) {
+          const afterRemove = calculateWidthOnHide(currentColumnWidths, ordering, removedColumnIDs);
+          const afterAdd = calculateWidthOnShow(afterRemove, ordering, addedColumnIDs, columns);
+          setCurrentColumnWidths(afterAdd);
+        } else if (visibleColumnsHaveWidth(ordering, columns)) {
           const propsColumnWidths = createNewWidthsMap(ordering, columns);
           if (!isEqual(currentColumnWidths, propsColumnWidths)) {
             setCurrentColumnWidths(propsColumnWidths);

--- a/src/components/Table/TableHead/TableHead.jsx
+++ b/src/components/Table/TableHead/TableHead.jsx
@@ -228,7 +228,6 @@ const TableHead = ({
       // which means that the layout engine will have to set the widths dynamically
       // before we know what they are.
       if (hasResize && columns.length && isEmpty(currentColumnWidths)) {
-        console.info('setting currentColumnWidths');
         const measuredWidths = measureColumnWidths();
         const adjustedWidths = adjustLastColumnWidth(ordering, columns, measuredWidths);
         const newWidthsMap = createNewWidthsMap(ordering, currentColumnWidths, adjustedWidths);

--- a/src/components/Table/TableSaveViewModal/TableSaveViewModal.test.jsx
+++ b/src/components/Table/TableSaveViewModal/TableSaveViewModal.test.jsx
@@ -277,7 +277,3 @@ describe('TableSaveViewModal', () => {
     expect(screen.queryByText(i18nDefault.cancelButtonLabelText)).not.toBeInTheDocument();
   });
 });
-
-// test callbacks works
-// test that disable works
-// test open/close


### PR DESCRIPTION
Closes #1428

**Summary**
Adding new column definitions (by adding them to the columns and ordering props) after initial rendering fails when hasResize is true. The same problem appears when removing columns. This issue was identified in the discussion #1358

**Change List (commits, features, bugs, etc)**

After the initial rendering the resizable column widths are now updated in the case of
a. The columns and order props are modified, either with new columns or by having columns removed.
b. The columns prop is modified and all the visible columns in that new prop state have a width.

1. Updated a table story to be able to reproduce and test the scenario where columns are added and removed by an application. This is different from toggling the visibility of already defined columns.
![image](https://user-images.githubusercontent.com/5167091/88976297-17035380-d2bc-11ea-9258-0a5ac7795315.png)

2. Fixed the cause of the issue in the useDeepCompareEffect of the TableHead.jsx. Now that hook will also check if any columns are added or removed and deal with that.
3. Added additional functions to columnWidthUtilityFunctions.js and refactored some existing ones to be able to handle multiple column changes (i.e. add/show or remove/hide) at the same time.
4. Added a small improvement to prevent columns from shrinking below the minimum size when new columns are added or shown. 
5. Added unit tests to cover the new functionality
6. Cleaned up some left over comments in TableSaveViewModal.test.jsx
7. Introduced a warning for supplying incorrect width in the column prop. A column width should be a string containing the width and the pixel unit  e.g. `100px` or have the value `undefined`. For backwards compatibility the resizing can also handle an empty string value which will have the same effect as not defining a width.


**Acceptance Test (how to verify the PR)**
1. Go to the modified story [/watson-iot-table--with-resize-oncolumnresize-callback-no-initial-column-width-and-column-management](https://deploy-preview-1455--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-table--with-resize-oncolumnresize-callback-no-initial-column-width-and-column-management)
2. Use the add and remove buttons and the input fields to add/remove columns

