### PR TITLE
feat(TimeSeriesCard): add addSpaceOnEdges prop

### DIFF
--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -75,6 +75,8 @@ const TimeSeriesCardPropTypes = {
     unit: PropTypes.string,
     /** Optionally addes a zoom bar to the chart */
     zoomBar: ZoomBarPropTypes,
+    /** Number of grid-line spaces to the left and right of the chart to add white space to. Defaults to 1 */
+    addSpaceOnEdges: PropTypes.number,
   }).isRequired,
   i18n: PropTypes.shape({
     alertDetected: PropTypes.string,
@@ -282,6 +284,7 @@ const TimeSeriesCard = ({
       unit,
       chartType,
       zoomBar,
+      addSpaceOnEdges,
     },
     values: valuesProp,
   } = handleCardVariables(titleProp, content, initialValues, others);
@@ -549,6 +552,9 @@ const TimeSeriesCard = ({
                       },
                     }
                   : {}),
+                timeScale: {
+                  addSpaceOnEdges: addSpaceOnEdges || 1,
+                },
               }}
               width="100%"
               height="100%"

--- a/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
@@ -39,6 +39,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             includeZeroOnXaxis: true,
             includeZeroOnYaxis: true,
             timeDataSourceId: 'timestamp',
+            addSpaceOnEdges: 1,
           })}
           values={getIntervalChartData(interval, 1, { min: 10, max: 100 }, 100)}
           interval={interval}
@@ -82,6 +83,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
               includeZeroOnXaxis: true,
               includeZeroOnYaxis: true,
               timeDataSourceId: 'timestamp',
+              addSpaceOnEdges: 1,
             })}
             values={getIntervalChartData(interval, 1, { min: 10, max: 100 }, 100)}
             interval={interval}
@@ -137,45 +139,6 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
       </div>
     );
   })
-  .add('medium / single line - custom domainRange', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
-    const data = getIntervalChartData('day', 50, { min: 10, max: 100 }, 100);
-    const timestamps = data.map(d => d.timestamp);
-    const minDate = new Date(Math.min(...timestamps));
-    const day = minDate.getDay();
-    minDate.setDate(day + 10);
-
-    return (
-      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
-        <TimeSeriesCard
-          title={text('title', 'Temperature')}
-          id="facility-temperature"
-          isLoading={boolean('isLoading', false)}
-          isExpanded={boolean('isExpandable', false)}
-          content={object('content', {
-            series: [
-              {
-                label: 'Temperature',
-                dataSourceId: 'temperature',
-              },
-            ],
-            xLabel: 'Time t',
-            yLabel: 'Temperature (˚F)',
-            includeZeroOnXaxis: true,
-            includeZeroOnYaxis: true,
-            timeDataSourceId: 'timestamp',
-          })}
-          values={data}
-          availableActions={{ range: true }}
-          interval="hour"
-          breakpoint="lg"
-          size={size}
-          onCardAction={action('onCardAction')}
-          domainRange={[minDate.valueOf(), Math.max(...timestamps)]}
-        />
-      </div>
-    );
-  })
   .add('multi line - (No X/Y Label)', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
     return (
@@ -198,6 +161,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             includeZeroOnXaxis: true,
             includeZeroOnYaxis: true,
             timeDataSourceId: 'timestamp',
+            addSpaceOnEdges: 1,
           })}
           values={getIntervalChartData('day', 30, { min: 10, max: 100 }, 100)}
           interval="day"
@@ -229,6 +193,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             includeZeroOnXaxis: true,
             includeZeroOnYaxis: true,
             timeDataSourceId: 'timestamp',
+            addSpaceOnEdges: 1,
           })}
           values={getIntervalChartData('month', 6, { min: 10, max: 100 }, 100, 1569945252000)}
           interval="month"
@@ -272,6 +237,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             includeZeroOnXaxis: true,
             includeZeroOnYaxis: true,
             timeDataSourceId: 'timestamp',
