### PR TITLE
fix(hierarchy-list): add prop for hierarchy menus

### DIFF
--- a/src/components/List/HierarchyList/HierarchyList.jsx
+++ b/src/components/List/HierarchyList/HierarchyList.jsx
@@ -264,39 +264,41 @@ const HierarchyList = ({
   const delayedSearch = useCallback(debounce(textInput => handleSearch(textInput), 150), [items]);
 
   return (
-    <List
-      title={title}
-      buttons={buttons}
-      search={
-        hasSearch
-          ? {
-              value: searchValue,
-              onChange: evt => {
-                setSearchValue(evt.target.value);
-                delayedSearch(evt.target.value);
-              },
-            }
-          : null
-      }
-      items={pageSize != null ? itemsToShow : filteredItems}
-      expandedIds={expandedIds}
-      toggleExpansion={id => {
-        if (expandedIds.filter(rowId => rowId === id).length > 0) {
-          // remove id from array
-          setExpandedIds(expandedIds.filter(rowId => rowId !== id));
-        } else {
-          setExpandedIds(expandedIds.concat([id]));
+    <div data-floating-menu-container style={{ position: 'relative' }}>
+      <List
+        title={title}
+        buttons={buttons}
+        search={
+          hasSearch
+            ? {
+                value: searchValue,
+                onChange: evt => {
+                  setSearchValue(evt.target.value);
+                  delayedSearch(evt.target.value);
+                },
+              }
+            : null
         }
-      }}
-      i18n={i18n}
-      pagination={hasPagination ? pagination : null}
-      isFullHeight={isFullHeight}
-      isLoading={isLoading}
-      selectedId={selectedId}
-      selectedIds={selectedIds}
-      handleSelect={handleSelect}
-      ref={selectedItemRef}
-    />
+        items={pageSize != null ? itemsToShow : filteredItems}
+        expandedIds={expandedIds}
+        toggleExpansion={id => {
+          if (expandedIds.filter(rowId => rowId === id).length > 0) {
+            // remove id from array
+            setExpandedIds(expandedIds.filter(rowId => rowId !== id));
+          } else {
+            setExpandedIds(expandedIds.concat([id]));
+          }
+        }}
+        i18n={i18n}
+        pagination={hasPagination ? pagination : null}
+        isFullHeight={isFullHeight}
+        isLoading={isLoading}
+        selectedId={selectedId}
+        selectedIds={selectedIds}
+        handleSelect={handleSelect}
+        ref={selectedItemRef}
+      />
+    </div>
   );
 };
 

--- a/src/components/List/HierarchyList/HierarchyList.jsx
+++ b/src/components/List/HierarchyList/HierarchyList.jsx
@@ -264,41 +264,39 @@ const HierarchyList = ({
   const delayedSearch = useCallback(debounce(textInput => handleSearch(textInput), 150), [items]);
 
   return (
-    <div data-floating-menu-container style={{ position: 'relative' }}>
-      <List
-        title={title}
-        buttons={buttons}
-        search={
-          hasSearch
-            ? {
-                value: searchValue,
-                onChange: evt => {
-                  setSearchValue(evt.target.value);
-                  delayedSearch(evt.target.value);
-                },
-              }
-            : null
+    <List
+      title={title}
+      buttons={buttons}
+      search={
+        hasSearch
+          ? {
+              value: searchValue,
+              onChange: evt => {
+                setSearchValue(evt.target.value);
+                delayedSearch(evt.target.value);
+              },
+            }
+          : null
+      }
+      items={pageSize != null ? itemsToShow : filteredItems}
+      expandedIds={expandedIds}
+      toggleExpansion={id => {
+        if (expandedIds.filter(rowId => rowId === id).length > 0) {
+          // remove id from array
+          setExpandedIds(expandedIds.filter(rowId => rowId !== id));
+        } else {
+          setExpandedIds(expandedIds.concat([id]));
         }
-        items={pageSize != null ? itemsToShow : filteredItems}
-        expandedIds={expandedIds}
-        toggleExpansion={id => {
-          if (expandedIds.filter(rowId => rowId === id).length > 0) {
-            // remove id from array
-            setExpandedIds(expandedIds.filter(rowId => rowId !== id));
-          } else {
-            setExpandedIds(expandedIds.concat([id]));
-          }
-        }}
-        i18n={i18n}
-        pagination={hasPagination ? pagination : null}
-        isFullHeight={isFullHeight}
-        isLoading={isLoading}
-        selectedId={selectedId}
-        selectedIds={selectedIds}
-        handleSelect={handleSelect}
-        ref={selectedItemRef}
-      />
-    </div>
+      }}
+      i18n={i18n}
+      pagination={hasPagination ? pagination : null}
+      isFullHeight={isFullHeight}
+      isLoading={isLoading}
+      selectedId={selectedId}
+      selectedIds={selectedIds}
+      handleSelect={handleSelect}
+      ref={selectedItemRef}
+    />
   );
 };
 

--- a/src/components/List/HierarchyList/HierarchyList.story.jsx
+++ b/src/components/List/HierarchyList/HierarchyList.story.jsx
@@ -108,7 +108,7 @@ storiesOf('Watson IoT Experimental/HierarchyList', module)
     </div>
   ))
   .add('With OverflowMenu', () => (
-    <div style={{ width: 400, height: 400, overflow: 'scroll' }}>
+    <div style={{ width: 400, height: 400 }}>
       <HierarchyList
         title={text('Title', 'MLB Expanded List')}
         items={[

--- a/src/components/List/HierarchyList/HierarchyList.story.jsx
+++ b/src/components/List/HierarchyList/HierarchyList.story.jsx
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { text, select, boolean } from '@storybook/addon-knobs';
 import { Add16 } from '@carbon/icons-react';
+import { OverflowMenu, OverflowMenuItem } from 'carbon-components-react';
 
 import { Button } from '../../..';
 import { sampleHierarchy } from '../List.story';
@@ -95,6 +96,74 @@ storiesOf('Watson IoT Experimental/HierarchyList', module)
               id: `${team}_${player}`,
               content: {
                 value: player,
+              },
+              isSelectable: true,
+            })),
+          })),
+        ]}
+        hasSearch
+        pageSize={select('Page Size', ['sm', 'lg', 'xl'], 'lg')}
+        isLoading={boolean('isLoading', false)}
+      />
+    </div>
+  ))
+  .add('With OverflowMenu', () => (
+    <div style={{ width: 400, height: 400, overflow: 'scroll' }}>
+      <HierarchyList
+        title={text('Title', 'MLB Expanded List')}
+        items={[
+          ...Object.keys(sampleHierarchy.MLB['American League']).map(team => ({
+            id: team,
+            isCategory: true,
+            content: {
+              value: team,
+            },
+            children: Object.keys(sampleHierarchy.MLB['American League'][team]).map(player => ({
+              id: `${team}_${player}`,
+              content: {
+                value: player,
+                rowActions: [
+                  <OverflowMenu title="data-item-menu" flipped>
+                    <OverflowMenuItem
+                      itemText="Configure"
+                      onClick={() => console.log('Configure')}
+                    />
+                    <OverflowMenuItem
+                      itemText="Delete"
+                      onClick={() => console.log('Delete')}
+                      isDelete
+                      hasDivider
+                    />
+                  </OverflowMenu>,
+                ],
+              },
+              isSelectable: true,
+            })),
+          })),
+          ...Object.keys(sampleHierarchy.MLB['National League']).map(team => ({
+            id: team,
+            isCategory: true,
+            content: {
+              value: team,
+            },
+            children: Object.keys(sampleHierarchy.MLB['National League'][team]).map(player => ({
+              id: `${team}_${player}`,
+              content: {
+                value: player,
+                rowActions: [
+                  <OverflowMenu title="data-item-menu" flipped>
+                    <OverflowMenuItem
+                      itemText="Configure"
+                      onClick={() => console.log('Configure')}
+                    />
+                    <OverflowMenuItem
+                      itemText="Delete"
+                      onClick={() => console.log('Delete')}
+                      isDelete
+                      hasDivider
+                    />
+                  </OverflowMenu>,
+                ],
               },
               isSelectable: true,
             })),

--- a/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
+++ b/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
@@ -21,100 +21,369 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
       }
     >
       <div
-        className="iot--list iot--list__full-height"
+        data-floating-menu-container={true}
+        style={
+          Object {
+            "position": "relative",
+          }
+        }
       >
         <div
-          className="iot--list-header-container"
+          className="iot--list iot--list__full-height"
         >
           <div
-            className="iot--list-header"
+            className="iot--list-header-container"
           >
             <div
-              className="iot--list-header--title"
+              className="iot--list-header"
             >
-              MLB Expanded List
+              <div
+                className="iot--list-header--title"
+              >
+                MLB Expanded List
+              </div>
+              <div
+                className="iot--list-header--btn-container"
+              >
+                <button
+                  className="iot--btn bx--btn bx--btn--sm bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  type="button"
+                >
+                  <span
+                    className="bx--assistive-text"
+                  >
+                    Add
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Add"
+                    className="bx--btn__icon"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 32 32"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                    />
+                  </svg>
+                </button>
+              </div>
             </div>
             <div
-              className="iot--list-header--btn-container"
+              className="iot--list-header--search"
             >
-              <button
-                className="iot--btn bx--btn bx--btn--sm bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                disabled={false}
-                onClick={[Function]}
-                tabIndex={0}
-                type="button"
+              <div
+                aria-labelledby="iot--list-header--search-search"
+                className="bx--search bx--search--sm"
+                role="search"
               >
-                <span
-                  className="bx--assistive-text"
-                >
-                  Add
-                </span>
                 <svg
-                  aria-hidden="true"
-                  aria-label="Add"
-                  className="bx--btn__icon"
+                  aria-hidden={true}
+                  className="bx--search-magnifier"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                  />
+                </svg>
+                <label
+                  className="bx--label"
+                  htmlFor="iot--list-header--search"
+                  id="iot--list-header--search-search"
+                >
+                  Enter a value
+                </label>
+                <input
+                  autoComplete="off"
+                  className="bx--search-input"
+                  id="iot--list-header--search"
+                  onChange={[Function]}
+                  placeholder="Enter a value"
+                  role="searchbox"
+                  type="text"
+                  value=""
+                />
+                <button
+                  aria-label="Clear search input"
+                  className="bx--search-close bx--search-close--hidden"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 32 32"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list--content__full-height iot--list--content"
+          >
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
                   focusable="false"
                   height={16}
                   preserveAspectRatio="xMidYMid meet"
                   role="img"
-                  viewBox="0 0 32 32"
+                  viewBox="0 0 16 16"
                   width={16}
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
-                    d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
                   />
                 </svg>
-              </button>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Chicago White Sox"
+                    >
+                      Chicago White Sox
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="New York Yankees"
+                    >
+                      New York Yankees
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Houston Astros"
+                    >
+                      Houston Astros
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Atlanta Braves"
+                    >
+                      Atlanta Braves
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="New York Mets"
+                    >
+                      New York Mets
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
           <div
-            className="iot--list-header--search"
+            className="iot--list--page"
           >
             <div
-              aria-labelledby="iot--list-header--search-search"
-              className="bx--search bx--search--sm"
-              role="search"
+              className="iot-simple-pagination-container"
             >
-              <svg
-                aria-hidden={true}
-                className="bx--search-magnifier"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                className="iot-simple-pagination-page-label"
+                maxpage={2}
               >
-                <path
-                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                />
-              </svg>
-              <label
-                className="bx--label"
-                htmlFor="iot--list-header--search"
-                id="iot--list-header--search-search"
-              >
-                Enter a value
-              </label>
-              <input
-                autoComplete="off"
-                className="bx--search-input"
-                id="iot--list-header--search"
-                onChange={[Function]}
-                placeholder="Enter a value"
-                role="searchbox"
-                type="text"
-                value=""
-              />
-              <button
-                aria-label="Clear search input"
-                className="bx--search-close bx--search-close--hidden"
-                onClick={[Function]}
-                type="button"
+                Page 1
+              </span>
+              <div
+                className="bx--pagination__button bx--pagination__button--backward iot-addons-simple-pagination-button-disabled"
+                role="button"
+                tabIndex={-1}
               >
                 <svg
                   aria-hidden={true}
+                  className="iot-simple-pagination-caret-disabled"
+                  description="Prev page"
+                  dir="ltr"
                   focusable="false"
                   height={16}
                   preserveAspectRatio="xMidYMid meet"
@@ -123,294 +392,455 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
-                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                    d="M20 24L10 16 20 8z"
                   />
                 </svg>
-              </button>
-            </div>
-          </div>
-        </div>
-        <div
-          className="iot--list--content__full-height iot--list--content"
-        >
-          <div
-            className="iot--list-item"
-          >
-            <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="Chicago White Sox"
-                  >
-                    Chicago White Sox
-                  </div>
-                </div>
               </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
-            <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
               <div
-                className="iot--list-item--content--values"
+                className="bx--pagination__button bx--pagination__button--forward iot-addons-simple-pagination-button"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <div
-                  className="iot--list-item--content--values--main"
+                <svg
+                  aria-hidden={true}
+                  className="iot-simple-pagination-caret"
+                  description="Next page"
+                  dir="ltr"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="New York Yankees"
-                  >
-                    New York Yankees
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
-            <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="Houston Astros"
-                  >
-                    Houston Astros
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
-            <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="Atlanta Braves"
-                  >
-                    Atlanta Braves
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
-            <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="New York Mets"
-                  >
-                    New York Mets
-                  </div>
-                </div>
+                  <path
+                    d="M12 8L22 16 12 24z"
+                  />
+                </svg>
               </div>
             </div>
           </div>
         </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/HierarchyList With OverflowMenu 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "height": 400,
+          "overflow": "scroll",
+          "width": 400,
+        }
+      }
+    >
+      <div
+        data-floating-menu-container={true}
+        style={
+          Object {
+            "position": "relative",
+          }
+        }
+      >
         <div
-          className="iot--list--page"
+          className="iot--list"
         >
           <div
-            className="iot-simple-pagination-container"
+            className="iot--list-header-container"
           >
-            <span
-              className="iot-simple-pagination-page-label"
-              maxpage={2}
-            >
-              Page 1
-            </span>
             <div
-              className="bx--pagination__button bx--pagination__button--backward iot-addons-simple-pagination-button-disabled"
-              role="button"
-              tabIndex={-1}
+              className="iot--list-header"
             >
-              <svg
-                aria-hidden={true}
-                className="iot-simple-pagination-caret-disabled"
-                description="Prev page"
-                dir="ltr"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                className="iot--list-header--title"
               >
-                <path
-                  d="M20 24L10 16 20 8z"
-                />
-              </svg>
+                MLB Expanded List
+              </div>
+              <div
+                className="iot--list-header--btn-container"
+              />
             </div>
             <div
-              className="bx--pagination__button bx--pagination__button--forward iot-addons-simple-pagination-button"
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              role="button"
-              tabIndex={0}
+              className="iot--list-header--search"
             >
-              <svg
-                aria-hidden={true}
-                className="iot-simple-pagination-caret"
-                description="Next page"
-                dir="ltr"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                aria-labelledby="iot--list-header--search-search"
+                className="bx--search bx--search--sm"
+                role="search"
               >
-                <path
-                  d="M12 8L22 16 12 24z"
+                <svg
+                  aria-hidden={true}
+                  className="bx--search-magnifier"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                  />
+                </svg>
+                <label
+                  className="bx--label"
+                  htmlFor="iot--list-header--search"
+                  id="iot--list-header--search-search"
+                >
+                  Enter a value
+                </label>
+                <input
+                  autoComplete="off"
+                  className="bx--search-input"
+                  id="iot--list-header--search"
+                  onChange={[Function]}
+                  placeholder="Enter a value"
+                  role="searchbox"
+                  type="text"
+                  value=""
                 />
-              </svg>
+                <button
+                  aria-label="Clear search input"
+                  className="bx--search-close bx--search-close--hidden"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 32 32"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list--content"
+          >
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Chicago White Sox"
+                    >
+                      Chicago White Sox
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="New York Yankees"
+                    >
+                      New York Yankees
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Houston Astros"
+                    >
+                      Houston Astros
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Atlanta Braves"
+                    >
+                      Atlanta Braves
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="New York Mets"
+                    >
+                      New York Mets
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Washington Nationals"
+                    >
+                      Washington Nationals
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list--page"
+          >
+            <div
+              className="iot-simple-pagination-container"
+            >
+              <span
+                className="iot-simple-pagination-page-label"
+                maxpage={1}
+              >
+                Page 1
+              </span>
             </div>
           </div>
         </div>
@@ -464,689 +894,698 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
       }
     >
       <div
-        className="iot--list"
+        data-floating-menu-container={true}
+        style={
+          Object {
+            "position": "relative",
+          }
+        }
       >
         <div
-          className="iot--list-header-container"
+          className="iot--list"
         >
           <div
-            className="iot--list-header"
+            className="iot--list-header-container"
           >
             <div
-              className="iot--list-header--title"
+              className="iot--list-header"
             >
-              MLB Expanded List
+              <div
+                className="iot--list-header--title"
+              >
+                MLB Expanded List
+              </div>
+              <div
+                className="iot--list-header--btn-container"
+              />
             </div>
             <div
-              className="iot--list-header--btn-container"
-            />
-          </div>
-          <div
-            className="iot--list-header--search"
-          >
-            <div
-              aria-labelledby="iot--list-header--search-search"
-              className="bx--search bx--search--sm"
-              role="search"
+              className="iot--list-header--search"
             >
-              <svg
-                aria-hidden={true}
-                className="bx--search-magnifier"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                />
-              </svg>
-              <label
-                className="bx--label"
-                htmlFor="iot--list-header--search"
-                id="iot--list-header--search-search"
-              >
-                Enter a value
-              </label>
-              <input
-                autoComplete="off"
-                className="bx--search-input"
-                id="iot--list-header--search"
-                onChange={[Function]}
-                placeholder="Enter a value"
-                role="searchbox"
-                type="text"
-                value=""
-              />
-              <button
-                aria-label="Clear search input"
-                className="bx--search-close bx--search-close--hidden"
-                onClick={[Function]}
-                type="button"
+              <div
+                aria-labelledby="iot--list-header--search-search"
+                className="bx--search bx--search--sm"
+                role="search"
               >
                 <svg
                   aria-hidden={true}
+                  className="bx--search-magnifier"
                   focusable="false"
                   height={16}
                   preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 32 32"
+                  viewBox="0 0 16 16"
                   width={16}
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
-                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                    d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                   />
                 </svg>
-              </button>
+                <label
+                  className="bx--label"
+                  htmlFor="iot--list-header--search"
+                  id="iot--list-header--search-search"
+                >
+                  Enter a value
+                </label>
+                <input
+                  autoComplete="off"
+                  className="bx--search-input"
+                  id="iot--list-header--search"
+                  onChange={[Function]}
+                  placeholder="Enter a value"
+                  role="searchbox"
+                  type="text"
+                  value=""
+                />
+                <button
+                  aria-label="Clear search input"
+                  className="bx--search-close bx--search-close--hidden"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 32 32"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                    />
+                  </svg>
+                </button>
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="iot--list--content"
-        >
           <div
-            className="iot--list-item"
+            className="iot--list--content"
           >
             <div
-              className="iot--list-item--expand-icon"
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Chicago White Sox"
+                    >
+                      Chicago White Sox
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="New York Yankees"
+                    >
+                      New York Yankees
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Houston Astros"
+                    >
+                      Houston Astros
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Atlanta Braves"
+                    >
+                      Atlanta Braves
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Expand"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="New York Mets"
+                    >
+                      New York Mets
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
               tabIndex={0}
             >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="Chicago White Sox"
+                    className="iot--list-item--content--values--main"
                   >
-                    Chicago White Sox
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Jeff McNeil"
+                    >
+                      Jeff McNeil
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
             <div
-              className="iot--list-item--expand-icon"
+              className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
               tabIndex={0}
             >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="New York Yankees"
+                    className="iot--list-item--content--values--main"
                   >
-                    New York Yankees
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Amed Rosario"
+                    >
+                      Amed Rosario
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
             <div
-              className="iot--list-item--expand-icon"
+              className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
               tabIndex={0}
             >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="Houston Astros"
+                    className="iot--list-item--content--values--main"
                   >
-                    Houston Astros
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Michael ConfortoMichael ConfortoMichael ConfortoMichael Conforto"
+                    >
+                      Michael ConfortoMichael ConfortoMichael ConfortoMichael Conforto
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
             <div
-              className="iot--list-item--expand-icon"
+              className="iot--list-item iot--list-item__selectable iot--list-item__selected"
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
               tabIndex={0}
             >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--content iot--list-item--content__selected"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="Atlanta Braves"
+                    className="iot--list-item--content--values--main"
                   >
-                    Atlanta Braves
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Pete Alonso"
+                    >
+                      Pete Alonso
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
             <div
-              className="iot--list-item--expand-icon"
+              className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
               tabIndex={0}
             >
-              <svg
-                aria-label="Expand"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
               <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="New York Mets"
-                  >
-                    New York Mets
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item iot--list-item__selectable"
-            onClick={[Function]}
-            onKeyPress={[Function]}
-            role="button"
-            tabIndex={0}
-          >
-            <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
                 }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
+              >
+                 
+              </div>
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Jeff McNeil"
+                    className="iot--list-item--content--values--main"
                   >
-                    Jeff McNeil
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Wilson Ramos"
+                    >
+                      Wilson Ramos
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            className="iot--list-item iot--list-item__selectable"
-            onClick={[Function]}
-            onKeyPress={[Function]}
-            role="button"
-            tabIndex={0}
-          >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Amed Rosario"
-                  >
-                    Amed Rosario
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item iot--list-item__selectable"
-            onClick={[Function]}
-            onKeyPress={[Function]}
-            role="button"
-            tabIndex={0}
-          >
-            <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Michael ConfortoMichael ConfortoMichael ConfortoMichael Conforto"
-                  >
-                    Michael ConfortoMichael ConfortoMichael ConfortoMichael Conforto
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item iot--list-item__selectable iot--list-item__selected"
-            onClick={[Function]}
-            onKeyPress={[Function]}
-            role="button"
-            tabIndex={0}
-          >
-            <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content iot--list-item--content__selected"
-            >
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Pete Alonso"
-                  >
-                    Pete Alonso
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item iot--list-item__selectable"
-            onClick={[Function]}
-            onKeyPress={[Function]}
-            role="button"
-            tabIndex={0}
-          >
-            <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Wilson Ramos"
-                  >
-                    Wilson Ramos
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item iot--list-item__selectable"
-            onClick={[Function]}
-            onKeyPress={[Function]}
-            role="button"
-            tabIndex={0}
-          >
-            <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Robinson Cano"
-                  >
-                    Robinson Cano
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item iot--list-item__selectable"
-            onClick={[Function]}
-            onKeyPress={[Function]}
-            role="button"
-            tabIndex={0}
-          >
-            <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="JD Davis"
-                  >
-                    JD Davis
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item iot--list-item__selectable"
-            onClick={[Function]}
-            onKeyPress={[Function]}
-            role="button"
-            tabIndex={0}
-          >
-            <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Brandon Nimmo"
-                  >
-                    Brandon Nimmo
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item iot--list-item__selectable"
-            onClick={[Function]}
-            onKeyPress={[Function]}
-            role="button"
-            tabIndex={0}
-          >
-            <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Jacob Degrom"
-                  >
-                    Jacob Degrom
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
-            <div
-              className="iot--list-item--expand-icon"
+              className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
               tabIndex={0}
             >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="Washington Nationals"
+                    className="iot--list-item--content--values--main"
                   >
-                    Washington Nationals
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Robinson Cano"
+                    >
+                      Robinson Cano
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--list-item iot--list-item__selectable"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="JD Davis"
+                    >
+                      JD Davis
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--list-item iot--list-item__selectable"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Brandon Nimmo"
+                    >
+                      Brandon Nimmo
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--list-item iot--list-item__selectable"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Jacob Degrom"
+                    >
+                      Jacob Degrom
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Washington Nationals"
+                    >
+                      Washington Nationals
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-        <div
-          className="iot--list--page"
-        >
           <div
-            className="iot-simple-pagination-container"
+            className="iot--list--page"
           >
-            <span
-              className="iot-simple-pagination-page-label"
-              maxpage={1}
+            <div
+              className="iot-simple-pagination-container"
             >
-              Page 1
-            </span>
+              <span
+                className="iot-simple-pagination-page-label"
+                maxpage={1}
+              >
+                Page 1
+              </span>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
+++ b/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
@@ -21,125 +21,121 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
       }
     >
       <div
-        data-floating-menu-container={true}
-        style={
-          Object {
-            "position": "relative",
-          }
-        }
+        className="iot--list iot--list__full-height"
       >
         <div
-          className="iot--list iot--list__full-height"
+          className="iot--list-header-container"
         >
           <div
-            className="iot--list-header-container"
+            className="iot--list-header"
           >
             <div
-              className="iot--list-header"
+              className="iot--list-header--title"
             >
-              <div
-                className="iot--list-header--title"
-              >
-                MLB Expanded List
-              </div>
-              <div
-                className="iot--list-header--btn-container"
-              >
-                <button
-                  className="iot--btn bx--btn bx--btn--sm bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  type="button"
-                >
-                  <span
-                    className="bx--assistive-text"
-                  >
-                    Add
-                  </span>
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Add"
-                    className="bx--btn__icon"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    viewBox="0 0 32 32"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
-                    />
-                  </svg>
-                </button>
-              </div>
+              MLB Expanded List
             </div>
             <div
-              className="iot--list-header--search"
+              className="iot--list-header--btn-container"
             >
-              <div
-                aria-labelledby="iot--list-header--search-search"
-                className="bx--search bx--search--sm"
-                role="search"
+              <button
+                className="iot--btn bx--btn bx--btn--sm bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
               >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Add
+                </span>
                 <svg
-                  aria-hidden={true}
-                  className="bx--search-magnifier"
+                  aria-hidden="true"
+                  aria-label="Add"
+                  className="bx--btn__icon"
                   focusable="false"
                   height={16}
                   preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
+                  role="img"
+                  viewBox="0 0 32 32"
                   width={16}
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
-                    d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                    d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
                   />
                 </svg>
-                <label
-                  className="bx--label"
-                  htmlFor="iot--list-header--search"
-                  id="iot--list-header--search-search"
-                >
-                  Enter a value
-                </label>
-                <input
-                  autoComplete="off"
-                  className="bx--search-input"
-                  id="iot--list-header--search"
-                  onChange={[Function]}
-                  placeholder="Enter a value"
-                  role="searchbox"
-                  type="text"
-                  value=""
-                />
-                <button
-                  aria-label="Clear search input"
-                  className="bx--search-close bx--search-close--hidden"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                    />
-                  </svg>
-                </button>
-              </div>
+              </button>
             </div>
           </div>
           <div
-            className="iot--list--content__full-height iot--list--content"
+            className="iot--list-header--search"
+          >
+            <div
+              aria-labelledby="iot--list-header--search-search"
+              className="bx--search bx--search--sm"
+              role="search"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--search-magnifier"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                />
+              </svg>
+              <label
+                className="bx--label"
+                htmlFor="iot--list-header--search"
+                id="iot--list-header--search-search"
+              >
+                Enter a value
+              </label>
+              <input
+                autoComplete="off"
+                className="bx--search-input"
+                id="iot--list-header--search"
+                onChange={[Function]}
+                placeholder="Enter a value"
+                role="searchbox"
+                type="text"
+                value=""
+              />
+              <button
+                aria-label="Clear search input"
+                className="bx--search-close bx--search-close--hidden"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--content__full-height iot--list--content"
+        >
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
               className="iot--list-item"
@@ -185,6 +181,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item"
             >
@@ -229,6 +230,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item"
             >
@@ -273,6 +279,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item"
             >
@@ -317,6 +328,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item"
             >
@@ -362,64 +378,64 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               </div>
             </div>
           </div>
+        </div>
+        <div
+          className="iot--list--page"
+        >
           <div
-            className="iot--list--page"
+            className="iot-simple-pagination-container"
           >
-            <div
-              className="iot-simple-pagination-container"
+            <span
+              className="iot-simple-pagination-page-label"
+              maxpage={2}
             >
-              <span
-                className="iot-simple-pagination-page-label"
-                maxpage={2}
+              Page 1
+            </span>
+            <div
+              className="bx--pagination__button bx--pagination__button--backward iot-addons-simple-pagination-button-disabled"
+              role="button"
+              tabIndex={-1}
+            >
+              <svg
+                aria-hidden={true}
+                className="iot-simple-pagination-caret-disabled"
+                description="Prev page"
+                dir="ltr"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
               >
-                Page 1
-              </span>
-              <div
-                className="bx--pagination__button bx--pagination__button--backward iot-addons-simple-pagination-button-disabled"
-                role="button"
-                tabIndex={-1}
+                <path
+                  d="M20 24L10 16 20 8z"
+                />
+              </svg>
+            </div>
+            <div
+              className="bx--pagination__button bx--pagination__button--forward iot-addons-simple-pagination-button"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-hidden={true}
+                className="iot-simple-pagination-caret"
+                description="Next page"
+                dir="ltr"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-hidden={true}
-                  className="iot-simple-pagination-caret-disabled"
-                  description="Prev page"
-                  dir="ltr"
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 32 32"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M20 24L10 16 20 8z"
-                  />
-                </svg>
-              </div>
-              <div
-                className="bx--pagination__button bx--pagination__button--forward iot-addons-simple-pagination-button"
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                role="button"
-                tabIndex={0}
-              >
-                <svg
-                  aria-hidden={true}
-                  className="iot-simple-pagination-caret"
-                  description="Next page"
-                  dir="ltr"
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 32 32"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M12 8L22 16 12 24z"
-                  />
-                </svg>
-              </div>
+                <path
+                  d="M12 8L22 16 12 24z"
+                />
+              </svg>
             </div>
           </div>
         </div>
@@ -468,101 +484,96 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
       style={
         Object {
           "height": 400,
-          "overflow": "scroll",
           "width": 400,
         }
       }
     >
       <div
-        data-floating-menu-container={true}
-        style={
-          Object {
-            "position": "relative",
-          }
-        }
+        className="iot--list"
       >
         <div
-          className="iot--list"
+          className="iot--list-header-container"
         >
           <div
-            className="iot--list-header-container"
+            className="iot--list-header"
           >
             <div
-              className="iot--list-header"
+              className="iot--list-header--title"
             >
-              <div
-                className="iot--list-header--title"
-              >
-                MLB Expanded List
-              </div>
-              <div
-                className="iot--list-header--btn-container"
-              />
+              MLB Expanded List
             </div>
             <div
-              className="iot--list-header--search"
+              className="iot--list-header--btn-container"
+            />
+          </div>
+          <div
+            className="iot--list-header--search"
+          >
+            <div
+              aria-labelledby="iot--list-header--search-search"
+              className="bx--search bx--search--sm"
+              role="search"
             >
-              <div
-                aria-labelledby="iot--list-header--search-search"
-                className="bx--search bx--search--sm"
-                role="search"
+              <svg
+                aria-hidden={true}
+                className="bx--search-magnifier"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                />
+              </svg>
+              <label
+                className="bx--label"
+                htmlFor="iot--list-header--search"
+                id="iot--list-header--search-search"
+              >
+                Enter a value
+              </label>
+              <input
+                autoComplete="off"
+                className="bx--search-input"
+                id="iot--list-header--search"
+                onChange={[Function]}
+                placeholder="Enter a value"
+                role="searchbox"
+                type="text"
+                value=""
+              />
+              <button
+                aria-label="Clear search input"
+                className="bx--search-close bx--search-close--hidden"
+                onClick={[Function]}
+                type="button"
               >
                 <svg
                   aria-hidden={true}
-                  className="bx--search-magnifier"
                   focusable="false"
                   height={16}
                   preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
+                  viewBox="0 0 32 32"
                   width={16}
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
-                    d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
                   />
                 </svg>
-                <label
-                  className="bx--label"
-                  htmlFor="iot--list-header--search"
-                  id="iot--list-header--search-search"
-                >
-                  Enter a value
-                </label>
-                <input
-                  autoComplete="off"
-                  className="bx--search-input"
-                  id="iot--list-header--search"
-                  onChange={[Function]}
-                  placeholder="Enter a value"
-                  role="searchbox"
-                  type="text"
-                  value=""
-                />
-                <button
-                  aria-label="Clear search input"
-                  className="bx--search-close bx--search-close--hidden"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                    />
-                  </svg>
-                </button>
-              </div>
+              </button>
             </div>
           </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
           <div
-            className="iot--list--content"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
               className="iot--list-item"
@@ -608,6 +619,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item"
             >
@@ -652,6 +668,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item"
             >
@@ -696,6 +717,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item"
             >
@@ -740,6 +766,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item"
             >
@@ -784,6 +815,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item"
             >
@@ -829,19 +865,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               </div>
             </div>
           </div>
+        </div>
+        <div
+          className="iot--list--page"
+        >
           <div
-            className="iot--list--page"
+            className="iot-simple-pagination-container"
           >
-            <div
-              className="iot-simple-pagination-container"
+            <span
+              className="iot-simple-pagination-page-label"
+              maxpage={1}
             >
-              <span
-                className="iot-simple-pagination-page-label"
-                maxpage={1}
-              >
-                Page 1
-              </span>
-            </div>
+              Page 1
+            </span>
           </div>
         </div>
       </div>
@@ -894,95 +930,91 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
       }
     >
       <div
