### PR TITLE
fix(TimeSeriesCard): Migrate to SCSS, and force white theme bg in zoombar

### DIFF
--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -1328,8 +1328,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   }
                 >
                   <div
-                    className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-                    size="MEDIUM"
+                    className="iot--time-series-card--wrapper"
                   >
                     <div
                       className="chart-holder"
@@ -1933,8 +1932,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   }
                 >
                   <div
-                    className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-                    size="LARGE"
+                    className="iot--time-series-card--wrapper"
                   >
                     <div
                       className="chart-holder"
@@ -3628,8 +3626,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   }
                 >
                   <div
-                    className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-                    size="MEDIUM"
+                    className="iot--time-series-card--wrapper"
                   >
                     <div
                       className="chart-holder"
@@ -4233,8 +4230,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   }
                 >
                   <div
-                    className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-                    size="LARGE"
+                    className="iot--time-series-card--wrapper"
                   >
                     <div
                       className="chart-holder"
@@ -5955,8 +5951,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   }
                 >
                   <div
-                    className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-                    size="MEDIUM"
+                    className="iot--time-series-card--wrapper"
                   >
                     <div
                       className="chart-holder"
@@ -6560,8 +6555,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   }
                 >
                   <div
-                    className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-                    size="LARGE"
+                    className="iot--time-series-card--wrapper"
                   >
                     <div
                       className="chart-holder"
@@ -7527,8 +7521,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                 }
               >
                 <div
-                  className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-                  size="LARGE"
+                  className="iot--time-series-card--wrapper"
                 >
                   <div
                     className="chart-holder"
@@ -10787,8 +10780,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   }
                 >
                   <div
-                    className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-                    size="MEDIUM"
+                    className="iot--time-series-card--wrapper"
                   >
                     <div
                       className="chart-holder"
@@ -11392,8 +11384,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   }
                 >
                   <div
-                    className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-                    size="LARGE"
+                    className="iot--time-series-card--wrapper"
                   >
                     <div
                       className="chart-holder"
@@ -25295,8 +25286,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   }
                 >
                   <div
-                    className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-                    size="MEDIUM"
+                    className="iot--time-series-card--wrapper"
                   >
                     <div
                       className="chart-holder"
@@ -25900,8 +25890,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   }
                 >
                   <div
