### PR TITLE
fix(datetime picker): externally set range not selected in calendar

### DIFF
--- a/src/components/DateTimePicker/DateTimePicker.jsx
+++ b/src/components/DateTimePicker/DateTimePicker.jsx
@@ -830,8 +830,8 @@ const DateTimePicker = ({
                         value={
                           absoluteValue
                             ? [
-                                moment(absoluteValue.startDate).format('MM/DD/YYYY'),
-                                moment(absoluteValue.endDate).format('MM/DD/YYYY'),
+                                moment(absoluteValue.startDate, dateTimeMask).format('MM/DD/YYYY'),
+                                moment(absoluteValue.endDate, dateTimeMask).format('MM/DD/YYYY'),
                               ]
                             : ''
                         }

--- a/src/components/DateTimePicker/DateTimePicker.jsx
+++ b/src/components/DateTimePicker/DateTimePicker.jsx
@@ -488,8 +488,7 @@ const DateTimePicker = ({
     });
   };
 
-  const parseDefaultValue = (lastValue = null) => {
-    const parsableValue = lastValue || defaultValue;
+  const parseDefaultValue = parsableValue => {
     const currentCustomRangeKind = showRelativeOption
       ? PICKER_KINDS.RELATIVE
       : PICKER_KINDS.ABSOLUTE;
@@ -551,7 +550,9 @@ const DateTimePicker = ({
   useEffect(
     () => {
       if (defaultValue || humanValue === null) {
-        parseDefaultValue();
+        parseDefaultValue(defaultValue);
+        setLastAppliedValue(defaultValue);
+        setIsExpanded(false);
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -570,6 +571,7 @@ const DateTimePicker = ({
   const onApplyClick = () => {
     setIsExpanded(false);
     const value = renderValue();
+    setLastAppliedValue(value);
     const returnValue = {
       timeRangeKind: value.kind,
       timeRangeValue: null,
@@ -577,15 +579,12 @@ const DateTimePicker = ({
     switch (value.kind) {
       case PICKER_KINDS.ABSOLUTE:
         returnValue.timeRangeValue = value.absolute;
-        setLastAppliedValue(value.absolute);
         break;
       case PICKER_KINDS.RELATIVE:
         returnValue.timeRangeValue = value.relative;
-        setLastAppliedValue(value.relative);
         break;
       default:
         returnValue.timeRangeValue = value.preset;
-        setLastAppliedValue(value.preset);
         break;
     }
 
@@ -828,19 +827,17 @@ const DateTimePicker = ({
                         ref={datePickerRef}
                         onChange={onDatePickerChange}
                         onClose={onDatePickerClose}
+                        value={
+                          absoluteValue
+                            ? [
+                                moment(absoluteValue.startDate).format('MM/DD/YYYY'),
+                                moment(absoluteValue.endDate).format('MM/DD/YYYY'),
+                              ]
+                            : ''
+                        }
                       >
-                        <DatePickerInput
-                          labelText=""
-                          id="date-picker-input-start"
-                          hideLabel
-                          value={absoluteValue ? absoluteValue.startDate : ''}
-                        />
-                        <DatePickerInput
-                          labelText=""
-                          id="date-picker-input-end"
-                          hideLabel
-                          value={absoluteValue ? absoluteValue.endDate : ''}
-                        />
+                        <DatePickerInput labelText="" id="date-picker-input-start" hideLabel />
+                        <DatePickerInput labelText="" id="date-picker-input-end" hideLabel />
                       </DatePicker>
                     </div>
                     {hasTimeInput ? (

--- a/src/components/DateTimePicker/DateTimePicker.jsx
+++ b/src/components/DateTimePicker/DateTimePicker.jsx
@@ -520,6 +520,8 @@ const DateTimePicker = ({
         if (!absolute.hasOwnProperty('end')) {
           absolute.end = moment(absolute.endDate).valueOf();
         }
+        absolute.startDate = moment(absolute.start).format('MM/DD/YYYY');
+        absolute.endDate = moment(absolute.end).format('MM/DD/YYYY');
         setAbsoluteValue(absolute);
       }
     } else {
@@ -552,7 +554,6 @@ const DateTimePicker = ({
       if (defaultValue || humanValue === null) {
         parseDefaultValue(defaultValue);
         setLastAppliedValue(defaultValue);
-        setIsExpanded(false);
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -828,12 +829,7 @@ const DateTimePicker = ({
                         onChange={onDatePickerChange}
                         onClose={onDatePickerClose}
                         value={
-                          absoluteValue
-                            ? [
-                                moment(absoluteValue.startDate, dateTimeMask).format('MM/DD/YYYY'),
-                                moment(absoluteValue.endDate, dateTimeMask).format('MM/DD/YYYY'),
-                              ]
-                            : ''
+                          absoluteValue ? [absoluteValue.startDate, absoluteValue.endDate] : ''
                         }
                       >
                         <DatePickerInput labelText="" id="date-picker-input-start" hideLabel />

--- a/src/components/DateTimePicker/DateTimePicker.test.jsx
+++ b/src/components/DateTimePicker/DateTimePicker.test.jsx
@@ -348,6 +348,61 @@ describe('DateTimePicker', () => {
     ).toHaveLength(1);
   });
 
+  it('should render with programmatically set absolute range', () => {
+    const wrapper = mount(<DateTimePicker {...dateTimePickerProps} />);
+    jest.runAllTimers();
+    expect(wrapper.find('.iot--date-time-picker__field')).toHaveLength(1);
+    expect(wrapper.find('.bx--tooltip__trigger').text()).toEqual(PRESET_VALUES[0].label);
+
+    wrapper.setProps({ defaultValue: defaultAbsoluteValue });
+    jest.runAllTimers();
+    expect(wrapper.find('.iot--date-time-picker__field')).toHaveLength(1);
+    expect(
+      wrapper
+        .find('.iot--date-time-picker__field')
+        .first()
+        .text()
+    ).toEqual('2020-04-01 12:34 to 2020-04-06 10:49');
+
+    wrapper
+      .find('.iot--date-time-picker__icon')
+      .first()
+      .simulate('click');
+    jest.runAllTimers();
+
+    wrapper
+      .find('.iot--time-picker__controls--btn.up-icon')
+      .first()
+      .simulate('click');
+    jest.runAllTimers();
+    expect(
+      wrapper
+        .find('.iot--date-time-picker__field')
+        .first()
+        .text()
+    ).toEqual('2020-04-01 13:34 to 2020-04-06 10:49');
+
+    wrapper
+      .find('.iot--date-time-picker__menu-btn-back')
+      .first()
+      .simulate('click');
+    jest.runAllTimers();
+    wrapper
+      .find('.iot--date-time-picker__menu-btn-cancel')
+      .first()
+      .simulate('click');
+    jest.runAllTimers();
+
+    expect(dateTimePickerProps.onCancel).toHaveBeenCalled();
+    expect(wrapper.find('.iot--date-time-picker__field')).toHaveLength(1);
+    expect(
+      wrapper
+        .find('.iot--date-time-picker__field')
+        .first()
+        .text()
+    ).toEqual('2020-04-01 12:34 to 2020-04-06 10:49');
+  });
+
   it('i18n string test', () => {
     const i18nTest = {
       toLabel: 'to-label',

--- a/src/components/DateTimePicker/__snapshots__/DateTimePicker.story.storyshot
+++ b/src/components/DateTimePicker/__snapshots__/DateTimePicker.story.storyshot
@@ -333,7 +333,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                               onClick={[Function]}
                               pattern="\\\\d{1,2}\\\\/\\\\d{1,2}\\\\/\\\\d{4}"
                               type="text"
-                              value="2020-04-01"
                             />
                             <svg
                               aria-hidden={true}
@@ -367,7 +366,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                               onClick={[Function]}
                               pattern="\\\\d{1,2}\\\\/\\\\d{1,2}\\\\/\\\\d{4}"
                               type="text"
-                              value="2020-04-06"
                             />
                             <svg
                               aria-hidden={true}


### PR DESCRIPTION
Closes #1482 #1494

**Summary**

- The external value is passed in as "defaultValue". Updated code to ensure that the external value is properly set and assigned to "lastAppliedValue" as well.
- The absolute value was not being passed to Carbon DatePicker correctly. Current code passes the absolute value startDate and endDate to DatePickerInput as "value" prop. DatePickerInput doesn't have any "value" prop. Passing the start and end date as an array to DatePicker's "value" prop.
- DatePicker dateFormat has been set as "m/d/Y". However, the format of the date that is passed to the "value" prop depends on the "dateTimeMask". So when we set the "dateTimeMask" to anything but "MM/DD/YYYY", the current selection is not set in calendar. Changed code to format the absolute value dates to "MM/DD/YYYY" before passing to DatePicker so that its independent of the format specified in "dateTimeMask".

**Change List (commits, features, bugs, etc)**

- https://github.com/carbon-design-system/carbon-addons-iot-react/commit/49187d9a2065cfb7316100ab39d75bd853adeb60

**Acceptance Test (how to verify the PR)**

- Tested the changes in Predict Asset Timeline widget.