-        data-floating-menu-container={true}
-        style={
-          Object {
-            "position": "relative",
-          }
-        }
+        className="iot--list"
       >
         <div
-          className="iot--list"
+          className="iot--list-header-container"
         >
           <div
-            className="iot--list-header-container"
+            className="iot--list-header"
           >
             <div
-              className="iot--list-header"
+              className="iot--list-header--title"
             >
-              <div
-                className="iot--list-header--title"
-              >
-                MLB Expanded List
-              </div>
-              <div
-                className="iot--list-header--btn-container"
-              />
+              MLB Expanded List
             </div>
             <div
-              className="iot--list-header--search"
+              className="iot--list-header--btn-container"
+            />
+          </div>
+          <div
+            className="iot--list-header--search"
+          >
+            <div
+              aria-labelledby="iot--list-header--search-search"
+              className="bx--search bx--search--sm"
+              role="search"
             >
-              <div
-                aria-labelledby="iot--list-header--search-search"
-                className="bx--search bx--search--sm"
-                role="search"
+              <svg
+                aria-hidden={true}
+                className="bx--search-magnifier"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                />
+              </svg>
+              <label
+                className="bx--label"
+                htmlFor="iot--list-header--search"
+                id="iot--list-header--search-search"
+              >
+                Enter a value
+              </label>
+              <input
+                autoComplete="off"
+                className="bx--search-input"
+                id="iot--list-header--search"
+                onChange={[Function]}
+                placeholder="Enter a value"
+                role="searchbox"
+                type="text"
+                value=""
+              />
+              <button
+                aria-label="Clear search input"
+                className="bx--search-close bx--search-close--hidden"
+                onClick={[Function]}
+                type="button"
               >
                 <svg
                   aria-hidden={true}
