### PR TITLE
Filter tags group initial implementation

### DIFF
--- a/.storybook/__snapshots__/Welcome.story.storyshot
+++ b/.storybook/__snapshots__/Welcome.story.storyshot
@@ -3325,6 +3325,18 @@ exports[`Storybook Snapshot tests and console checks Storyshots 0/Getting Starte
                   <div
                     className="bx--structured-list-td"
                   >
+                    FilterTags
+                  </div>
+                </div>
+                <div
+                  className="bx--structured-list-row"
+                >
+                  <div
+                    className="bx--structured-list-td"
+                  />
+                  <div
+                    className="bx--structured-list-td"
+                  >
                     determineCardRange
                   </div>
                 </div>

--- a/src/components/FilterTags/FilterTags.jsx
+++ b/src/components/FilterTags/FilterTags.jsx
@@ -1,24 +1,24 @@
 import React, { useRef, useEffect, useState, Children } from 'react';
 import PropTypes from 'prop-types';
 import useResizeObserver from 'use-resize-observer';
-import { OverflowMenuItem, OverflowMenu, Tag } from 'carbon-components-react';
+import { OverflowMenuItem, OverflowMenu } from 'carbon-components-react';
 import { Close16 } from '@carbon/icons-react';
-
+/* eslint-disable-next-line react/prop-types */
 const DefaultWrapper = React.forwardRef(({ children, ...props }, ref) => {
   return (
-    <span {...props} ref={ref}>
+    <div {...props} ref={ref}>
       {children}
-    </span>
+    </div>
   );
 });
-
+/* eslint-disable-next-line react/prop-types */
 const OverflowTag = ({ children }) => (
   <span>
     {children} <Close16 />
   </span>
 );
 
-const FilterTags = ({ children, hasOverflow, startingIndex }) => {
+const FilterTags = ({ children, hasOverflow, id }) => {
   const overFlowContainerRef = useRef(null);
   useResizeObserver({
     ref: overFlowContainerRef,
@@ -30,9 +30,10 @@ const FilterTags = ({ children, hasOverflow, startingIndex }) => {
 
   useEffect(
     () => {
+      /* istanbul ignore else */
       if (hasOverflow && overFlowContainerRef) {
         setOverflowItems([]);
-        setVisibleItems(childrenItems.slice(startingIndex));
+        setVisibleItems(childrenItems.slice(0));
       }
     }, // eslint-disable-next-line react-hooks/exhaustive-deps
     [children]
@@ -40,6 +41,7 @@ const FilterTags = ({ children, hasOverflow, startingIndex }) => {
 
   useEffect(
     () => {
+      /* istanbul ignore else */
       if (overFlowContainerRef.current) {
         const clientWidth = overFlowContainerRef.current?.clientWidth;
         const scrollWidth = overFlowContainerRef.current?.scrollWidth;
@@ -75,7 +77,12 @@ const FilterTags = ({ children, hasOverflow, startingIndex }) => {
   );
 
   return (
-    <DefaultWrapper className="filtertags--container" ref={overFlowContainerRef}>
+    <DefaultWrapper
+      id={id}
+      data-testid={id}
+      className="filtertags--container"
+      ref={overFlowContainerRef}
+    >
       {visibleItems}
       {overflowItems.length > 0 && (
         <OverflowMenu
@@ -89,7 +96,6 @@ const FilterTags = ({ children, hasOverflow, startingIndex }) => {
         >
           {overflowItems.map((child, i) => (
             <OverflowMenuItem
-              // {...child.props}
               primaryFocus={i === 0}
               className="filtertags--overflow-item"
               title={child.props.children}
@@ -106,9 +112,13 @@ const FilterTags = ({ children, hasOverflow, startingIndex }) => {
 
 const propTypes = {
   /**
+   * ID for filter tag container
+   */
+  id: PropTypes.string,
+  /**
    * Tag components nested inside Filter tag component
    */
-  children: PropTypes.node,
+  children: PropTypes.node.isRequired,
   /**
    * Bit to determine if tags collapse into overflow tag
    */
@@ -116,8 +126,8 @@ const propTypes = {
 };
 
 const defaultProps = {
+  id: 'filter-tag-container',
   hasOverflow: true,
-  startingIndex: 0,
 };
 
 FilterTags.propTypes = propTypes;

--- a/src/components/FilterTags/FilterTags.jsx
+++ b/src/components/FilterTags/FilterTags.jsx
@@ -1,0 +1,125 @@
+import React, { useRef, useEffect, useState, Children } from 'react';
+import PropTypes from 'prop-types';
+import useResizeObserver from 'use-resize-observer';
+import { OverflowMenuItem, OverflowMenu, Tag } from 'carbon-components-react';
+import { Close16 } from '@carbon/icons-react';
+
+const DefaultWrapper = React.forwardRef(({ children, ...props }, ref) => {
+  return (
+    <span {...props} ref={ref}>
+      {children}
+    </span>
+  );
+});
+
+const OverflowTag = ({ children }) => (
+  <span>
+    {children} <Close16 />
+  </span>
+);
+
+const FilterTags = ({ children, hasOverflow, startingIndex }) => {
+  const overFlowContainerRef = useRef(null);
+  useResizeObserver({
+    ref: overFlowContainerRef,
+  });
+  const childrenItems = Children.map(children, child => child);
+  const breakingWidth = useRef([]);
+  const [overflowItems, setOverflowItems] = useState([]);
+  const [visibleItems, setVisibleItems] = useState(childrenItems);
+
+  useEffect(
+    () => {
+      if (hasOverflow && overFlowContainerRef) {
+        setOverflowItems([]);
+        setVisibleItems(childrenItems.slice(startingIndex));
+      }
+    }, // eslint-disable-next-line react-hooks/exhaustive-deps
+    [children]
+  );
+
+  useEffect(
+    () => {
+      if (overFlowContainerRef.current) {
+        const clientWidth = overFlowContainerRef.current?.clientWidth;
+        const scrollWidth = overFlowContainerRef.current?.scrollWidth;
+        const currBreakingWidth = breakingWidth.current;
+        const breakingWidthLength = currBreakingWidth.length;
+        const tooBig = scrollWidth > clientWidth;
+
+        if (tooBig) {
+          currBreakingWidth.push(scrollWidth);
+          if (visibleItems.length > 1) {
+            // Move item to the hidden list
+            setOverflowItems([visibleItems.pop(), ...overflowItems]);
+            setVisibleItems([...visibleItems]);
+          }
+        } else if (
+          currBreakingWidth[breakingWidthLength - 1] >= 0 &&
+          clientWidth > currBreakingWidth[breakingWidthLength - 1] &&
+          overflowItems.length > 0
+        ) {
+          // Move the item to the visible list
+          setVisibleItems([...visibleItems, overflowItems.shift()]);
+          setOverflowItems([...overflowItems]);
+          currBreakingWidth.shift();
+        }
+      }
+    } /* eslint-disable react-hooks/exhaustive-deps */,
+    [
+      overFlowContainerRef?.current?.scrollWidth,
+      overFlowContainerRef?.current?.clientWidth,
+      childrenItems,
+    ]
+    /* eslint-enable react-hooks/exhaustive-deps */
+  );
+
+  return (
+    <DefaultWrapper className="filtertags--container" ref={overFlowContainerRef}>
+      {visibleItems}
+      {overflowItems.length > 0 && (
+        <OverflowMenu
+          data-floating-menu-container
+          className="filtertags--overflow"
+          renderIcon={() => <div className="bx--tag">{`More: ${overflowItems.length}`}</div>}
+          menuOptionsClass="filtertags--overflow-items"
+          menuOffset={{
+            top: 15,
+          }}
+        >
+          {overflowItems.map((child, i) => (
+            <OverflowMenuItem
+              // {...child.props}
+              primaryFocus={i === 0}
+              className="filtertags--overflow-item"
+              title={child.props.children}
+              key={`${child.props.children}-${i}`}
+              onClick={child.props.onClose}
+              itemText={<OverflowTag filter>{child.props.children}</OverflowTag>}
+            />
+          ))}
+        </OverflowMenu>
+      )}
+    </DefaultWrapper>
+  );
+};
+
+const propTypes = {
+  /**
+   * Tag components nested inside Filter tag component
+   */
+  children: PropTypes.node,
+  /**
+   * Bit to determine if tags collapse into overflow tag
+   */
+  hasOverflow: PropTypes.bool,
+};
+
+const defaultProps = {
+  hasOverflow: true,
+  startingIndex: 0,
+};
+
+FilterTags.propTypes = propTypes;
+FilterTags.defaultProps = defaultProps;
+export default FilterTags;

--- a/src/components/FilterTags/FilterTags.jsx
+++ b/src/components/FilterTags/FilterTags.jsx
@@ -3,6 +3,11 @@ import PropTypes from 'prop-types';
 import useResizeObserver from 'use-resize-observer';
 import { OverflowMenuItem, OverflowMenu } from 'carbon-components-react';
 import { Close16 } from '@carbon/icons-react';
+import classnames from 'classnames';
+
+import { settings } from '../../constants/Settings';
+
+const { prefix, iotPrefix } = settings;
 /* eslint-disable-next-line react/prop-types */
 const DefaultWrapper = React.forwardRef(({ children, ...props }, ref) => {
   return (
@@ -42,7 +47,7 @@ const FilterTags = ({ children, hasOverflow, id }) => {
   useEffect(
     () => {
       /* istanbul ignore else */
-      if (overFlowContainerRef.current) {
+      if (hasOverflow && overFlowContainerRef.current) {
         const clientWidth = overFlowContainerRef.current?.clientWidth;
         const scrollWidth = overFlowContainerRef.current?.scrollWidth;
         const currBreakingWidth = breakingWidth.current;
@@ -80,16 +85,20 @@ const FilterTags = ({ children, hasOverflow, id }) => {
     <DefaultWrapper
       id={id}
       data-testid={id}
-      className="filtertags--container"
+      className={classnames(`${iotPrefix}--filtertags-container`, {
+        [`${iotPrefix}--filtertags-container__wrap`]: hasOverflow,
+      })}
       ref={overFlowContainerRef}
     >
       {visibleItems}
       {overflowItems.length > 0 && (
         <OverflowMenu
           data-floating-menu-container
-          className="filtertags--overflow"
-          renderIcon={() => <div className="bx--tag">{`More: ${overflowItems.length}`}</div>}
-          menuOptionsClass="filtertags--overflow-items"
+          className={`${iotPrefix}--filtertags-overflow-menu`}
+          renderIcon={() => (
+            <div className={`${prefix}--tag`}>{`More: ${overflowItems.length}`}</div>
+          )}
+          menuOptionsClass={`${iotPrefix}--filtertags-overflow-items`}
           menuOffset={{
             top: 15,
           }}
@@ -97,7 +106,7 @@ const FilterTags = ({ children, hasOverflow, id }) => {
           {overflowItems.map((child, i) => (
             <OverflowMenuItem
               primaryFocus={i === 0}
-              className="filtertags--overflow-item"
+              className={`${iotPrefix}--filtertags-overflow-item`}
               title={child.props.children}
               key={`${child.props.children}-${i}`}
               onClick={child.props.onClose}

--- a/src/components/FilterTags/FilterTags.jsx
+++ b/src/components/FilterTags/FilterTags.jsx
@@ -101,7 +101,7 @@ const FilterTags = ({ children, hasOverflow, id }) => {
               title={child.props.children}
               key={`${child.props.children}-${i}`}
               onClick={child.props.onClose}
-              itemText={<OverflowTag filter>{child.props.children}</OverflowTag>}
+              itemText={<OverflowTag>{child.props.children}</OverflowTag>}
             />
           ))}
         </OverflowMenu>

--- a/src/components/FilterTags/FilterTags.jsx
+++ b/src/components/FilterTags/FilterTags.jsx
@@ -34,7 +34,6 @@ const FilterTags = ({ children, hasOverflow, id, tagContainer }) => {
 
   useEffect(
     () => {
-      /* istanbul ignore else */
       if (hasOverflow && overFlowContainerRef) {
         setOverflowItems([]);
         setVisibleItems(childrenItems.slice(0));
@@ -45,7 +44,6 @@ const FilterTags = ({ children, hasOverflow, id, tagContainer }) => {
 
   useLayoutEffect(
     () => {
-      /* istanbul ignore else */
       if (hasOverflow && overFlowContainerRef.current) {
         const clientWidth = overFlowContainerRef.current?.clientWidth;
         const scrollWidth = overFlowContainerRef.current?.scrollWidth;

--- a/src/components/FilterTags/FilterTags.jsx
+++ b/src/components/FilterTags/FilterTags.jsx
@@ -23,7 +23,8 @@ const OverflowTag = ({ children }) => (
   </span>
 );
 
-const FilterTags = ({ children, hasOverflow, id }) => {
+const FilterTags = ({ children, hasOverflow, id, tagContainer }) => {
+  const TagContainer = tagContainer || DefaultWrapper;
   const overFlowContainerRef = useRef(null);
   useResizeObserver({
     ref: overFlowContainerRef,
@@ -82,7 +83,7 @@ const FilterTags = ({ children, hasOverflow, id }) => {
   );
 
   return (
-    <DefaultWrapper
+    <TagContainer
       id={id}
       data-testid={id}
       className={classnames(`${iotPrefix}--filtertags-container`, {
@@ -115,7 +116,7 @@ const FilterTags = ({ children, hasOverflow, id }) => {
           ))}
         </OverflowMenu>
       )}
-    </DefaultWrapper>
+    </TagContainer>
   );
 };
 
@@ -132,11 +133,16 @@ const propTypes = {
    * Bit to determine if tags collapse into overflow tag
    */
   hasOverflow: PropTypes.bool,
+  /**
+   * Optional container for filter tags
+   */
+  tagContainer: PropTypes.elementType,
 };
 
 const defaultProps = {
   id: 'filter-tag-container',
   hasOverflow: true,
+  tagContainer: null,
 };
 
 FilterTags.propTypes = propTypes;

--- a/src/components/FilterTags/FilterTags.jsx
+++ b/src/components/FilterTags/FilterTags.jsx
@@ -1,11 +1,11 @@
-import React, { useRef, useEffect, useState, Children } from 'react';
+import React, { useRef, useEffect, useLayoutEffect, useState, Children } from 'react';
 import PropTypes from 'prop-types';
-import useResizeObserver from 'use-resize-observer';
 import { OverflowMenuItem, OverflowMenu } from 'carbon-components-react';
 import { Close16 } from '@carbon/icons-react';
 import classnames from 'classnames';
 
 import { settings } from '../../constants/Settings';
+import { useResize } from '../../internal/UseResizeObserver';
 
 const { prefix, iotPrefix } = settings;
 /* eslint-disable-next-line react/prop-types */
@@ -26,9 +26,7 @@ const OverflowTag = ({ children }) => (
 const FilterTags = ({ children, hasOverflow, id, tagContainer }) => {
   const TagContainer = tagContainer || DefaultWrapper;
   const overFlowContainerRef = useRef(null);
-  useResizeObserver({
-    ref: overFlowContainerRef,
-  });
+  useResize(overFlowContainerRef);
   const childrenItems = Children.map(children, child => child);
   const breakingWidth = useRef([]);
   const [overflowItems, setOverflowItems] = useState([]);
@@ -45,7 +43,7 @@ const FilterTags = ({ children, hasOverflow, id, tagContainer }) => {
     [children]
   );
 
-  useEffect(
+  useLayoutEffect(
     () => {
       /* istanbul ignore else */
       if (hasOverflow && overFlowContainerRef.current) {
@@ -84,6 +82,7 @@ const FilterTags = ({ children, hasOverflow, id, tagContainer }) => {
 
   return (
     <TagContainer
+      key={`${hasOverflow}-Tag-Container`}
       id={id}
       data-testid={id}
       className={classnames(`${iotPrefix}--filtertags-container`, {

--- a/src/components/FilterTags/FilterTags.story.jsx
+++ b/src/components/FilterTags/FilterTags.story.jsx
@@ -79,34 +79,57 @@ const StatefulFilterTags = ({ tags }) => {
 };
 
 storiesOf('Watson IoT Experimental/FilterTags', module)
-  .add('Default Example', () => <StatefulFilterTags tags={tagData} />)
-  .add('With hasOverflow set to false', () => (
-    <FilterTags hasOverflow={false}>
-      {tagData.map(tag => (
-        <Tag
-          key={`tag-${tag.id}`}
-          filter
-          type={tag.type}
-          title="Clear Filter"
-          style={{ marginRight: '1rem' }}
-        >
-          {tag.text}
-        </Tag>
-      ))}
-    </FilterTags>
-  ))
-  .add('With tagContainer prop', () => (
-    <FilterTags hasOverflow={false} tagContainer={TagWrapper}>
-      {tagData.map(tag => (
-        <Tag
-          key={`tag-${tag.id}`}
-          filter
-          type={tag.type}
-          title="Clear Filter"
-          style={{ marginRight: '1rem' }}
-        >
-          {tag.text}
-        </Tag>
-      ))}
-    </FilterTags>
-  ));
+  .add('Default Example', () => <StatefulFilterTags tags={tagData} />, {
+    info: {
+      propTables: [FilterTags],
+      propTablesExclude: [StatefulFilterTags],
+    },
+  })
+  .add(
+    'With hasOverflow set to false',
+    () => (
+      <FilterTags hasOverflow={false}>
+        {tagData.map(tag => (
+          <Tag
+            key={`tag-${tag.id}`}
+            filter
+            type={tag.type}
+            title="Clear Filter"
+            style={{ marginRight: '1rem' }}
+          >
+            {tag.text}
+          </Tag>
+        ))}
+      </FilterTags>
+    ),
+    {
+      info: {
+        propTables: [FilterTags],
+        propTablesExclude: [Tag],
+      },
+    }
+  )
+  .add(
+    'With tagContainer prop',
+    () => (
+      <FilterTags hasOverflow={false} tagContainer={TagWrapper}>
+        {tagData.map(tag => (
+          <Tag
+            key={`tag-${tag.id}`}
+            filter
+            type={tag.type}
+            title="Clear Filter"
+            style={{ marginRight: '1rem' }}
+          >
+            {tag.text}
+          </Tag>
+        ))}
+      </FilterTags>
+    ),
+    {
+      info: {
+        propTables: [FilterTags],
+        propTablesExclude: [Tag],
+      },
+    }
+  );

--- a/src/components/FilterTags/FilterTags.story.jsx
+++ b/src/components/FilterTags/FilterTags.story.jsx
@@ -5,7 +5,7 @@ import { Tag, Button } from '../../index';
 
 import FilterTags from './FilterTags';
 
-const tagData = [
+export const tagData = [
   {
     id: 'tag-one',
     text: 'Hello World',
@@ -50,10 +50,8 @@ const StatefulFilterTags = ({ tags }) => {
   };
 
   return (
-    <div style={{ display: 'flex', overflow: 'hidden' }}>
-      <Button onClick={() => handleOnClick()} style={{ marginBottom: '1rem' }}>
-        Add tag
-      </Button>
+    <div style={{ display: 'flex' }}>
+      <Button onClick={() => handleOnClick()}>Add tag</Button>
       <FilterTags>
         {renderedTags.map(tag => (
           <Tag

--- a/src/components/FilterTags/FilterTags.story.jsx
+++ b/src/components/FilterTags/FilterTags.story.jsx
@@ -31,6 +31,14 @@ export const tagData = [
     type: 'red',
   },
 ];
+
+const TagWrapper = React.forwardRef(({ children, ...props }, ref) => {
+  return (
+    <div {...props} ref={ref} style={{ border: '1px solid red' }}>
+      {children}
+    </div>
+  );
+});
 const StatefulFilterTags = ({ tags }) => {
   const index = useRef(0);
   const [renderedTags, setRenderedTags] = useState(tags);
@@ -74,6 +82,21 @@ storiesOf('Watson IoT Experimental/FilterTags', module)
   .add('Default Example', () => <StatefulFilterTags tags={tagData} />)
   .add('With hasOverflow set to false', () => (
     <FilterTags hasOverflow={false}>
+      {tagData.map(tag => (
+        <Tag
+          key={`tag-${tag.id}`}
+          filter
+          type={tag.type}
+          title="Clear Filter"
+          style={{ marginRight: '1rem' }}
+        >
+          {tag.text}
+        </Tag>
+      ))}
+    </FilterTags>
+  ))
+  .add('With tagContainer prop', () => (
+    <FilterTags hasOverflow={false} tagContainer={TagWrapper}>
       {tagData.map(tag => (
         <Tag
           key={`tag-${tag.id}`}

--- a/src/components/FilterTags/FilterTags.story.jsx
+++ b/src/components/FilterTags/FilterTags.story.jsx
@@ -70,20 +70,20 @@ const StatefulFilterTags = ({ tags }) => {
   );
 };
 
-storiesOf('Watson IoT Experimental/FilterTags', module).add('Default Example', () => (
-  <StatefulFilterTags tags={tagData} />
-  // <FilterTags>
-  //   <Tag filter title="Clear Filter" style={{ marginRight: '1rem' }}>
-  //     Hello world
-  //   </Tag>
-  //   <Tag filter title="Clear Filter" style={{ marginRight: '1rem' }}>
-  //     Hello Space
-  //   </Tag>
-  //   <Tag filter title="Clear Filter" style={{ marginRight: '1rem' }}>
-  //     Hello Sun
-  //   </Tag>
-  //   <Tag filter title="Clear Filter">
-  //     Hello Daughter
-  //   </Tag>
-  // </FilterTags>
-));
+storiesOf('Watson IoT Experimental/FilterTags', module)
+  .add('Default Example', () => <StatefulFilterTags tags={tagData} />)
+  .add('With hasOverflow set to false', () => (
+    <FilterTags hasOverflow={false}>
+      {tagData.map(tag => (
+        <Tag
+          key={`tag-${tag.id}`}
+          filter
+          type={tag.type}
+          title="Clear Filter"
+          style={{ marginRight: '1rem' }}
+        >
+          {tag.text}
+        </Tag>
+      ))}
+    </FilterTags>
+  ));

--- a/src/components/FilterTags/FilterTags.story.jsx
+++ b/src/components/FilterTags/FilterTags.story.jsx
@@ -1,0 +1,91 @@
+import React, { useState, useRef } from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { Tag, Button } from '../../index';
+
+import FilterTags from './FilterTags';
+
+const tagData = [
+  {
+    id: 'tag-one',
+    text: 'Hello World',
+    onClose: () => console.log('closed tag-one'),
+    type: 'red',
+  },
+  {
+    id: 'tag-two',
+    text: 'Hello Space',
+    onClose: () => console.log('closed tag-two'),
+    type: 'blue',
+  },
+  {
+    id: 'tag-three',
+    text: 'Hello Sun',
+    onClose: () => console.log('closed tag-three'),
+    type: 'red',
+  },
+  {
+    id: 'tag-four',
+    text: 'Hello Daughter',
+    onClose: () => console.log('closed tag-four'),
+    type: 'red',
+  },
+];
+const StatefulFilterTags = ({ tags }) => {
+  const index = useRef(0);
+  const [renderedTags, setRenderedTags] = useState(tags);
+  const handleOnClose = id => {
+    setRenderedTags(renderedTags.filter(x => x.id !== id));
+    tags.filter(x => x.id === id)[0].onClose();
+  };
+  const handleOnClick = () => {
+    const newTag = {
+      id: `tag-${index.current}`,
+      text: `tag-${index.current}`,
+      onClose: () => console.log(`Close ${index.current}`),
+      type: 'red',
+    };
+    index.current += 1;
+    setRenderedTags([newTag, ...renderedTags]);
+  };
+
+  return (
+    <div style={{ display: 'flex', overflow: 'hidden' }}>
+      <Button onClick={() => handleOnClick()} style={{ marginBottom: '1rem' }}>
+        Add tag
+      </Button>
+      <FilterTags>
+        {renderedTags.map(tag => (
+          <Tag
+            key={`tag-${tag.id}`}
+            filter
+            type={tag.type}
+            title="Clear Filter"
+            style={{ marginRight: '1rem' }}
+            onClose={() => handleOnClose(tag.id)}
+          >
+            {tag.text}
+          </Tag>
+        ))}
+      </FilterTags>
+    </div>
+  );
+};
+
+storiesOf('Watson IoT Experimental/FilterTags', module).add('Default Example', () => (
+  <StatefulFilterTags tags={tagData} />
+  // <FilterTags>
+  //   <Tag filter title="Clear Filter" style={{ marginRight: '1rem' }}>
+  //     Hello world
+  //   </Tag>
+  //   <Tag filter title="Clear Filter" style={{ marginRight: '1rem' }}>
+  //     Hello Space
+  //   </Tag>
+  //   <Tag filter title="Clear Filter" style={{ marginRight: '1rem' }}>
+  //     Hello Sun
+  //   </Tag>
+  //   <Tag filter title="Clear Filter">
+  //     Hello Daughter
+  //   </Tag>
+  // </FilterTags>
+));

--- a/src/components/FilterTags/FilterTags.test.jsx
+++ b/src/components/FilterTags/FilterTags.test.jsx
@@ -67,6 +67,25 @@ describe('Filtertags', () => {
     expect(screen.queryByText(/More:*/)).toBeFalsy();
   });
 
+  it('will render tags without overflow when hasOverflow is false', async () => {
+    render(
+      <FilterTags hasOverflow={false}>
+        {tagData.map(tag => (
+          <Tag
+            key={`tag-${tag.id}`}
+            filter
+            type={tag.type}
+            title="Clear Filter"
+            style={{ marginRight: '1rem' }}
+          >
+            {tag.text}
+          </Tag>
+        ))}
+      </FilterTags>
+    );
+    expect(screen.queryByText(/More:*/)).toBeFalsy();
+  });
+
   it('will render tags with overflow tag when size is too small', async () => {
     render(
       <FilterTags>

--- a/src/components/FilterTags/FilterTags.test.jsx
+++ b/src/components/FilterTags/FilterTags.test.jsx
@@ -26,7 +26,7 @@ describe('Filtertags', () => {
     delete HTMLElement.prototype.scrollWidth;
   });
 
-  it('will render tags without overflow when size is large enough', async () => {
+  it('will render tags without overflow when size is large enough', () => {
     const { rerender } = render(
       <FilterTags>
         {tagData.map(tag => (
@@ -67,7 +67,7 @@ describe('Filtertags', () => {
     expect(screen.queryByText(/More:*/)).toBeFalsy();
   });
 
-  it('will render tags without overflow when hasOverflow is false', async () => {
+  it('will render tags without overflow when hasOverflow is false', () => {
     render(
       <FilterTags hasOverflow={false}>
         {tagData.map(tag => (
@@ -86,7 +86,7 @@ describe('Filtertags', () => {
     expect(screen.queryByText(/More:*/)).toBeFalsy();
   });
 
-  it('will render tags with overflow tag when size is too small', async () => {
+  it('will render tags with overflow tag when size is too small', () => {
     render(
       <FilterTags>
         {tagData.map(tag => (
@@ -105,7 +105,7 @@ describe('Filtertags', () => {
     expect(screen.queryByText(/More:*/)).toBeTruthy();
   });
 
-  it('will collapse tags that do not fit into an overflow menu', async () => {
+  it('will collapse tags that do not fit into an overflow menu', () => {
     render(
       <FilterTags>
         {tagData.map(tag => (
@@ -128,7 +128,7 @@ describe('Filtertags', () => {
     expect(screen.getByText('Hello Daughter')).toBeTruthy();
   });
 
-  it('will pass onClose cb to corresponding OverflowItem', async () => {
+  it('will pass onClose cb to corresponding OverflowItem', () => {
     const mockOnClose = jest.fn();
     render(
       <FilterTags>

--- a/src/components/FilterTags/FilterTags.test.jsx
+++ b/src/components/FilterTags/FilterTags.test.jsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Tag } from '../../index';
+
+import FilterTags from './FilterTags';
+import { tagData } from './FilterTags.story';
+
+describe('Filtertags', () => {
+  beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      writable: true,
+      configurable: true,
+      value: 400,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+      writable: true,
+      configurable: true,
+      value: 500,
+    });
+  });
+
+  afterAll(() => {
+    delete HTMLElement.prototype.clientWidth;
+    delete HTMLElement.prototype.scrollWidth;
+  });
+
+  it('will render tags without overflow when size is large enough', async () => {
+    const { rerender } = render(
+      <FilterTags>
+        {tagData.map(tag => (
+          <Tag
+            key={`tag-${tag.id}`}
+            filter
+            type={tag.type}
+            title="Clear Filter"
+            style={{ marginRight: '1rem' }}
+          >
+            {tag.text}
+          </Tag>
+        ))}
+      </FilterTags>
+    );
+    expect(screen.getByTestId('filter-tag-container')).toBeTruthy();
+    expect(screen.queryByText(/More:*/)).toBeTruthy();
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      writable: true,
+      configurable: true,
+      value: 600,
+    });
+    rerender(
+      <FilterTags>
+        {tagData.map(tag => (
+          <Tag
+            key={`tag-${tag.id}`}
+            filter
+            type={tag.type}
+            title="Clear Filter"
+            style={{ marginRight: '1rem' }}
+          >
+            {tag.text}
+          </Tag>
+        ))}
+      </FilterTags>
+    );
+    expect(screen.queryByText(/More:*/)).toBeFalsy();
+  });
+
+  it('will render tags with overflow tag when size is too small', async () => {
+    render(
+      <FilterTags>
+        {tagData.map(tag => (
+          <Tag
+            key={`tag-${tag.id}`}
+            filter
+            type={tag.type}
+            title="Clear Filter"
+            style={{ marginRight: '1rem' }}
+          >
+            {tag.text}
+          </Tag>
+        ))}
+      </FilterTags>
+    );
+    expect(screen.queryByText(/More:*/)).toBeTruthy();
+  });
+
+  it('will collapse tags that do not fit into an overflow menu', async () => {
+    render(
+      <FilterTags>
+        {tagData.map(tag => (
+          <Tag
+            key={`tag-${tag.id}`}
+            filter
+            type={tag.type}
+            title="Clear Filter"
+            style={{ marginRight: '1rem' }}
+          >
+            {tag.text}
+          </Tag>
+        ))}
+      </FilterTags>
+    );
+    const moreButton = screen.queryByText(/More:*/);
+
+    expect(moreButton).toBeTruthy();
+    userEvent.click(moreButton);
+    expect(screen.getByText('Hello Daughter')).toBeTruthy();
+  });
+
+  it('will pass onClose cb to corresponding OverflowItem', async () => {
+    const mockOnClose = jest.fn();
+    render(
+      <FilterTags>
+        {tagData.map(tag => (
+          <Tag
+            key={`tag-${tag.id}`}
+            filter
+            type={tag.type}
+            title="Clear Filter"
+            style={{ marginRight: '1rem' }}
+            onClose={() => mockOnClose(tag.id)}
+          >
+            {tag.text}
+          </Tag>
+        ))}
+      </FilterTags>
+    );
+    const moreButton = screen.queryByText(/More:*/);
+    userEvent.click(moreButton);
+    expect(screen.getByText('Hello Daughter')).toBeTruthy();
+    userEvent.click(screen.getByText('Hello Daughter'));
+    expect(mockOnClose).toHaveBeenCalledWith('tag-four');
+  });
+});

--- a/src/components/FilterTags/__snapshots__/FilterTags.story.storyshot
+++ b/src/components/FilterTags/__snapshots__/FilterTags.story.storyshot
@@ -1,0 +1,203 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/FilterTags Default Example 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "display": "flex",
+        }
+      }
+    >
+      <button
+        className="iot--btn bx--btn bx--btn--primary"
+        disabled={false}
+        onClick={[Function]}
+        tabIndex={0}
+        type="button"
+      >
+        Add tag
+      </button>
+      <div
+        className="filtertags--container"
+        data-testid="filter-tag-container"
+        id="filter-tag-container"
+      >
+        <div
+          aria-label="Clear Filter Hello World"
+          className="bx--tag bx--tag--filter bx--tag--red"
+          id="tag-1"
+          style={
+            Object {
+              "marginRight": "1rem",
+            }
+          }
+        >
+          <span
+            className="bx--tag__label"
+          >
+            Hello World
+          </span>
+          <button
+            aria-labelledby="tag-1"
+            className="bx--tag__close-icon"
+            onClick={[Function]}
+          >
+            <svg
+              aria-hidden={true}
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          aria-label="Clear Filter Hello Space"
+          className="bx--tag bx--tag--filter bx--tag--blue"
+          id="tag-2"
+          style={
+            Object {
+              "marginRight": "1rem",
+            }
+          }
+        >
+          <span
+            className="bx--tag__label"
+          >
+            Hello Space
+          </span>
+          <button
+            aria-labelledby="tag-2"
+            className="bx--tag__close-icon"
+            onClick={[Function]}
+          >
+            <svg
+              aria-hidden={true}
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          aria-label="Clear Filter Hello Sun"
+          className="bx--tag bx--tag--filter bx--tag--red"
+          id="tag-3"
+          style={
+            Object {
+              "marginRight": "1rem",
+            }
+          }
+        >
+          <span
+            className="bx--tag__label"
+          >
+            Hello Sun
+          </span>
+          <button
+            aria-labelledby="tag-3"
+            className="bx--tag__close-icon"
+            onClick={[Function]}
+          >
+            <svg
+              aria-hidden={true}
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          aria-label="Clear Filter Hello Daughter"
+          className="bx--tag bx--tag--filter bx--tag--red"
+          id="tag-4"
+          style={
+            Object {
+              "marginRight": "1rem",
+            }
+          }
+        >
+          <span
+            className="bx--tag__label"
+          >
+            Hello Daughter
+          </span>
+          <button
+            aria-labelledby="tag-4"
+            className="bx--tag__close-icon"
+            onClick={[Function]}
+          >
+            <svg
+              aria-hidden={true}
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/FilterTags/__snapshots__/FilterTags.story.storyshot
+++ b/src/components/FilterTags/__snapshots__/FilterTags.story.storyshot
@@ -386,3 +386,193 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
   </button>
 </div>
 `;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/FilterTags With tagContainer prop 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="iot--filtertags-container"
+      data-testid="filter-tag-container"
+      id="filter-tag-container"
+      style={
+        Object {
+          "border": "1px solid red",
+        }
+      }
+    >
+      <div
+        aria-label="Clear Filter Hello World"
+        className="bx--tag bx--tag--filter bx--tag--red"
+        id="tag-9"
+        style={
+          Object {
+            "marginRight": "1rem",
+          }
+        }
+      >
+        <span
+          className="bx--tag__label"
+        >
+          Hello World
+        </span>
+        <button
+          aria-labelledby="tag-9"
+          className="bx--tag__close-icon"
+          onClick={[Function]}
+        >
+          <svg
+            aria-hidden={true}
+            focusable="false"
+            height={16}
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 32 32"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        aria-label="Clear Filter Hello Space"
+        className="bx--tag bx--tag--filter bx--tag--blue"
+        id="tag-10"
+        style={
+          Object {
+            "marginRight": "1rem",
+          }
+        }
+      >
+        <span
+          className="bx--tag__label"
+        >
+          Hello Space
+        </span>
+        <button
+          aria-labelledby="tag-10"
+          className="bx--tag__close-icon"
+          onClick={[Function]}
+        >
+          <svg
+            aria-hidden={true}
+            focusable="false"
+            height={16}
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 32 32"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        aria-label="Clear Filter Hello Sun"
+        className="bx--tag bx--tag--filter bx--tag--red"
+        id="tag-11"
+        style={
+          Object {
+            "marginRight": "1rem",
+          }
+        }
+      >
+        <span
+          className="bx--tag__label"
+        >
+          Hello Sun
+        </span>
+        <button
+          aria-labelledby="tag-11"
+          className="bx--tag__close-icon"
+          onClick={[Function]}
+        >
+          <svg
+            aria-hidden={true}
+            focusable="false"
+            height={16}
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 32 32"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        aria-label="Clear Filter Hello Daughter"
+        className="bx--tag bx--tag--filter bx--tag--red"
+        id="tag-12"
+        style={
+          Object {
+            "marginRight": "1rem",
+          }
+        }
+      >
+        <span
+          className="bx--tag__label"
+        >
+          Hello Daughter
+        </span>
+        <button
+          aria-labelledby="tag-12"
+          className="bx--tag__close-icon"
+          onClick={[Function]}
+        >
+          <svg
+            aria-hidden={true}
+            focusable="false"
+            height={16}
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 32 32"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/FilterTags/__snapshots__/FilterTags.story.storyshot
+++ b/src/components/FilterTags/__snapshots__/FilterTags.story.storyshot
@@ -29,7 +29,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         Add tag
       </button>
       <div
-        className="filtertags--container"
+        className="iot--filtertags-container iot--filtertags-container__wrap"
         data-testid="filter-tag-container"
         id="filter-tag-container"
       >
@@ -173,6 +173,191 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </svg>
           </button>
         </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/FilterTags With hasOverflow set to false 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="iot--filtertags-container"
+      data-testid="filter-tag-container"
+      id="filter-tag-container"
+    >
+      <div
+        aria-label="Clear Filter Hello World"
+        className="bx--tag bx--tag--filter bx--tag--red"
+        id="tag-5"
+        style={
+          Object {
+            "marginRight": "1rem",
+          }
+        }
+      >
+        <span
+          className="bx--tag__label"
+        >
+          Hello World
+        </span>
+        <button
+          aria-labelledby="tag-5"
+          className="bx--tag__close-icon"
+          onClick={[Function]}
+        >
+          <svg
+            aria-hidden={true}
+            focusable="false"
+            height={16}
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 32 32"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        aria-label="Clear Filter Hello Space"
+        className="bx--tag bx--tag--filter bx--tag--blue"
+        id="tag-6"
+        style={
+          Object {
+            "marginRight": "1rem",
+          }
+        }
+      >
+        <span
+          className="bx--tag__label"
+        >
+          Hello Space
+        </span>
+        <button
+          aria-labelledby="tag-6"
+          className="bx--tag__close-icon"
+          onClick={[Function]}
+        >
+          <svg
+            aria-hidden={true}
+            focusable="false"
+            height={16}
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 32 32"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        aria-label="Clear Filter Hello Sun"
+        className="bx--tag bx--tag--filter bx--tag--red"
+        id="tag-7"
+        style={
+          Object {
+            "marginRight": "1rem",
+          }
+        }
+      >
+        <span
+          className="bx--tag__label"
+        >
+          Hello Sun
+        </span>
+        <button
+          aria-labelledby="tag-7"
+          className="bx--tag__close-icon"
+          onClick={[Function]}
+        >
+          <svg
+            aria-hidden={true}
+            focusable="false"
+            height={16}
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 32 32"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        aria-label="Clear Filter Hello Daughter"
+        className="bx--tag bx--tag--filter bx--tag--red"
+        id="tag-8"
+        style={
+          Object {
+            "marginRight": "1rem",
+          }
+        }
+      >
+        <span
+          className="bx--tag__label"
+        >
+          Hello Daughter
+        </span>
+        <button
+          aria-labelledby="tag-8"
+          className="bx--tag__close-icon"
+          onClick={[Function]}
+        >
+          <svg
+            aria-hidden={true}
+            focusable="false"
+            height={16}
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 32 32"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+            />
+          </svg>
+        </button>
       </div>
     </div>
   </div>

--- a/src/components/FilterTags/_filter-tags.scss
+++ b/src/components/FilterTags/_filter-tags.scss
@@ -1,0 +1,44 @@
+.bx--overflow-menu {
+  width: auto;
+  min-width: 4.5rem;
+}
+
+.filtertags--container {
+  white-space: nowrap;
+}
+.filtertags--overflow {
+  display: inline-block;
+
+  .bx--overflow-menu {
+    box-shadow: none;
+    background-color: unset;
+  }
+}
+
+.bx--overflow-menu-options[data-floating-menu-direction='bottom']::after {
+  background-color: unset;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-bottom: 10px solid white;
+  bottom: 100%;
+  height: 0;
+  left: 50%;
+  top: unset;
+  transform: translateX(-50%);
+  width: 0;
+}
+
+.bx--overflow-menu.bx--overflow-menu--open,
+.bx--overflow-menu.bx--overflow-menu--open:hover,
+.bx--overflow-menu:hover,
+.bx--overflow-menu__trigger:hover {
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.filtertags--overflow-item span {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+}

--- a/src/components/FilterTags/_filter-tags.scss
+++ b/src/components/FilterTags/_filter-tags.scss
@@ -5,6 +5,8 @@
 
 .filtertags--container {
   white-space: nowrap;
+  min-width: 0;
+  flex: 1;
 }
 .filtertags--overflow {
   display: inline-block;

--- a/src/components/FilterTags/_filter-tags.scss
+++ b/src/components/FilterTags/_filter-tags.scss
@@ -17,6 +17,10 @@
     box-shadow: none;
     background-color: unset;
     display: inline-block;
+
+    .#{$prefix}--tag {
+      cursor: pointer;
+    }
   }
   .#{$iot-prefix}--filtertags-overflow-items[data-floating-menu-direction='bottom']::after {
     background-color: unset;

--- a/src/components/FilterTags/_filter-tags.scss
+++ b/src/components/FilterTags/_filter-tags.scss
@@ -1,44 +1,38 @@
-.bx--overflow-menu {
-  width: auto;
-  min-width: 4.5rem;
-}
+.#{$iot-prefix}--filtertags-container {
+  &__wrap {
+    white-space: nowrap;
+    min-width: 0;
+    flex: 1;
 
-.filtertags--container {
-  white-space: nowrap;
-  min-width: 0;
-  flex: 1;
-}
-.filtertags--overflow {
-  display: inline-block;
+    .#{$prefix}--overflow-menu {
+      width: auto;
+      min-width: 4.5rem;
+    }
+  }
 
-  .bx--overflow-menu {
+  .#{$iot-prefix}--filtertags-overflow-menu,
+  .#{$iot-prefix}--filtertags-overflow-menu.#{$prefix}--overflow-menu--open,
+  .#{$prefix}--overflow-menu.#{$prefix}--overflow-menu--open:hover,
+  .#{$iot-prefix}--filtertags-overflow-menu:hover {
     box-shadow: none;
     background-color: unset;
+    display: inline-block;
+  }
+  .#{$iot-prefix}--filtertags-overflow-items[data-floating-menu-direction='bottom']::after {
+    background-color: unset;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    border-bottom: 10px solid white;
+    bottom: 100%;
+    height: 0;
+    left: 50%;
+    top: unset;
+    transform: translateX(-50%);
+    width: 0;
   }
 }
 
