### PR TITLE
fix(table): allow empty row actions for some rows of a table

### DIFF
--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -1154,32 +1154,33 @@ storiesOf('Watson IoT/Table', module)
         columns={tableColumns}
         data={tableData.map((i, idx) => ({
           ...i,
-          rowActions: [
-            idx % 4 === 0
-              ? {
-                  id: 'drilldown',
-                  renderIcon: Arrow,
-                  iconDescription: 'See more',
-                  labelText: 'See more',
-                }
-              : null,
-            {
-              id: 'add',
-              renderIcon: Add,
-              iconDescription: 'Add',
-              labelText: 'Add',
-              isOverflow: true,
-              hasDivider: true,
-            },
-            {
-              id: 'delete',
-              renderIcon: TrashCan16,
-              iconDescription: 'Delete',
-              labelText: 'Delete',
-              isOverflow: true,
-              isDelete: true,
-            },
-          ].filter(i => i),
+          rowActions:
+            idx % 4 === 0 // every 4th row shouldn't have any actions
+              ? []
+              : [
+                  {
+                    id: 'drilldown',
+                    renderIcon: Arrow,
+                    iconDescription: 'See more',
+                    labelText: 'See more',
+                  },
+                  {
+                    id: 'add',
+                    renderIcon: Add,
+                    iconDescription: 'Add',
+                    labelText: 'Add',
+                    isOverflow: true,
+                    hasDivider: true,
+                  },
+                  {
+                    id: 'delete',
+                    renderIcon: TrashCan16,
+                    iconDescription: 'Delete',
+                    labelText: 'Delete',
+                    isOverflow: true,
+                    isDelete: true,
+                  },
+                ].filter(i => i),
         }))}
         actions={actions}
         options={{

--- a/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
+++ b/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
@@ -129,7 +129,7 @@ class RowActionsCell extends React.Component {
       >
         {singleRowEditButtons}
       </TableCell>
-    ) : actions && actions.length > 0 ? (
+    ) : actions ? (
       <TableCell
         key={`${id}-row-actions-cell`}
         className={`${iotPrefix}--row-actions-cell--table-cell`}

--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -452,7 +452,7 @@ const TableBodyRow = ({
           </TableCell>
         ) : null;
       })}
-      {hasRowActions && rowActions && rowActions.length > 0 ? (
+      {hasRowActions && rowActions ? (
         <RowActionsCell
           id={id}
           langDir={langDir}


### PR DESCRIPTION
Closes #1457 

**Summary**

- Allow an empty array to be passed for 'row actions' and have it render the row actions cell with empty actions for that row so the table isn't missing a column for that row

**Change List (commits, features, bugs, etc)**

- test(Table.story): have one of the stories skip row actions for a row every four rows
- fix(TableBodyRow): allow empty row actions to actually render the cell
- fix(RowActionsCell): allow empty row actions to actually render the cell so the table looks good

**Acceptance Test (how to verify the PR)**

- Test the one updated story: `watson-iot-table--with-row-expansion-and-actions`
