### PR TITLE
feat(CardRangePicker): allow for custom time range options

### DIFF
--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -211,6 +211,7 @@ const Card = props => {
     id,
     tooltip,
     timeRange,
+    timeRangeOptions,
     onCardAction,
     availableActions,
     breakpoint,
@@ -293,6 +294,7 @@ const Card = props => {
                 isEditable={isEditable}
                 isExpanded={isExpanded}
                 timeRange={timeRange}
+                timeRangeOptions={timeRangeOptions}
                 onCardAction={cachedOnCardAction}
               />
             ) : null;

--- a/src/components/Card/Card.story.jsx
+++ b/src/components/Card/Card.story.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { text, select, boolean } from '@storybook/addon-knobs';
+import { text, select, boolean, object } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
 import { CARD_SIZES } from '../../constants/LayoutConstants';
@@ -150,7 +150,7 @@ storiesOf('Watson IoT/Card', module)
           availableActions={{
             range: true,
           }}
-          timeRangeOptions={{
+          timeRangeOptions={object('timeRangeOptions', {
             last8Hours: 'Last 8 Hours',
             last4Hours: 'Last 4 Hours',
             last2Hours: 'Last 2 Hours',
@@ -159,7 +159,7 @@ storiesOf('Watson IoT/Card', module)
             this4Hours: 'This 4 Hours',
             this2Hours: 'This 2 Hours',
             thisHour: 'This Hour',
-          }}
+          })}
         />
       </div>
     );

--- a/src/components/Card/Card.story.jsx
+++ b/src/components/Card/Card.story.jsx
@@ -69,7 +69,6 @@ storiesOf('Watson IoT/Card', module)
       </div>
     );
   })
