### PR TITLE
feat(SideNav): 4 Levels deep, non-leaf onClick support

### DIFF
--- a/src/components/SideNav/SideNav.jsx
+++ b/src/components/SideNav/SideNav.jsx
@@ -98,6 +98,7 @@ const SideNav = ({ links, defaultExpanded, isSideNavExpanded, i18n, ...props }) 
 
   useEffect(() => {
     buttonBindings.forEach(binding => {
+      debugger;
       binding.buttonref.current.addEventListener('click', e => {
         binding.callback();
       });
@@ -143,9 +144,9 @@ function getChildren(links, link) {
       );
     });
 
-    if (link.metaData && link.metaData.onclick) {
+    if (link.metaData && link.metaData.onClick) {
       const buttonref = useRef(null);
-      buttonBindings.push({ buttonref: buttonref, callback: link.metaData.onclick });
+      buttonBindings.push({ buttonref: buttonref, callback: link.metaData.onClick });
 
       return (
         <SideNavMenu

--- a/src/components/SideNav/SideNav.jsx
+++ b/src/components/SideNav/SideNav.jsx
@@ -98,7 +98,6 @@ const SideNav = ({ links, defaultExpanded, isSideNavExpanded, i18n, ...props }) 
 
   useEffect(() => {
     buttonBindings.forEach(binding => {
-      debugger;
       binding.buttonref.current.addEventListener('click', e => {
         binding.callback();
       });

--- a/src/components/SideNav/_side-nav.scss
+++ b/src/components/SideNav/_side-nav.scss
@@ -176,6 +176,48 @@ button.#{$prefix}--side-nav__link {
   height: 3rem;
 }
 
+//Handling for menus more than two levels deep.
+.#{$prefix}--side-nav__item:not(.#{$prefix}--side-nav__item--active):hover
+  .#{$prefix}--side-nav__item:not(.#{$prefix}--side-nav__item--active)
+  > .#{$prefix}--side-nav__submenu:hover {
+  background-color: $inverse-02;
+  color: $ui-02;
+}
+
+//3-levels deep text
+.#{$prefix}--side-nav__item
+  .#{$prefix}--side-nav__menu
+  .#{$prefix}--side-nav__item
+  .#{$prefix}--side-nav__submenu-title {
+  padding-left: 55px;
+}
+
+.#{$prefix}--side-nav__item
+  .#{$prefix}--side-nav__menu
+  .#{$prefix}--side-nav__item
+  .#{$prefix}--side-nav__link-text {
+  padding-left: 15px;
+}
+
+//4-levels deep text
+.#{$prefix}--side-nav__item
+  .#{$prefix}--side-nav__menu
+  .#{$prefix}--side-nav__item
+  .#{$prefix}--side-nav__menu
+  .#{$prefix}--side-nav__item
+  .#{$prefix}--side-nav__submenu-title {
+  padding-left: 70px;
+}
+
+.#{$prefix}--side-nav__item
+  .#{$prefix}--side-nav__menu
+  .#{$prefix}--side-nav__item
+  .#{$prefix}--side-nav__menu
+  .#{$prefix}--side-nav__item
+  .#{$prefix}--side-nav__link-text {
+  padding-left: 30px;
+}
+
 // RTL style fixes
 html[dir='rtl'] {
   .#{$prefix}--side-nav__icon:not(.#{$prefix}--side-nav__submenu-chevron) {


### PR DESCRIPTION
…actions on non leaf node clicks

Closes #

**Summary**
This change adds support for menu hierarchies that are more than 2 levels deep. This change also adds support for click events on non-leaf menu nodes.

**Change List (commits, features, bugs, etc)**

N/A

**Acceptance Test (how to verify the PR)**

Create a menu hierarchy that is more than 2 levels deep such as:

const links = [
  {
    isEnabled: true,
    icon: Dashboard,
    metaData: {
      label: 'Dashboards',
      href: 'https://google.com',
      element: 'a',
      target: '_blank',
    },
    linkContent: 'Dashboards',
    childContent: [
      {
        metaData: {
          label: 'Link 1',
          title: 'Link 1',
          onClick: ()=>{alert('Link 1 click')},
          element: 'button',
        },
        linkContent: 'Link 1',
        childContent: [
	      {
	        metaData: {
	          label: 'Link 2',
	          title: 'Link 2',
	          onClick: ()=>{alert('Link 2 click')},
	          element: 'button',
	        },
	        linkContent: 'Link 2',
	        childContent: [
		      {
		        metaData: {
		          label: 'Link 3',
		          title: 'Link 3',
		          onClick: ()=>{alert('Link 3 click')},
		          element: 'button',
		        },
		        content: 'Link 3',
		      },
		    ]
	      },
	    ]
      },
    ],
  },
];

Verify that the menu hierarchy is honored by the Navigation. Verify that the onClick functions defined in non-leaf menu nodes are executed.
