### PR TITLE
fix(modal): prop types support to node #1471

### DIFF
--- a/src/components/ComposedModal/ComposedModal.jsx
+++ b/src/components/ComposedModal/ComposedModal.jsx
@@ -24,8 +24,8 @@ export const ComposedModalPropTypes = {
    * helpText, additional information will stay at the top of the screen when scrolling dialog content
    */
   header: PropTypes.shape({
-    label: PropTypes.string,
-    title: PropTypes.string,
+    label: PropTypes.node,
+    title: PropTypes.node,
     helpText: PropTypes.node,
   }),
   /** ability to add translation string to close icon */

--- a/src/components/ComposedModal/ComposedModal.story.jsx
+++ b/src/components/ComposedModal/ComposedModal.story.jsx
@@ -111,6 +111,16 @@ REDUXFORM or REDUXDIALOG`,
       onClose={action('close')}
     />
   ))
+  .add('header custom nodes', () => (
+    <ComposedModal
+      header={{
+        label: <strong>Custom node label</strong>,
+        title: <strong>Custom node title</strong>,
+      }}
+      onClose={action('close')}
+      onSubmit={action('submit')}
+    />
+  ))
   .add('i18n', () => (
     <ComposedModal
       header={{

--- a/src/components/ComposedModal/__snapshots__/ComposedModal.story.storyshot
+++ b/src/components/ComposedModal/__snapshots__/ComposedModal.story.storyshot
@@ -527,6 +527,142 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Compo
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/ComposedModal header custom nodes 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--modal is-visible iot--composed-modal"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onClose={[Function]}
+      onKeyDown={[Function]}
+      onTransitionEnd={[Function]}
+      open={true}
+      role="presentation"
+    >
+      <span
+        className="bx--visually-hidden"
+        role="link"
+        tabIndex="0"
+      >
+        Focus sentinel
+      </span>
+      <div
+        className="bx--modal-container"
+        tabIndex={-1}
+      >
+        <div
+          className="bx--modal-header"
+        >
+          <p
+            className="bx--modal-header__label bx--type-delta"
+          >
+            <strong>
+              Custom node label
+            </strong>
+          </p>
+          <p
+            className="bx--modal-header__heading bx--type-beta"
+          >
+            <strong>
+              Custom node title
+            </strong>
+          </p>
+          <button
+            aria-label="Close"
+            className="bx--modal-close"
+            onClick={[Function]}
+            title="Close"
+            type="button"
+          >
+            <svg
+              aria-hidden={true}
+              className="bx--modal-close__icon"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className="bx--modal-footer iot--composed-modal-footer"
+          inputref={
+            Object {
+              "current": null,
+            }
+          }
+        >
+          <button
+            className="iot--btn bx--btn bx--btn--secondary"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            className="iot--btn bx--btn bx--btn--primary"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+      <span
+        className="bx--visually-hidden"
+        role="link"
+        tabIndex="0"
+      >
+        Focus sentinel
+      </span>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/ComposedModal i18n 1`] = `
 <div
   className="storybook-container"

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -177,10 +177,10 @@ Map {
               "type": "node",
             },
             "label": Object {
-              "type": "string",
+              "type": "node",
             },
             "title": Object {
-              "type": "string",
+              "type": "node",
             },
           },
         ],


### PR DESCRIPTION
Closes #1471 

**Summary**

- Carbon ComposedModal support node, we should also support, preventing console browser warning.
https://github.com/carbon-design-system/carbon-components-react/blob/master/src/components/ComposedModal/ComposedModal.js

**Change List (commits, features, bugs, etc)**

- PropTypes title and label support to node

**Acceptance Test (how to verify the PR)**

- We now support custom title/label
