### PR TITLE
feat(listitem): add tags

### DIFF
--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 import { settings } from '../../constants/Settings';
 import SimplePagination, { SimplePaginationPropTypes } from '../SimplePagination/SimplePagination';
 import { SkeletonText } from '../SkeletonText';
-import { ListTagsPropTypes } from '../../constants/SharedPropTypes';
 
 import ListItem from './ListItem/ListItem';
 import ListHeader from './ListHeader/ListHeader';
@@ -17,7 +16,8 @@ export const itemPropTypes = {
   content: PropTypes.shape({
     value: PropTypes.string,
     icon: PropTypes.node,
-    tags: ListTagsPropTypes,
+    /** The nodes should be Carbon Tags components */
+    tags: PropTypes.arrayOf(PropTypes.node),
   }),
   children: PropTypes.arrayOf(PropTypes.object),
   isSelectable: PropTypes.bool,

--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import { settings } from '../../constants/Settings';
 import SimplePagination, { SimplePaginationPropTypes } from '../SimplePagination/SimplePagination';
 import { SkeletonText } from '../SkeletonText';
+import { ListTagsPropTypes } from '../../constants/SharedPropTypes';
 
 import ListItem from './ListItem/ListItem';
 import ListHeader from './ListHeader/ListHeader';
@@ -16,6 +17,7 @@ export const itemPropTypes = {
   content: PropTypes.shape({
     value: PropTypes.string,
     icon: PropTypes.node,
+    tags: ListTagsPropTypes,
   }),
   children: PropTypes.arrayOf(PropTypes.object),
   isSelectable: PropTypes.bool,
@@ -108,7 +110,7 @@ const List = forwardRef((props, ref) => {
     const isExpanded = expandedIds.filter(rowId => rowId === item.id).length > 0;
 
     const {
-      content: { value, secondaryValue, icon, rowActions },
+      content: { value, secondaryValue, icon, rowActions, tags },
       isSelectable,
       isCategory,
     } = item;
@@ -133,6 +135,7 @@ const List = forwardRef((props, ref) => {
         isSelectable={isSelectable}
         i18n={i18n}
         selectedItemRef={isSelected ? selectedItemRef : null}
+        tags={tags}
       />,
       ...(hasChildren && isExpanded
         ? item.children.map(child => renderItemAndChildren(child, level + 1))

--- a/src/components/List/List.story.jsx
+++ b/src/components/List/List.story.jsx
@@ -7,6 +7,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import someDeep from 'deepdash/someDeep';
 
 import { Button, OverflowMenu, OverflowMenuItem, Checkbox } from '../..';
+import { Tag } from '../Tag';
 
 import List from './List';
 
@@ -468,7 +469,14 @@ storiesOf('Watson IoT Experimental/List', module)
         items={Object.entries(sampleHierarchy.MLB['American League']['New York Yankees']).map(
           ([key]) => ({
             id: key,
-            content: { value: key, tags: [{ type: 'blue', content: 'my tag 1' }] },
+            content: {
+              value: key,
+              tags: [
+                <Tag type="blue" title="descriptor" key="tag1">
+                  default
+                </Tag>,
+              ],
+            },
           })
         )}
         isLoading={boolean('isLoading', false)}

--- a/src/components/List/List.story.jsx
+++ b/src/components/List/List.story.jsx
@@ -460,4 +460,18 @@ storiesOf('Watson IoT Experimental/List', module)
       );
     };
     return <MultiSelectList />;
-  });
+  })
+  .add('with tags', () => (
+    <div style={{ width: 400 }}>
+      <List
+        title={text('title', 'NY Yankees')}
+        items={Object.entries(sampleHierarchy.MLB['American League']['New York Yankees']).map(
+          ([key]) => ({
+            id: key,
+            content: { value: key, tags: [{ type: 'blue', content: 'my tag 1' }] },
+          })
+        )}
+        isLoading={boolean('isLoading', false)}
+      />
+    </div>
+  ));

--- a/src/components/List/ListItem/ListItem.jsx
+++ b/src/components/List/ListItem/ListItem.jsx
@@ -4,6 +4,8 @@ import { ChevronUp16, ChevronDown16 } from '@carbon/icons-react';
 import PropTypes from 'prop-types';
 import isEmpty from 'lodash/isEmpty';
 
+import { Tag } from '../../Tag';
+import { ListTagsPropTypes } from '../../../constants/SharedPropTypes';
 import { settings } from '../../../constants/Settings';
 
 const { iotPrefix } = settings;
@@ -74,6 +76,7 @@ const ListItemPropTypes = {
     // Or the instance of a DOM native element (see the note about SSR)
     PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   ]),
