### PR TITLE
fix(statefultable): customToolbarContent element props unaffected

### DIFF
--- a/src/components/Table/StatefulTable.jsx
+++ b/src/components/Table/StatefulTable.jsx
@@ -34,6 +34,9 @@ const StatefulTable = ({ data: initialData, expandedData, ...other }) => {
     id: tableId,
     columns,
     options,
+    view: {
+      toolbar: { customToolbarContent },
+    },
     view: initialState,
     actions: callbackActions,
     lightweight,
@@ -233,6 +236,7 @@ const StatefulTable = ({ data: initialData, expandedData, ...other }) => {
             ...view?.toolbar?.search,
             defaultValue: initialDefaultSearch,
           },
+          customToolbarContent,
         },
         pagination: {
           ...view.pagination,

--- a/src/components/Table/StatefulTable.test.jsx
+++ b/src/components/Table/StatefulTable.test.jsx
@@ -269,4 +269,28 @@ describe('stateful table with real reducer', () => {
     expect(fourthFilteredRowsOptionC).toHaveLength(4);
     expect(fourthItemCount).toBeInTheDocument();
   });
+
+  it('re-renders custom toolbar elements', () => {
+    const tableId = 'tableId';
+    const TestComp = ({ myMessage }) => {
+      return <div>{myMessage}</div>;
+    };
+    const AppWrapper = ({ message }) => {
+      return (
+        <StatefulTable
+          id={tableId}
+          {...merge({}, initialState, {
+            view: { toolbar: { customToolbarContent: <TestComp myMessage={message} /> } },
+          })}
+          actions={mockActions}
+        />
+      );
+    };
+
+    const { rerender } = render(<AppWrapper message="message1" />);
+    expect(screen.queryByText('message1')).toBeVisible();
+
+    rerender(<AppWrapper message="message2" />);
+    expect(screen.queryByText('message2')).toBeVisible();
+  });
 });


### PR DESCRIPTION
Closes #1551

**Summary**
The props of the elements placed in the customToolbarContent are not updated after the initial render since they are preserved by the state of the StatefulTable. That means that the App cannot update the customToolbarContent elements when the state of the app changes.

**Change List (commits, features, bugs, etc)**
- Removed the customToolbarContent from the state management in StatefulTable
- Added unit tests

**Acceptance Test (how to verify the PR)**
- Verify that stories with customToolbarContent are still working
