### PR TITLE
fix(flyoutmenu): add export to index.js

### DIFF
--- a/.storybook/__snapshots__/Welcome.story.storyshot
+++ b/.storybook/__snapshots__/Welcome.story.storyshot
@@ -3313,6 +3313,18 @@ exports[`Storybook Snapshot tests and console checks Storyshots 0/Getting Starte
                   <div
                     className="bx--structured-list-td"
                   >
+                    FlyoutMenu
+                  </div>
+                </div>
+                <div
+                  className="bx--structured-list-row"
+                >
+                  <div
+                    className="bx--structured-list-td"
+                  />
+                  <div
+                    className="bx--structured-list-td"
+                  >
                     determineCardRange
                   </div>
                 </div>

--- a/src/components/FlyoutMenu/index.js
+++ b/src/components/FlyoutMenu/index.js
@@ -1,0 +1,1 @@
+export default from './FlyoutMenu';

--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,6 @@ export {
 
 // Experimental
 export ListCard from './components/ListCard/ListCard';
-
 export PageWizard from './components/PageWizard/PageWizard';
 export PageWizardStep from './components/PageWizard/PageWizardStep/PageWizardStep';
 export PageWizardStepContent from './components/PageWizard/PageWizardStep/PageWizardStepContent';
@@ -79,28 +78,18 @@ export PageWizardStepDescription from './components/PageWizard/PageWizardStep/Pa
 export PageWizardStepExtraContent from './components/PageWizard/PageWizardStep/PageWizardStepExtraContent';
 export PageWizardStepTitle from './components/PageWizard/PageWizardStep/PageWizardStepTitle';
 export StatefulPageWizard from './components/PageWizard/StatefulPageWizard';
-
 export TileGallery from './components/TileGallery/TileGallery';
-
 export TileGallerySection from './components/TileGallery/TileGallerySection';
-
 export TileGalleryItem from './components/TileGallery/TileGalleryItem';
-
 export TileGalleryViewSwitcher from './components/TileGallery/TileGalleryViewSwitcher';
-
 export TileGallerySearch from './components/TileGallery/TileGallerySearch';
-
 export StatefulTileGallery from './components/TileGallery/StatefulTileGallery';
-
 export List from './components/List/List';
-
 export SimpleList from './components/List/SimpleList/SimpleList';
-
 export IconSwitch, { ICON_SWITCH_SIZES } from './components/IconSwitch/IconSwitch';
-
 export AccordionItemDefer from './components/Accordion/AccordionItemDefer';
-
 export ComboBox from './components/ComboBox';
+export FlyoutMenu from './components/FlyoutMenu';
 
 // Carbon proxy
 export {

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -14298,6 +14298,149 @@ Map {
       },
     },
   },
+  "FlyoutMenu" => Object {
+    "defaultProps": Object {
+      "buttonSize": "default",
+      "children": undefined,
+      "customFooter": null,
+      "defaultOpen": false,
+      "direction": "bottom-start",
+      "disabled": false,
+      "i18n": Object {
+        "applyButtonText": "Apply",
+        "cancelButtonText": "Cancel",
+      },
+      "light": true,
+      "menuOffset": Object {
+        "left": 0,
+        "top": 0,
+      },
+      "onApply": null,
+      "onCancel": null,
+      "passive": false,
+      "renderIcon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
+      "tabIndex": 0,
+      "testId": "flyout-menu",
+      "tooltipClassName": "",
+      "tooltipId": "flyout-tooltip",
+      "triggerId": "flyout-trigger-id",
+    },
+    "propTypes": Object {
+      "buttonSize": Object {
+        "type": "string",
+      },
+      "children": Object {
+        "type": "node",
+      },
+      "customFooter": Object {
+        "type": "elementType",
+      },
+      "defaultOpen": Object {
+        "type": "bool",
+      },
+      "direction": Object {
+        "args": Array [
+          Array [
+            "bottom-start",
+            "bottom-end",
+            "top-start",
+            "top-end",
+            "left-start",
+            "left-end",
+            "right-start",
+            "right-end",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "i18n": Object {
+        "args": Array [
+          Object {
+            "applyButton": Object {
+              "type": "string",
+            },
+            "cancelButton": Object {
+              "type": "string",
+            },
+          },
+        ],
+        "type": "shape",
+      },
+      "iconDescription": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "light": Object {
+        "type": "bool",
+      },
+      "menuOffset": Object {
+        "args": Array [
+          Array [
+            Object {
+              "args": Array [
+                Object {
+                  "left": Object {
+                    "type": "number",
+                  },
+                  "top": Object {
+                    "type": "number",
+                  },
+                },
+              ],
+              "type": "shape",
+            },
+            Object {
+              "type": "func",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+      "onApply": Object {
+        "type": "func",
+      },
+      "onCancel": Object {
+        "type": "func",
+      },
+      "passive": Object {
+        "type": "bool",
+      },
+      "renderIcon": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "func",
+            },
+            Object {
+              "type": "object",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+      "tabIndex": Object {
+        "type": "number",
+      },
+      "testId": Object {
+        "type": "string",
+      },
+      "tooltipClassName": Object {
+        "type": "string",
+      },
+      "tooltipId": Object {
+        "type": "string",
+      },
+      "triggerId": Object {
+        "type": "string",
+      },
+    },
+  },
   "Accordion" => Object {
     "defaultProps": Object {
       "align": "end",


### PR DESCRIPTION
Continuation of #1306, #1266 

**Summary**

- Add the FlyoutMenu as an export.

**Change List (commits, features, bugs, etc)**

- add export, remove some unnecessary empty lines

**Acceptance Test (how to verify the PR)**

- status checks should pass, you can pull down and run `yarn build` to validate FlyoutMenu is included as an export. I see it generated locally 
![image](https://user-images.githubusercontent.com/3360588/89552761-36294600-d7d2-11ea-9375-f63437bfe30d.png)

