### PR TITLE
Multiselect table filter default filter fix

### DIFF
--- a/src/components/Table/StatefulTable.test.jsx
+++ b/src/components/Table/StatefulTable.test.jsx
@@ -233,6 +233,7 @@ describe('stateful table with real reducer', () => {
     const initialFilteredRowsOptionB = screen.getAllByTitle('option-B');
     const initialFilteredRowsOptionC = screen.getAllByTitle('option-C');
     const initialItemCount = screen.getByText('1–10 of 100 items'); // confirm row count in the pagination
+    expect(screen.queryByLabelText('Clear Selection')).toBeNull(); // there should be no clear button when there are no filters selected
     expect(initialFilteredRowsOptionA).toHaveLength(5);
     expect(initialFilteredRowsOptionB).toHaveLength(4);
     expect(initialFilteredRowsOptionC).toHaveLength(4);

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -681,6 +681,52 @@ storiesOf('Watson IoT/Table', module)
     }
   )
   .add(
+    'Stateful Example with pre-set multiselect filtering',
+    () => (
+      <FullWidthWrapper>
+        <StatefulTable
+          {...initialState}
+          columns={initialState.columns.map(column => {
+            if (column.filter) {
+              return {
+                ...column,
+                filter: { ...column.filter, isMultiselect: !!column.filter?.options },
+              };
+            }
+            return column;
+          })}
+          view={{
+            ...initialState.view,
+            pagination: {
+              ...initialState.view.pagination,
+              maxPages: 5,
+            },
+            toolbar: {
+              activeBar: 'filter',
+            },
+          }}
+          secondaryTitle={text('Secondary Title', `Row count: ${initialState.data.length}`)}
+          actions={actions}
+          isSortable
+          lightweight={boolean('lightweight', false)}
+          options={{
+            ...initialState.options,
+            hasFilter: select('hasFilter', ['onKeyPress', 'onEnterAndBlur'], 'onKeyPress'),
+            wrapCellText: select('wrapCellText', selectTextWrapping, 'always'),
+            hasSingleRowEdit: true,
+          }}
+        />
+      </FullWidthWrapper>
+    ),
+    {
+      info: {
+        text: `This table has a multiselect filter. To support multiselect filtering, make sure to pass isMultiselect: true to the filter prop on the table.`,
+        propTables: [Table],
+        propTablesExclude: [StatefulTable],
+      },
+    }
+  )
+  .add(
     'Stateful Example with multiselect filtering',
     () => (
       <FullWidthWrapper>
@@ -704,6 +750,7 @@ storiesOf('Watson IoT/Table', module)
             toolbar: {
               activeBar: 'filter',
             },
+            filters: [],
           }}
           secondaryTitle={text('Secondary Title', `Row count: ${initialState.data.length}`)}
           actions={actions}