-                  className="bx--search-magnifier"
                   focusable="false"
                   height={16}
                   preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
+                  viewBox="0 0 32 32"
                   width={16}
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
-                    d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
                   />
                 </svg>
-                <label
-                  className="bx--label"
-                  htmlFor="iot--list-header--search"
-                  id="iot--list-header--search-search"
-                >
-                  Enter a value
-                </label>
-                <input
-                  autoComplete="off"
-                  className="bx--search-input"
-                  id="iot--list-header--search"
-                  onChange={[Function]}
-                  placeholder="Enter a value"
-                  role="searchbox"
-                  type="text"
-                  value=""
-                />
-                <button
-                  aria-label="Clear search input"
-                  className="bx--search-close bx--search-close--hidden"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                    />
-                  </svg>
-                </button>
-              </div>
+              </button>
             </div>
           </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
           <div
-            className="iot--list--content"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
               className="iot--list-item"
@@ -1028,6 +1060,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item"
             >
@@ -1072,6 +1109,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item"
             >
@@ -1116,6 +1158,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item"
             >
@@ -1160,6 +1207,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item"
             >
@@ -1204,6 +1256,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
@@ -1240,6 +1297,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
@@ -1276,6 +1338,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
@@ -1312,6 +1379,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item iot--list-item__selectable iot--list-item__selected"
               onClick={[Function]}