+  tags: ListTagsPropTypes,
 };
 
 const ListItemDefaultProps = {
@@ -95,6 +98,7 @@ const ListItemDefaultProps = {
     close: 'Close',
   },
   selectedItemRef: null,
+  tags: null,
 };
 
 const ListItem = ({
@@ -115,6 +119,7 @@ const ListItem = ({
   isCategory,
   i18n,
   selectedItemRef,
+  tags,
 }) => {
   const handleExpansionClick = () => isExpandable && onExpand(id);
 
@@ -159,6 +164,17 @@ const ListItem = ({
       <div className={`${iotPrefix}--list-item--content--row-actions`}>{rowActions}</div>
     ) : null;
 
+  const renderTags = () =>
+    tags && tags.length > 0 ? (
+      <div>
+        {tags.map((tag, i) => (
+          <Tag key={`tag-${i}`} type={tag.type}>
+            {tag.content}
+          </Tag>
+        ))}
+      </div>
+    ) : null;
+
   return (
     <ListItemWrapper {...{ id, isSelectable, selected, isLargeRow, onSelect }}>
       {renderNestingOffset()}
@@ -193,6 +209,7 @@ const ListItem = ({
                 >
                   {value}
                 </div>
+                {renderTags()}
                 {renderRowActions()}
               </div>
               {secondaryValue ? (
@@ -238,6 +255,7 @@ const ListItem = ({
                     {secondaryValue}
                   </div>
                 ) : null}
+                {renderTags()}
                 {renderRowActions()}
               </div>
             </>

--- a/src/components/List/ListItem/ListItem.jsx
+++ b/src/components/List/ListItem/ListItem.jsx
@@ -4,8 +4,6 @@ import { ChevronUp16, ChevronDown16 } from '@carbon/icons-react';
 import PropTypes from 'prop-types';
 import isEmpty from 'lodash/isEmpty';
 
-import { Tag } from '../../Tag';
-import { ListTagsPropTypes } from '../../../constants/SharedPropTypes';
 import { settings } from '../../../constants/Settings';
 
 const { iotPrefix } = settings;
@@ -76,7 +74,8 @@ const ListItemPropTypes = {
     // Or the instance of a DOM native element (see the note about SSR)
     PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   ]),
-  tags: ListTagsPropTypes,
+  /** The nodes should be Carbon Tags components */
+  tags: PropTypes.arrayOf(PropTypes.node),
 };
 
 const ListItemDefaultProps = {
@@ -164,16 +163,7 @@ const ListItem = ({
       <div className={`${iotPrefix}--list-item--content--row-actions`}>{rowActions}</div>
     ) : null;
 
-  const renderTags = () =>
-    tags && tags.length > 0 ? (
-      <div>
-        {tags.map((tag, i) => (
-          <Tag key={`tag-${i}`} type={tag.type}>
-            {tag.content}
-          </Tag>
-        ))}
-      </div>
-    ) : null;
+  const renderTags = () => (tags && tags.length > 0 ? <div>{tags}</div> : null);
 
   return (
     <ListItemWrapper {...{ id, isSelectable, selected, isLargeRow, onSelect }}>

--- a/src/components/List/ListItem/ListItem.story.jsx
+++ b/src/components/List/ListItem/ListItem.story.jsx
@@ -16,6 +16,8 @@ storiesOf('Watson IoT Experimental/ListItem', module)
     const iconComponent =
       iconName === 'Star16' ? Star16 : iconName === 'StarFilled16' ? StarFilled16 : null;
     const rowActionSet = select('row action example', ['none', 'single', 'multi'], 'none');
+    const tagsConfig = select('tags example', ['none', 'single', 'multi'], 'none');
+
     const rowActionComponent =
       rowActionSet === 'single'
         ? [
@@ -39,6 +41,12 @@ storiesOf('Watson IoT Experimental/ListItem', module)
             </OverflowMenu>,
           ]
         : [];
+    const tagsData =
+      tagsConfig === 'single'
+        ? [{ type: 'blue', content: 'default' }]
+        : tagsConfig === 'multi'
+        ? [{ type: 'blue', content: 'default' }, { type: 'red', content: 'warning' }]
+        : undefined;
     return (
       <div style={{ width: 400 }}>
         <ListItem
@@ -57,6 +65,7 @@ storiesOf('Watson IoT Experimental/ListItem', module)
           isLargeRow={boolean('isLargeRow', false)}
           nestingLevel={select('nestingLevel', [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 0)}
           rowActions={rowActionComponent}
+          tags={tagsData}
         />
       </div>
     );
@@ -183,6 +192,15 @@ storiesOf('Watson IoT Experimental/ListItem', module)
             <OverflowMenuItem itemText="Danger option" hasDivider isDelete />
           </OverflowMenu>,
         ]}
+      />
+    </div>
+  ))
+  .add('with Tags', () => (
+    <div style={{ width: 400 }}>
+      <ListItem
+        id="list-item"
+        value={text('value', 'List Item')}
+        tags={[{ type: 'blue', content: 'default' }, { type: 'red', content: 'warning' }]}
       />
     </div>
   ));

--- a/src/components/List/ListItem/ListItem.story.jsx
+++ b/src/components/List/ListItem/ListItem.story.jsx
@@ -5,6 +5,7 @@ import { text, select, boolean } from '@storybook/addon-knobs';
 import { Edit16, Star16, StarFilled16 } from '@carbon/icons-react';
 
 import { Button, OverflowMenu, OverflowMenuItem } from '../../..';
+import { Tag } from '../../Tag';
 
 import ListItem from './ListItem';
 
@@ -43,9 +44,20 @@ storiesOf('Watson IoT Experimental/ListItem', module)
         : [];
     const tagsData =
       tagsConfig === 'single'
-        ? [{ type: 'blue', content: 'default' }]
+        ? [
+            <Tag type="blue" title="descriptor" key="tag1">
+              default
+            </Tag>,
+          ]
         : tagsConfig === 'multi'
-        ? [{ type: 'blue', content: 'default' }, { type: 'red', content: 'warning' }]
+        ? [
+            <Tag type="blue" title="descriptor" key="tag1">
+              default
+            </Tag>,
+            <Tag type="red" disabled key="tag2">
+              disabled tag
+            </Tag>,
+          ]
         : undefined;
     return (
       <div style={{ width: 400 }}>
@@ -200,7 +212,14 @@ storiesOf('Watson IoT Experimental/ListItem', module)
       <ListItem
         id="list-item"
         value={text('value', 'List Item')}
-        tags={[{ type: 'blue', content: 'default' }, { type: 'red', content: 'warning' }]}
+        tags={[
+          <Tag type="blue" title="descriptor" key="tag1">
+            default
+          </Tag>,
+          <Tag type="red" disabled key="tag2">
+            disabled tag
+          </Tag>,
+        ]}
       />
     </div>
   ));

--- a/src/components/List/ListItem/ListItem.test.jsx
+++ b/src/components/List/ListItem/ListItem.test.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
 import { Add16, Edit16 } from '@carbon/icons-react';
 
+import { Tag } from '../../Tag';
+
 import ListItem from './ListItem';
 
 describe('ListItem', () => {
@@ -97,7 +99,14 @@ describe('ListItem', () => {
   });
 
   it('shows Tags when available', () => {
-    const tags = [{ type: 'blue', content: 'my tag 1' }, { type: 'red', content: 'my tag 2' }];
+    const tags = [
+      <Tag type="blue" title="descriptor" key="tag1">
+        my tag 1
+      </Tag>,
+      <Tag type="red" disabled key="tag2">
+        my tag 2
+      </Tag>,
+    ];
     const { rerender } = render(<ListItem id="1" value="test" />);
     expect(screen.queryByText('my tag 1')).not.toBeInTheDocument();
     expect(screen.queryByText('my tag 2')).not.toBeInTheDocument();

--- a/src/components/List/ListItem/ListItem.test.jsx
+++ b/src/components/List/ListItem/ListItem.test.jsx
@@ -95,4 +95,15 @@ describe('ListItem', () => {
     expect(screen.getByLabelText(i18nTest.expand)).toBeInTheDocument();
     expect(screen.queryByLabelText(i18nDefaults.expand)).not.toBeInTheDocument();
   });
+
+  it('shows Tags when available', () => {
+    const tags = [{ type: 'blue', content: 'my tag 1' }, { type: 'red', content: 'my tag 2' }];
+    const { rerender } = render(<ListItem id="1" value="test" />);
+    expect(screen.queryByText('my tag 1')).not.toBeInTheDocument();
+    expect(screen.queryByText('my tag 2')).not.toBeInTheDocument();
+
+    rerender(<ListItem id="1" value="test" tags={tags} />);
+    expect(screen.getByText('my tag 1')).toBeVisible();
+    expect(screen.getByText('my tag 2')).toBeVisible();
+  });
 });

--- a/src/components/List/__snapshots__/List.story.storyshot
+++ b/src/components/List/__snapshots__/List.story.storyshot
@@ -5860,3 +5860,364 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
   </button>
 </div>
 `;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/List with tags 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              NY Yankees
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            />
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="DJ LeMahieu"
+                  >
+                    DJ LeMahieu
+                  </div>
+                  <div>
+                    <span
+                      className="bx--tag bx--tag--blue"
+                    >
+                      my tag 1
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Luke Voit"
+                  >
+                    Luke Voit
+                  </div>
+                  <div>
+                    <span
+                      className="bx--tag bx--tag--blue"
+                    >
+                      my tag 1
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Gary Sanchez"
+                  >
+                    Gary Sanchez
+                  </div>
+                  <div>
+                    <span
+                      className="bx--tag bx--tag--blue"
+                    >
+                      my tag 1
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Kendrys Morales"
+                  >
+                    Kendrys Morales
+                  </div>
+                  <div>
+                    <span
+                      className="bx--tag bx--tag--blue"
+                    >
+                      my tag 1
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Gleyber Torres"
+                  >
+                    Gleyber Torres
+                  </div>
+                  <div>
+                    <span
+                      className="bx--tag bx--tag--blue"
+                    >
+                      my tag 1
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Clint Frazier"
+                  >
+                    Clint Frazier
+                  </div>
+                  <div>
+                    <span
+                      className="bx--tag bx--tag--blue"
+                    >
+                      my tag 1
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Brett Gardner"
+                  >
+                    Brett Gardner
+                  </div>
+                  <div>
+                    <span
+                      className="bx--tag bx--tag--blue"
+                    >
+                      my tag 1
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Gio Urshela"
+                  >
+                    Gio Urshela
+                  </div>
+                  <div>
+                    <span
+                      className="bx--tag bx--tag--blue"
+                    >
+                      my tag 1
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Cameron Maybin"
+                  >
+                    Cameron Maybin
+                  </div>
+                  <div>
+                    <span
+                      className="bx--tag bx--tag--blue"
+                    >
+                      my tag 1
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Robinson Cano"
+                  >
+                    Robinson Cano
+                  </div>
+                  <div>
+                    <span
+                      className="bx--tag bx--tag--blue"
+                    >
+                      my tag 1
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/List/__snapshots__/List.story.storyshot
+++ b/src/components/List/__snapshots__/List.story.storyshot
@@ -6403,290 +6403,340 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           className="iot--list--content"
         >
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="DJ LeMahieu"
+                    className="iot--list-item--content--values--main"
                   >
-                    DJ LeMahieu
-                  </div>
-                  <div>
-                    <span
-                      className="bx--tag bx--tag--blue"
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="DJ LeMahieu"
                     >
-                      my tag 1
-                    </span>
+                      DJ LeMahieu
+                    </div>
+                    <div>
+                      <span
+                        className="bx--tag bx--tag--blue"
+                      >
+                        default
+                      </span>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Luke Voit"
+                    className="iot--list-item--content--values--main"
                   >
-                    Luke Voit
-                  </div>
-                  <div>
-                    <span
-                      className="bx--tag bx--tag--blue"
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Luke Voit"
                     >
-                      my tag 1
-                    </span>
+                      Luke Voit
+                    </div>
+                    <div>
+                      <span
+                        className="bx--tag bx--tag--blue"
+                      >
+                        default
+                      </span>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Gary Sanchez"
+                    className="iot--list-item--content--values--main"
                   >
-                    Gary Sanchez
-                  </div>
-                  <div>
-                    <span
-                      className="bx--tag bx--tag--blue"
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Gary Sanchez"
                     >
-                      my tag 1
-                    </span>
+                      Gary Sanchez
+                    </div>
+                    <div>
+                      <span
+                        className="bx--tag bx--tag--blue"
+                      >
+                        default
+                      </span>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Kendrys Morales"
+                    className="iot--list-item--content--values--main"
                   >
-                    Kendrys Morales
-                  </div>
-                  <div>
-                    <span
-                      className="bx--tag bx--tag--blue"
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Kendrys Morales"
                     >
-                      my tag 1
-                    </span>
+                      Kendrys Morales
+                    </div>
+                    <div>
+                      <span
+                        className="bx--tag bx--tag--blue"
+                      >
+                        default
+                      </span>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Gleyber Torres"
+                    className="iot--list-item--content--values--main"
                   >
-                    Gleyber Torres
-                  </div>
-                  <div>
-                    <span
-                      className="bx--tag bx--tag--blue"
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Gleyber Torres"
                     >
-                      my tag 1
-                    </span>
+                      Gleyber Torres
+                    </div>
+                    <div>
+                      <span
+                        className="bx--tag bx--tag--blue"
+                      >
+                        default
+                      </span>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Clint Frazier"
+                    className="iot--list-item--content--values--main"
                   >
-                    Clint Frazier
-                  </div>
-                  <div>
-                    <span
-                      className="bx--tag bx--tag--blue"
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Clint Frazier"
                     >
-                      my tag 1
-                    </span>
+                      Clint Frazier
+                    </div>
+                    <div>
+                      <span
+                        className="bx--tag bx--tag--blue"
+                      >
+                        default
+                      </span>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Brett Gardner"
+                    className="iot--list-item--content--values--main"
                   >
-                    Brett Gardner
-                  </div>
-                  <div>
-                    <span
-                      className="bx--tag bx--tag--blue"
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Brett Gardner"
                     >
-                      my tag 1
-                    </span>
+                      Brett Gardner
+                    </div>
+                    <div>
+                      <span
+                        className="bx--tag bx--tag--blue"
+                      >
+                        default
+                      </span>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Gio Urshela"
+                    className="iot--list-item--content--values--main"
                   >
-                    Gio Urshela
-                  </div>
-                  <div>
-                    <span
-                      className="bx--tag bx--tag--blue"
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Gio Urshela"
                     >
-                      my tag 1
-                    </span>
+                      Gio Urshela
+                    </div>
+                    <div>
+                      <span
+                        className="bx--tag bx--tag--blue"
+                      >
+                        default
+                      </span>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Cameron Maybin"
+                    className="iot--list-item--content--values--main"
                   >
-                    Cameron Maybin
-                  </div>
-                  <div>
-                    <span
-                      className="bx--tag bx--tag--blue"
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Cameron Maybin"
                     >
-                      my tag 1
-                    </span>
+                      Cameron Maybin
+                    </div>
+                    <div>
+                      <span
+                        className="bx--tag bx--tag--blue"
+                      >
+                        default
+                      </span>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="iot--list-item"
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
           >
             <div
-              className="iot--list-item--content"
+              className="iot--list-item"
             >
               <div
-                className="iot--list-item--content--values"
+                className="iot--list-item--content"
               >
                 <div
-                  className="iot--list-item--content--values--main"
+                  className="iot--list-item--content--values"
                 >
                   <div
-                    className="iot--list-item--content--values--value"
-                    title="Robinson Cano"
+                    className="iot--list-item--content--values--main"
                   >
-                    Robinson Cano
-                  </div>
-                  <div>
-                    <span
-                      className="bx--tag bx--tag--blue"
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="Robinson Cano"
                     >
-                      my tag 1
-                    </span>
+                      Robinson Cano
+                    </div>
+                    <div>
+                      <span
+                        className="bx--tag bx--tag--blue"
+                      >
+                        default
+                      </span>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/src/constants/SharedPropTypes.js
+++ b/src/constants/SharedPropTypes.js
@@ -4,3 +4,12 @@ export const OverridePropTypes = PropTypes.shape({
   props: PropTypes.object,
   component: PropTypes.elementType,
 });
+
+export const ListTagsPropTypes = PropTypes.arrayOf(
+  PropTypes.shape({
+    /** The content of the tag */
+    content: PropTypes.string,
+    /** The type (normally color, see Tag component) */
+    type: PropTypes.string,
+  })
+);

--- a/src/constants/SharedPropTypes.js
+++ b/src/constants/SharedPropTypes.js
@@ -4,12 +4,3 @@ export const OverridePropTypes = PropTypes.shape({
   props: PropTypes.object,
   component: PropTypes.elementType,
 });
-
-export const ListTagsPropTypes = PropTypes.arrayOf(
-  PropTypes.shape({
-    /** The content of the tag */
-    content: PropTypes.string,
-    /** The type (normally color, see Tag component) */
-    type: PropTypes.string,
-  })
-);

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -13671,17 +13671,7 @@ Map {
                       "tags": Object {
                         "args": Array [
                           Object {
-                            "args": Array [
-                              Object {
-                                "content": Object {
-                                  "type": "string",
-                                },
-                                "type": Object {
-                                  "type": "string",
-                                },
-                              },
-                            ],
-                            "type": "shape",
+                            "type": "node",
                           },
                         ],
                         "type": "arrayOf",

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -13668,6 +13668,24 @@ Map {
                       "icon": Object {
                         "type": "node",
                       },
+                      "tags": Object {
+                        "args": Array [
+                          Object {
+                            "args": Array [
+                              Object {
+                                "content": Object {
+                                  "type": "string",
+                                },
+                                "type": Object {
+                                  "type": "string",
+                                },
+                              },
+                            ],
+                            "type": "shape",
+                          },
+                        ],
+                        "type": "arrayOf",
+                      },
                       "value": Object {
                         "type": "string",
                       },


### PR DESCRIPTION
Closes #1518 

**Summary**
Adds the possibility to add one or more tags to an ListItem in a List.
![image](https://user-images.githubusercontent.com/5167091/90565440-37317e80-e1a7-11ea-842f-8dc1ae3753cb.png)
![image](https://user-images.githubusercontent.com/5167091/90565487-44e70400-e1a7-11ea-9197-14283738704f.png)


**Change List (commits, features, bugs, etc)**
1. Added a new tag prop to the ListItem.jsx and a new ListTagsPropTypes PropType in SharedPropTypes.js since the prop type is shared between List and ListItem
2. Updated ListItem tests and stories
3. Modified the content prop in List.jsx to include an optional tags prop
4. Updated List tests and stories

**Acceptance Test (how to verify the PR)**

1. Go to /story/watson-iot-experimental-listitem--basic-w-knobs
2. Enable tags using the knobs, verify that it looks ok
3. Enable all the other features and make sure it all plays well together
4. Verify that the rest of the ListItem stories look good
5. Go to /story/watson-iot-experimental-list--with-tags
6. Make sure that the tag is rendered properly for each item
7. Verify that the rest of the List stories look good