--- a/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
+++ b/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
@@ -214,7 +214,9 @@ class FilterHeaderRow extends Component {
                         ? columnStateValue.map(value =>
                             typeof value !== 'object' ? { id: value, text: value } : value
                           )
-                        : [{ id: columnStateValue, text: columnStateValue }]
+                        : columnStateValue
+                        ? [{ id: columnStateValue, text: columnStateValue }]
+                        : []
                     }
                     onChange={evt => {
                       this.setState(

--- a/src/components/Table/TableViewDropdown/__snapshots__/TableViewDropdown.story.storyshot
+++ b/src/components/Table/TableViewDropdown/__snapshots__/TableViewDropdown.story.storyshot
@@ -47,7 +47,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           >
             <span
               className="bx--list-box__label"
-              htmlFor="downshift-11-input"
+              htmlFor="downshift-12-input"
               id="dropdown-field-label-iot--view-dropdown"
               title={
                 <TableViewDropdownItem
@@ -145,7 +145,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           >
             <div
               className="bx--list-box__menu-item bx--list-box__menu-item--active bx--list-box__menu-item--highlighted"
-              id="downshift-11-item-0"
+              id="downshift-12-item-0"
               onClick={[Function]}
               onMouseDown={[Function]}
               onMouseMove={[Function]}
@@ -234,7 +234,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
             </div>
             <div
               className="bx--list-box__menu-item"
-              id="downshift-11-item-1"
+              id="downshift-12-item-1"
               onClick={[Function]}
               onMouseDown={[Function]}
               onMouseMove={[Function]}
@@ -281,7 +281,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
             </div>
             <div
               className="bx--list-box__menu-item"
-              id="downshift-11-item-2"
+              id="downshift-12-item-2"
               onClick={[Function]}
               onMouseDown={[Function]}
               onMouseMove={[Function]}
@@ -328,7 +328,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
             </div>
             <div
               className="bx--list-box__menu-item"
-              id="downshift-11-item-3"
+              id="downshift-12-item-3"
               onClick={[Function]}
               onMouseDown={[Function]}
               onMouseMove={[Function]}
@@ -375,7 +375,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
             </div>
             <div
               className="bx--list-box__menu-item"
-              id="downshift-11-item-4"
+              id="downshift-12-item-4"
               onClick={[Function]}
               onMouseDown={[Function]}
               onMouseMove={[Function]}
@@ -423,7 +423,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
             </div>
             <div
               className="bx--list-box__menu-item"
-              id="downshift-11-item-5"
+              id="downshift-12-item-5"
               onClick={[Function]}
               onMouseDown={[Function]}
               onMouseMove={[Function]}
@@ -471,7 +471,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
             </div>
             <div
               className="bx--list-box__menu-item"
-              id="downshift-11-item-6"
+              id="downshift-12-item-6"
               onClick={[Function]}
               onMouseDown={[Function]}
               onMouseMove={[Function]}

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -2219,8 +2219,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-27"
-                  id="bx-pagination-select-27-count-label"
+                  htmlFor="bx-pagination-select-28"
+                  id="bx-pagination-select-28-count-label"
                 >
                   Items per page:
                 </label>
@@ -2239,7 +2239,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-27"
+                          id="bx-pagination-select-28"
                           onChange={[Function]}
                           value={10}
                         >
@@ -2303,7 +2303,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-27-right"
+                      htmlFor="bx-pagination-select-28-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -2316,7 +2316,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-27-right"
+                          id="bx-pagination-select-28-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -3395,8 +3395,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-23"
-                  id="bx-pagination-select-23-count-label"
+                  htmlFor="bx-pagination-select-24"
+                  id="bx-pagination-select-24-count-label"
                 >
                   Items per page:
                 </label>
@@ -3415,7 +3415,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-23"
+                          id="bx-pagination-select-24"
                           onChange={[Function]}
                           value={10}
                         >
@@ -3479,7 +3479,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-23-right"
+                      htmlFor="bx-pagination-select-24-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -3492,7 +3492,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-23-right"
+                          id="bx-pagination-select-24-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -6096,8 +6096,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-24"
-                  id="bx-pagination-select-24-count-label"
+                  htmlFor="bx-pagination-select-25"
+                  id="bx-pagination-select-25-count-label"
                 >
                   Items per page:
                 </label>
@@ -6116,7 +6116,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-24"
+                          id="bx-pagination-select-25"
                           onChange={[Function]}
                           value={10}
                         >
@@ -6180,7 +6180,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-24-right"
+                      htmlFor="bx-pagination-select-25-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -6193,7 +6193,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-24-right"
+                          id="bx-pagination-select-25-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -7491,8 +7491,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-37"
-                  id="bx-pagination-select-37-count-label"
+                  htmlFor="bx-pagination-select-38"
+                  id="bx-pagination-select-38-count-label"
                 >
                   Items per page:
                 </label>
@@ -7511,7 +7511,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-37"
+                          id="bx-pagination-select-38"
                           onChange={[Function]}
                           value={10}
                         >
@@ -7575,7 +7575,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-37-right"
+                      htmlFor="bx-pagination-select-38-right"
                     >
                       Page number, of 1 pages
                     </label>
@@ -7588,7 +7588,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-37-right"
+                          id="bx-pagination-select-38-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -9192,8 +9192,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-38"
-                  id="bx-pagination-select-38-count-label"
+                  htmlFor="bx-pagination-select-39"
+                  id="bx-pagination-select-39-count-label"
                 >
                   Items per page:
                 </label>
@@ -9212,7 +9212,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-38"
+                          id="bx-pagination-select-39"
                           onChange={[Function]}
                           value={10}
                         >
@@ -9276,7 +9276,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-38-right"
+                      htmlFor="bx-pagination-select-39-right"
                     >
                       Page number, of 1 pages
                     </label>
@@ -9289,7 +9289,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-38-right"
+                          id="bx-pagination-select-39-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -12418,8 +12418,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-39"
-                  id="bx-pagination-select-39-count-label"
+                  htmlFor="bx-pagination-select-40"
+                  id="bx-pagination-select-40-count-label"
                 >
                   Items per page:
                 </label>
@@ -12438,7 +12438,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-39"
+                          id="bx-pagination-select-40"
                           onChange={[Function]}
                           value={10}
                         >
@@ -12502,7 +12502,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-39-right"
+                      htmlFor="bx-pagination-select-40-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -12515,7 +12515,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-39-right"
+                          id="bx-pagination-select-40-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -13838,8 +13838,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-36"
-                  id="bx-pagination-select-36-count-label"
+                  htmlFor="bx-pagination-select-37"
+                  id="bx-pagination-select-37-count-label"
                 >
                   Items per page:
                 </label>
@@ -13858,7 +13858,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-36"
+                          id="bx-pagination-select-37"
                           onChange={[Function]}
                           value={10}
                         >
@@ -13922,7 +13922,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-36-right"
+                      htmlFor="bx-pagination-select-37-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -13935,7 +13935,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-36-right"
+                          id="bx-pagination-select-37-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -15496,8 +15496,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-31"
-                  id="bx-pagination-select-31-count-label"
+                  htmlFor="bx-pagination-select-32"
+                  id="bx-pagination-select-32-count-label"
                 >
                   Items per page:
                 </label>
@@ -15516,7 +15516,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-31"
+                          id="bx-pagination-select-32"
                           onChange={[Function]}
                           value={10}
                         >
@@ -15580,7 +15580,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-31-right"
+                      htmlFor="bx-pagination-select-32-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -15593,7 +15593,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-31-right"
+                          id="bx-pagination-select-32-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -16916,8 +16916,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-32"
-                  id="bx-pagination-select-32-count-label"
+                  htmlFor="bx-pagination-select-33"
+                  id="bx-pagination-select-33-count-label"
                 >
                   Items per page:
                 </label>
@@ -16936,7 +16936,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-32"
+                          id="bx-pagination-select-33"
                           onChange={[Function]}
                           value={10}
                         >
@@ -17000,7 +17000,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-32-right"
+                      htmlFor="bx-pagination-select-33-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -17013,7 +17013,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-32-right"
+                          id="bx-pagination-select-33-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -18920,8 +18920,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-22"
-                  id="bx-pagination-select-22-count-label"
+                  htmlFor="bx-pagination-select-23"
+                  id="bx-pagination-select-23-count-label"
                 >
                   Items per page:
                 </label>
@@ -18940,7 +18940,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-22"
+                          id="bx-pagination-select-23"
                           onChange={[Function]}
                           value={10}
                         >
@@ -19004,7 +19004,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-22-right"
+                      htmlFor="bx-pagination-select-23-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -19017,7 +19017,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-22-right"
+                          id="bx-pagination-select-23-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -19137,1740 +19137,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
 `;
 
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TableCard table with row expansion 1`] = `
-<div
-  className="storybook-container"
->
-  <div
-    style={
-      Object {
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "margin": "1rem4",
-          "width": "520px",
-        }
-      }
-    >
-      <div
-        className="iot--card iot--card--wrapper"
-        data-testid="Card"
-        id="table-list"
-        role="presentation"
-        style={
-          Object {
-            "--card-default-height": "624px",
-          }
-        }
-      >
-        <div
-          className="iot--card--content"
-          style={
-            Object {
-              "--card-content-height": "576px",
-            }
-          }
-        >
-          <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
-          >
-            <section
-              aria-label="data table toolbar"
-              className="bx--table-toolbar"
-            >
-              <div
-                className="bx--batch-actions iot--table-batch-actions"
-              >
-                <div
-                  className="bx--action-list"
-                >
-                  <button
-                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    Cancel
-                  </button>
-                </div>
-                <div
-                  className="bx--batch-summary"
-                >
-                  <p
-                    className="bx--batch-summary__para"
-                  >
-                    <span>
-                      0 item selected
-                    </span>
-                  </p>
-                </div>
-              </div>
-              <label
-                className="iot--table-toolbar-secondary-title"
-              >
-                Open Alerts
-              </label>
-              <div
-                className="iot--table-tooltip-container"
-              >
-                <div
-                  className="bx--tooltip__label"
-                  id="card-tooltip-trigger-table-for-card-table-list"
-                >
-                  
-                  <div
-                    aria-describedby={null}
-                    className="bx--tooltip__trigger"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
-                    <svg
-                      aria-hidden={true}
-                      description={null}
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role={null}
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
-                      />
-                      <path
-                        d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-content iot--table-toolbar-content"
-              >
-                <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  tabIndex="0"
-                >
-                  <div
-                    aria-labelledby="table-for-card-table-list-toolbar-search-search"
-                    className="bx--search bx--search--sm table-toolbar-search"
-                    role="search"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="bx--search-magnifier"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                      />
-                    </svg>
-                    <label
-                      className="bx--label"
-                      htmlFor="table-for-card-table-list-toolbar-search"
-                      id="table-for-card-table-list-toolbar-search-search"
-                    >
-                      Search
-                    </label>
-                    <input
-                      aria-hidden={true}
-                      autoComplete="off"
-                      className="bx--search-input"
-                      id="table-for-card-table-list-toolbar-search"
-                      onChange={[Function]}
-                      placeholder="Search"
-                      role="searchbox"
-                      tabIndex="-1"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Clear search input"
-                      className="bx--search-close bx--search-close--hidden"
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-                <button
-                  className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
-                  data-testid="download-button"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Download table content"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Download table content"
-                    className="bx--btn__icon"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
-                    />
-                    <path
-                      d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
-                  data-testid="filter-button"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Filters"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Filters"
-                    className="bx--btn__icon"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M18,28H14a2,2,0,0,1-2-2V18.41L4.59,11A2,2,0,0,1,4,9.59V6A2,2,0,0,1,6,4H26a2,2,0,0,1,2,2V9.59A2,2,0,0,1,27.41,11L20,18.41V26A2,2,0,0,1,18,28ZM6,6V9.59l8,8V26h4V17.59l8-8V6Z"
-                    />
-                  </svg>
-                </button>
-                <div
-                  className="iot--card--toolbar"
-                >
-                  <div
-                    className="iot--card--toolbar-date-range-wrapper"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="iot--card--toolbar-date-range-action bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
-                      title="Select time range"
-                    >
-                      <svg
-                        aria-label="Select time range"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={16}
-                        onClick={[Function]}
-                        onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
-                        />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
-                        />
-                        <path
-                          d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
-                        />
-                        <title>
-                          Select time range
-                        </title>
-                      </svg>
-                    </button>
-                  </div>
-                  <button
-                    className="iot--card--toolbar-action iot--card--toolbar-svg-wrapper bx--btn--icon-only bx--btn bx--btn--ghost"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    title="Expand to fullscreen"
-                    type="button"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      aria-label="Expand to fullscreen"
-                      className="bx--btn__icon"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      viewBox="0 0 32 32"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M28,4H10A2.0059,2.0059,0,0,0,8,6V20a2.0059,2.0059,0,0,0,2,2H28a2.0059,2.0059,0,0,0,2-2V6A2.0059,2.0059,0,0,0,28,4Zm0,16H10V6H28Z"
-                      />
-                      <path
-                        d="M18,26H4V16H6V14H4a2.0059,2.0059,0,0,0-2,2V26a2.0059,2.0059,0,0,0,2,2H18a2.0059,2.0059,0,0,0,2-2V24H18Z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-            </section>
-            <div
-              className="addons-iot-table-container"
-            >
-              <table
-                className="bx--data-table bx--data-table--no-border"
-                title={null}
-              >
-                <thead
-                  onMouseMove={null}
-                  onMouseUp={null}
-                >
-                  <tr>
-                    <th
-                      className="bx--table-expand"
-                      scope="col"
-                    />
-                    <th
-                      aria-sort="none"
-                      className="table-header-label-start iot--table-head--table-header table-header-sortable"
-                      scope="col"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
-                      width=""
-                    >
-                      <button
-                        align="start"
-                        className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
-                        data-column="alert"
-                        id="column-alert"
-                        onClick={[Function]}
-                        style={
-                          Object {
-                            "--table-header-width": "",
-                          }
-                        }
-                        width=""
-                      >
-                        <span
-                          className="bx--table-header-label"
-                        >
-                          <span
-                            className=""
-                            title="Alert"
-                          >
-                            Alert
-                          </span>
-                        </span>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon-unsorted"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                      </button>
-                    </th>
-                    <th
-                      aria-sort="none"
-                      className="table-header-label-start iot--table-head--table-header table-header-sortable"
-                      scope="col"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
-                      width=""
-                    >
-                      <button
-                        align="start"
-                        className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
-                        data-column="hour"
-                        id="column-hour"
-                        onClick={[Function]}
-                        style={
-                          Object {
-                            "--table-header-width": "",
-                          }
-                        }
-                        width=""
-                      >
-                        <span
-                          className="bx--table-header-label"
-                        >
-                          <span
-                            className=""
-                            title="Hour"
-                          >
-                            Hour
-                          </span>
-                        </span>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon-unsorted"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                      </button>
-                    </th>
-                    <th
-                      aria-sort="none"
-                      className="table-header-label-start iot--table-head--table-header table-header-sortable"
-                      scope="col"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
-                      width=""
-                    >
-                      <button
-                        align="start"
-                        className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
-                        data-column="pressure"
-                        id="column-pressure"
-                        onClick={[Function]}
-                        style={
-                          Object {
-                            "--table-header-width": "",
-                          }
-                        }
-                        width=""
-                      >
-                        <span
-                          className="bx--table-header-label"
-                        >
-                          <span
-                            className=""
-                            title="Pressure"
-                          >
-                            Pressure
-                          </span>
-                        </span>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon-unsorted"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                      </button>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody
-                  aria-live="polite"
-                >
-                  <tr
-                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-alert"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-hour"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-pressure"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="0"
-                        >
-                          0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-alert"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-hour"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-pressure"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="1"
-                        >
-                          1
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-1-alert"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="AHI005 Asset failure"
-                        >
-                          AHI005 Asset failure
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-1-hour"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-1-pressure"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="0"
-                        >
-                          0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-2-alert"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="AHI003 process need to optimize adjust X variables"
-                        >
-                          AHI003 process need to optimize adjust X variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-2-hour"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-2-pressure"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="2"
-                        >
-                          2
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-6-alert"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="AHI001 proccess need to optimize."
-                        >
-                          AHI001 proccess need to optimize.
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-6-hour"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-6-pressure"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="68"
-                        >
-                          68
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-pressure"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="10"
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-4-alert"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-4-hour"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-4-pressure"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="0"
-                        >
-                          0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-8-alert"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-8-hour"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-8-pressure"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="0"
-                        >
-                          0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-9-alert"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-9-hour"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-9-pressure"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="0"
-                        >
-                          0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-5-alert"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="AHI001 proccess need to optimize"
-                        >
-                          AHI001 proccess need to optimize
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-5-hour"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-5-pressure"
-                      offset={0}
-                      width=""
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      >
-                        <span
-                          className=""
-                          title="10"
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-            <div
-              className="bx--pagination iot--pagination iot--pagination--hide-page"
-              disabled={false}
-              style={
-                Object {
-                  "--pagination-text-display": "flex",
-                }
-              }
-            >
-              <div
-                className="bx--pagination__left"
-              >
-                <label
-                  className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-33"
-                  id="bx-pagination-select-33-count-label"
-                >
-                  Items per page:
-                </label>
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__item-count"
-                  >
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-33"
-                          onChange={[Function]}
-                          value={10}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={10}
-                          >
-                            10
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={25}
-                          >
-                            25
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={100}
-                          >
-                            100
-                          </option>
-                        </select>
-                        <svg
-                          aria-hidden={true}
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1–10 of 11 items
-                </span>
-              </div>
-              <div
-                className="bx--pagination__right"
-              >
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__page-number"
-                  >
-                    <label
-                      className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-33-right"
-                    >
-                      Page number, of 2 pages
-                    </label>
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-33-right"
-                          onChange={[Function]}
-                          value={1}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={1}
-                          >
-                            1
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={2}
-                          >
-                            2
-                          </option>
-                        </select>
-                        <svg
-                          aria-hidden={true}
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1 of 2 pages
-                </span>
-                <button
-                  aria-label="Previous page"
-                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
-                  disabled={true}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M20 24L10 16 20 8z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  aria-label="Next page"
-                  className="bx--pagination__button bx--pagination__button--forward"
-                  disabled={false}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M12 8L22 16 12 24z"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <button
-    className="info__show-button"
-    onClick={[Function]}
-    style={
-      Object {
-        "background": "#027ac5",
-        "border": "none",
-        "borderRadius": "0 0 0 5px",
-        "color": "#fff",
-        "cursor": "pointer",
-        "display": "block",
-        "fontFamily": "sans-serif",
-        "fontSize": 12,
-        "padding": "5px 15px",
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
-    type="button"
-  >
-    Show Info
-  </button>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TableCard table with row expansion and link variables 1`] = `
 <div
   className="storybook-container"
 >
@@ -22604,7 +20870,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TableCard table with row expansion and row specific link variables 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TableCard table with row expansion and link variables 1`] = `
 <div
   className="storybook-container"
 >
@@ -24338,6 +22604,1740 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TableCard table with row expansion and row specific link variables 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": "1rem4",
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="iot--card iot--card--wrapper"
+        data-testid="Card"
+        id="table-list"
+        role="presentation"
+        style={
+          Object {
+            "--card-default-height": "624px",
+          }
+        }
+      >
+        <div
+          className="iot--card--content"
+          style={
+            Object {
+              "--card-content-height": "576px",
+            }
+          }
+        >
+          <div
+            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+          >
+            <section
+              aria-label="data table toolbar"
+              className="bx--table-toolbar"
+            >
+              <div
+                className="bx--batch-actions iot--table-batch-actions"
+              >
+                <div
+                  className="bx--action-list"
+                >
+                  <button
+                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={-1}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+                <div
+                  className="bx--batch-summary"
+                >
+                  <p
+                    className="bx--batch-summary__para"
+                  >
+                    <span>
+                      0 item selected
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <label
+                className="iot--table-toolbar-secondary-title"
+              >
+                Open Alerts
+              </label>
+              <div
+                className="iot--table-tooltip-container"
+              >
+                <div
+                  className="bx--tooltip__label"
+                  id="card-tooltip-trigger-table-for-card-table-list"
+                >
+                  
+                  <div
+                    aria-describedby={null}
+                    className="bx--tooltip__trigger"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      description={null}
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role={null}
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
+                      />
+                      <path
+                        d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="bx--toolbar-content iot--table-toolbar-content"
+              >
+                <div
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  tabIndex="0"
+                >
+                  <div
+                    aria-labelledby="table-for-card-table-list-toolbar-search-search"
+                    className="bx--search bx--search--sm table-toolbar-search"
+                    role="search"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="bx--search-magnifier"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                      />
+                    </svg>
+                    <label
+                      className="bx--label"
+                      htmlFor="table-for-card-table-list-toolbar-search"
+                      id="table-for-card-table-list-toolbar-search-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      autoComplete="off"
+                      className="bx--search-input"
+                      id="table-for-card-table-list-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      role="searchbox"
+                      tabIndex="-1"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <button
+                  className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
+                  data-testid="download-button"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  title="Download table content"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Download table content"
+                    className="bx--btn__icon"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                    />
+                    <path
+                      d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
+                  data-testid="filter-button"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  title="Filters"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Filters"
+                    className="bx--btn__icon"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M18,28H14a2,2,0,0,1-2-2V18.41L4.59,11A2,2,0,0,1,4,9.59V6A2,2,0,0,1,6,4H26a2,2,0,0,1,2,2V9.59A2,2,0,0,1,27.41,11L20,18.41V26A2,2,0,0,1,18,28ZM6,6V9.59l8,8V26h4V17.59l8-8V6Z"
+                    />
+                  </svg>
+                </button>
+                <div
+                  className="iot--card--toolbar"
+                >
+                  <div
+                    className="iot--card--toolbar-date-range-wrapper"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="iot--card--toolbar-date-range-action bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                      title="Select time range"
+                    >
+                      <svg
+                        aria-label="Select time range"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
+                        />
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        />
+                        <path
+                          d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
+                        />
+                        <title>
+                          Select time range
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                  <button
+                    className="iot--card--toolbar-action iot--card--toolbar-svg-wrapper bx--btn--icon-only bx--btn bx--btn--ghost"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    title="Expand to fullscreen"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Expand to fullscreen"
+                      className="bx--btn__icon"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M28,4H10A2.0059,2.0059,0,0,0,8,6V20a2.0059,2.0059,0,0,0,2,2H28a2.0059,2.0059,0,0,0,2-2V6A2.0059,2.0059,0,0,0,28,4Zm0,16H10V6H28Z"
+                      />
+                      <path
+                        d="M18,26H4V16H6V14H4a2.0059,2.0059,0,0,0-2,2V26a2.0059,2.0059,0,0,0,2,2H18a2.0059,2.0059,0,0,0,2-2V24H18Z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </section>
+            <div
+              className="addons-iot-table-container"
+            >
+              <table
+                className="bx--data-table bx--data-table--no-border"
+                title={null}
+              >
+                <thead
+                  onMouseMove={null}
+                  onMouseUp={null}
+                >
+                  <tr>
+                    <th
+                      className="bx--table-expand"
+                      scope="col"
+                    />
+                    <th
+                      aria-sort="none"
+                      className="table-header-label-start iot--table-head--table-header table-header-sortable"
+                      scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
+                      width=""
+                    >
+                      <button
+                        align="start"
+                        className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
+                        data-column="alert"
+                        id="column-alert"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "--table-header-width": "",
+                          }
+                        }
+                        width=""
+                      >
+                        <span
+                          className="bx--table-header-label"
+                        >
+                          <span
+                            className=""
+                            title="Alert"
+                          >
+                            Alert
+                          </span>
+                        </span>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          />
+                        </svg>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon-unsorted"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="table-header-label-start iot--table-head--table-header table-header-sortable"
+                      scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
+                      width=""
+                    >
+                      <button
+                        align="start"
+                        className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
+                        data-column="hour"
+                        id="column-hour"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "--table-header-width": "",
+                          }
+                        }
+                        width=""
+                      >
+                        <span
+                          className="bx--table-header-label"
+                        >
+                          <span
+                            className=""
+                            title="Hour"
+                          >
+                            Hour
+                          </span>
+                        </span>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          />
+                        </svg>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon-unsorted"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="table-header-label-start iot--table-head--table-header table-header-sortable"
+                      scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
+                      width=""
+                    >
+                      <button
+                        align="start"
+                        className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
+                        data-column="pressure"
+                        id="column-pressure"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "--table-header-width": "",
+                          }
+                        }
+                        width=""
+                      >
+                        <span
+                          className="bx--table-header-label"
+                        >
+                          <span
+                            className=""
+                            title="Pressure"
+                          >
+                            Pressure
+                          </span>
+                        </span>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          />
+                        </svg>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon-unsorted"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  aria-live="polite"
+                >
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="0"
+                        >
+                          0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="1"
+                        >
+                          1
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-1-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI005 Asset failure"
+                        >
+                          AHI005 Asset failure
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-1-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-1-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="0"
+                        >
+                          0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-2-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI003 process need to optimize adjust X variables"
+                        >
+                          AHI003 process need to optimize adjust X variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-2-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-2-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="2"
+                        >
+                          2
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-6-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI001 proccess need to optimize."
+                        >
+                          AHI001 proccess need to optimize.
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-6-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-6-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="68"
+                        >
+                          68
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10"
+                        >
+                          10
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-4-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-4-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-4-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="0"
+                        >
+                          0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-8-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-8-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-8-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="0"
+                        >
+                          0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-9-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-9-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-9-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="0"
+                        >
+                          0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-5-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI001 proccess need to optimize"
+                        >
+                          AHI001 proccess need to optimize
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-5-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-5-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10"
+                        >
+                          10
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div
+              className="bx--pagination iot--pagination iot--pagination--hide-page"
+              disabled={false}
+              style={
+                Object {
+                  "--pagination-text-display": "flex",
+                }
+              }
+            >
+              <div
+                className="bx--pagination__left"
+              >
+                <label
+                  className="bx--pagination__text"
+                  htmlFor="bx-pagination-select-36"
+                  id="bx-pagination-select-36-count-label"
+                >
+                  Items per page:
+                </label>
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__item-count"
+                  >
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-36"
+                          onChange={[Function]}
+                          value={10}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={10}
+                          >
+                            10
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={25}
+                          >
+                            25
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={100}
+                          >
+                            100
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden={true}
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1–10 of 11 items
+                </span>
+              </div>
+              <div
+                className="bx--pagination__right"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__page-number"
+                  >
+                    <label
+                      className="bx--label bx--visually-hidden"
+                      htmlFor="bx-pagination-select-36-right"
+                    >
+                      Page number, of 2 pages
+                    </label>
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-36-right"
+                          onChange={[Function]}
+                          value={1}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={1}
+                          >
+                            1
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={2}
+                          >
+                            2
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden={true}
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1 of 2 pages
+                </span>
+                <button
+                  aria-label="Previous page"
+                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
+                  disabled={true}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M20 24L10 16 20 8z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Next page"
+                  className="bx--pagination__button bx--pagination__button--forward"
+                  disabled={false}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M12 8L22 16 12 24z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TableCard table with single actions 1`] = `
 <div
   className="storybook-container"
@@ -25906,8 +25906,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-25"
-                  id="bx-pagination-select-25-count-label"
+                  htmlFor="bx-pagination-select-26"
+                  id="bx-pagination-select-26-count-label"
                 >
                   Items per page:
                 </label>
@@ -25926,7 +25926,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-25"
+                          id="bx-pagination-select-26"
                           onChange={[Function]}
                           value={10}
                         >
@@ -25990,7 +25990,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-25-right"
+                      htmlFor="bx-pagination-select-26-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -26003,7 +26003,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-25-right"
+                          id="bx-pagination-select-26-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -28541,8 +28541,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-28"
-                  id="bx-pagination-select-28-count-label"
+                  htmlFor="bx-pagination-select-29"
+                  id="bx-pagination-select-29-count-label"
                 >
                   Items per page:
                 </label>
@@ -28561,7 +28561,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-28"
+                          id="bx-pagination-select-29"
                           onChange={[Function]}
                           value={10}
                         >
@@ -28625,7 +28625,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-28-right"
+                      htmlFor="bx-pagination-select-29-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -28638,7 +28638,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-28-right"
+                          id="bx-pagination-select-29-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -30644,8 +30644,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-29"
-                  id="bx-pagination-select-29-count-label"
+                  htmlFor="bx-pagination-select-30"
+                  id="bx-pagination-select-30-count-label"
                 >
                   Items per page:
                 </label>
@@ -30664,7 +30664,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-29"
+                          id="bx-pagination-select-30"
                           onChange={[Function]}
                           value={10}
                         >
@@ -30728,7 +30728,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-29-right"
+                      htmlFor="bx-pagination-select-30-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -30741,7 +30741,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-29-right"
+                          id="bx-pagination-select-30-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -33313,8 +33313,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-26"
-                  id="bx-pagination-select-26-count-label"
+                  htmlFor="bx-pagination-select-27"
+                  id="bx-pagination-select-27-count-label"
                 >
                   Items per page:
                 </label>
@@ -33333,7 +33333,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-26"
+                          id="bx-pagination-select-27"
                           onChange={[Function]}
                           value={10}
                         >
@@ -33397,7 +33397,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-26-right"
+                      htmlFor="bx-pagination-select-27-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -33410,7 +33410,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-26-right"
+                          id="bx-pagination-select-27-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -35694,8 +35694,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-30"
-                  id="bx-pagination-select-30-count-label"
+                  htmlFor="bx-pagination-select-31"
+                  id="bx-pagination-select-31-count-label"
                 >
                   Items per page:
                 </label>
@@ -35714,7 +35714,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-30"
+                          id="bx-pagination-select-31"
                           onChange={[Function]}
                           value={10}
                         >
@@ -35778,7 +35778,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-30-right"
+                      htmlFor="bx-pagination-select-31-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -35791,7 +35791,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-30-right"
+                          id="bx-pagination-select-31-right"
                           onChange={[Function]}
                           value={1}
                         >

--- a/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -2264,8 +2264,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
                 >
                   <label
                     className="bx--pagination__text"
-                    htmlFor="bx-pagination-select-40"
-                    id="bx-pagination-select-40-count-label"
+                    htmlFor="bx-pagination-select-41"
+                    id="bx-pagination-select-41-count-label"
                   >
                     Items per page:
                   </label>
@@ -2284,7 +2284,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
                         >
                           <select
                             className="bx--select-input"
-                            id="bx-pagination-select-40"
+                            id="bx-pagination-select-41"
                             onChange={[Function]}
                             value={10}
                           >
@@ -2348,7 +2348,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
                     >
                       <label
                         className="bx--label bx--visually-hidden"
-                        htmlFor="bx-pagination-select-40-right"
+                        htmlFor="bx-pagination-select-41-right"
                       >
                         Page number, of 1 pages
                       </label>
@@ -2361,7 +2361,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
                         >
                           <select
                             className="bx--select-input"
-                            id="bx-pagination-select-40-right"
+                            id="bx-pagination-select-41-right"
                             onChange={[Function]}
                             value={1}
                           >


### PR DESCRIPTION
Part of https://github.com/carbon-design-system/carbon-addons-iot-react/issues/1432

**Summary**

Quick fix for a bug a where the multiselect would show a `clearSelection` button even if there were no pre-determined filters applied.

**Change List (commits, features, bugs, etc)**

Give an empty multiselect an empty array instead of an empty string.

**Acceptance Test (how to verify the PR)**

checkout the 'Stateful Example with multiselect filtering' story and its 'with pre-set' counterpart, to confirm that the multiselect only shows the clear all button if there is a pre-set filter.