@@ -1348,6 +1420,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
@@ -1384,6 +1461,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
@@ -1420,6 +1502,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
@@ -1456,6 +1543,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
@@ -1492,6 +1584,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
@@ -1528,6 +1625,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
             <div
               className="iot--list-item"
             >
@@ -1573,19 +1675,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               </div>
             </div>
           </div>
+        </div>
+        <div
+          className="iot--list--page"
+        >
           <div
-            className="iot--list--page"
+            className="iot-simple-pagination-container"
           >
-            <div
-              className="iot-simple-pagination-container"
+            <span
+              className="iot-simple-pagination-page-label"
+              maxpage={1}
             >
-              <span
-                className="iot-simple-pagination-page-label"
-                maxpage={1}
-              >
-                Page 1
-              </span>
-            </div>
+              Page 1
+            </span>
           </div>
         </div>
       </div>

--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -114,26 +114,33 @@ const List = forwardRef((props, ref) => {
     } = item;
 
     return [
-      <ListItem
-        id={item.id}
-        key={`${item.id}-list-item-${level}-${value}`}
-        nestingLevel={level}
-        value={value}
-        icon={icon}
-        iconPosition={iconPosition}
-        secondaryValue={secondaryValue}
-        rowActions={rowActions}
-        onSelect={handleSelect}
-        onExpand={toggleExpansion}
-        selected={isSelected}
-        expanded={isExpanded}
-        isExpandable={hasChildren}
-        isLargeRow={isLargeRow}
-        isCategory={isCategory}
-        isSelectable={isSelectable}
-        i18n={i18n}
-        selectedItemRef={isSelected ? selectedItemRef : null}
-      />,
+      // data-floating-menu-container is a work around for this carbon issue: https://github.com/carbon-design-system/carbon/issues/4755
+      <div
+        key={`${item.id}-list-item-parent-${level}-${value}`}
+        data-floating-menu-container
+        className={`${iotPrefix}--list-item-parent`}
+      >
+        <ListItem
+          id={item.id}
+          key={`${item.id}-list-item-${level}-${value}`}
+          nestingLevel={level}
+          value={value}
+          icon={icon}
+          iconPosition={iconPosition}
+          secondaryValue={secondaryValue}
+          rowActions={rowActions}
+          onSelect={handleSelect}
+          onExpand={toggleExpansion}
+          selected={isSelected}
+          expanded={isExpanded}
+          isExpandable={hasChildren}
+          isLargeRow={isLargeRow}
+          isCategory={isCategory}
+          isSelectable={isSelectable}
+          i18n={i18n}
+          selectedItemRef={isSelected ? selectedItemRef : null}
+        />
+      </div>,
       ...(hasChildren && isExpanded
         ? item.children.map(child => renderItemAndChildren(child, level + 1))
         : []),

--- a/src/components/List/ListItem/_list-item.scss
+++ b/src/components/List/ListItem/_list-item.scss
@@ -1,5 +1,9 @@
 @import '../../../globals/vars';
 
+.#{$iot-prefix}--list-item-parent {
+  position: relative;
+}
+
 .#{$iot-prefix}--list-item {
   background: $ui-01;
   border-bottom: 1px solid $ui-03;

--- a/src/components/List/__snapshots__/List.story.storyshot
+++ b/src/components/List/__snapshots__/List.story.storyshot
@@ -42,220 +42,270 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           className="iot--list--content"
         >
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="DJ LeMahieu"
+                    className="iot--list-item--content--values--main"
                   >
-                    DJ LeMahieu
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="DJ LeMahieu"
+                    >
+                      DJ LeMahieu
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Luke Voit"
+                    className="iot--list-item--content--values--main"
                   >
-                    Luke Voit
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Luke Voit"
+                    >
+                      Luke Voit
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Gary Sanchez"
+                    className="iot--list-item--content--values--main"
                   >
-                    Gary Sanchez
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Gary Sanchez"
+                    >
+                      Gary Sanchez
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Kendrys Morales"
+                    className="iot--list-item--content--values--main"
                   >
-                    Kendrys Morales
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Kendrys Morales"
+                    >
+                      Kendrys Morales
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Gleyber Torres"
+                    className="iot--list-item--content--values--main"
                   >
-                    Gleyber Torres
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Gleyber Torres"
+                    >
+                      Gleyber Torres
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Clint Frazier"
+                    className="iot--list-item--content--values--main"
                   >
-                    Clint Frazier
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Clint Frazier"
+                    >
+                      Clint Frazier
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Brett Gardner"
+                    className="iot--list-item--content--values--main"
                   >
-                    Brett Gardner
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Brett Gardner"
+                    >
+                      Brett Gardner
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Gio Urshela"
+                    className="iot--list-item--content--values--main"
                   >
-                    Gio Urshela
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Gio Urshela"
+                    >
+                      Gio Urshela
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Cameron Maybin"
+                    className="iot--list-item--content--values--main"
                   >
-                    Cameron Maybin
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Cameron Maybin"
+                    >
+                      Cameron Maybin
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Robinson Cano"
+                    className="iot--list-item--content--values--main"
                   >
-                    Robinson Cano
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Robinson Cano"
+                    >
+                      Robinson Cano
+                    </div>
                   </div>
                 </div>
               </div>
@@ -364,986 +414,1111 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           className="iot--list--content"
         >
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="Chicago White Sox"
+                    className="iot--list-item--content--values--main"
                   >
-                    Chicago White Sox
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Chicago White Sox"
+                    >
+                      Chicago White Sox
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Expand"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Expand"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="New York Yankees"
+                    className="iot--list-item--content--values--main"
                   >
-                    New York Yankees
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="New York Yankees"
+                    >
+                      New York Yankees
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
                 }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
+              >
+                 
+              </div>
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="DJ LeMahieu"
+                    className="iot--list-item--content--values--main"
                   >
-                    DJ LeMahieu
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="2B"
-                  >
-                    2B
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="DJ LeMahieu"
+                    >
+                      DJ LeMahieu
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="2B"
+                    >
+                      2B
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
                 }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
+              >
+                 
+              </div>
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Luke Voit"
+                    className="iot--list-item--content--values--main"
                   >
-                    Luke Voit
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="1B"
-                  >
-                    1B
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Luke Voit"
+                    >
+                      Luke Voit
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="1B"
+                    >
+                      1B
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
                 }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
+              >
+                 
+              </div>
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Gary Sanchez"
+                    className="iot--list-item--content--values--main"
                   >
-                    Gary Sanchez
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="C"
-                  >
-                    C
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Gary Sanchez"
+                    >
+                      Gary Sanchez
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="C"
+                    >
+                      C
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
                 }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
+              >
+                 
+              </div>
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Kendrys Morales"
+                    className="iot--list-item--content--values--main"
                   >
-                    Kendrys Morales
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="DH"
-                  >
-                    DH
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Kendrys Morales"
+                    >
+                      Kendrys Morales
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="DH"
+                    >
+                      DH
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
                 }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
+              >
+                 
+              </div>
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Gleyber Torres"
+                    className="iot--list-item--content--values--main"
                   >
-                    Gleyber Torres
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="SS"
-                  >
-                    SS
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Gleyber Torres"
+                    >
+                      Gleyber Torres
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="SS"
+                    >
+                      SS
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
                 }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
+              >
+                 
+              </div>
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Clint Frazier"
+                    className="iot--list-item--content--values--main"
                   >
-                    Clint Frazier
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="RF"
-                  >
-                    RF
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Clint Frazier"
+                    >
+                      Clint Frazier
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="RF"
+                    >
+                      RF
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
                 }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
+              >
+                 
+              </div>
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Brett Gardner"
+                    className="iot--list-item--content--values--main"
                   >
-                    Brett Gardner
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="LF"
-                  >
-                    LF
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Brett Gardner"
+                    >
+                      Brett Gardner
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="LF"
+                    >
+                      LF
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
                 }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
+              >
+                 
+              </div>
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Gio Urshela"
+                    className="iot--list-item--content--values--main"
                   >
-                    Gio Urshela
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="3B"
-                  >
-                    3B
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Gio Urshela"
+                    >
+                      Gio Urshela
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="3B"
+                    >
+                      3B
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
                 }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
+              >
+                 
+              </div>
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Cameron Maybin"
+                    className="iot--list-item--content--values--main"
                   >
-                    Cameron Maybin
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="RF"
-                  >
-                    RF
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Cameron Maybin"
+                    >
+                      Cameron Maybin
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="RF"
+                    >
+                      RF
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
                 }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
+              >
+                 
+              </div>
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Robinson Cano"
+                    className="iot--list-item--content--values--main"
                   >
-                    Robinson Cano
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="2B"
-                  >
-                    2B
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Robinson Cano"
+                    >
+                      Robinson Cano
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="2B"
+                    >
+                      2B
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="Houston Astros"
+                    className="iot--list-item--content--values--main"
                   >
-                    Houston Astros
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Houston Astros"
+                    >
+                      Houston Astros
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Expand"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Expand"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="Atlanta Braves"
+                    className="iot--list-item--content--values--main"
                   >
-                    Atlanta Braves
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Atlanta Braves"
+                    >
+                      Atlanta Braves
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
                 }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
+              >
+                 
+              </div>
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Ronald Acuna Jr."
+                    className="iot--list-item--content--values--main"
                   >
-                    Ronald Acuna Jr.
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="CF"
-                  >
-                    CF
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Ronald Acuna Jr."
+                    >
+                      Ronald Acuna Jr.
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="CF"
+                    >
+                      CF
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
                 }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
+              >
+                 
+              </div>
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Dansby Swanson"
+                    className="iot--list-item--content--values--main"
                   >
-                    Dansby Swanson
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="SS"
-                  >
-                    SS
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Dansby Swanson"
+                    >
+                      Dansby Swanson
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="SS"
+                    >
+                      SS
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
                 }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
+              >
+                 
+              </div>
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Freddie Freeman"
+                    className="iot--list-item--content--values--main"
                   >
-                    Freddie Freeman
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="1B"
-                  >
-                    1B
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Freddie Freeman"
+                    >
+                      Freddie Freeman
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="1B"
+                    >
+                      1B
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
                 }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
+              >
+                 
+              </div>
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Josh Donaldson"
+                    className="iot--list-item--content--values--main"
                   >
-                    Josh Donaldson
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="3B"
-                  >
-                    3B
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Josh Donaldson"
+                    >
+                      Josh Donaldson
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="3B"
+                    >
+                      3B
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
                 }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
+              >
+                 
+              </div>
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Nick Markakis"
+                    className="iot--list-item--content--values--main"
                   >
-                    Nick Markakis
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="RF"
-                  >
-                    RF
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Nick Markakis"
+                    >
+                      Nick Markakis
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="RF"
+                    >
+                      RF
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
                 }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
+              >
+                 
+              </div>
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Austin Riley"
+                    className="iot--list-item--content--values--main"
                   >
-                    Austin Riley
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="LF"
-                  >
-                    LF
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Austin Riley"
+                    >
+                      Austin Riley
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="LF"
+                    >
+                      LF
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
                 }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
+              >
+                 
+              </div>
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Brian McCann"
+                    className="iot--list-item--content--values--main"
                   >
-                    Brian McCann
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="C"
-                  >
-                    C
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Brian McCann"
+                    >
+                      Brian McCann
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="C"
+                    >
+                      C
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
                 }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
+              >
+                 
+              </div>
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Ozzie Albies"
+                    className="iot--list-item--content--values--main"
                   >
-                    Ozzie Albies
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="2B"
-                  >
-                    2B
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Ozzie Albies"
+                    >
+                      Ozzie Albies
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="2B"
+                    >
+                      2B
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
                 }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
+              >
+                 
+              </div>
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Kevin Gausman"
+                    className="iot--list-item--content--values--main"
                   >
-                    Kevin Gausman
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="P"
-                  >
-                    P
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Kevin Gausman"
+                    >
+                      Kevin Gausman
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="P"
+                    >
+                      P
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="New York Mets"
+                    className="iot--list-item--content--values--main"
                   >
-                    New York Mets
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="New York Mets"
+                    >
+                      New York Mets
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="Washington Nationals"
+                    className="iot--list-item--content--values--main"
                   >