-
   .add('basic with render prop', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
     return (
@@ -129,6 +128,37 @@ storiesOf('Watson IoT/Card', module)
           onCardAction={action('onCardAction')}
           availableActions={{
             range: true,
+          }}
+        />
+      </div>
+    );
+  })
+  .add('with custom range selector', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
+    return (
+      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+        <Card
+          title={text('title', 'Card Title')}
+          id="facilitycard-with-loading"
+          size={size}
+          isLoading={boolean('isLoading', false)}
+          isEmpty={boolean('isEmpty', false)}
+          isEditable={boolean('isEditable', false)}
+          isExpanded={boolean('isExpanded', false)}
+          breakpoint="lg"
+          onCardAction={action('onCardAction')}
+          availableActions={{
+            range: true,
+          }}
+          timeRangeOptions={{
+            last8Hours: 'Last 8 Hours',
+            last4Hours: 'Last 4 Hours',
+            last2Hours: 'Last 2 Hours',
+            lastHour: 'Last Hour',
+            this8Hours: 'This 8 Hours',
+            this4Hours: 'This 4 Hours',
+            this2Hours: 'This 2 Hours',
+            thisHour: 'This Hour',
           }}
         />
       </div>

--- a/src/components/Card/CardRangePicker.jsx
+++ b/src/components/Card/CardRangePicker.jsx
@@ -10,19 +10,10 @@ import { settings } from '../../constants/Settings';
 const { iotPrefix } = settings;
 
 export const CardRangePickerPropTypes = {
-  /** Optional range to pass at the card level */
-  timeRange: PropTypes.oneOf([
-    'last24Hours',
-    'last7Days',
-    'lastMonth',
-    'lastQuarter',
-    'lastYear',
-    'thisWeek',
-    'thisMonth',
-    'thisQuarter',
-    'thisYear',
-    '',
-  ]),
+  /** Optional selected range to pass at the card level */
+  timeRange: PropTypes.string,
+  /** Generates the available time range selection options */
+  timeRangeOptions: PropTypes.objectOf(PropTypes.string).isRequired,
   /** callback to handle interactions with the range picker */
   onCardAction: PropTypes.func.isRequired,
   /** set of internationalized labels */
@@ -37,20 +28,26 @@ const defaultProps = {
   cardWidth: undefined,
 };
 
-const CardRangePicker = ({ i18n, timeRange: timeRangeProp, onCardAction, cardWidth }) => {
+const CardRangePicker = ({
+  i18n,
+  timeRange: timeRangeProp,
+  timeRangeOptions,
+  onCardAction,
+  cardWidth,
+}) => {
   const [timeRange, setTimeRange] = useState(timeRangeProp);
   // maps the timebox internal label to a translated string
-  const timeBoxLabels = {
-    last24Hours: i18n.last24HoursLabel,
-    last7Days: i18n.last7DaysLabel,
-    lastMonth: i18n.lastMonthLabel,
-    lastQuarter: i18n.lastQuarterLabel,
-    lastYear: i18n.lastYearLabel,
-    thisWeek: i18n.thisWeekLabel,
-    thisMonth: i18n.thisMonthLabel,
-    thisQuarter: i18n.thisQuarterLabel,
-    thisYear: i18n.thisYearLabel,
-  };
+  // const timeBoxLabels = {
+  //   last24Hours: i18n.last24HoursLabel,
+  //   last7Days: i18n.last7DaysLabel,
+  //   lastMonth: i18n.lastMonthLabel,
+  //   lastQuarter: i18n.lastQuarterLabel,
+  //   lastYear: i18n.lastYearLabel,
+  //   thisWeek: i18n.thisWeekLabel,
+  //   thisMonth: i18n.thisMonthLabel,
+  //   thisQuarter: i18n.thisQuarterLabel,
+  //   thisYear: i18n.thisYearLabel,
+  // };
 
   const handleTimeRange = useCallback(
     value => {
@@ -65,7 +62,7 @@ const CardRangePicker = ({ i18n, timeRange: timeRangeProp, onCardAction, cardWid
       <ToolbarItem>
         {cardWidth > 400 ? (
           <div id="timeRange" className={`${iotPrefix}--card--toolbar-timerange-label`}>
-            {timeBoxLabels[timeRange] || i18n.defaultLabel}
+            {timeRangeOptions[timeRange] || i18n.defaultLabel}
           </div>
         ) : null}
 
@@ -87,27 +84,27 @@ const CardRangePicker = ({ i18n, timeRange: timeRangeProp, onCardAction, cardWid
             })}
             primaryFocus
           />
-          {Object.keys(timeBoxLabels)
+          {Object.keys(timeRangeOptions)
             .filter(i => i.includes('last'))
             .map((i, index) => (
               <OverflowMenuItem
                 key={i}
                 hasDivider={index === 0}
                 onClick={() => handleTimeRange(i)}
-                itemText={timeBoxLabels[i]}
+                itemText={timeRangeOptions[i]}
                 className={classnames({
                   [`${iotPrefix}--card--overflow-menuitem-active`]: timeRange === i,
                 })}
               />
             ))}
-          {Object.keys(timeBoxLabels)
+          {Object.keys(timeRangeOptions)
             .filter(i => i.includes('this'))
             .map((i, index) => (
               <OverflowMenuItem
                 key={i}
                 hasDivider={index === 0}
                 onClick={() => handleTimeRange(i)}
-                itemText={timeBoxLabels[i]}
+                itemText={timeRangeOptions[i]}
                 className={classnames({
                   [`${iotPrefix}--card--overflow-menuitem-active`]: timeRange === i,
                 })}

--- a/src/components/Card/CardRangePicker.jsx
+++ b/src/components/Card/CardRangePicker.jsx
@@ -5,6 +5,7 @@ import { ToolbarItem, OverflowMenu, OverflowMenuItem } from 'carbon-components-r
 import classnames from 'classnames';
 import isNil from 'lodash/isNil';
 
+import { TimeRangeOptionsPropTypes } from '../../constants/CardPropTypes';
 import { settings } from '../../constants/Settings';
 
 const { iotPrefix } = settings;
@@ -12,8 +13,10 @@ const { iotPrefix } = settings;
 export const CardRangePickerPropTypes = {
   /** Optional selected range to pass at the card level */
   timeRange: PropTypes.string,
-  /** Generates the available time range selection options */
-  timeRangeOptions: PropTypes.objectOf(PropTypes.string).isRequired,
+  /** Generates the available time range selection options. Each option should include 'this' or 'last'.
+   * i.e. { thisWeek: 'This week', lastWeek: 'Last week'}
+   */
+  timeRangeOptions: TimeRangeOptionsPropTypes, // eslint-disable-line react/require-default-props
   /** callback to handle interactions with the range picker */
   onCardAction: PropTypes.func.isRequired,
   /** set of internationalized labels */

--- a/src/components/Card/CardRangePicker.jsx
+++ b/src/components/Card/CardRangePicker.jsx
@@ -36,18 +36,6 @@ const CardRangePicker = ({
   cardWidth,
 }) => {
   const [timeRange, setTimeRange] = useState(timeRangeProp);
-  // maps the timebox internal label to a translated string
-  // const timeBoxLabels = {
-  //   last24Hours: i18n.last24HoursLabel,
-  //   last7Days: i18n.last7DaysLabel,
-  //   lastMonth: i18n.lastMonthLabel,
-  //   lastQuarter: i18n.lastQuarterLabel,
-  //   lastYear: i18n.lastYearLabel,
-  //   thisWeek: i18n.thisWeekLabel,
-  //   thisMonth: i18n.thisMonthLabel,
-  //   thisQuarter: i18n.thisQuarterLabel,
-  //   thisYear: i18n.thisYearLabel,
-  // };
 
   const handleTimeRange = useCallback(
     value => {

--- a/src/components/Card/CardRangePicker.test.jsx
+++ b/src/components/Card/CardRangePicker.test.jsx
@@ -16,6 +16,18 @@ describe('CardRangePicker', () => {
   const last24HoursLabel = 'Last 24 Hours';
   const thisWeekLabel = 'This week';
 
+  const defaultTimeRangeOptions = {
+    last24Hours: last24HoursLabel,
+    last7Days: 'Last 7 days',
+    lastMonth: 'Last month',
+    lastQuarter: 'Last quarter',
+    lastYear: 'Last year',
+    thisWeek: thisWeekLabel,
+    thisMonth: 'This month',
+    thisQuarter: 'This quarter',
+    thisYear: 'This year',
+  };
+
   it('card editable actions', async () => {
     render(
       <CardRangePicker
@@ -25,6 +37,7 @@ describe('CardRangePicker', () => {
           last24HoursLabel,
           thisWeekLabel,
         }}
+        timeRangeOptions={defaultTimeRangeOptions}
         onCardAction={mockOnCardAction}
       />
     );
@@ -64,6 +77,7 @@ describe('CardRangePicker', () => {
         onCardAction={mockOnCardAction}
         cardWidth={500}
         timeRange="thisWeek"
+        timeRangeOptions={defaultTimeRangeOptions}
       />
     );
     expect(wrapper.find(`.${iotPrefix}--card--toolbar-timerange-label`)).toHaveLength(1);
@@ -76,8 +90,46 @@ describe('CardRangePicker', () => {
         onCardAction={mockOnCardAction}
         cardWidth={229}
         timeRange="thisWeek"
+        timeRangeOptions={defaultTimeRangeOptions}
       />
     );
     expect(wrapper2.find(`.${iotPrefix}--card--toolbar-timerange-label`)).toHaveLength(0);
+  });
+
+  it('should show custom time range options', async () => {
+    const last2hoursLabel = 'Last 2 Hours';
+    const customTimeRangeOptions = {
+      last8Hours: 'Last 8 Hours',
+      last4Hours: 'Last 4 Hours',
+      last2Hours: last2hoursLabel,
+      lastHour: 'Last Hour',
+      this8Hours: 'This 8 Hours',
+      this4Hours: 'This 4 Hours',
+      this2Hours: 'This 2 Hours',
+      thisHour: 'This Hour',
+    };
+
+    render(
+      <CardRangePicker
+        i18n={{
+          selectTimeRangeLabel,
+          defaultLabel,
+          last24HoursLabel,
+          thisWeekLabel,
+        }}
+        timeRangeOptions={customTimeRangeOptions}
+        onCardAction={mockOnCardAction}
+      />
+    );
+
+    // first click the CardRangePicker
+    fireEvent.click(screen.getAllByTitle(selectTimeRangeLabel)[0]);
+    // then find the options
+    const last2hours = await screen.findByText(last2hoursLabel);
+    fireEvent.click(last2hours);
+    expect(mockOnCardAction).toHaveBeenCalledWith(CARD_ACTIONS.CHANGE_TIME_RANGE, {
+      range: 'last2Hours',
+    });
+    mockOnCardAction.mockClear();
   });
 });

--- a/src/components/Card/CardToolbar.jsx
+++ b/src/components/Card/CardToolbar.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import omit from 'lodash/omit';
 import { Close16, Popup16 } from '@carbon/icons-react';
@@ -6,6 +6,7 @@ import { OverflowMenu, OverflowMenuItem, Button } from 'carbon-components-react'
 import classnames from 'classnames';
 
 import { settings } from '../../constants/Settings';
+import { TimeRangeOptionsPropTypes } from '../../constants/CardPropTypes';
 import { CARD_ACTIONS } from '../../constants/LayoutConstants';
 
 import CardRangePicker, { CardRangePickerPropTypes } from './CardRangePicker';
@@ -35,15 +36,19 @@ const propTypes = {
   isExpanded: PropTypes.bool,
   className: PropTypes.string,
   ...omit(CardRangePickerPropTypes, 'onClose'),
-  /** Generates the available time range selection options */
-  timeRangeOptions: PropTypes.objectOf(PropTypes.string),
+  /** Generates the available time range selection options. Each option should include 'this' or 'last'.
+   * i.e. { thisWeek: 'This week', lastWeek: 'Last week'}
+   */
+  timeRangeOptions: TimeRangeOptionsPropTypes, // eslint-disable-line react/require-default-props
 };
+
 const defaultProps = {
   isEditable: false,
   isExpanded: false,
   className: null,
   timeRangeOptions: null,
 };
+
 const CardToolbar = ({
   i18n,
   width,
@@ -51,23 +56,39 @@ const CardToolbar = ({
   isExpanded,
   availableActions,
   timeRange,
-  timeRangeOptions,
+  timeRangeOptions: timeRangeOptionsProp,
   onCardAction,
   className,
 }) => {
   // maps the timebox internal label to a translated string
   // Need the default here in case that the CardToolbar is used by multiple different components
-  const timeBoxLabels = {
-    last24Hours: i18n.last24HoursLabel,
-    last7Days: i18n.last7DaysLabel,
-    lastMonth: i18n.lastMonthLabel,
-    lastQuarter: i18n.lastQuarterLabel,
-    lastYear: i18n.lastYearLabel,
-    thisWeek: i18n.thisWeekLabel,
-    thisMonth: i18n.thisMonthLabel,
-    thisQuarter: i18n.thisQuarterLabel,
-    thisYear: i18n.thisYearLabel,
-  };
+  // Also needs to reassign itself if i18n changes
+  const timeRangeOptions = useMemo(
+    () =>
+      timeRangeOptionsProp || {
+        last24Hours: i18n.last24HoursLabel,
+        last7Days: i18n.last7DaysLabel,
+        lastMonth: i18n.lastMonthLabel,
+        lastQuarter: i18n.lastQuarterLabel,
+        lastYear: i18n.lastYearLabel,
+        thisWeek: i18n.thisWeekLabel,
+        thisMonth: i18n.thisMonthLabel,
+        thisQuarter: i18n.thisQuarterLabel,
+        thisYear: i18n.thisYearLabel,
+      },
+    [
+      i18n.last24HoursLabel,
+      i18n.last7DaysLabel,
+      i18n.lastMonthLabel,
+      i18n.lastQuarterLabel,
+      i18n.lastYearLabel,
+      i18n.thisMonthLabel,
+      i18n.thisQuarterLabel,
+      i18n.thisWeekLabel,
+      i18n.thisYearLabel,
+      timeRangeOptionsProp,
+    ]
+  );
 
   return isEditable ? (
     <div className={classnames(className, `${iotPrefix}--card--toolbar`)}>
@@ -109,7 +130,7 @@ const CardToolbar = ({
           width={width}
           i18n={i18n}
           timeRange={timeRange}
-          timeRangeOptions={timeRangeOptions || timeBoxLabels}
+          timeRangeOptions={timeRangeOptions}
           onCardAction={onCardAction}
           cardWidth={width}
         />

--- a/src/components/Card/CardToolbar.jsx
+++ b/src/components/Card/CardToolbar.jsx
@@ -35,11 +35,14 @@ const propTypes = {
   isExpanded: PropTypes.bool,
   className: PropTypes.string,
   ...omit(CardRangePickerPropTypes, 'onClose'),
+  /** Generates the available time range selection options */
+  timeRangeOptions: PropTypes.objectOf(PropTypes.string),
 };
 const defaultProps = {
   isEditable: false,
   isExpanded: false,
   className: null,
+  timeRangeOptions: null,
 };
 const CardToolbar = ({
   i18n,
@@ -48,9 +51,24 @@ const CardToolbar = ({
   isExpanded,
   availableActions,
   timeRange,
+  timeRangeOptions,
   onCardAction,
   className,
 }) => {
+  // maps the timebox internal label to a translated string
+  // Need the default here in case that the CardToolbar is used by multiple different components
+  const timeBoxLabels = {
+    last24Hours: i18n.last24HoursLabel,
+    last7Days: i18n.last7DaysLabel,
+    lastMonth: i18n.lastMonthLabel,
+    lastQuarter: i18n.lastQuarterLabel,
+    lastYear: i18n.lastYearLabel,
+    thisWeek: i18n.thisWeekLabel,
+    thisMonth: i18n.thisMonthLabel,
+    thisQuarter: i18n.thisQuarterLabel,
+    thisYear: i18n.thisYearLabel,
+  };
+
   return isEditable ? (
     <div className={classnames(className, `${iotPrefix}--card--toolbar`)}>
       {(availableActions.edit || availableActions.clone || availableActions.delete) && (
@@ -91,6 +109,7 @@ const CardToolbar = ({
           width={width}
           i18n={i18n}
           timeRange={timeRange}
+          timeRangeOptions={timeRangeOptions || timeBoxLabels}
           onCardAction={onCardAction}
           cardWidth={width}
         />

--- a/src/components/Card/__snapshots__/Card.story.storyshot
+++ b/src/components/Card/__snapshots__/Card.story.storyshot
@@ -1865,6 +1865,135 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Card 
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Card with custom range selector 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "252px",
+        }
+      }
+    >
+      <div
+        className="iot--card iot--card--wrapper"
+        data-testid="Card"
+        id="facilitycard-with-loading"
+        role="presentation"
+        style={
+          Object {
+            "--card-default-height": "304px",
+          }
+        }
+      >
+        <div
+          className="iot--card--header"
+        >
+          <span
+            className="iot--card--title"
+            title="Card Title"
+          >
+            <div
+              className="iot--card--title--text"
+            >
+              Card Title
+            </div>
+          </span>
+          <div
+            className="iot--card--toolbar"
+          >
+            <div
+              className="iot--card--toolbar-date-range-wrapper"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                aria-label="Menu"
+                className="iot--card--toolbar-date-range-action bx--overflow-menu"
+                onClick={[Function]}
+                onClose={[Function]}
+                onKeyDown={[Function]}
+                open={false}
+                tabIndex={0}
+                title="Select time range"
+              >
+                <svg
+                  aria-label="Select time range"
+                  className="bx--overflow-menu__icon"
+                  focusable="false"
+                  height={16}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
+                  />
+                  <path
+                    d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                  />
+                  <path
+                    d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
+                  />
+                  <title>
+                    Select time range
+                  </title>
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--card--content"
+          style={
+            Object {
+              "--card-content-height": "256px",
+            }
+          }
+        />
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Card with ellipsed title tooltip & external tooltip 1`] = `
 <div
   className="storybook-container"

--- a/src/constants/CardPropTypes.js
+++ b/src/constants/CardPropTypes.js
@@ -395,19 +395,10 @@ export const CardPropTypes = {
   size: PropTypes.oneOf(Object.values(LEGACY_CARD_SIZES)),
   layout: PropTypes.oneOf(Object.values(CARD_LAYOUTS)),
   breakpoint: PropTypes.oneOf(Object.values(DASHBOARD_SIZES)),
-  /** Optional range to pass at the card level */
-  timeRange: PropTypes.oneOf([
-    'last24Hours',
-    'last7Days',
-    'lastMonth',
-    'lastQuarter',
-    'lastYear',
-    'thisWeek',
-    'thisMonth',
-    'thisQuarter',
-    'thisYear',
-    '',
-  ]),
+  /** Optional selected range to pass at the card level */
+  timeRange: PropTypes.string,
+  /** Generates the available time range selection options */
+  timeRangeOptions: PropTypes.objectOf(PropTypes.string),
 
   availableActions: PropTypes.shape({
     edit: PropTypes.bool,

--- a/src/constants/CardPropTypes.js
+++ b/src/constants/CardPropTypes.js
@@ -377,6 +377,26 @@ export const CardSizesToDimensionsPropTypes = PropTypes.shape({
   XLARGE: CardDimensionsPropTypes,
 });
 
+export const TimeRangeOptionsPropTypes = (props, propName, componentName) => {
+  let error;
+  // if the
+  if (props[propName]) {
+    const timeRangeKeys = Object.keys(props[propName]);
+    // only validate the options if they are populated
+    if (timeRangeKeys.length > 0) {
+      // throw error if timeRangeOptions does not include 'this' or 'last'
+      const isError = timeRangeKeys.some(key => !key.includes('this') && !key.includes('last'));
+
+      if (isError) {
+        error = new Error(
+          `\`${componentName}\` prop \`${propName}\` key's should include \`this\` or \`last\` i.e. \`{ thisWeek: 'This week', lastWeek: 'Last week'}\``
+        );
+      }
+    }
+  }
+  return error;
+};
+
 export const CardPropTypes = {
   title: PropTypes.string,
   id: PropTypes.string,
@@ -397,9 +417,10 @@ export const CardPropTypes = {
   breakpoint: PropTypes.oneOf(Object.values(DASHBOARD_SIZES)),
   /** Optional selected range to pass at the card level */
   timeRange: PropTypes.string,
-  /** Generates the available time range selection options */
-  timeRangeOptions: PropTypes.objectOf(PropTypes.string),
-
+  /** Generates the available time range selection options. Each option should include 'this' or 'last'.
+   * i.e. { thisWeek: 'This week', lastWeek: 'Last week'}
+   */
+  timeRangeOptions: TimeRangeOptionsPropTypes,
   availableActions: PropTypes.shape({
     edit: PropTypes.bool,
     clone: PropTypes.bool,

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -4608,14 +4608,7 @@ Map {
       "timeRange": Object {
         "type": "string",
       },
-      "timeRangeOptions": Object {
-        "args": Array [
-          Object {
-            "type": "string",
-          },
-        ],
-        "type": "objectOf",
-      },
+      "timeRangeOptions": [Function],
       "title": Object {
         "type": "string",
       },
@@ -7779,14 +7772,7 @@ Map {
       "timeRange": Object {
         "type": "string",
       },
-      "timeRangeOptions": Object {
-        "args": Array [
-          Object {
-            "type": "string",
-          },
-        ],
-        "type": "objectOf",
-      },
+      "timeRangeOptions": [Function],
       "title": Object {
         "type": "string",
       },
@@ -8657,14 +8643,7 @@ Map {
       "timeRange": Object {
         "type": "string",
       },
-      "timeRangeOptions": Object {
-        "args": Array [
-          Object {
-            "type": "string",
-          },
-        ],
-        "type": "objectOf",
-      },
+      "timeRangeOptions": [Function],
       "title": Object {
         "type": "string",
       },
@@ -9503,14 +9482,7 @@ Map {
       "timeRange": Object {
         "type": "string",
       },
-      "timeRangeOptions": Object {
-        "args": Array [
-          Object {
-            "type": "string",
-          },
-        ],
-        "type": "objectOf",
-      },
+      "timeRangeOptions": [Function],
       "title": Object {
         "type": "string",
       },
@@ -10253,14 +10225,7 @@ Map {
       "timeRange": Object {
         "type": "string",
       },
-      "timeRangeOptions": Object {
-        "args": Array [
-          Object {
-            "type": "string",
-          },
-        ],
-        "type": "objectOf",
-      },
+      "timeRangeOptions": [Function],
       "title": Object {
         "type": "string",
       },
@@ -11105,14 +11070,7 @@ Map {
       "timeRange": Object {
         "type": "string",
       },
-      "timeRangeOptions": Object {
-        "args": Array [
-          Object {
-            "type": "string",
-          },
-        ],
-        "type": "objectOf",
-      },
+      "timeRangeOptions": [Function],
       "title": Object {
         "type": "string",
       },
@@ -12017,14 +11975,7 @@ Map {
       "timeRange": Object {
         "type": "string",
       },
-      "timeRangeOptions": Object {
-        "args": Array [
-          Object {
-            "type": "string",
-          },
-        ],
-        "type": "objectOf",
-      },
+      "timeRangeOptions": [Function],
       "title": Object {
         "type": "string",
       },
@@ -12819,14 +12770,7 @@ Map {
       "timeRange": Object {
         "type": "string",
       },
-      "timeRangeOptions": Object {
-        "args": Array [
-          Object {
-            "type": "string",
-          },
-        ],
-        "type": "objectOf",
-      },
+      "timeRangeOptions": [Function],
       "title": Object {
         "type": "string",
       },

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -4606,21 +4606,15 @@ Map {
         "type": "string",
       },
       "timeRange": Object {
+        "type": "string",
+      },
+      "timeRangeOptions": Object {
         "args": Array [
-          Array [
-            "last24Hours",
-            "last7Days",
-            "lastMonth",
-            "lastQuarter",
-            "lastYear",
-            "thisWeek",
-            "thisMonth",
-            "thisQuarter",
-            "thisYear",
-            "",
-          ],
+          Object {
+            "type": "string",
+          },
         ],
-        "type": "oneOf",
+        "type": "objectOf",
       },
       "title": Object {
         "type": "string",
@@ -7783,21 +7777,15 @@ Map {
         "type": "string",
       },
       "timeRange": Object {
+        "type": "string",
+      },
+      "timeRangeOptions": Object {
         "args": Array [
-          Array [
-            "last24Hours",
-            "last7Days",
-            "lastMonth",
-            "lastQuarter",
-            "lastYear",
-            "thisWeek",
-            "thisMonth",
-            "thisQuarter",
-            "thisYear",
-            "",
-          ],
+          Object {
+            "type": "string",
+          },
         ],
-        "type": "oneOf",
+        "type": "objectOf",
       },
       "title": Object {
         "type": "string",
@@ -8667,21 +8655,15 @@ Map {
         "type": "string",
       },
       "timeRange": Object {
+        "type": "string",
+      },
+      "timeRangeOptions": Object {
         "args": Array [
-          Array [
-            "last24Hours",
-            "last7Days",
-            "lastMonth",
-            "lastQuarter",
-            "lastYear",
-            "thisWeek",
-            "thisMonth",
-            "thisQuarter",
-            "thisYear",
-            "",
-          ],
+          Object {
+            "type": "string",
+          },
         ],
-        "type": "oneOf",
+        "type": "objectOf",
       },
       "title": Object {
         "type": "string",
@@ -9519,21 +9501,15 @@ Map {
         "type": "string",
       },
       "timeRange": Object {
+        "type": "string",
+      },
+      "timeRangeOptions": Object {
         "args": Array [
-          Array [
-            "last24Hours",
-            "last7Days",
-            "lastMonth",
-            "lastQuarter",
-            "lastYear",
-            "thisWeek",
-            "thisMonth",
-            "thisQuarter",
-            "thisYear",
-            "",
-          ],
+          Object {
+            "type": "string",
+          },
         ],
-        "type": "oneOf",
+        "type": "objectOf",
       },
       "title": Object {
         "type": "string",
@@ -10275,21 +10251,15 @@ Map {
         "type": "string",
       },
       "timeRange": Object {
+        "type": "string",
+      },
+      "timeRangeOptions": Object {
         "args": Array [
-          Array [
-            "last24Hours",
-            "last7Days",
-            "lastMonth",
-            "lastQuarter",
-            "lastYear",
-            "thisWeek",
-            "thisMonth",
-            "thisQuarter",
-            "thisYear",
-            "",
-          ],
+          Object {
+            "type": "string",
+          },
         ],
-        "type": "oneOf",
+        "type": "objectOf",
       },
       "title": Object {
         "type": "string",
@@ -11133,21 +11103,15 @@ Map {
         "type": "string",
       },
       "timeRange": Object {
+        "type": "string",
+      },
+      "timeRangeOptions": Object {
         "args": Array [
-          Array [
-            "last24Hours",
-            "last7Days",
-            "lastMonth",
-            "lastQuarter",
-            "lastYear",
-            "thisWeek",
-            "thisMonth",
-            "thisQuarter",
-            "thisYear",
-            "",
-          ],
+          Object {
+            "type": "string",
+          },
         ],
-        "type": "oneOf",
+        "type": "objectOf",
       },
       "title": Object {
         "type": "string",
@@ -12051,21 +12015,15 @@ Map {
         "type": "string",
       },
       "timeRange": Object {
+        "type": "string",
+      },
+      "timeRangeOptions": Object {
         "args": Array [
-          Array [
-            "last24Hours",
-            "last7Days",
-            "lastMonth",
-            "lastQuarter",
-            "lastYear",
-            "thisWeek",
-            "thisMonth",
-            "thisQuarter",
-            "thisYear",
-            "",
-          ],
+          Object {
+            "type": "string",
+          },
         ],
-        "type": "oneOf",
+        "type": "objectOf",
       },
       "title": Object {
         "type": "string",
@@ -12859,21 +12817,15 @@ Map {
         "type": "string",
       },
       "timeRange": Object {
+        "type": "string",
+      },
+      "timeRangeOptions": Object {
         "args": Array [
-          Array [
-            "last24Hours",
-            "last7Days",
-            "lastMonth",
-            "lastQuarter",
-            "lastYear",
-            "thisWeek",
-            "thisMonth",
-            "thisQuarter",
-            "thisYear",
-            "",
-          ],
+          Object {
+            "type": "string",
+          },
         ],
-        "type": "oneOf",
+        "type": "objectOf",
       },
       "title": Object {
         "type": "string",


### PR DESCRIPTION
Closes #1485 

**Summary**

- Allows the CardRangePicker to receive custom `timeRangeOptions`

**Change List (commits, features, bugs, etc)**

- Added a new prop `timeRangeOptions` that is identical to the current implementation of the default options to Card, CardToolbar, and CardRangePicker (so that it can be passed all the way through)
- Moved the current default options to CardToolbar so they could get their default i18n labels and so that other components using CardToolbar can receive the same default options
- Updated tests to use the new prop
- Added a test to ensure the custom option does display
- Added a story for custom `timeRangeOptions`

**Acceptance Test (how to verify the PR)**

- Go to Card / custom range selector story and see that the options are customizable with the knob