### PR TITLE
fix(modal): overflow menu and tooltip contents hidden in modal

### DIFF
--- a/src/components/ComposedModal/ComposedModal.jsx
+++ b/src/components/ComposedModal/ComposedModal.jsx
@@ -166,6 +166,7 @@ class ComposedModal extends React.Component {
         {...props}
         open={open}
         onClose={this.doNotClose}
+        data-floating-menu-container
         className={classnames(
           className,
           {

--- a/src/components/ComposedModal/ComposedModal.jsx
+++ b/src/components/ComposedModal/ComposedModal.jsx
@@ -166,7 +166,7 @@ class ComposedModal extends React.Component {
         {...props}
         open={open}
         onClose={this.doNotClose}
-        data-floating-menu-container
+        data-floating-menu-container // TODO: Can remove once this issue is fixed: https://github.com/carbon-design-system/carbon/issues/6662
         className={classnames(
           className,
           {

--- a/src/components/ComposedModal/ComposedModal.story.jsx
+++ b/src/components/ComposedModal/ComposedModal.story.jsx
@@ -4,7 +4,7 @@ import { action } from '@storybook/addon-actions';
 import { boolean, object, text } from '@storybook/addon-knobs';
 import { spacing05 } from '@carbon/layout';
 import styled from 'styled-components';
-import { OverflowMenu, OverflowMenuItem } from 'carbon-components-react';
+import { OverflowMenu, OverflowMenuItem, Tooltip } from 'carbon-components-react';
 
 import ComposedModal from './ComposedModal';
 
@@ -134,7 +134,7 @@ REDUXFORM or REDUXDIALOG`,
       onSubmit={action('submit')}
     />
   ))
-  .add('composed modal with overflow', () => (
+  .add('composed modal with overflow and tooltip', () => (
     <ComposedModal
       header={{
         label: 'Translated bottom buttons',
@@ -148,5 +148,8 @@ REDUXFORM or REDUXDIALOG`,
       <OverflowMenu title="Test Overflow" iconDescription="Expand">
         <OverflowMenuItem key="default" onClick={action('onClick')} itemText="Click me" />
       </OverflowMenu>
+      <Tooltip triggerId="my test tooltip" triggerText="Trigger Text">
+        Hi there
+      </Tooltip>
     </ComposedModal>
   ));

--- a/src/components/ComposedModal/ComposedModal.story.jsx
+++ b/src/components/ComposedModal/ComposedModal.story.jsx
@@ -4,6 +4,7 @@ import { action } from '@storybook/addon-actions';
 import { boolean, object, text } from '@storybook/addon-knobs';
 import { spacing05 } from '@carbon/layout';
 import styled from 'styled-components';
+import { OverflowMenu, OverflowMenuItem } from 'carbon-components-react';
 
 import ComposedModal from './ComposedModal';
 
@@ -132,4 +133,20 @@ REDUXFORM or REDUXDIALOG`,
       onClose={action('close')}
       onSubmit={action('submit')}
     />
+  ))
+  .add('composed modal with overflow', () => (
+    <ComposedModal
+      header={{
+        label: 'Translated bottom buttons',
+        title: 'Dialog with bottom buttons and close button flyover translated',
+      }}
+      iconDescription="My Close Button"
+      footer={{ primaryButtonLabel: 'My Submit', secondaryButtonLabel: 'My Cancel' }}
+      onClose={action('close')}
+      onSubmit={action('submit')}
+    >
+      <OverflowMenu title="Test Overflow" iconDescription="Expand">
+        <OverflowMenuItem key="default" onClick={action('onClick')} itemText="Click me" />
+      </OverflowMenu>
+    </ComposedModal>
   ));

--- a/src/components/ComposedModal/__snapshots__/ComposedModal.story.storyshot
+++ b/src/components/ComposedModal/__snapshots__/ComposedModal.story.storyshot
@@ -14,6 +14,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Compo
   >
     <div
       className="bx--modal is-visible iot--composed-modal--large iot--composed-modal"
+      data-floating-menu-container={true}
       onBlur={[Function]}
       onClick={[Function]}
       onClose={[Function]}
@@ -133,6 +134,186 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Compo
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/ComposedModal composed modal with overflow 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--modal is-visible iot--composed-modal"
+      data-floating-menu-container={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onClose={[Function]}
+      onKeyDown={[Function]}
+      onTransitionEnd={[Function]}
+      open={true}
+      role="presentation"
+    >
+      <span
+        className="bx--visually-hidden"
+        role="link"
+        tabIndex="0"
+      >
+        Focus sentinel
+      </span>
+      <div
+        className="bx--modal-container"
+        role="dialog"
+      >
+        <div
+          className="bx--modal-header"
+        >
+          <p
+            className="bx--modal-header__label bx--type-delta"
+          >
+            Translated bottom buttons
+          </p>
+          <p
+            className="bx--modal-header__heading bx--type-beta"
+          >
+            Dialog with bottom buttons and close button flyover translated
+          </p>
+          <button
+            aria-label="My Close Button"
+            className="bx--modal-close"
+            onClick={[Function]}
+            title="My Close Button"
+            type="button"
+          >
+            <svg
+              aria-hidden={true}
+              className="bx--modal-close__icon"
+              fill="currentColor"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className="bx--modal-content"
+        >
+          <button
+            aria-expanded={false}
+            aria-haspopup={true}
+            aria-label="Menu"
+            className="bx--overflow-menu"
+            onClick={[Function]}
+            onClose={[Function]}
+            onKeyDown={[Function]}
+            open={false}
+            tabIndex={0}
+            title="Test Overflow"
+            type="button"
+          >
+            <svg
+              aria-label="Expand"
+              className="bx--overflow-menu__icon"
+              fill="currentColor"
+              focusable="false"
+              height={16}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              viewBox="0 0 32 32"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle
+                cx="16"
+                cy="8"
+                r="2"
+              />
+              <circle
+                cx="16"
+                cy="16"
+                r="2"
+              />
+              <circle
+                cx="16"
+                cy="24"
+                r="2"
+              />
+              <title>
+                Expand
+              </title>
+            </svg>
+          </button>
+        </div>
+        <div
+          className="bx--modal-footer iot--composed-modal-footer"
+        >
+          <button
+            className="iot--btn bx--btn bx--btn--secondary"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            My Cancel
+          </button>
+          <button
+            className="iot--btn bx--btn bx--btn--primary"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            My Submit
+          </button>
+        </div>
+      </div>
+      <span
+        className="bx--visually-hidden"
+        role="link"
+        tabIndex="0"
+      >
+        Focus sentinel
+      </span>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/ComposedModal custom footer 1`] = `
 <div
   className="storybook-container"
@@ -147,6 +328,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Compo
   >
     <div
       className="bx--modal is-visible iot--composed-modal"
+      data-floating-menu-container={true}
       onBlur={[Function]}
       onClick={[Function]}
       onClose={[Function]}
@@ -262,6 +444,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Compo
   >
     <div
       className="bx--modal is-visible iot--composed-modal"
+      data-floating-menu-container={true}
       onBlur={[Function]}
       onClick={[Function]}
       onClose={[Function]}
@@ -531,6 +714,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Compo
   >
     <div
       className="bx--modal is-visible iot--composed-modal"
+      data-floating-menu-container={true}
       onBlur={[Function]}
       onClick={[Function]}
       onClose={[Function]}
@@ -663,6 +847,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Compo
   >
     <div
       className="bx--modal is-visible iot--composed-modal"
+      data-floating-menu-container={true}
       onBlur={[Function]}
       onClick={[Function]}
       onClose={[Function]}
@@ -791,6 +976,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Compo
   >
     <div
       className="bx--modal is-visible iot--composed-modal"
+      data-floating-menu-container={true}
       onBlur={[Function]}
       onClick={[Function]}
       onClose={[Function]}
@@ -897,6 +1083,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Compo
   >
     <div
       className="bx--modal is-visible iot--composed-modal"
+      data-floating-menu-container={true}
       onBlur={[Function]}
       onClick={[Function]}
       onClose={[Function]}
@@ -1016,6 +1203,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Compo
   >
     <div
       className="bx--modal is-visible iot--composed-modal"
+      data-floating-menu-container={true}
       onBlur={[Function]}
       onClick={[Function]}
       onClose={[Function]}
@@ -1177,6 +1365,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Compo
   >
     <div
       className="bx--modal is-visible iot--composed-modal"
+      data-floating-menu-container={true}
       onBlur={[Function]}
       onClick={[Function]}
       onClose={[Function]}

--- a/src/components/ComposedModal/__snapshots__/ComposedModal.story.storyshot
+++ b/src/components/ComposedModal/__snapshots__/ComposedModal.story.storyshot
@@ -134,7 +134,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Compo
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/ComposedModal composed modal with overflow 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/ComposedModal composed modal with overflow and tooltip 1`] = `
 <div
   className="storybook-container"
 >
@@ -255,6 +255,45 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Compo
               </title>
             </svg>
           </button>
+          <div
+            className="bx--tooltip__label"
+            id="my test tooltip"
+          >
+            Trigger Text
+            <div
+              aria-describedby={null}
+              aria-labelledby="my test tooltip"
+              className="bx--tooltip__trigger"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-hidden={true}
+                description={null}
+                fill="currentColor"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role={null}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
+                />
+                <path
+                  d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
+                />
+              </svg>
+            </div>
+          </div>
         </div>
         <div
           className="bx--modal-footer iot--composed-modal-footer"

--- a/src/components/ComposedModal/_composed-modal.scss
+++ b/src/components/ComposedModal/_composed-modal.scss
@@ -8,12 +8,13 @@
     }
   }
 
-  // Needed to workaround this carbon issue: https://github.com/carbon-design-system/carbon/issues/6662
   .#{$prefix}--overflow-menu-options {
+    // TODO: Can remove once this issue is fixed: https://github.com/carbon-design-system/carbon/issues/6662
     z-index: 10000;
   }
 
   .#{$prefix}--tooltip {
+    // TODO: Can remove once this issue is fixed: https://github.com/carbon-design-system/carbon/issues/6662
     z-index: 10000;
   }
 

--- a/src/components/ComposedModal/_composed-modal.scss
+++ b/src/components/ComposedModal/_composed-modal.scss
@@ -13,6 +13,10 @@
     z-index: 10000;
   }
 
+  .#{$prefix}--tooltip {
+    z-index: 10000;
+  }
+
   /* support large modals for ll the sizes */
   &.#{$iot-prefix}--composed-modal--large {
     .#{$prefix}--modal-header {

--- a/src/components/ComposedModal/_composed-modal.scss
+++ b/src/components/ComposedModal/_composed-modal.scss
@@ -8,6 +8,11 @@
     }
   }
 
+  // Needed to workaround this carbon issue: https://github.com/carbon-design-system/carbon/issues/6662
+  .#{$prefix}--overflow-menu-options {
+    z-index: 10000;
+  }
+
   /* support large modals for ll the sizes */
   &.#{$iot-prefix}--composed-modal--large {
     .#{$prefix}--modal-header {

--- a/src/components/Table/TableManageViewsModal/__snapshots__/TableManageViewsModal.story.storyshot
+++ b/src/components/Table/TableManageViewsModal/__snapshots__/TableManageViewsModal.story.storyshot
@@ -14,6 +14,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
   >
     <div
       className="bx--modal is-visible iot--manage-views-modal iot--composed-modal"
+      data-floating-menu-container={true}
       data-testid="TableManageViewsModal"
       onBlur={[Function]}
       onClick={[Function]}
@@ -1322,6 +1323,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
   >
     <div
       className="bx--modal is-visible iot--manage-views-modal iot--composed-modal"
+      data-floating-menu-container={true}
       data-testid="TableManageViewsModal"
       onBlur={[Function]}
       onClick={[Function]}

--- a/src/components/Table/TableSaveViewModal/__snapshots__/TableSaveViewModal.story.storyshot
+++ b/src/components/Table/TableSaveViewModal/__snapshots__/TableSaveViewModal.story.storyshot
@@ -14,6 +14,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
   >
     <div
       className="bx--modal is-visible iot--composed-modal"
+      data-floating-menu-container={true}
       data-testid="TableSaveViewModal"
       onBlur={[Function]}
       onClick={[Function]}
@@ -324,6 +325,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
   >
     <div
       className="bx--modal is-visible iot--composed-modal"
+      data-floating-menu-container={true}
       data-testid="TableSaveViewModal"
       onBlur={[Function]}
       onClick={[Function]}
@@ -486,6 +488,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
   >
     <div
       className="bx--modal is-visible iot--composed-modal"
+      data-floating-menu-container={true}
       data-testid="TableSaveViewModal"
       onBlur={[Function]}
       onClick={[Function]}
@@ -713,6 +716,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
   >
     <div
       className="bx--modal is-visible iot--composed-modal"
+      data-floating-menu-container={true}
       data-testid="TableSaveViewModal"
       onBlur={[Function]}
       onClick={[Function]}

--- a/src/components/WizardModal/__snapshots__/WizardModal.story.storyshot
+++ b/src/components/WizardModal/__snapshots__/WizardModal.story.storyshot
@@ -14,6 +14,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Wizar
   >
     <div
       className="bx--modal is-visible iot--wizard-modal iot--composed-modal"
+      data-floating-menu-container={true}
       onBlur={[Function]}
       onClick={[Function]}
       onClose={[Function]}
@@ -327,6 +328,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Wizar
   >
     <div
       className="bx--modal is-visible iot--wizard-modal WizardModalstory__StyledWizard-sc-1z46gj-0 eiobyI iot--composed-modal"
+      data-floating-menu-container={true}
       onBlur={[Function]}
       onClick={[Function]}
       onClose={[Function]}
@@ -647,6 +649,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Wizar
   >
     <div
       className="bx--modal is-visible iot--wizard-modal iot--composed-modal"
+      data-floating-menu-container={true}
       onBlur={[Function]}
       onClick={[Function]}
       onClose={[Function]}


### PR DESCRIPTION
Closes #1593

Internal issue:
https://github.ibm.com/wiotp/monitoring-dashboard/issues/1398

**Summary**

- Fix to override the z-index for overflow menu contents and tooltips shown in modals

**Change List (commits, features, bugs, etc)**

- fix(composedmodal): use the data attribute to tell the tooltip where to attach for css access, then override the z-index in that case

**Acceptance Test (how to verify the PR)**

- Verify the new story that the z-index is higher in the tooltip and overflow menu contents than the modal
