### PR TITLE
fix(TimeSeriesCard): don't filter null values

### DIFF
--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -156,10 +156,10 @@ export const formatChartData = (timeDataSourceId = 'timestamp', series, values) 
       // First filter based on on the dataFilter
       const filteredData = filter(values, dataFilter);
       if (!isEmpty(filteredData)) {
-        // have to filter out null values from the dataset, as it causes Carbon Charts to break
         filteredData
           .filter(dataItem => {
-            return !isNil(dataItem[dataSourceId]) && dataItem[timeDataSourceId] === timestamp;
+            // only allow valid timestamp matches
+            return !isNil(dataItem[timeDataSourceId]) && dataItem[timeDataSourceId] === timestamp;
           })
           .forEach(dataItem =>
             data.push({


### PR DESCRIPTION
Closes #1528 

**Summary**

- When null values are passed to TimeSeriesCard, we should display a gap in the line charts where the data is missing to give the user an indication of the null values

Related Carbon Charts PR: https://github.com/carbon-design-system/carbon-charts/pull/464/files

**Change List (commits, features, bugs, etc)**

- Remove null filtering of data values
- Add additional conditional to timestamp to make sure the `undefined === undefined` race condition does not occur

**Acceptance Test (how to verify the PR)**

- Go to any TimeSeriesCard story and pass it a mix of null and valid values
- You should see a gap in the line where the null values were passed
