### PR TITLE
fix(timeseriescard): respect 0 for addSpaceOnEdges

### DIFF
--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -517,7 +517,7 @@ const TimeSeriesCard = ({
                     }
                   : {}),
                 timeScale: {
-                  addSpaceOnEdges: addSpaceOnEdges || 1,
+                  addSpaceOnEdges: !isNil(addSpaceOnEdges) ? addSpaceOnEdges : 1,
                 },
               }}
               width="100%"


### PR DESCRIPTION
Closes #

**Summary**

- Small fix to addSpaceOnEdges to actually respect a 0 passed

**Change List (commits, features, bugs, etc)**

- fix(TimeSeriesCard): need to check addSpaceOnEdges for not nil so that we can respect 0 passed there.

**Acceptance Test (how to verify the PR)**

- Pass 0 to addSpaceOnEdges and make sure the space goes away