-                    Washington Nationals
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Washington Nationals"
+                    >
+                      Washington Nationals
+                    </div>
                   </div>
                 </div>
               </div>
@@ -1451,456 +1626,486 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           className="iot--list--content"
         >
           <div
-            className="iot--list-item iot--list-item__selectable"
-            onClick={[Function]}
-            onKeyPress={[Function]}
-            role="button"
-            tabIndex={0}
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--expand-icon"
+              className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
               tabIndex={0}
             >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
               <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="bx--form-item bx--checkbox-wrapper"
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
                 >
-                  <input
-                    checked={false}
-                    className="bx--checkbox"
-                    id="Chicago White Sox-checkbox"
-                    name="Chicago White Sox"
-                    onChange={[Function]}
-                    onClick={[Function]}
-                    type="checkbox"
-                  />
-                  <label
-                    className="bx--checkbox-label"
-                    htmlFor="Chicago White Sox-checkbox"
-                    title={null}
+                  <div
+                    className="bx--form-item bx--checkbox-wrapper"
                   >
-                    <span
-                      className="bx--checkbox-label-text"
+                    <input
+                      checked={false}
+                      className="bx--checkbox"
+                      id="Chicago White Sox-checkbox"
+                      name="Chicago White Sox"
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      type="checkbox"
+                    />
+                    <label
+                      className="bx--checkbox-label"
+                      htmlFor="Chicago White Sox-checkbox"
+                      title={null}
+                    >
+                      <span
+                        className="bx--checkbox-label-text"
+                      >
+                        Chicago White Sox
+                      </span>
+                    </label>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Chicago White Sox"
                     >
                       Chicago White Sox
-                    </span>
-                  </label>
-                </div>
-              </div>
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="Chicago White Sox"
-                  >
-                    Chicago White Sox
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item iot--list-item__selectable"
-            onClick={[Function]}
-            onKeyPress={[Function]}
-            role="button"
-            tabIndex={0}
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--expand-icon"
+              className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
               tabIndex={0}
             >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
               <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="bx--form-item bx--checkbox-wrapper"
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
                 >
-                  <input
-                    checked={false}
-                    className="bx--checkbox"
-                    id="New York Yankees-checkbox"
-                    name="New York Yankees"
-                    onChange={[Function]}
-                    onClick={[Function]}
-                    type="checkbox"
-                  />
-                  <label
-                    className="bx--checkbox-label"
-                    htmlFor="New York Yankees-checkbox"
-                    title={null}
+                  <div
+                    className="bx--form-item bx--checkbox-wrapper"
                   >
-                    <span
-                      className="bx--checkbox-label-text"
+                    <input
+                      checked={false}
+                      className="bx--checkbox"
+                      id="New York Yankees-checkbox"
+                      name="New York Yankees"
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      type="checkbox"
+                    />
+                    <label
+                      className="bx--checkbox-label"
+                      htmlFor="New York Yankees-checkbox"
+                      title={null}
+                    >
+                      <span
+                        className="bx--checkbox-label-text"
+                      >
+                        New York Yankees
+                      </span>
+                    </label>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="New York Yankees"
                     >
                       New York Yankees
-                    </span>
-                  </label>
-                </div>
-              </div>
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="New York Yankees"
-                  >
-                    New York Yankees
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item iot--list-item__selectable"
-            onClick={[Function]}
-            onKeyPress={[Function]}
-            role="button"
-            tabIndex={0}
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--expand-icon"
+              className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
               tabIndex={0}
             >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
               <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="bx--form-item bx--checkbox-wrapper"
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
                 >
-                  <input
-                    checked={false}
-                    className="bx--checkbox"
-                    id="Houston Astros-checkbox"
-                    name="Houston Astros"
-                    onChange={[Function]}
-                    onClick={[Function]}
-                    type="checkbox"
-                  />
-                  <label
-                    className="bx--checkbox-label"
-                    htmlFor="Houston Astros-checkbox"
-                    title={null}
+                  <div
+                    className="bx--form-item bx--checkbox-wrapper"
                   >
-                    <span
-                      className="bx--checkbox-label-text"
+                    <input
+                      checked={false}
+                      className="bx--checkbox"
+                      id="Houston Astros-checkbox"
+                      name="Houston Astros"
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      type="checkbox"
+                    />
+                    <label
+                      className="bx--checkbox-label"
+                      htmlFor="Houston Astros-checkbox"
+                      title={null}
+                    >
+                      <span
+                        className="bx--checkbox-label-text"
+                      >
+                        Houston Astros
+                      </span>
+                    </label>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Houston Astros"
                     >
                       Houston Astros
-                    </span>
-                  </label>
-                </div>
-              </div>
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="Houston Astros"
-                  >
-                    Houston Astros
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item iot--list-item__selectable"
-            onClick={[Function]}
-            onKeyPress={[Function]}
-            role="button"
-            tabIndex={0}
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--expand-icon"
+              className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
               tabIndex={0}
             >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
               <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="bx--form-item bx--checkbox-wrapper"
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
                 >
-                  <input
-                    checked={false}
-                    className="bx--checkbox"
-                    id="Atlanta Braves-checkbox"
-                    name="Atlanta Braves"
-                    onChange={[Function]}
-                    onClick={[Function]}
-                    type="checkbox"
-                  />
-                  <label
-                    className="bx--checkbox-label"
-                    htmlFor="Atlanta Braves-checkbox"
-                    title={null}
+                  <div
+                    className="bx--form-item bx--checkbox-wrapper"
                   >
-                    <span
-                      className="bx--checkbox-label-text"
+                    <input
+                      checked={false}
+                      className="bx--checkbox"
+                      id="Atlanta Braves-checkbox"
+                      name="Atlanta Braves"
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      type="checkbox"
+                    />
+                    <label
+                      className="bx--checkbox-label"
+                      htmlFor="Atlanta Braves-checkbox"
+                      title={null}
+                    >
+                      <span
+                        className="bx--checkbox-label-text"
+                      >
+                        Atlanta Braves
+                      </span>
+                    </label>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Atlanta Braves"
                     >
                       Atlanta Braves
-                    </span>
-                  </label>
-                </div>
-              </div>
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="Atlanta Braves"
-                  >
-                    Atlanta Braves
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item iot--list-item__selectable"
-            onClick={[Function]}
-            onKeyPress={[Function]}
-            role="button"
-            tabIndex={0}
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--expand-icon"
+              className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
               tabIndex={0}
             >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
               <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="bx--form-item bx--checkbox-wrapper"
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
                 >
-                  <input
-                    checked={false}
-                    className="bx--checkbox"
-                    id="New York Mets-checkbox"
-                    name="New York Mets"
-                    onChange={[Function]}
-                    onClick={[Function]}
-                    type="checkbox"
-                  />
-                  <label
-                    className="bx--checkbox-label"
-                    htmlFor="New York Mets-checkbox"
-                    title={null}
+                  <div
+                    className="bx--form-item bx--checkbox-wrapper"
                   >
-                    <span
-                      className="bx--checkbox-label-text"
+                    <input
+                      checked={false}
+                      className="bx--checkbox"
+                      id="New York Mets-checkbox"
+                      name="New York Mets"
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      type="checkbox"
+                    />
+                    <label
+                      className="bx--checkbox-label"
+                      htmlFor="New York Mets-checkbox"
+                      title={null}
+                    >
+                      <span
+                        className="bx--checkbox-label-text"
+                      >
+                        New York Mets
+                      </span>
+                    </label>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="New York Mets"
                     >
                       New York Mets
-                    </span>
-                  </label>
-                </div>
-              </div>
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="New York Mets"
-                  >
-                    New York Mets
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item iot--list-item__selectable"
-            onClick={[Function]}
-            onKeyPress={[Function]}
-            role="button"
-            tabIndex={0}
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--expand-icon"
+              className="iot--list-item iot--list-item__selectable"
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
               tabIndex={0}
             >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
               <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <div
-                  className="bx--form-item bx--checkbox-wrapper"
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <input
-                    checked={false}
-                    className="bx--checkbox"
-                    id="Washington Nationals-checkbox"
-                    name="Washington Nationals"
-                    onChange={[Function]}
-                    onClick={[Function]}
-                    type="checkbox"
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
                   />
-                  <label
-                    className="bx--checkbox-label"
-                    htmlFor="Washington Nationals-checkbox"
-                    title={null}
-                  >
-                    <span
-                      className="bx--checkbox-label-text"
-                    >
-                      Washington Nationals
-                    </span>
-                  </label>
-                </div>
+                </svg>
               </div>
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--category"
-                    title="Washington Nationals"
+                    className="bx--form-item bx--checkbox-wrapper"
                   >
-                    Washington Nationals
+                    <input
+                      checked={false}
+                      className="bx--checkbox"
+                      id="Washington Nationals-checkbox"
+                      name="Washington Nationals"
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      type="checkbox"
+                    />
+                    <label
+                      className="bx--checkbox-label"
+                      htmlFor="Washington Nationals-checkbox"
+                      title={null}
+                    >
+                      <span
+                        className="bx--checkbox-label-text"
+                      >
+                        Washington Nationals
+                      </span>
+                    </label>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Washington Nationals"
+                    >
+                      Washington Nationals
+                    </div>
                   </div>
                 </div>
               </div>
@@ -2008,1390 +2213,1485 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           className="iot--list--content"
         >
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Expand"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Expand"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="MLB"
+                    className="iot--list-item--content--values--main"
                   >
-                    MLB
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="MLB"
+                    >
+                      MLB
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Expand"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Expand"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="American League"
+                    className="iot--list-item--content--values--main"
                   >
-                    American League
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "color": "black",
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="American League"
+                    >
+                      American League
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "color": "black",
+                          }
                         }
-                      }
-                      tabIndex={0}
-                      type="button"
-                    >
-                      <span
-                        className="bx--assistive-text"
+                        tabIndex={0}
+                        type="button"
                       >
-                        Edit
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Edit"
-                        className="bx--btn__icon"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                        />
-                      </svg>
-                    </button>
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Edit
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Edit"
+                          className="bx--btn__icon"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "60px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "60px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Chicago White Sox"
+                    className="iot--list-item--content--values--main"
                   >
-                    Chicago White Sox
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Chicago White Sox"
                     >
-                      <svg
-                        aria-label="open and close list of options"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={16}
+                      Chicago White Sox
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="bx--overflow-menu"
                         onClick={[Function]}
+                        onClose={[Function]}
                         onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
+                        open={false}
+                        tabIndex={0}
                       >
-                        <circle
-                          cx="16"
-                          cy="8"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="16"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="24"
-                          r="2"
-                        />
-                        <title>
-                          open and close list of options
-                        </title>
-                      </svg>
-                    </button>
+                        <svg
+                          aria-label="open and close list of options"
+                          className="bx--overflow-menu__icon"
+                          focusable="false"
+                          height={16}
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="16"
+                            cy="8"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="16"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="24"
+                            r="2"
+                          />
+                          <title>
+                            open and close list of options
+                          </title>
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "60px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Expand"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "60px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Expand"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="New York Yankees"
+                    className="iot--list-item--content--values--main"
                   >
-                    New York Yankees
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="New York Yankees"
                     >