+            addSpaceOnEdges: 1,
           })}
           values={getIntervalChartData('month', 6, { min: 10, max: 100 }, 100, 1569945252000)}
           interval="month"
@@ -306,6 +272,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             includeZeroOnXaxis: true,
             includeZeroOnYaxis: true,
             timeDataSourceId: 'timestamp',
+            addSpaceOnEdges: 1,
           })}
           values={getIntervalChartData('year', 2, { min: 10, max: 100 }, 100)}
           interval="year"
@@ -358,6 +325,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             includeZeroOnXaxis: true,
             includeZeroOnYaxis: true,
             timeDataSourceId: 'timestamp',
+            addSpaceOnEdges: 1,
           })}
           values={getIntervalChartData(interval, 12, { min: 10, max: 100 }, 100)}
           interval={interval}
@@ -395,6 +363,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
               axes: 'top',
               // initialZoomDomain: []
             },
+            addSpaceOnEdges: 1,
           })}
           values={getIntervalChartData('minute', 15, { min: 4700000, max: 4800000 }, 100)}
           interval="minute"
@@ -425,6 +394,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             includeZeroOnXaxis: true,
             includeZeroOnYaxis: true,
             timeDataSourceId: 'timestamp',
+            addSpaceOnEdges: 1,
           })}
           values={getIntervalChartData('day', 7, { min: 10, max: 100 }, 100)}
           interval="day"
@@ -456,6 +426,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             includeZeroOnXaxis: true,
             includeZeroOnYaxis: true,
             timeDataSourceId: 'timestamp',
+            addSpaceOnEdges: 1,
           })}
           values={getIntervalChartData('day', 30, { min: 10, max: 100 }, 100)}
           interval="day"
@@ -492,6 +463,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
               axes: 'top',
               // initialZoomDomain: []
             },
+            addSpaceOnEdges: 1,
           })}
           values={getIntervalChartData('month', 24, { min: 10, max: 100 }, 100)}
           interval="month"
@@ -528,6 +500,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
               axes: 'top',
               // initialZoomDomain: []
             },
+            addSpaceOnEdges: 1,
           })}
           values={getIntervalChartData('year', 10, { min: 10, max: 100 }, 100)}
           interval="year"
@@ -567,6 +540,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
               axes: 'top',
               // initialZoomDomain: []
             },
+            addSpaceOnEdges: 1,
           })}
           values={getIntervalChartData('day', 12, { min: 10, max: 100 }, 100)}
           breakpoint="lg"
@@ -614,6 +588,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             includeZeroOnXaxis: true,
             includeZeroOnYaxis: true,
             timeDataSourceId: 'timestamp',
+            addSpaceOnEdges: 1,
           })}
           values={getIntervalChartData(interval, 12, { min: 10, max: 100 }, 100)}
           interval={interval}
@@ -648,6 +623,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             includeZeroOnXaxis: true,
             includeZeroOnYaxis: true,
             timeDataSourceId: 'timestamp',
+            addSpaceOnEdges: 1,
           })}
           values={getIntervalChartData('day', 10, { min: 10, max: 100 }, 100)}
           interval="day"
@@ -685,12 +661,53 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
               axes: 'top',
               view: 'slider_view',
             },
+            addSpaceOnEdges: 1,
           })}
           values={getIntervalChartData('month', 24, { min: 10, max: 100 }, 100)}
           interval="month"
           breakpoint="lg"
           size={size}
           onCardAction={action('onCardAction')}
