### PR TITLE
fix(button): proper icon placement in RTL

### DIFF
--- a/src/components/Button/_button.scss
+++ b/src/components/Button/_button.scss
@@ -55,8 +55,15 @@
   outline-color: transparent;
 }
 
-[dir='rtl'] .#{$iot-prefix}--btn:not(.#{$prefix}--btn--icon-only) {
-  text-align: right;
-  padding-left: 60px; // fixed values to invert $button-padding of Carbon's theme-tokens.scss
-  padding-right: 12px;
+[dir='rtl'] {
+  .#{$iot-prefix}--btn:not(.#{$prefix}--btn--icon-only) {
+    text-align: right;
+    padding-left: 60px; // fixed values to invert $button-padding of Carbon's theme-tokens.scss
+    padding-right: 12px;
+  }
+
+  .#{$prefix}--btn .#{$prefix}--btn__icon {
+    left: $spacing-05;
+    right: initial;
+  }
 }


### PR DESCRIPTION
Closes #1317

**Summary**

- Icons no longer are laid over the text when in RTL

**Change List (commits, features, bugs, etc)**

- update _button.scss

**Acceptance Test (how to verify the PR)**

- View the default button story 
  - https://deploy-preview-1558--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-button--default
- Configure an icon to be placed in the button via the knobs
- Click the RTL button/knob
- Icons should be laid out to the left of the text (inverse of when RTL is off) ![image](https://user-images.githubusercontent.com/3360588/91868683-a0e76900-ec3a-11ea-81d6-d5d70ff4fb90.png)
- Other stories should remain unchanged