-                      <svg
-                        aria-label="open and close list of options"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={16}
-                        onClick={[Function]}
-                        onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <circle
-                          cx="16"
-                          cy="8"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="16"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="24"
-                          r="2"
-                        />
-                        <title>
-                          open and close list of options
-                        </title>
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
-            <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "90px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
-              >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
-                  />
-                </svg>
-              </div>
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="DJ LeMahieu"
-                  >
-                    DJ LeMahieu
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="2B"
-                  >
-                    2B
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
-            <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "90px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
-              >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
-                  />
-                </svg>
-              </div>
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Luke Voit"
-                  >
-                    Luke Voit
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="1B"
-                  >
-                    1B
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
-            <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "90px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
-              >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
-                  />
-                </svg>
-              </div>
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Gary Sanchez"
-                  >
-                    Gary Sanchez
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="C"
-                  >
-                    C
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
-            <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "90px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
-              >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
-                  />
-                </svg>
-              </div>
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Kendrys Morales"
-                  >
-                    Kendrys Morales
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="DH"
-                  >
-                    DH
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
-            <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "90px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
-              >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
-                  />
-                </svg>
-              </div>
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Gleyber Torres"
-                  >
-                    Gleyber Torres
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="SS"
-                  >
-                    SS
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
-            <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "90px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
-              >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
-                  />
-                </svg>
-              </div>
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Clint Frazier"
-                  >
-                    Clint Frazier
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="RF"
-                  >
-                    RF
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
-            <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "90px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
-              >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
-                  />
-                </svg>
-              </div>
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Brett Gardner"
-                  >
-                    Brett Gardner
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="LF"
-                  >
-                    LF
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
-            <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "90px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
-              >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
-                  />
-                </svg>
-              </div>
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Gio Urshela"
-                  >
-                    Gio Urshela
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="3B"
-                  >
-                    3B
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
-            <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "90px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
-              >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
-                  />
-                </svg>
-              </div>
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Cameron Maybin"
-                  >
-                    Cameron Maybin
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="RF"
-                  >
-                    RF
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
-            <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "90px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
-              >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
-                  />
-                </svg>
-              </div>
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Robinson Cano"
-                  >
-                    Robinson Cano
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="2B"
-                  >
-                    2B
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--list-item"
-          >
-            <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "60px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
-            >
-              <div
-                className="iot--list-item--content--values"
-              >
-                <div
-                  className="iot--list-item--content--values--main"
-                >
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Houston Astros"
-                  >
-                    Houston Astros
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
+                      New York Yankees
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
                     >
-                      <svg
-                        aria-label="open and close list of options"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={16}
+                      <button
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="bx--overflow-menu"
                         onClick={[Function]}
+                        onClose={[Function]}
                         onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
+                        open={false}
+                        tabIndex={0}
                       >
-                        <circle
-                          cx="16"
-                          cy="8"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="16"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="24"
-                          r="2"
-                        />
-                        <title>
-                          open and close list of options
-                        </title>
-                      </svg>
-                    </button>
+                        <svg
+                          aria-label="open and close list of options"
+                          className="bx--overflow-menu__icon"
+                          focusable="false"
+                          height={16}
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="16"
+                            cy="8"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="16"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="24"
+                            r="2"
+                          />
+                          <title>
+                            open and close list of options
+                          </title>
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "30px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Expand"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "90px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="National League"
+                    className="iot--list-item--content--values--main"
                   >
-                    National League
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="DJ LeMahieu"
+                    >
+                      DJ LeMahieu
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="2B"
+                    >
+                      2B
+                    </div>
                   </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "90px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    <button
-                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "color": "black",
+                    <path
+                      d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Luke Voit"
+                    >
+                      Luke Voit
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="1B"
+                    >
+                      1B
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "90px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Gary Sanchez"
+                    >
+                      Gary Sanchez
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="C"
+                    >
+                      C
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "90px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Kendrys Morales"
+                    >
+                      Kendrys Morales
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="DH"
+                    >
+                      DH
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "90px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Gleyber Torres"
+                    >
+                      Gleyber Torres
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="SS"
+                    >
+                      SS
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "90px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Clint Frazier"
+                    >
+                      Clint Frazier
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="RF"
+                    >
+                      RF
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "90px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Brett Gardner"
+                    >
+                      Brett Gardner
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="LF"
+                    >
+                      LF
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "90px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Gio Urshela"
+                    >
+                      Gio Urshela
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="3B"
+                    >
+                      3B
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "90px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Cameron Maybin"
+                    >
+                      Cameron Maybin
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="RF"
+                    >
+                      RF
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "90px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Robinson Cano"
+                    >
+                      Robinson Cano
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="2B"
+                    >
+                      2B
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "60px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Houston Astros"
+                    >
+                      Houston Astros
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="bx--overflow-menu"
+                        onClick={[Function]}
+                        onClose={[Function]}
+                        onKeyDown={[Function]}
+                        open={false}
+                        tabIndex={0}
+                      >
+                        <svg
+                          aria-label="open and close list of options"
+                          className="bx--overflow-menu__icon"
+                          focusable="false"
+                          height={16}
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="16"
+                            cy="8"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="16"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="24"
+                            r="2"
+                          />
+                          <title>
+                            open and close list of options
+                          </title>
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Expand"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="National League"
+                    >
+                      National League
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "color": "black",
+                          }
                         }
-                      }
-                      tabIndex={0}
-                      type="button"
-                    >
-                      <span
-                        className="bx--assistive-text"
+                        tabIndex={0}
+                        type="button"
                       >
-                        Edit
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Edit"
-                        className="bx--btn__icon"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                        />
-                      </svg>
-                    </button>
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Edit
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Edit"
+                          className="bx--btn__icon"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "60px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "60px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Atlanta Braves"
+                    className="iot--list-item--content--values--main"
                   >
-                    Atlanta Braves
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Atlanta Braves"
                     >
-                      <svg
-                        aria-label="open and close list of options"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={16}
+                      Atlanta Braves
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="bx--overflow-menu"
                         onClick={[Function]}
+                        onClose={[Function]}
                         onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
+                        open={false}
+                        tabIndex={0}
                       >
-                        <circle
-                          cx="16"
-                          cy="8"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="16"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="24"
-                          r="2"
-                        />
-                        <title>
-                          open and close list of options
-                        </title>
-                      </svg>
-                    </button>
+                        <svg
+                          aria-label="open and close list of options"
+                          className="bx--overflow-menu__icon"
+                          focusable="false"
+                          height={16}
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="16"
+                            cy="8"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="16"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="24"
+                            r="2"
+                          />
+                          <title>
+                            open and close list of options
+                          </title>
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "60px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "60px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="New York Mets"
+                    className="iot--list-item--content--values--main"
                   >
-                    New York Mets
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="New York Mets"
                     >
-                      <svg
-                        aria-label="open and close list of options"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={16}
+                      New York Mets
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="bx--overflow-menu"
                         onClick={[Function]}
+                        onClose={[Function]}
                         onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
+                        open={false}
+                        tabIndex={0}
                       >
-                        <circle
-                          cx="16"
-                          cy="8"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="16"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="24"
-                          r="2"
-                        />
-                        <title>
-                          open and close list of options
-                        </title>
-                      </svg>
-                    </button>
+                        <svg
+                          aria-label="open and close list of options"
+                          className="bx--overflow-menu__icon"
+                          focusable="false"
+                          height={16}
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="16"
+                            cy="8"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="16"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="24"
+                            r="2"
+                          />
+                          <title>
+                            open and close list of options
+                          </title>
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--nesting-offset"
-              style={
-                Object {
-                  "width": "60px",
-                }
-              }
-            >
-               
-            </div>
-            <div
-              className="iot--list-item--expand-icon"
-              onClick={[Function]}
-              onKeyPress={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="Close"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                />
-              </svg>
-            </div>
-            <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "60px",
+                  }
+                }
+              >
+                 
+              </div>
+              <div
+                className="iot--list-item--expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Washington Nationals"
+                    className="iot--list-item--content--values--main"
                   >
-                    Washington Nationals
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Washington Nationals"
                     >
-                      <svg
-                        aria-label="open and close list of options"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={16}
+                      Washington Nationals
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="bx--overflow-menu"
                         onClick={[Function]}
+                        onClose={[Function]}
                         onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
+                        open={false}
+                        tabIndex={0}
                       >
-                        <circle
-                          cx="16"
-                          cy="8"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="16"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="24"
-                          r="2"
-                        />
-                        <title>
-                          open and close list of options
-                        </title>
-                      </svg>
-                    </button>
+                        <svg
+                          aria-label="open and close list of options"
+                          className="bx--overflow-menu__icon"
+                          focusable="false"
+                          height={16}
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="16"
+                            cy="8"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="16"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="24"
+                            r="2"
+                          />
+                          <title>
+                            open and close list of options
+                          </title>
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -3469,451 +3769,501 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           className="iot--list--content"
         >
           <div
-            className="iot--list-item iot--list-item__large"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content iot--list-item--content__large"
+              className="iot--list-item iot--list-item__large"
             >
               <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
-              >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
-                  />
-                </svg>
-              </div>
-              <div
-                className="iot--list-item--content--values iot--list-item--content--values__large"
+                className="iot--list-item--content iot--list-item--content__large"
               >
                 <div
-                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
                 >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="DJ LeMahieu"
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    DJ LeMahieu
-                  </div>
+                    <path
+                      d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                    />
+                  </svg>
                 </div>
                 <div
-                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
-                  title="2B"
+                  className="iot--list-item--content--values iot--list-item--content--values__large"
                 >
-                  2B
+                  <div
+                    className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="DJ LeMahieu"
+                    >
+                      DJ LeMahieu
+                    </div>
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                    title="2B"
+                  >
+                    2B
+                  </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item iot--list-item__large"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content iot--list-item--content__large"
+              className="iot--list-item iot--list-item__large"
             >
               <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
-              >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
-                  />
-                </svg>
-              </div>
-              <div
-                className="iot--list-item--content--values iot--list-item--content--values__large"
+                className="iot--list-item--content iot--list-item--content__large"
               >
                 <div
-                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
                 >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Luke Voit"
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    Luke Voit
-                  </div>
+                    <path
+                      d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                    />
+                  </svg>
                 </div>
                 <div
-                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
-                  title="1B"
+                  className="iot--list-item--content--values iot--list-item--content--values__large"
                 >
-                  1B
+                  <div
+                    className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Luke Voit"
+                    >
+                      Luke Voit
+                    </div>
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                    title="1B"
+                  >
+                    1B
+                  </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item iot--list-item__large"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content iot--list-item--content__large"
+              className="iot--list-item iot--list-item__large"
             >
               <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
-              >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
-                  />
-                </svg>
-              </div>
-              <div
-                className="iot--list-item--content--values iot--list-item--content--values__large"
+                className="iot--list-item--content iot--list-item--content__large"
               >
                 <div
-                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
                 >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Gary Sanchez"
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    Gary Sanchez
-                  </div>
+                    <path
+                      d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                    />
+                  </svg>
                 </div>
                 <div
-                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
-                  title="C"
+                  className="iot--list-item--content--values iot--list-item--content--values__large"
                 >
-                  C
+                  <div
+                    className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Gary Sanchez"
+                    >
+                      Gary Sanchez
+                    </div>
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                    title="C"
+                  >
+                    C
+                  </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item iot--list-item__large"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content iot--list-item--content__large"
+              className="iot--list-item iot--list-item__large"
             >
               <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
-              >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
-                  />
-                </svg>
-              </div>
-              <div
-                className="iot--list-item--content--values iot--list-item--content--values__large"
+                className="iot--list-item--content iot--list-item--content__large"
               >
                 <div
-                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
                 >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Kendrys Morales"
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    Kendrys Morales
-                  </div>
+                    <path
+                      d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                    />
+                  </svg>
                 </div>
                 <div
-                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
-                  title="DH"
+                  className="iot--list-item--content--values iot--list-item--content--values__large"
                 >
-                  DH
+                  <div
+                    className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Kendrys Morales"
+                    >
+                      Kendrys Morales
+                    </div>
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                    title="DH"
+                  >
+                    DH
+                  </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item iot--list-item__large"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content iot--list-item--content__large"
+              className="iot--list-item iot--list-item__large"
             >
               <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
-              >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
-                  />
-                </svg>
-              </div>
-              <div
-                className="iot--list-item--content--values iot--list-item--content--values__large"
+                className="iot--list-item--content iot--list-item--content__large"
               >
                 <div
-                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
                 >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Gleyber Torres"
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    Gleyber Torres
-                  </div>
+                    <path
+                      d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                    />
+                  </svg>
                 </div>
                 <div
-                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
-                  title="SS"
+                  className="iot--list-item--content--values iot--list-item--content--values__large"
                 >
-                  SS
+                  <div
+                    className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Gleyber Torres"
+                    >
+                      Gleyber Torres
+                    </div>
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                    title="SS"
+                  >
+                    SS
+                  </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item iot--list-item__large"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content iot--list-item--content__large"
+              className="iot--list-item iot--list-item__large"
             >
               <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
-              >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
-                  />
-                </svg>
-              </div>
-              <div
-                className="iot--list-item--content--values iot--list-item--content--values__large"
+                className="iot--list-item--content iot--list-item--content__large"
               >
                 <div
-                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
                 >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Clint Frazier"
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    Clint Frazier
-                  </div>
+                    <path
+                      d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                    />
+                  </svg>
                 </div>
                 <div
