### PR TITLE
Export PageSwitcher

### DIFF
--- a/.storybook/__snapshots__/Welcome.story.storyshot
+++ b/.storybook/__snapshots__/Welcome.story.storyshot
@@ -2881,6 +2881,18 @@ exports[`Storybook Snapshot tests and console checks Storyshots 0/Getting Starte
                   <div
                     className="bx--structured-list-td"
                   >
+                    PageSwitcher
+                  </div>
+                </div>
+                <div
+                  className="bx--structured-list-row"
+                >
+                  <div
+                    className="bx--structured-list-td"
+                  />
+                  <div
+                    className="bx--structured-list-td"
+                  >
                     Dashboard
                   </div>
                 </div>

--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,7 @@ export EditPage from './components/Page/EditPage';
 export NavigationBar from './components/NavigationBar/NavigationBar';
 export Header from './components/Header';
 export SideNav from './components/SideNav';
+export PageSwitcher from './components/Page/PageSwitcher';
 
 // Dashboard
 export Dashboard from './components/Dashboard/Dashboard';

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -5745,6 +5745,48 @@ Map {
       },
     },
   },
+  "PageSwitcher" => Object {
+    "defaultProps": Object {
+      "switcher": Object {
+        "onChange": null,
+        "selectedIndex": null,
+      },
+    },
+    "propTypes": Object {
+      "switcher": Object {
+        "args": Array [
+          Object {
+            "onChange": Object {
+              "type": "func",
+            },
+            "options": Object {
+              "args": Array [
+                Object {
+                  "args": Array [
+                    Object {
+                      "id": Object {
+                        "type": "string",
+                      },
+                      "text": Object {
+                        "type": "string",
+                      },
+                    },
+                  ],
+                  "type": "shape",
+                },
+              ],
+              "isRequired": true,
+              "type": "arrayOf",
+            },
+            "selectedIndex": Object {
+              "type": "number",
+            },
+          },
+        ],
+        "type": "shape",
+      },
+    },
+  },
   "Dashboard" => Object {
     "defaultProps": Object {
       "actions": Array [],


### PR DESCRIPTION
Closes #

**Summary**

We have use for the `PageSwitcher` component in monitor, but it is not being exported.

**Change List (commits, features, bugs, etc)**

Add `PageSwitcher` to index.js exports.