+        />
+      </div>
+    );
+  })
+  .add('domainRange', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
+    const data = getIntervalChartData('day', 50, { min: 10, max: 100 }, 100);
+    const timestamps = data.map(d => d.timestamp);
+    const minDate = new Date(Math.min(...timestamps));
+    const day = minDate.getDay();
+    minDate.setDate(day + 10);
+
+    return (
+      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+        <TimeSeriesCard
+          title={text('title', 'Temperature')}
+          id="facility-temperature"
+          isLoading={boolean('isLoading', false)}
+          isExpanded={boolean('isExpandable', false)}
+          content={object('content', {
+            series: [
+              {
+                label: 'Temperature',
+                dataSourceId: 'temperature',
+              },
+            ],
+            xLabel: 'Time t',
+            yLabel: 'Temperature (˚F)',
+            includeZeroOnXaxis: true,
+            includeZeroOnYaxis: true,
+            timeDataSourceId: 'timestamp',
+            addSpaceOnEdges: 1,
+          })}
+          values={data}
+          availableActions={{ range: true }}
+          interval="hour"
+          breakpoint="lg"
+          size={size}
+          onCardAction={action('onCardAction')}
+          domainRange={[minDate.valueOf(), Math.max(...timestamps)]}
         />
       </div>
     );
@@ -759,6 +776,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 details: 'Less severe',
               },
             ],
+            addSpaceOnEdges: 1,
           })}
           values={getIntervalChartData('day', 100, { min: 10, max: 100 }, 100, 1572824320000)}
           interval="hour"
@@ -790,6 +808,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             timeDataSourceId: 'timestamp',
             includeZeroOnXaxis: true,
             includeZeroOnYaxis: true,
+            addSpaceOnEdges: 1,
           })}
           range="day"
           interval="hour"
@@ -823,6 +842,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             includeZeroOnXaxis: true,
             includeZeroOnYaxis: true,
             timeDataSourceId: 'timestamp',
+            addSpaceOnEdges: 1,
           })}
           values={getIntervalChartData('day', 100, { min: 10, max: 100 }, 100, 1572824320000)}
           interval="hour"
@@ -866,6 +886,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             includeZeroOnXaxis: true,
             includeZeroOnYaxis: true,
             timeDataSourceId: 'timestamp',
+            addSpaceOnEdges: 1,
           })}
           interval={select('interval', ['hour', 'day', 'week', 'month', 'year'], 'hour')}
           breakpoint="lg"
@@ -977,6 +998,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
               enabled: true,
               axes: 'top',
             },
+            addSpaceOnEdges: 1,
           })}
           values={staticData}
           interval="month"
@@ -1022,6 +1044,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             includeZeroOnXaxis: true,
             includeZeroOnYaxis: true,
             timeDataSourceId: 'timestamp',
+            addSpaceOnEdges: 1,
           })}
           values={getIntervalChartData('day', 12, { min: 10, max: 100 }, 100).reduce(
             (acc, dataPoint) => {
@@ -1068,6 +1091,7 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             includeZeroOnXaxis: true,
             includeZeroOnYaxis: true,
             timeDataSourceId: 'timestamp',
+            addSpaceOnEdges: 1,
           })}
           locale={select('locale', ['fr', 'en'], 'fr')}
           values={getIntervalChartData('day', 12, { min: 10, max: 100000 }, 100)}

--- a/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -182,6 +182,144 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeSeriesCard domainRange 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "252px",
+        }
+      }
+    >
+      <div
+        className="iot--card iot--card--wrapper"
+        data-testid="Card"
+        id="facility-temperature"
+        role="presentation"
+        style={
+          Object {
+            "--card-default-height": "304px",
+          }
+        }
+      >
+        <div
+          className="iot--card--header"
+        >
+          <span
+            className="iot--card--title"
+            title="Temperature"
+          >
+            <div
+              className="iot--card--title--text"
+            >
+              Temperature
+            </div>
+          </span>
+          <div
+            className="iot--card--toolbar"
+          >
+            <div
+              className="iot--card--toolbar-date-range-wrapper"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                aria-label="Menu"
+                className="iot--card--toolbar-date-range-action bx--overflow-menu"
+                onClick={[Function]}
+                onClose={[Function]}
+                onKeyDown={[Function]}
+                open={false}
+                tabIndex={0}
+                title="Select time range"
+              >
+                <svg
+                  aria-label="Select time range"
+                  className="bx--overflow-menu__icon"
+                  focusable="false"
+                  height={16}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
+                  />
+                  <path
+                    d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                  />
+                  <path
+                    d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
+                  />
+                  <title>
+                    Select time range
+                  </title>
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--card--content"
+          style={
+            Object {
+              "--card-content-height": "256px",
+            }
+          }
+        >
+          <div
+            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
+            size="MEDIUM"
+          >
+            <div
+              className="chart-holder"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeSeriesCard empty 1`] = `
 <div
   className="storybook-container"