-                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
-                  title="RF"
+                  className="iot--list-item--content--values iot--list-item--content--values__large"
                 >
-                  RF
+                  <div
+                    className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Clint Frazier"
+                    >
+                      Clint Frazier
+                    </div>
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                    title="RF"
+                  >
+                    RF
+                  </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item iot--list-item__large"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content iot--list-item--content__large"
+              className="iot--list-item iot--list-item__large"
             >
               <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
-              >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
-                  />
-                </svg>
-              </div>
-              <div
-                className="iot--list-item--content--values iot--list-item--content--values__large"
+                className="iot--list-item--content iot--list-item--content__large"
               >
                 <div
-                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
                 >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Brett Gardner"
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    Brett Gardner
-                  </div>
+                    <path
+                      d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                    />
+                  </svg>
                 </div>
                 <div
-                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
-                  title="LF"
+                  className="iot--list-item--content--values iot--list-item--content--values__large"
                 >
-                  LF
+                  <div
+                    className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Brett Gardner"
+                    >
+                      Brett Gardner
+                    </div>
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                    title="LF"
+                  >
+                    LF
+                  </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item iot--list-item__large"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content iot--list-item--content__large"
+              className="iot--list-item iot--list-item__large"
             >
               <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
-              >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
-                  />
-                </svg>
-              </div>
-              <div
-                className="iot--list-item--content--values iot--list-item--content--values__large"
+                className="iot--list-item--content iot--list-item--content__large"
               >
                 <div
-                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
                 >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Gio Urshela"
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    Gio Urshela
-                  </div>
+                    <path
+                      d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                    />
+                  </svg>
                 </div>
                 <div
-                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
-                  title="3B"
+                  className="iot--list-item--content--values iot--list-item--content--values__large"
                 >
-                  3B
+                  <div
+                    className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Gio Urshela"
+                    >
+                      Gio Urshela
+                    </div>
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                    title="3B"
+                  >
+                    3B
+                  </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item iot--list-item__large"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content iot--list-item--content__large"
+              className="iot--list-item iot--list-item__large"
             >
               <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
-              >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
-                  />
-                </svg>
-              </div>
-              <div
-                className="iot--list-item--content--values iot--list-item--content--values__large"
+                className="iot--list-item--content iot--list-item--content__large"
               >
                 <div
-                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
                 >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Cameron Maybin"
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    Cameron Maybin
-                  </div>
+                    <path
+                      d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                    />
+                  </svg>
                 </div>
                 <div
-                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
-                  title="RF"
+                  className="iot--list-item--content--values iot--list-item--content--values__large"
                 >
-                  RF
+                  <div
+                    className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Cameron Maybin"
+                    >
+                      Cameron Maybin
+                    </div>
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                    title="RF"
+                  >
+                    RF
+                  </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item iot--list-item__large"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content iot--list-item--content__large"
+              className="iot--list-item iot--list-item__large"
             >
               <div
-                className="iot--list-item--content--icon iot--list-item--content--icon__left"
-              >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
-                  />
-                </svg>
-              </div>
-              <div
-                className="iot--list-item--content--values iot--list-item--content--values__large"
+                className="iot--list-item--content iot--list-item--content__large"
               >
                 <div
-                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                  className="iot--list-item--content--icon iot--list-item--content--icon__left"
                 >
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="Robinson Cano"
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    Robinson Cano
-                  </div>
+                    <path
+                      d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                    />
+                  </svg>
                 </div>
                 <div
-                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
-                  title="2B"
+                  className="iot--list-item--content--values iot--list-item--content--values__large"
                 >
-                  2B
+                  <div
+                    className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Robinson Cano"
+                    >
+                      Robinson Cano
+                    </div>
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                    title="2B"
+                  >
+                    2B
+                  </div>
                 </div>
               </div>
             </div>
@@ -3990,760 +4340,810 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           className="iot--list--content"
         >
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="DJ LeMahieu"
+                    className="iot--list-item--content--values--main"
                   >
-                    DJ LeMahieu
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="2B"
-                  >
-                    2B
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="DJ LeMahieu"
                     >
-                      <svg
-                        aria-label="open and close list of options"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={16}
+                      DJ LeMahieu
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="2B"
+                    >
+                      2B
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="bx--overflow-menu"
                         onClick={[Function]}
+                        onClose={[Function]}
                         onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
+                        open={false}
+                        tabIndex={0}
                       >
-                        <circle
-                          cx="16"
-                          cy="8"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="16"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="24"
-                          r="2"
-                        />
-                        <title>
-                          open and close list of options
-                        </title>
-                      </svg>
-                    </button>
+                        <svg
+                          aria-label="open and close list of options"
+                          className="bx--overflow-menu__icon"
+                          focusable="false"
+                          height={16}
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="16"
+                            cy="8"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="16"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="24"
+                            r="2"
+                          />
+                          <title>
+                            open and close list of options
+                          </title>
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Luke Voit"
+                    className="iot--list-item--content--values--main"
                   >
-                    Luke Voit
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="1B"
-                  >
-                    1B
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Luke Voit"
                     >
-                      <svg
-                        aria-label="open and close list of options"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={16}
+                      Luke Voit
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="1B"
+                    >
+                      1B
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="bx--overflow-menu"
                         onClick={[Function]}
+                        onClose={[Function]}
                         onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
+                        open={false}
+                        tabIndex={0}
                       >
-                        <circle
-                          cx="16"
-                          cy="8"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="16"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="24"
-                          r="2"
-                        />
-                        <title>
-                          open and close list of options
-                        </title>
-                      </svg>
-                    </button>
+                        <svg
+                          aria-label="open and close list of options"
+                          className="bx--overflow-menu__icon"
+                          focusable="false"
+                          height={16}
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="16"
+                            cy="8"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="16"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="24"
+                            r="2"
+                          />
+                          <title>
+                            open and close list of options
+                          </title>
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Gary Sanchez"
+                    className="iot--list-item--content--values--main"
                   >
-                    Gary Sanchez
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="C"
-                  >
-                    C
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Gary Sanchez"
                     >
-                      <svg
-                        aria-label="open and close list of options"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={16}
+                      Gary Sanchez
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="C"
+                    >
+                      C
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="bx--overflow-menu"
                         onClick={[Function]}
+                        onClose={[Function]}
                         onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
+                        open={false}
+                        tabIndex={0}
                       >
-                        <circle
-                          cx="16"
-                          cy="8"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="16"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="24"
-                          r="2"
-                        />
-                        <title>
-                          open and close list of options
-                        </title>
-                      </svg>
-                    </button>
+                        <svg
+                          aria-label="open and close list of options"
+                          className="bx--overflow-menu__icon"
+                          focusable="false"
+                          height={16}
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="16"
+                            cy="8"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="16"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="24"
+                            r="2"
+                          />
+                          <title>
+                            open and close list of options
+                          </title>
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Kendrys Morales"
+                    className="iot--list-item--content--values--main"
                   >
-                    Kendrys Morales
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="DH"
-                  >
-                    DH
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Kendrys Morales"
                     >
-                      <svg
-                        aria-label="open and close list of options"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={16}
+                      Kendrys Morales
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="DH"
+                    >
+                      DH
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="bx--overflow-menu"
                         onClick={[Function]}
+                        onClose={[Function]}
                         onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
+                        open={false}
+                        tabIndex={0}
                       >
-                        <circle
-                          cx="16"
-                          cy="8"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="16"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="24"
-                          r="2"
-                        />
-                        <title>
-                          open and close list of options
-                        </title>
-                      </svg>
-                    </button>
+                        <svg
+                          aria-label="open and close list of options"
+                          className="bx--overflow-menu__icon"
+                          focusable="false"
+                          height={16}
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="16"
+                            cy="8"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="16"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="24"
+                            r="2"
+                          />
+                          <title>
+                            open and close list of options
+                          </title>
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Gleyber Torres"
+                    className="iot--list-item--content--values--main"
                   >
-                    Gleyber Torres
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="SS"
-                  >
-                    SS
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Gleyber Torres"
                     >
-                      <svg
-                        aria-label="open and close list of options"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={16}
+                      Gleyber Torres
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="SS"
+                    >
+                      SS
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="bx--overflow-menu"
                         onClick={[Function]}
+                        onClose={[Function]}
                         onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
+                        open={false}
+                        tabIndex={0}
                       >
-                        <circle
-                          cx="16"
-                          cy="8"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="16"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="24"
-                          r="2"
-                        />
-                        <title>
-                          open and close list of options
-                        </title>
-                      </svg>
-                    </button>
+                        <svg
+                          aria-label="open and close list of options"
+                          className="bx--overflow-menu__icon"
+                          focusable="false"
+                          height={16}
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="16"
+                            cy="8"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="16"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="24"
+                            r="2"
+                          />
+                          <title>
+                            open and close list of options
+                          </title>
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Clint Frazier"
+                    className="iot--list-item--content--values--main"
                   >
-                    Clint Frazier
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="RF"
-                  >
-                    RF
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Clint Frazier"
                     >
-                      <svg
-                        aria-label="open and close list of options"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={16}
+                      Clint Frazier
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="RF"
+                    >
+                      RF
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="bx--overflow-menu"
                         onClick={[Function]}
+                        onClose={[Function]}
                         onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
+                        open={false}
+                        tabIndex={0}
                       >
-                        <circle
-                          cx="16"
-                          cy="8"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="16"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="24"
-                          r="2"
-                        />
-                        <title>
-                          open and close list of options
-                        </title>
-                      </svg>
-                    </button>
+                        <svg
+                          aria-label="open and close list of options"
+                          className="bx--overflow-menu__icon"
+                          focusable="false"
+                          height={16}
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="16"
+                            cy="8"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="16"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="24"
+                            r="2"
+                          />
+                          <title>
+                            open and close list of options
+                          </title>
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Brett Gardner"
+                    className="iot--list-item--content--values--main"
                   >
-                    Brett Gardner
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="LF"
-                  >
-                    LF
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Brett Gardner"
                     >
-                      <svg
-                        aria-label="open and close list of options"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={16}
+                      Brett Gardner
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="LF"
+                    >
+                      LF
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="bx--overflow-menu"
                         onClick={[Function]}
+                        onClose={[Function]}
                         onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
+                        open={false}
+                        tabIndex={0}
                       >
-                        <circle
-                          cx="16"
-                          cy="8"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="16"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="24"
-                          r="2"
-                        />
-                        <title>
-                          open and close list of options
-                        </title>
-                      </svg>
-                    </button>
+                        <svg
+                          aria-label="open and close list of options"
+                          className="bx--overflow-menu__icon"
+                          focusable="false"
+                          height={16}
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="16"
+                            cy="8"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="16"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="24"
+                            r="2"
+                          />
+                          <title>
+                            open and close list of options
+                          </title>
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Gio Urshela"
+                    className="iot--list-item--content--values--main"
                   >
-                    Gio Urshela
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="3B"
-                  >
-                    3B
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Gio Urshela"
                     >
-                      <svg
-                        aria-label="open and close list of options"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={16}
+                      Gio Urshela
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="3B"
+                    >
+                      3B
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="bx--overflow-menu"
                         onClick={[Function]}
+                        onClose={[Function]}
                         onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
+                        open={false}
+                        tabIndex={0}
                       >
-                        <circle
-                          cx="16"
-                          cy="8"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="16"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="24"
-                          r="2"
-                        />
-                        <title>
-                          open and close list of options
-                        </title>
-                      </svg>
-                    </button>
+                        <svg
+                          aria-label="open and close list of options"
+                          className="bx--overflow-menu__icon"
+                          focusable="false"
+                          height={16}
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="16"
+                            cy="8"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="16"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="24"
+                            r="2"
+                          />
+                          <title>
+                            open and close list of options
+                          </title>
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Cameron Maybin"
+                    className="iot--list-item--content--values--main"
                   >
-                    Cameron Maybin
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="RF"
-                  >
-                    RF
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Cameron Maybin"
                     >
-                      <svg
-                        aria-label="open and close list of options"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={16}
+                      Cameron Maybin
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="RF"
+                    >
+                      RF
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="bx--overflow-menu"
                         onClick={[Function]}
+                        onClose={[Function]}
                         onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
+                        open={false}
+                        tabIndex={0}
                       >