-.bx--overflow-menu-options[data-floating-menu-direction='bottom']::after {
-  background-color: unset;
-  border-left: 10px solid transparent;
-  border-right: 10px solid transparent;
-  border-bottom: 10px solid white;
-  bottom: 100%;
-  height: 0;
-  left: 50%;
-  top: unset;
-  transform: translateX(-50%);
-  width: 0;
-}
-
-.bx--overflow-menu.bx--overflow-menu--open,
-.bx--overflow-menu.bx--overflow-menu--open:hover,
-.bx--overflow-menu:hover,
-.bx--overflow-menu__trigger:hover {
-  background-color: transparent;
-  box-shadow: none;
-}
-
-.filtertags--overflow-item span {
+.#{$iot-prefix}--filtertags-overflow-item span {
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/src/index.js
+++ b/src/index.js
@@ -90,6 +90,7 @@ export IconSwitch, { ICON_SWITCH_SIZES } from './components/IconSwitch/IconSwitc
 export AccordionItemDefer from './components/Accordion/AccordionItemDefer';
 export ComboBox from './components/ComboBox';
 export FlyoutMenu from './components/FlyoutMenu';
+export FilterTags from './components/FilterTags/FilterTags';
 
 // Carbon proxy
 export {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -209,3 +209,4 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 @import 'components/TimeSeriesCard/time-series-card';
 @import 'components/WizardInline/wizard-inline';
 @import 'components/WizardModal/wizard-modal';
+@import 'components/FilterTags/filter-tags';

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -14359,6 +14359,7 @@ Map {
     "defaultProps": Object {
       "hasOverflow": true,
       "id": "filter-tag-container",
+      "tagContainer": null,
     },
     "propTypes": Object {
       "children": Object {
@@ -14370,6 +14371,9 @@ Map {
       },
       "id": Object {
         "type": "string",
+      },
+      "tagContainer": Object {
+        "type": "elementType",
       },
     },
   },

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -14355,6 +14355,24 @@ Map {
       },
     },
   },
+  "FilterTags" => Object {
+    "defaultProps": Object {
+      "hasOverflow": true,
+      "id": "filter-tag-container",
+    },
+    "propTypes": Object {
+      "children": Object {
+        "isRequired": true,
+        "type": "node",
+      },
+      "hasOverflow": Object {
+        "type": "bool",
+      },
+      "id": Object {
+        "type": "string",
+      },
+    },
+  },
   "Accordion" => Object {
     "defaultProps": Object {
       "align": "end",


### PR DESCRIPTION
Closes #676 

**Summary**

Wrapper to add the functionality of collapsing filter tags that do not fit in their containers into an overflow menu. 

**Change List (commits, features, bugs, etc)**

- Added `FilterTags.jsx`, `FilterTags.story.jsx`, `_filter-tags.scss`, and `FilterTags.test.jsx `
- Added import of styles to `styles.scss`
- Added export of this component to `index.js`

**Acceptance Test (how to verify the PR)**

- Checkout story that was added for this component.