-                    className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-                    size="LARGE"
+                    className="iot--time-series-card--wrapper"
                   >
                     <div
                       className="chart-holder"

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -1,11 +1,10 @@
 import React, { useRef, useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
+import classNames from 'classnames';
 import 'moment/min/locales';
 import LineChart from '@carbon/charts-react/line-chart';
 import StackedBarChart from '@carbon/charts-react/bar-chart-stacked';
-import { spacing02, spacing05 } from '@carbon/layout';
-import styled from 'styled-components';
 import isNil from 'lodash/isNil';
 import isEmpty from 'lodash/isEmpty';
 import omit from 'lodash/omit';
@@ -104,40 +103,6 @@ const TimeSeriesCardPropTypes = {
   /** tooltip format pattern that follows the moment formatting patterns */
   tooltipDateFormatPattern: PropTypes.string,
 };
-
-const LineChartWrapper = styled.div`
-  padding-left: ${spacing05};
-  padding-right: ${spacing05};
-  padding-top: 0px;
-  padding-bottom: ${spacing05};
-  position: absolute;
-  width: 100%;
-  height: ${props => (props.isExpanded ? '55%' : '100%')};
-
-  &&& {
-    .chart-wrapper g.x.axis g.tick text {
-      transform: rotateY(0);
-      text-anchor: initial !important;
-    }
-    .chart-holder {
-      width: 100%;
-      padding-top: ${spacing02};
-    }
-    .axis-title {
-      font-weight: 500;
-    }
-    .bx--cc--chart-svg {
-      width: 100%;
-      height: 100%;
-      circle.dot.unfilled {
-        opacity: ${props => (props.numberOfPoints > 50 ? '0' : '1')};
-      }
-    }
-    .bx--cc--tooltip {
-      display: ${props => (props.isEditable ? 'none' : '')};
-    }
-  }
-`;
 
 /**
  * Translates our raw data into a language the carbon-charts understand
@@ -486,11 +451,13 @@ const TimeSeriesCard = ({
     >
       {!isChartDataEmpty ? (
         <>
-          <LineChartWrapper
-            size={newSize}
-            isEditable={isEditable}
-            isExpanded={isExpanded}
-            numberOfPoints={valueSort && valueSort.length}
+          <div
+            className={classNames(`${iotPrefix}--time-series-card--wrapper`, {
+              [`${iotPrefix}--time-series-card--wrapper--expanded`]: isExpanded,
+              [`${iotPrefix}--time-series-card--wrapper--lots-of-points`]:
+                valueSort && valueSort.length > 50,
+              [`${iotPrefix}--time-series-card--wrapper--editable`]: isEditable,
+            })}
           >
             <ChartComponent
               ref={el => {
@@ -563,7 +530,7 @@ const TimeSeriesCard = ({
               width="100%"
               height="100%"
             />
-          </LineChartWrapper>
+          </div>
           {isExpanded ? (
             <StatefulTable
               id="TimeSeries-table"

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -453,10 +453,10 @@ const TimeSeriesCard = ({
         <>
           <div
             className={classNames(`${iotPrefix}--time-series-card--wrapper`, {
-              [`${iotPrefix}--time-series-card--wrapper--expanded`]: isExpanded,
-              [`${iotPrefix}--time-series-card--wrapper--lots-of-points`]:
+              [`${iotPrefix}--time-series-card--wrapper__expanded`]: isExpanded,
+              [`${iotPrefix}--time-series-card--wrapper__lots-of-points`]:
                 valueSort && valueSort.length > 50,
-              [`${iotPrefix}--time-series-card--wrapper--editable`]: isEditable,
+              [`${iotPrefix}--time-series-card--wrapper__editable`]: isEditable,
             })}
           >
             <ChartComponent

--- a/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -54,8 +54,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="LARGE"
+            className="iot--time-series-card--wrapper"
           >
             <div
               className="chart-holder"
@@ -145,8 +144,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="LARGE"
+            className="iot--time-series-card--wrapper"
           >
             <div
               className="chart-holder"
@@ -283,8 +281,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="MEDIUM"
+            className="iot--time-series-card--wrapper"
           >
             <div
               className="chart-holder"
@@ -467,8 +464,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="LARGE"
+            className="iot--time-series-card--wrapper"
           >
             <div
               className="chart-holder"
@@ -558,8 +554,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kGvWug"
-            size="MEDIUM"
+            className="iot--time-series-card--wrapper iot--time-series-card--wrapper--lots-of-points"
           >
             <div
               className="chart-holder"
@@ -649,8 +644,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 jbTSBO"
-            size="LARGE"
+            className="iot--time-series-card--wrapper iot--time-series-card--wrapper--editable"
           >
             <div
               className="chart-holder"
@@ -745,8 +739,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
             }
           >
             <div
-              className="TimeSeriesCard__LineChartWrapper-q25vbg-0 cUshBn"
-              size="MEDIUM"
+              className="iot--time-series-card--wrapper iot--time-series-card--wrapper--expanded"
             >
               <div
                 className="chart-holder"
@@ -2665,8 +2658,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="LARGE"
+            className="iot--time-series-card--wrapper"
           >
             <div
               className="chart-holder"
@@ -2756,8 +2748,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="LARGE"
+            className="iot--time-series-card--wrapper"
           >
             <div
               className="chart-holder"
@@ -2847,8 +2838,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="LARGE"
+            className="iot--time-series-card--wrapper"
           >
             <div
               className="chart-holder"
@@ -2938,8 +2928,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="LARGE"
+            className="iot--time-series-card--wrapper"
           >
             <div
               className="chart-holder"
@@ -3029,8 +3018,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="LARGE"
+            className="iot--time-series-card--wrapper"
           >
             <div
               className="chart-holder"
@@ -3120,8 +3108,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="LARGE"
+            className="iot--time-series-card--wrapper"
           >
             <div
               className="chart-holder"
@@ -3211,8 +3198,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="LARGE"
+            className="iot--time-series-card--wrapper"
           >
             <div
               className="chart-holder"
@@ -3302,8 +3288,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="LARGE"
+            className="iot--time-series-card--wrapper"
           >
             <div
               className="chart-holder"
@@ -3393,8 +3378,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kGvWug"
-            size="MEDIUM"
+            className="iot--time-series-card--wrapper iot--time-series-card--wrapper--lots-of-points"
           >
             <div
               className="chart-holder"
@@ -3484,8 +3468,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="MEDIUM"
+            className="iot--time-series-card--wrapper"
           >
             <div
               className="chart-holder"
@@ -3575,8 +3558,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="MEDIUM"
+            className="iot--time-series-card--wrapper"
           >
             <div
               className="chart-holder"
@@ -3666,8 +3648,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="MEDIUM"
+            className="iot--time-series-card--wrapper"
           >
             <div
               className="chart-holder"
@@ -3757,8 +3738,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="MEDIUM"
+            className="iot--time-series-card--wrapper"
           >
             <div
               className="chart-holder"
@@ -3848,8 +3828,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="MEDIUM"
+            className="iot--time-series-card--wrapper"
           >
             <div
               className="chart-holder"
@@ -3939,8 +3918,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="MEDIUM"
+            className="iot--time-series-card--wrapper"
           >
             <div
               className="chart-holder"
@@ -4030,8 +4008,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="MEDIUM"
+            className="iot--time-series-card--wrapper"
           >
             <div
               className="chart-holder"
@@ -4121,8 +4098,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="MEDIUM"
+            className="iot--time-series-card--wrapper"
           >
             <div
               className="chart-holder"
@@ -4212,8 +4188,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="TimeSeriesCard__LineChartWrapper-q25vbg-0 kjKxHK"
-            size="LARGE"
+            className="iot--time-series-card--wrapper"
           >
             <div
               className="chart-holder"

--- a/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -554,7 +554,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="iot--time-series-card--wrapper iot--time-series-card--wrapper--lots-of-points"
+            className="iot--time-series-card--wrapper iot--time-series-card--wrapper__lots-of-points"
           >
             <div
               className="chart-holder"
@@ -644,7 +644,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="iot--time-series-card--wrapper iot--time-series-card--wrapper--editable"
+            className="iot--time-series-card--wrapper iot--time-series-card--wrapper__editable"
           >
             <div
               className="chart-holder"
@@ -739,7 +739,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
             }
           >
             <div
-              className="iot--time-series-card--wrapper iot--time-series-card--wrapper--expanded"
+              className="iot--time-series-card--wrapper iot--time-series-card--wrapper__expanded"
             >
               <div
                 className="chart-holder"
@@ -3378,7 +3378,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
           }
         >
           <div
-            className="iot--time-series-card--wrapper iot--time-series-card--wrapper--lots-of-points"
+            className="iot--time-series-card--wrapper iot--time-series-card--wrapper__lots-of-points"
           >
             <div
               className="chart-holder"

--- a/src/components/TimeSeriesCard/_time-series-card.scss
+++ b/src/components/TimeSeriesCard/_time-series-card.scss
@@ -6,3 +6,58 @@
   top: 55%;
   width: 100%;
 }
+
+.#{$iot-prefix}--time-series-card--wrapper {
+  padding-left: $spacing-05;
+  padding-right: $spacing-05;
+  padding-top: 0px;
+  padding-bottom: $spacing-05;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+
+  .chart-wrapper g.x.axis g.tick text {
+    transform: rotateY(0);
+    text-anchor: initial !important;
+  }
+  .chart-holder {
+    width: 100%;
+    padding-top: $spacing-02;
+  }
+  .axis-title {
+    font-weight: 500;
+  }
+  .bx--cc--chart-svg {
+    width: 100%;
+    height: 100%;
+    circle.dot.unfilled {
+      opacity: 1;
+    }
+  }
+  .bx--cc--tooltip {
+    display: initial;
+  }
+  // force the slider to be the white theme background color until
+  // https://github.com/carbon-design-system/carbon-charts/issues/750 is fixed
+  g.bx--cc--zoom-bar rect.zoom-slider-bg {
+    fill: #f4f4f4;
+  }
+}
+
+.#{$iot-prefix}--time-series-card--wrapper--expanded {
+  height: 55%;
+}
+
+.#{$iot-prefix}--time-series-card--wrapper--lots-of-points {
+  .bx--cc--chart-svg {
+    circle.dot.unfilled {
+      opacity: 0;
+    }
+  }
+}
+
+.#{$iot-prefix}--time-series-card--wrapper--editable {
+  .bx--cc--tooltip {
+    display: none;
+  }
+}

--- a/src/components/TimeSeriesCard/_time-series-card.scss
+++ b/src/components/TimeSeriesCard/_time-series-card.scss
@@ -27,37 +27,37 @@
   .axis-title {
     font-weight: 500;
   }
-  .bx--cc--chart-svg {
+  .#{$prefix}--cc--chart-svg {
     width: 100%;
     height: 100%;
     circle.dot.unfilled {
       opacity: 1;
     }
   }
-  .bx--cc--tooltip {
+  .#{$prefix}--cc--tooltip {
     display: initial;
   }
   // force the slider to be the white theme background color until
   // https://github.com/carbon-design-system/carbon-charts/issues/750 is fixed
-  g.bx--cc--zoom-bar rect.zoom-slider-bg {
+  g.#{$prefix}--cc--zoom-bar rect.zoom-slider-bg {
     fill: #f4f4f4;
   }
 }
 
-.#{$iot-prefix}--time-series-card--wrapper--expanded {
+.#{$iot-prefix}--time-series-card--wrapper__expanded {
   height: 55%;
 }
 
-.#{$iot-prefix}--time-series-card--wrapper--lots-of-points {
-  .bx--cc--chart-svg {
+.#{$iot-prefix}--time-series-card--wrapper__lots-of-points {
+  .#{$prefix}--cc--chart-svg {
     circle.dot.unfilled {
       opacity: 0;
     }
   }
 }
 
-.#{$iot-prefix}--time-series-card--wrapper--editable {
-  .bx--cc--tooltip {
+.#{$iot-prefix}--time-series-card--wrapper__editable {
+  .#{$prefix}--cc--tooltip {
     display: none;
   }
 }


### PR DESCRIPTION
Band-aid fix for #1548 until the carbon charts issue is solved 
Part of https://github.com/carbon-design-system/carbon-addons-iot-react/issues/370

**Summary**

- Themes are incorrect with the zoombar in carbon charts causing the background of the slider view zoombar to be white, meaning it blends in with the card's white background

See https://github.com/carbon-design-system/carbon-charts/issues/750 for more details about the broader issue

**Change List (commits, features, bugs, etc)**

- Migrate from styled components to SCSS
- Add styling to fix the background color to be the proper grayish color (I'd like to stay away from the carbon variables as this is a temporary fix)

**Acceptance Test (how to verify the PR)**

- Go to TimeSeriesCard - zoombar story, slide the zoom handles over some, and see that there is now a background color

**Regression Test (how to make sure this PR doesn't break anything)**

- Go to TimeSeriesCard - lots of points story and ensure there is no dots showing
- Go to expanded story and ensure the height ratio looks correct
- Go to editable story and ensure the tooltips are disabled

![Screen Shot 2020-08-27 at 4 47 05 PM](https://user-images.githubusercontent.com/25177649/91498207-f8758580-e884-11ea-98a3-05408de1f343.png)
