### PR TITLE
feat(list-item): add disabled prop and functionality

### DIFF
--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -117,6 +117,7 @@ const List = forwardRef((props, ref) => {
       content: { value, secondaryValue, icon, rowActions, tags },
       isSelectable,
       isCategory,
+      disabled,
     } = item;
 
     return [
@@ -132,6 +133,7 @@ const List = forwardRef((props, ref) => {
           nestingLevel={level}
           value={value}
           icon={icon}
+          disabled={disabled}
           iconPosition={iconPosition}
           secondaryValue={secondaryValue}
           rowActions={rowActions}

--- a/src/components/List/ListItem/ListItem.jsx
+++ b/src/components/List/ListItem/ListItem.jsx
@@ -9,8 +9,16 @@ import { settings } from '../../../constants/Settings';
 const { iotPrefix } = settings;
 
 // internal component
-const ListItemWrapper = ({ id, isSelectable, onSelect, selected, isLargeRow, children }) =>
-  isSelectable ? (
+const ListItemWrapper = ({
+  id,
+  isSelectable,
+  onSelect,
+  selected,
+  isLargeRow,
+  children,
+  disabled,
+}) =>
+  isSelectable && !disabled ? (
     <div
       role="button"
       tabIndex={0}
@@ -44,6 +52,7 @@ const ListItemWrapperProps = {
   onSelect: PropTypes.func.isRequired,
   selected: PropTypes.bool.isRequired,
   children: PropTypes.node.isRequired,
+  disabled: PropTypes.node.isRequired,
 };
 
 const ListItemPropTypes = {
@@ -52,6 +61,7 @@ const ListItemPropTypes = {
   isExpandable: PropTypes.bool,
   onExpand: PropTypes.func,
   isSelectable: PropTypes.bool,
+  disabled: PropTypes.bool,
   onSelect: PropTypes.func,
   selected: PropTypes.bool,
   expanded: PropTypes.bool,
@@ -83,6 +93,7 @@ const ListItemDefaultProps = {
   isExpandable: false,
   onExpand: () => {},
   isSelectable: false,
+  disabled: false,
   onSelect: () => {},
   selected: false,
   expanded: false,
@@ -109,6 +120,7 @@ const ListItem = ({
   isSelectable,
   onSelect,
   selected,
+  disabled,
   value,
   secondaryValue,
   rowActions,
@@ -166,7 +178,7 @@ const ListItem = ({
   const renderTags = () => (tags && tags.length > 0 ? <div>{tags}</div> : null);
 
   return (
-    <ListItemWrapper {...{ id, isSelectable, selected, isLargeRow, onSelect }}>
+    <ListItemWrapper {...{ id, isSelectable, selected, isLargeRow, onSelect, disabled }}>
       {renderNestingOffset()}
       {renderExpander()}
       <div
@@ -191,6 +203,7 @@ const ListItem = ({
                 <div
                   className={classnames(`${iotPrefix}--list-item--content--values--value`, {
                     [`${iotPrefix}--list-item--category`]: isCategory,
+                    [`${iotPrefix}--list-item--content--values__disabled`]: disabled,
                     [`${iotPrefix}--list-item--content--values--value__with-actions`]: !isEmpty(
                       rowActions
                     ),
@@ -212,6 +225,7 @@ const ListItem = ({
                       [`${iotPrefix}--list-item--content--values--value__with-actions`]: !isEmpty(
                         rowActions
                       ),
+                      [`${iotPrefix}--list-item--content--values__disabled`]: disabled,
                     }
                   )}
                 >
@@ -225,6 +239,7 @@ const ListItem = ({
                 <div
                   className={classnames(`${iotPrefix}--list-item--content--values--value`, {
                     [`${iotPrefix}--list-item--category`]: isCategory,
+                    [`${iotPrefix}--list-item--content--values__disabled`]: disabled,
                     [`${iotPrefix}--list-item--content--values--value__with-actions`]: !isEmpty(
                       rowActions
                     ),
@@ -240,6 +255,7 @@ const ListItem = ({
                       [`${iotPrefix}--list-item--content--values--value__with-actions`]: !isEmpty(
                         rowActions
                       ),
+                      [`${iotPrefix}--list-item--content--values__disabled`]: disabled,
                     })}
                   >
                     {secondaryValue}

--- a/src/components/List/ListItem/ListItem.story.jsx
+++ b/src/components/List/ListItem/ListItem.story.jsx
@@ -189,6 +189,29 @@ storiesOf('Watson IoT Experimental/ListItem', module)
       />
     </div>
   ))
+  .add('with disabled', () => (
+    <div style={{ width: 400 }}>
+      <ListItem
+        id="list-item"
+        value={text('value', 'List Item')}
+        secondaryValue={text('secondaryValue', 'Secondary Value')}
+        disabled
+        rowActions={[
+          <Button
+            key="list-item-edit"
+            style={{ color: 'black' }}
+            renderIcon={Edit16}
+            hasIconOnly
+            disabled
+            kind="ghost"
+            size="small"
+            onClick={() => action('row action clicked')}
+            iconDescription="Edit"
+          />,
+        ]}
+      />
+    </div>
+  ))
   .add('with OverflowMenu row actions', () => (
     <div style={{ width: 400 }}>
       <ListItem

--- a/src/components/List/ListItem/ListItem.story.jsx
+++ b/src/components/List/ListItem/ListItem.story.jsx
@@ -195,14 +195,15 @@ storiesOf('Watson IoT Experimental/ListItem', module)
         id="list-item"
         value={text('value', 'List Item')}
         secondaryValue={text('secondaryValue', 'Secondary Value')}
-        disabled
+        disabled={boolean('disabled', true)}
+        isSelectable={boolean('isSelectable', true)}
         rowActions={[
           <Button
             key="list-item-edit"
             style={{ color: 'black' }}
             renderIcon={Edit16}
             hasIconOnly
-            disabled
+            disabled={boolean('action disabled', true)}
             kind="ghost"
             size="small"
             onClick={() => action('row action clicked')}

--- a/src/components/List/ListItem/_list-item.scss
+++ b/src/components/List/ListItem/_list-item.scss
@@ -97,6 +97,9 @@
           overflow: hidden;
         }
       }
+      &__disabled {
+        opacity: 0.4;
+      }
     }
     &--row-actions {
       flex: 0;


### PR DESCRIPTION
Closes #1603

**Summary**

Adds a `disabled` prop on `ListItem` that disables the item.

**Change List (commits, features, bugs, etc)**

 - Add `disabled` prop
 - Lower opacity for disabled items

**Acceptance Test (how to verify the PR)**

Go to the `with disabled` story in `ListItem` and alter the knobs to verify the styling and functionality.

![Screen Shot 2020-09-14 at 3 26 06 PM](https://user-images.githubusercontent.com/53092833/93134631-a44d0c80-f69e-11ea-9009-210a57c9f5f5.png)