-                        <circle
-                          cx="16"
-                          cy="8"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="16"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="24"
-                          r="2"
-                        />
-                        <title>
-                          open and close list of options
-                        </title>
-                      </svg>
-                    </button>
+                        <svg
+                          aria-label="open and close list of options"
+                          className="bx--overflow-menu__icon"
+                          focusable="false"
+                          height={16}
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="16"
+                            cy="8"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="16"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="24"
+                            r="2"
+                          />
+                          <title>
+                            open and close list of options
+                          </title>
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Robinson Cano"
+                    className="iot--list-item--content--values--main"
                   >
-                    Robinson Cano
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="2B"
-                  >
-                    2B
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Robinson Cano"
                     >
-                      <svg
-                        aria-label="open and close list of options"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={16}
+                      Robinson Cano
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="2B"
+                    >
+                      2B
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="bx--overflow-menu"
                         onClick={[Function]}
+                        onClose={[Function]}
                         onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
+                        open={false}
+                        tabIndex={0}
                       >
-                        <circle
-                          cx="16"
-                          cy="8"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="16"
-                          r="2"
-                        />
-                        <circle
-                          cx="16"
-                          cy="24"
-                          r="2"
-                        />
-                        <title>
-                          open and close list of options
-                        </title>
-                      </svg>
-                    </button>
+                        <svg
+                          aria-label="open and close list of options"
+                          className="bx--overflow-menu__icon"
+                          focusable="false"
+                          height={16}
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="16"
+                            cy="8"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="16"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="24"
+                            r="2"
+                          />
+                          <title>
+                            open and close list of options
+                          </title>
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -4821,660 +5221,710 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           className="iot--list--content"
         >
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="DJ LeMahieu"
+                    className="iot--list-item--content--values--main"
                   >
-                    DJ LeMahieu
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="2B"
-                  >
-                    2B
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "color": "black",
-                        }
-                      }
-                      tabIndex={0}
-                      type="button"
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="DJ LeMahieu"
                     >
-                      <span
-                        className="bx--assistive-text"
+                      DJ LeMahieu
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="2B"
+                    >
+                      2B
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "color": "black",
+                          }
+                        }
+                        tabIndex={0}
+                        type="button"
                       >
-                        Edit
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Edit"
-                        className="bx--btn__icon"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                        />
-                      </svg>
-                    </button>
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Edit
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Edit"
+                          className="bx--btn__icon"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Luke Voit"
+                    className="iot--list-item--content--values--main"
                   >
-                    Luke Voit
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="1B"
-                  >
-                    1B
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "color": "black",
-                        }
-                      }
-                      tabIndex={0}
-                      type="button"
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Luke Voit"
                     >
-                      <span
-                        className="bx--assistive-text"
+                      Luke Voit
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="1B"
+                    >
+                      1B
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "color": "black",
+                          }
+                        }
+                        tabIndex={0}
+                        type="button"
                       >
-                        Edit
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Edit"
-                        className="bx--btn__icon"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                        />
-                      </svg>
-                    </button>
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Edit
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Edit"
+                          className="bx--btn__icon"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Gary Sanchez"
+                    className="iot--list-item--content--values--main"
                   >
-                    Gary Sanchez
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="C"
-                  >
-                    C
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "color": "black",
-                        }
-                      }
-                      tabIndex={0}
-                      type="button"
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Gary Sanchez"
                     >
-                      <span
-                        className="bx--assistive-text"
+                      Gary Sanchez
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="C"
+                    >
+                      C
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "color": "black",
+                          }
+                        }
+                        tabIndex={0}
+                        type="button"
                       >
-                        Edit
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Edit"
-                        className="bx--btn__icon"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                        />
-                      </svg>
-                    </button>
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Edit
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Edit"
+                          className="bx--btn__icon"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Kendrys Morales"
+                    className="iot--list-item--content--values--main"
                   >
-                    Kendrys Morales
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="DH"
-                  >
-                    DH
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "color": "black",
-                        }
-                      }
-                      tabIndex={0}
-                      type="button"
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Kendrys Morales"
                     >
-                      <span
-                        className="bx--assistive-text"
+                      Kendrys Morales
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="DH"
+                    >
+                      DH
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "color": "black",
+                          }
+                        }
+                        tabIndex={0}
+                        type="button"
                       >
-                        Edit
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Edit"
-                        className="bx--btn__icon"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                        />
-                      </svg>
-                    </button>
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Edit
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Edit"
+                          className="bx--btn__icon"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Gleyber Torres"
+                    className="iot--list-item--content--values--main"
                   >
-                    Gleyber Torres
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="SS"
-                  >
-                    SS
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "color": "black",
-                        }
-                      }
-                      tabIndex={0}
-                      type="button"
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Gleyber Torres"
                     >
-                      <span
-                        className="bx--assistive-text"
+                      Gleyber Torres
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="SS"
+                    >
+                      SS
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "color": "black",
+                          }
+                        }
+                        tabIndex={0}
+                        type="button"
                       >
-                        Edit
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Edit"
-                        className="bx--btn__icon"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                        />
-                      </svg>
-                    </button>
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Edit
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Edit"
+                          className="bx--btn__icon"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Clint Frazier"
+                    className="iot--list-item--content--values--main"
                   >
-                    Clint Frazier
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="RF"
-                  >
-                    RF
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "color": "black",
-                        }
-                      }
-                      tabIndex={0}
-                      type="button"
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Clint Frazier"
                     >
-                      <span
-                        className="bx--assistive-text"
+                      Clint Frazier
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="RF"
+                    >
+                      RF
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "color": "black",
+                          }
+                        }
+                        tabIndex={0}
+                        type="button"
                       >
-                        Edit
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Edit"
-                        className="bx--btn__icon"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                        />
-                      </svg>
-                    </button>
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Edit
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Edit"
+                          className="bx--btn__icon"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Brett Gardner"
+                    className="iot--list-item--content--values--main"
                   >
-                    Brett Gardner
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="LF"
-                  >
-                    LF
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "color": "black",
-                        }
-                      }
-                      tabIndex={0}
-                      type="button"
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Brett Gardner"
                     >
-                      <span
-                        className="bx--assistive-text"
+                      Brett Gardner
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="LF"
+                    >
+                      LF
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "color": "black",
+                          }
+                        }
+                        tabIndex={0}
+                        type="button"
                       >
-                        Edit
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Edit"
-                        className="bx--btn__icon"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                        />
-                      </svg>
-                    </button>
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Edit
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Edit"
+                          className="bx--btn__icon"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Gio Urshela"
+                    className="iot--list-item--content--values--main"
                   >
-                    Gio Urshela
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="3B"
-                  >
-                    3B
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "color": "black",
-                        }
-                      }
-                      tabIndex={0}
-                      type="button"
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Gio Urshela"
                     >
-                      <span
-                        className="bx--assistive-text"
+                      Gio Urshela
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="3B"
+                    >
+                      3B
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "color": "black",
+                          }
+                        }
+                        tabIndex={0}
+                        type="button"
                       >
-                        Edit
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Edit"
-                        className="bx--btn__icon"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                        />
-                      </svg>
-                    </button>
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Edit
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Edit"
+                          className="bx--btn__icon"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Cameron Maybin"
+                    className="iot--list-item--content--values--main"
                   >
-                    Cameron Maybin
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="RF"
-                  >
-                    RF
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "color": "black",
-                        }
-                      }
-                      tabIndex={0}
-                      type="button"
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Cameron Maybin"
                     >
-                      <span
-                        className="bx--assistive-text"
+                      Cameron Maybin
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="RF"
+                    >
+                      RF
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "color": "black",
+                          }
+                        }
+                        tabIndex={0}
+                        type="button"
                       >
-                        Edit
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Edit"
-                        className="bx--btn__icon"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                        />
-                      </svg>
-                    </button>
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Edit
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Edit"
+                          className="bx--btn__icon"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Robinson Cano"
+                    className="iot--list-item--content--values--main"
                   >
-                    Robinson Cano
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="2B"
-                  >
-                    2B
-                  </div>
-                  <div
-                    className="iot--list-item--content--row-actions"
-                  >
-                    <button
-                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "color": "black",
-                        }
-                      }
-                      tabIndex={0}
-                      type="button"
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="Robinson Cano"
                     >
-                      <span
-                        className="bx--assistive-text"
+                      Robinson Cano
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                      title="2B"
+                    >
+                      2B
+                    </div>
+                    <div
+                      className="iot--list-item--content--row-actions"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "color": "black",
+                          }
+                        }
+                        tabIndex={0}
+                        type="button"
                       >
-                        Edit
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Edit"
-                        className="bx--btn__icon"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                        />
-                      </svg>
-                    </button>
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Edit
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Edit"
+                          className="bx--btn__icon"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -5552,280 +6002,330 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           className="iot--list--content"
         >
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="DJ LeMahieu"
+                    className="iot--list-item--content--values--main"
                   >
-                    DJ LeMahieu
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="2B"
-                  >
-                    2B
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="DJ LeMahieu"
+                    >
+                      DJ LeMahieu
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="2B"
+                    >
+                      2B
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Luke Voit"
+                    className="iot--list-item--content--values--main"
                   >
-                    Luke Voit
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="1B"
-                  >
-                    1B
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Luke Voit"
+                    >
+                      Luke Voit
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="1B"
+                    >
+                      1B
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Gary Sanchez"
+                    className="iot--list-item--content--values--main"
                   >
-                    Gary Sanchez
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="C"
-                  >
-                    C
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Gary Sanchez"
+                    >
+                      Gary Sanchez
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="C"
+                    >
+                      C
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Kendrys Morales"
+                    className="iot--list-item--content--values--main"
                   >
-                    Kendrys Morales
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="DH"
-                  >
-                    DH
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Kendrys Morales"
+                    >
+                      Kendrys Morales
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="DH"
+                    >
+                      DH
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Gleyber Torres"
+                    className="iot--list-item--content--values--main"
                   >
-                    Gleyber Torres
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="SS"
-                  >
-                    SS
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Gleyber Torres"
+                    >
+                      Gleyber Torres
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="SS"
+                    >
+                      SS
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Clint Frazier"
+                    className="iot--list-item--content--values--main"
                   >
-                    Clint Frazier
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="RF"
-                  >
-                    RF
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Clint Frazier"
+                    >
+                      Clint Frazier
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="RF"
+                    >
+                      RF
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Brett Gardner"
+                    className="iot--list-item--content--values--main"
                   >
-                    Brett Gardner
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="LF"
-                  >
-                    LF
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Brett Gardner"
+                    >
+                      Brett Gardner
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="LF"
+                    >
+                      LF
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Gio Urshela"
+                    className="iot--list-item--content--values--main"
                   >
-                    Gio Urshela
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="3B"
-                  >
-                    3B
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Gio Urshela"
+                    >
+                      Gio Urshela
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="3B"
+                    >
+                      3B
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Cameron Maybin"
+                    className="iot--list-item--content--values--main"
                   >
-                    Cameron Maybin
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="RF"
-                  >
-                    RF
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Cameron Maybin"
+                    >
+                      Cameron Maybin
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="RF"
+                    >
+                      RF
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Robinson Cano"
+                    className="iot--list-item--content--values--main"
                   >
-                    Robinson Cano
-                  </div>
-                  <div
-                    className="iot--list-item--content--values--value"
-                    title="2B"
-                  >
-                    2B
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Robinson Cano"
+                    >
+                      Robinson Cano
+                    </div>
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="2B"
+                    >
+                      2B
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-addons-iot-react/issues/1495

**Summary**

When an `OverflowMenu` is used in the `HierarchyList`, the menu is positioned incorrectly because it it implemented as a portal. As a result it is positioned absolute, relative to the body instead of the container we would expect.

Relevant issue in Monitor: https://github.ibm.com/wiotp/monitoring-dashboard/issues/1125

Relevant issue in Carbon: https://github.com/carbon-design-system/carbon/issues/4755

**Change List (commits, features, bugs, etc)**

Adding `data-floating-menu-container` and `style={{ position: 'relative' }}` to a wrapper div forces the menu to be placed back into the DOM where we would expect it, and to be positioned relative to the `HierarchyList` container itself, rather than the body

**Acceptance Test (how to verify the PR)**

Go to the `With OverflowMenu` story  and verify that the position stays with the menu icon through the `scrollIntoView` and as you scroll.
