### PR TITLE
feat(catalogcontent): allow description to be node

### DIFF
--- a/src/components/TileCatalog/CatalogContent.jsx
+++ b/src/components/TileCatalog/CatalogContent.jsx
@@ -9,7 +9,7 @@ const propTypes = {
   /** optional icon to visually describe catalog item */
   icon: PropTypes.node,
   title: PropTypes.string.isRequired,
-  description: PropTypes.string,
+  description: PropTypes.node,
 };
 
 const defaultProps = {

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -3330,7 +3330,7 @@ Map {
     },
     "propTypes": Object {
       "description": Object {
-        "type": "string",
+        "type": "node",
       },
       "icon": Object {
         "type": "node",


### PR DESCRIPTION
Closes #1475

**Summary**

- Adds the ability for the catalogcontent.description to be a node instead of just a string

**Change List (commits, features, bugs, etc)**

- Small change to accept node types for the catalogcontent

