### PR TITLE
fix(rowactionscell): isrowexpanded proptypes error being thrown for overflowmenu

### DIFF
--- a/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
+++ b/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
@@ -181,7 +181,6 @@ class RowActionsCell extends React.Component {
                     flipped={langDir === 'ltr'}
                     ariaLabel={overflowMenuAria}
                     onClick={event => event.stopPropagation()}
-                    isRowExpanded={isRowExpanded}
                     iconDescription={overflowMenuAria}
                     onOpen={this.handleOpen}
                     onClose={this.handleClose}

--- a/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
+++ b/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
@@ -20,8 +20,6 @@ const { TableCell } = DataTable;
 const { iotPrefix } = settings;
 
 const propTypes = {
-  /** Need to render different styles if expanded */
-  isRowExpanded: PropTypes.bool,
   /** Unique id for each row, passed back for each click */
   id: PropTypes.string.isRequired,
   /** Unique id for the table */
@@ -59,7 +57,6 @@ const propTypes = {
 };
 
 const defaultProps = {
-  isRowExpanded: false,
   actions: null,
   isRowActionRunning: false,
   rowActionsError: null,
@@ -100,7 +97,6 @@ class RowActionsCell extends React.Component {
 
   render() {
     const {
-      isRowExpanded,
       id,
       tableId,
       actions,

--- a/src/components/Table/TableBody/TableBodyRow/__snapshots__/TableBodyRow.story.storyshot
+++ b/src/components/Table/TableBody/TableBodyRow/__snapshots__/TableBodyRow.story.storyshot
@@ -646,7 +646,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     className="iot--row-actions-cell--overflow-menu bx--overflow-menu"
                     data-testid="tableId-rowId-row-actions-cell-overflow"
                     id="tableId-rowId-row-actions-cell-overflow"
-                    isRowExpanded={false}
                     onClick={[Function]}
                     onClose={[Function]}
                     onKeyDown={[Function]}


### PR DESCRIPTION
An extra (invalid) prop was being passed to the OverflowMenu if a rowActions had an overflow
![image](https://user-images.githubusercontent.com/6663002/89589227-d7cc8980-d80a-11ea-98ef-68b3a67f329d.png)


**Summary**

- Fixes a propType error that was being thrown because the isRowExpanded prop was being passed all the way through to the <button DOM element if a table row had overflow actions

**Change List (commits, features, bugs, etc)**

- fix(RowActionsCell): remove the isRowExpanded prop from the OverflowMenu

**Acceptance Test (how to verify the PR)**

- Verify that for table rows with overflow that no proptype errors are shown