@@ -3427,144 +3565,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
               Temperature
             </div>
           </span>
-        </div>
-        <div
-          className="iot--card--content"
-          style={
-            Object {
-              "--card-content-height": "256px",
-            }
-          }
-        >
-          <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="MEDIUM"
-          >
-            <div
-              className="chart-holder"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <button
-    className="info__show-button"
-    onClick={[Function]}
-    style={
-      Object {
-        "background": "#027ac5",
-        "border": "none",
-        "borderRadius": "0 0 0 5px",
-        "color": "#fff",
-        "cursor": "pointer",
-        "display": "block",
-        "fontFamily": "sans-serif",
-        "fontSize": 12,
-        "padding": "5px 15px",
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
-    type="button"
-  >
-    Show Info
-  </button>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeSeriesCard medium / single line - custom domainRange 1`] = `
-<div
-  className="storybook-container"
->
-  <div
-    style={
-      Object {
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "margin": 20,
-          "width": "252px",
-        }
-      }
-    >
-      <div
-        className="iot--card iot--card--wrapper"
-        data-testid="Card"
-        id="facility-temperature"
-        role="presentation"
-        style={
-          Object {
-            "--card-default-height": "304px",
-          }
-        }
-      >
-        <div
-          className="iot--card--header"
-        >
-          <span
-            className="iot--card--title"
-            title="Temperature"
-          >
-            <div
-              className="iot--card--title--text"
-            >
-              Temperature
-            </div>
-          </span>
-          <div
-            className="iot--card--toolbar"
-          >
-            <div
-              className="iot--card--toolbar-date-range-wrapper"
-            >
-              <button
-                aria-expanded={false}
-                aria-haspopup={true}
-                aria-label="Menu"
-                className="iot--card--toolbar-date-range-action bx--overflow-menu"
-                onClick={[Function]}
-                onClose={[Function]}
-                onKeyDown={[Function]}
-                open={false}
-                tabIndex={0}
-                title="Select time range"
-              >
-                <svg
-                  aria-label="Select time range"
-                  className="bx--overflow-menu__icon"
-                  focusable="false"
-                  height={16}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  preserveAspectRatio="xMidYMid meet"
-                  role="img"
-                  viewBox="0 0 32 32"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
-                  />
-                  <path
-                    d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
-                  />
-                  <path
-                    d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
-                  />
-                  <title>
-                    Select time range
-                  </title>
-                </svg>
-              </button>
-            </div>
-          </div>
         </div>
         <div
           className="iot--card--content"

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -9208,6 +9208,9 @@ Map {
       "content": Object {
         "args": Array [
           Object {
+            "addSpaceOnEdges": Object {
+              "type": "number",
+            },
             "chartType": [Function],
             "includeZeroOnXaxis": Object {
               "type": "bool",


### PR DESCRIPTION
Closes #1531 

**Summary**

- Adds `addSpaceOnEdges` prop to TimeSeriesCard which allows the left and right side of the charts white-space to be customized

**Change List (commits, features, bugs, etc)**

- Added propType definition
- Defaults to 1
- Added prop to each TimeSeriesCard story (I don't think this is worthy of an individual story)

**Acceptance Test (how to verify the PR)**

- Go to any TimeSeriesCard story thats displaying a chart, then adjust the `addSpaceOnEdges` prop to multiple, different numbers to see the chart adjust the spacing
