### PR TITLE
fix(BarChartCard): show actual timestamp in tooltip

### DIFF
--- a/src/components/BarChartCard/BarChartCard.jsx
+++ b/src/components/BarChartCard/BarChartCard.jsx
@@ -183,13 +183,7 @@ const BarChartCard = ({
                 valueFormatter: tooltipValue =>
                   chartValueFormatter(tooltipValue, size, unit, locale),
                 customHTML: (...args) =>
-                  handleTooltip(
-                    ...args,
-                    timeDataSourceId,
-                    colors,
-                    showTimeInGMT,
-                    tooltipDateFormatPattern
-                  ),
+                  handleTooltip(...args, timeDataSourceId, showTimeInGMT, tooltipDateFormatPattern),
               },
               // zoomBar should only be enabled for time-based charts
               ...(zoomBar?.enabled &&
@@ -266,6 +260,8 @@ BarChartCard.defaultProps = {
     layout: BAR_CHART_LAYOUTS.VERTICAL,
   },
   locale: 'en',
+  showTimeInGMT: false,
+  tooltipDateFormatPattern: 'L HH:mm:ss',
 };
 
 export default BarChartCard;

--- a/src/components/BarChartCard/BarChartCard.jsx
+++ b/src/components/BarChartCard/BarChartCard.jsx
@@ -62,6 +62,8 @@ const BarChartCard = ({
       unit,
       type = BAR_CHART_TYPES.SIMPLE,
       zoomBar,
+      showTimeInGMT,
+      tooltipDateFormatPattern,
     },
     values: valuesProp,
   } = handleCardVariables(titleProp, content, initialValues, others);
@@ -180,7 +182,14 @@ const BarChartCard = ({
               tooltip: {
                 valueFormatter: tooltipValue =>
                   chartValueFormatter(tooltipValue, size, unit, locale),
-                customHTML: (...args) => handleTooltip(...args, timeDataSourceId, colors, locale),
+                customHTML: (...args) =>
+                  handleTooltip(
+                    ...args,
+                    timeDataSourceId,
+                    colors,
+                    showTimeInGMT,
+                    tooltipDateFormatPattern
+                  ),
               },
               // zoomBar should only be enabled for time-based charts
               ...(zoomBar?.enabled &&

--- a/src/components/BarChartCard/barChartUtils.js
+++ b/src/components/BarChartCard/barChartUtils.js
@@ -302,7 +302,6 @@ export const formatColors = (series, datasetNames, isEditable) => {
  * @param {object} data data object for this particular datapoint
  * @param {string} defaultTooltip Default HTML generated for this tooltip that needs to be marked up
  * @param {string} timeDatasourceId time-based attribute
- * @param {Object} colors defined by the user and formatted for carbon charts
  * @param {bool} showTimeInGMT
  * @param {string} tooltipDataFormatPattern
  */
@@ -310,39 +309,32 @@ export const handleTooltip = (
   dataOrHoveredElement,
   defaultTooltip,
   timeDataSourceId,
-  colors,
   showTimeInGMT,
   tooltipDateFormatPattern = 'L HH:mm:ss'
 ) => {
-  // console.log(defaultTooltip);
   // TODO: need to fix this in carbon-charts to support true stacked bar charts in the tooltip
   const data = dataOrHoveredElement.__data__ ? dataOrHoveredElement.__data__ : dataOrHoveredElement; // eslint-disable-line no-underscore-dangle
+  const typedData = Array.isArray(data) ? data[0] : data;
 
   // First add the dataset name as the current implementation only shows the value
   let updatedTooltip = defaultTooltip.replace(
     `<div class="datapoint-tooltip"><p class="value">`,
-    `<p class="label">${dataOrHoveredElement.group}</p><p class="value">`
+    `<p class="label">${typedData.group}</p><p class="value">`
   );
   updatedTooltip = updatedTooltip.replace('</div>', '');
 
-  // add the dataset color to the dataset name row
-  const coloredTooltip = `<div class="datapoint-tooltip"><a style="background-color:${
-    colors.scale[dataOrHoveredElement.group]
-  }" class="tooltip-color"></a>${updatedTooltip}</div>`;
-
-  let updatedWithColorTooltip = coloredTooltip;
   // If theres a time attribute, add an extra list item with the formatted date
   if (timeDataSourceId) {
     // First remove carbon charts tooltips
     // the first <li> will always be carbon chart's Dates row
-    const carbonChartsDateIndex = updatedWithColorTooltip.indexOf(`<li>`);
-    const endOfDateIndex = updatedWithColorTooltip.indexOf(`</li>`);
-    updatedWithColorTooltip = updatedWithColorTooltip.replace(
-      updatedWithColorTooltip.substring(carbonChartsDateIndex, endOfDateIndex + 5),
+    const carbonChartsDateIndex = updatedTooltip.indexOf(`<li>`);
+    const endOfDateIndex = updatedTooltip.indexOf(`</li>`);
+    updatedTooltip = updatedTooltip.replace(
+      updatedTooltip.substring(carbonChartsDateIndex, endOfDateIndex + 5),
       ''
     );
 
-    const timestamp = Array.isArray(data) ? data[0]?.date?.getTime() : data?.date?.getTime();
+    const timestamp = typedData?.date?.getTime();
     const dateLabel = timestamp
       ? `<li class='datapoint-tooltip'>
             <p class='label'>
@@ -354,10 +346,10 @@ export const handleTooltip = (
       : '';
 
     // wrap to make single a multi-tooltip
-    updatedWithColorTooltip = `<ul class='multi-tooltip'>${dateLabel}<li>${updatedWithColorTooltip}</li></ul>`;
+    updatedTooltip = `<ul class='multi-tooltip'>${dateLabel}<li>${updatedTooltip}</li></ul>`;
   }
 
-  return updatedWithColorTooltip;
+  return updatedTooltip;
 };
 
 /**

--- a/src/components/BarChartCard/barChartUtils.test.js
+++ b/src/components/BarChartCard/barChartUtils.test.js
@@ -704,44 +704,102 @@ describe('barChartUtils', () => {
     ]);
   });
 
-  it('handleTooltip returns dataset name, color and value', () => {
+  it('handleTooltip returns correct format if data is not time-based', () => {
     const simpleFormattedData = {
-      group: 'Amsterdam',
-      value: 512,
-    };
-
-    const defaultTooltip = `<p class="value">512</p>`;
-
-    const colors = {
-      scale: {
-        Amsterdam: 'blue',
-      },
-    };
-
-    expect(handleTooltip(simpleFormattedData, defaultTooltip, null, colors)).toEqual(
-      '<div class="datapoint-tooltip"><a style="background-color:blue" class="tooltip-color"></a><p class="value">512</p></div>'
-    );
-  });
-
-  it('handleTooltip returns dataset name, value, color, and date', () => {
-    const simpleFormattedData = {
-      group: 'Amsterdam',
+      group: 'San Francisco',
       value: 512,
       date: new Date(1581438225000),
     };
 
-    const defaultTooltip = `<p class="value">512</p>`;
+    const defaultTooltip = `<ul class='multi-tooltip'><li>
+    <div class="datapoint-tooltip ">
+      
+      <p class="label">Cities </p>
+      <p class="value">San Francisco</p>
+    </div>
+  </li><li>
+    <div class="datapoint-tooltip ">
+      
+      <p class="label">Particles </p>
+      <p class="value">512</p>
+    </div>
+  </li><li>
+    <div class="datapoint-tooltip ">
+      <a style="background-color: #4589ff" class="tooltip-color"></a>
+      <p class="label">Group</p>
+      <p class="value">Particles</p>
+    </div>
+  </li></ul>`;
 
-    const colors = {
-      scale: {
-        Amsterdam: 'blue',
+    expect(handleTooltip(simpleFormattedData, defaultTooltip, undefined)).toEqual(
+      `<ul class='multi-tooltip'><li>
+    <div class="datapoint-tooltip ">
+      
+      <p class="label">Cities </p>
+      <p class="value">San Francisco</p>
+    
+  </li><li>
+    <div class="datapoint-tooltip ">
+      
+      <p class="label">Particles </p>
+      <p class="value">512</p>
+    </div>
+  </li><li>
+    <div class="datapoint-tooltip ">
+      <a style="background-color: #4589ff" class="tooltip-color"></a>
+      <p class="label">Group</p>
+      <p class="value">Particles</p>
+    </div>
+  </li></ul>`
+    );
+  });
+
+  it('handleTooltip returns correct format if data is array', () => {
+    const simpleFormattedData = [
+      {
+        group: 'Particles',
+        value: 565,
+        date: new Date(1581438225000),
       },
-    };
+    ];
 
-    expect(handleTooltip(simpleFormattedData, defaultTooltip, 'timestamp', colors)).toEqual(
+    const defaultTooltip = `<ul class='multi-tooltip'><li>
+    <div class="datapoint-tooltip ">
+      
+      <p class="label">Dates </p>
+      <p class="value">Feb 12, 2020</p>
+    </div>
+  </li><li>
+    <div class="datapoint-tooltip ">
+      
+      <p class="label">Total </p>
+      <p class="value">565</p>
+    </div>
+  </li><li>
+    <div class="datapoint-tooltip ">
+      <a style="background-color: #4589ff" class="tooltip-color"></a>
+      <p class="label">Group</p>
+      <p class="value">Particles</p>
+    </div>
+  </li></ul>`;
+
+    expect(handleTooltip(simpleFormattedData, defaultTooltip, 'timestamp')).toEqual(
       `<ul class='multi-tooltip'><li class='datapoint-tooltip'>
-                        <p class='label'>02/11/2020 10:23:45</p>
-                      </li><li><div class="datapoint-tooltip"><a style="background-color:blue" class="tooltip-color"></a><p class="value">512</p></div></li></ul>`
+            <p class='label'>
+              02/11/2020 10:23:45</p>
+          </li><li><ul class='multi-tooltip'><li>
+    <div class="datapoint-tooltip ">
+      
+      <p class="label">Total </p>
+      <p class="value">565</p>
+    </div>
+  </li><li>
+    <div class="datapoint-tooltip ">
+      <a style="background-color: #4589ff" class="tooltip-color"></a>
+      <p class="label">Group</p>
+      <p class="value">Particles</p>
+    </div>
+  </li></ul></li></ul>`
     );
   });
 });

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -62,10 +62,6 @@ const TimeSeriesCardPropTypes = {
     includeZeroOnYaxis: PropTypes.bool,
     /** Which attribute is the time attribute i.e. 'timestamp' */
     timeDataSourceId: PropTypes.string,
-    /** Show timestamp in browser local time or GMT */
-    showTimeInGMT: PropTypes.bool,
-    /** tooltip format pattern that follows the moment formatting patterns */
-    tooltipDateFormatPattern: PropTypes.string,
     /** should it be a line chart or bar chart, default is line chart */
     chartType: deprecate(
       PropTypes.oneOf(Object.values(TIME_SERIES_TYPES)),
@@ -99,6 +95,12 @@ const TimeSeriesCardPropTypes = {
    * can be date instance or timestamp
    */
   domainRange: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.object])),
+  /** Region for value and text formatting */
+  locale: PropTypes.string,
+  /** Show timestamp in browser local time or GMT */
+  showTimeInGMT: PropTypes.bool,
+  /** tooltip format pattern that follows the moment formatting patterns */
+  tooltipDateFormatPattern: PropTypes.string,
 };
 
 const LineChartWrapper = styled.div`

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -156,10 +156,10 @@ export const formatChartData = (timeDataSourceId = 'timestamp', series, values) 
       // First filter based on on the dataFilter
       const filteredData = filter(values, dataFilter);
       if (!isEmpty(filteredData)) {
+        // have to filter out null values from the dataset, as it causes Carbon Charts to break
         filteredData
           .filter(dataItem => {
-            // only allow valid timestamp matches
-            return !isNil(dataItem[timeDataSourceId]) && dataItem[timeDataSourceId] === timestamp;
+            return !isNil(dataItem[dataSourceId]) && dataItem[timeDataSourceId] === timestamp;
           })
           .forEach(dataItem =>
             data.push({
@@ -187,6 +187,7 @@ const memoizedGenerateSampleValues = memoize(generateSampleValues);
  * @param {array} alertRanges Array of alert range information to search
  * @param {string} alertDetected Translated string to indicate that the alert is detected
  * @param {bool} showTimeInGMT
+ * @param {string} tooltipDataFormatPattern
  */
 export const handleTooltip = (
   dataOrHoveredElement,
@@ -265,8 +266,6 @@ const TimeSeriesCard = ({
   isLazyLoading,
   isLoading,
   domainRange,
-  showTimeInGMT,
-  tooltipDateFormatPattern,
   ...others
 }) => {
   const {
@@ -282,6 +281,8 @@ const TimeSeriesCard = ({
       unit,
       chartType,
       zoomBar,
+      showTimeInGMT,
+      tooltipDateFormatPattern,
     },
     values: valuesProp,
   } = handleCardVariables(titleProp, content, initialValues, others);

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -161,7 +161,8 @@ export const formatChartData = (timeDataSourceId = 'timestamp', series, values) 
         // have to filter out null values from the dataset, as it causes Carbon Charts to break
         filteredData
           .filter(dataItem => {
-            return !isNil(dataItem[dataSourceId]) && dataItem[timeDataSourceId] === timestamp;
+            // only allow valid timestamp matches
+            return !isNil(dataItem[timeDataSourceId]) && dataItem[timeDataSourceId] === timestamp;
           })
           .forEach(dataItem =>
             data.push({

--- a/src/constants/CardPropTypes.js
+++ b/src/constants/CardPropTypes.js
@@ -279,6 +279,10 @@ export const BarChartCardPropTypes = {
     unit: PropTypes.string,
     /** Optionally addes a zoom bar to the chart */
     zoomBar: ZoomBarPropTypes,
+    /** Show timestamp in browser local time or GMT */
+    showTimeInGMT: PropTypes.bool,
+    /** tooltip format pattern that follows the moment formatting patterns */
+    tooltipDateFormatPattern: PropTypes.string,
   }).isRequired,
   /** array of data from the backend for instance [{quarter: '2020-Q1', city: 'Amsterdam', particles: 44700}, ...] */
   values: PropTypes.arrayOf(PropTypes.object),

--- a/src/constants/CardPropTypes.js
+++ b/src/constants/CardPropTypes.js
@@ -279,10 +279,6 @@ export const BarChartCardPropTypes = {
     unit: PropTypes.string,
     /** Optionally addes a zoom bar to the chart */
     zoomBar: ZoomBarPropTypes,
-    /** Show timestamp in browser local time or GMT */
-    showTimeInGMT: PropTypes.bool,
-    /** tooltip format pattern that follows the moment formatting patterns */
-    tooltipDateFormatPattern: PropTypes.string,
   }).isRequired,
   /** array of data from the backend for instance [{quarter: '2020-Q1', city: 'Amsterdam', particles: 44700}, ...] */
   values: PropTypes.arrayOf(PropTypes.object),
@@ -293,6 +289,10 @@ export const BarChartCardPropTypes = {
   /** optional domain to graph from. First value is the beginning of the range. Second value is the end of the range
    * can be date instance or timestamp */
   domainRange: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.object])),
+  /** Show timestamp in browser local time or GMT */
+  showTimeInGMT: PropTypes.bool,
+  /** tooltip format pattern that follows the moment formatting patterns */
+  tooltipDateFormatPattern: PropTypes.string,
 };
 
 export const DonutCardPropTypes = {

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -3923,7 +3923,9 @@ Map {
         "noDataLabel": "No data",
       },
       "locale": "en",
+      "showTimeInGMT": false,
       "size": "MEDIUMWIDE",
+      "tooltipDateFormatPattern": "L HH:mm:ss",
     },
     "propTypes": Object {
       "availableActions": Object {
@@ -4635,6 +4637,9 @@ Map {
         "type": "shape",
       },
       "showOverflow": [Function],
+      "showTimeInGMT": Object {
+        "type": "bool",
+      },
       "size": [Function],
       "testID": Object {
         "type": "string",
@@ -4651,6 +4656,9 @@ Map {
       },
       "tooltip": Object {
         "type": "element",
+      },
+      "tooltipDateFormatPattern": Object {
+        "type": "string",
       },
       "values": Object {
         "args": Array [
@@ -9280,13 +9288,7 @@ Map {
               "isRequired": true,
               "type": "oneOfType",
             },
-            "showTimeInGMT": Object {
-              "type": "bool",
-            },
             "timeDataSourceId": Object {
-              "type": "string",
-            },
-            "tooltipDateFormatPattern": Object {
               "type": "string",
             },
             "unit": Object {
@@ -9499,6 +9501,9 @@ Map {
         "type": "shape",
       },
       "showOverflow": [Function],
+      "showTimeInGMT": Object {
+        "type": "bool",
+      },
       "size": Object {
         "args": Array [
           Array [
@@ -9534,6 +9539,9 @@ Map {
       },
       "tooltip": Object {
         "type": "element",
+      },
+      "tooltipDateFormatPattern": Object {
+        "type": "string",
       },
       "values": Object {
         "args": Array [


### PR DESCRIPTION
Closes #1534 

**Summary**

- Stacked bar chart data comes in as an array which was not being handled by the tooltipFormatter. This PR adds a check for an array and passes the actual data, whether its an object or array, correctly to the tooltip formatting flow

**Change List (commits, features, bugs, etc)**

- Fixed propTypes for TimeSeriesCards (`tooltipDataFormatPattern`, `showTimeInGMT` were in the content object mistakenly)
- Added `tooltipDataFormatPattern`, `showTimeInGMT` props to BarChartCard
- Updated `tooltipFormatter` to take in above props for formatting
- Removed custom color formatting as carbon charts does this by default now
- Removed default date row from tooltip as we create a custom date ourselves
- Updated tests to reflect changes (beware the diffs are a bit nasty as the spacing and returned format of the tooltip is all over the place)

**Acceptance Test (how to verify the PR)**

- Go to each time-based BarChartCard story, hover over the bars, and ensure that the dates match the actual data