### PR TITLE
fix(list): adjust hierarchy indentations to match spec

### DIFF
--- a/src/components/CardEditor/__snapshots__/CardEditor.story.storyshot
+++ b/src/components/CardEditor/__snapshots__/CardEditor.story.storyshot
@@ -775,6 +775,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -854,6 +862,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -935,6 +951,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -1014,6 +1038,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -1097,6 +1129,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >

--- a/src/components/List/HierarchyList/HierarchyList.story.jsx
+++ b/src/components/List/HierarchyList/HierarchyList.story.jsx
@@ -277,4 +277,100 @@ storiesOf('Watson IoT Experimental/HierarchyList', module)
         defaultExpandedIds={['Chicago White Sox', 'New York Yankees']}
       />
     </div>
+  ))
+  .add('with mixed hierarchies', () => (
+    <div style={{ width: 400 }}>
+      <HierarchyList
+        title={text('Title', 'Items with mixed nested hierarchies')}
+        items={[
+          {
+            id: 'Tasks',
+            isCategory: true,
+            content: {
+              value: 'Tasks',
+            },
+            children: [
+              {
+                id: 'Task 1',
+                content: {
+                  value: 'Task 1',
+                },
+                isSelectable: true,
+              },
+            ],
+          },
+          {
+            id: 'My Reports',
+            content: {
+              value: 'My Reports',
+            },
+            isSelectable: true,
+          },
+          {
+            id: 'Requests',
+            isCategory: true,
+            content: {
+              value: 'Requests',
+            },
+            children: [
+              {
+                id: 'Request 1',
+                content: {
+                  value: 'Request 1',
+                },
+                isSelectable: true,
+              },
+              {
+                id: 'Request 2',
+                isCategory: true,
+                content: {
+                  value: 'Request 2',
+                },
+                children: [
+                  {
+                    id: 'Request 2 details',
+                    content: {
+                      value: 'Request 2 details',
+                    },
+                  },
+                ],
+              },
+              {
+                id: 'Request 3',
+                content: {
+                  value: 'Request 3',
+                },
+                isSelectable: true,
+              },
+            ],
+          },
+        ]}
+        // items={[
+        //   ...Object.keys(sampleHierarchy.MLB['American League']).map(team => ({
+        //     id: team,
+        //     isCategory: true,
+        //     content: {
+        //       value: team,
+        //     },
+        //     children: Object.keys(sampleHierarchy.MLB['American League'][team]).map(player => ({
+        //       id: `${team}_${player}`,
+        //       content: {
+        //         value: player,
+        //       },
+        //       isSelectable: true,
+        //     })),
+        //   })),
+        //   ...Object.keys(sampleHierarchy.MLB['National League']).map(team => ({
+        //     id: team,
+        //     isCategory: true,
+        //     content: {
+        //       value: team,
+        //     },
+        //   })),
+        // ]}
+        hasSearch
+        pageSize={select('Page Size', ['sm', 'lg', 'xl'], 'xl')}
+        isLoading={boolean('isLoading', false)}
+      />
+    </div>
   ));

--- a/src/components/List/HierarchyList/HierarchyList.story.jsx
+++ b/src/components/List/HierarchyList/HierarchyList.story.jsx
@@ -345,29 +345,6 @@ storiesOf('Watson IoT Experimental/HierarchyList', module)
             ],
           },
         ]}
-        // items={[
-        //   ...Object.keys(sampleHierarchy.MLB['American League']).map(team => ({
-        //     id: team,
-        //     isCategory: true,
-        //     content: {
-        //       value: team,
-        //     },
-        //     children: Object.keys(sampleHierarchy.MLB['American League'][team]).map(player => ({
-        //       id: `${team}_${player}`,
-        //       content: {
-        //         value: player,
-        //       },
-        //       isSelectable: true,
-        //     })),
-        //   })),
-        //   ...Object.keys(sampleHierarchy.MLB['National League']).map(team => ({
-        //     id: team,
-        //     isCategory: true,
-        //     content: {
-        //       value: team,
-        //     },
-        //   })),
-        // ]}
         hasSearch
         pageSize={select('Page Size', ['sm', 'lg', 'xl'], 'xl')}
         isLoading={boolean('isLoading', false)}

--- a/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
+++ b/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
@@ -1910,7 +1910,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   className="iot--list-item--nesting-offset"
                   style={
                     Object {
-                      "width": "30px",
+                      "width": "60px",
                     }
                   }
                 />
@@ -2002,7 +2002,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   className="iot--list-item--nesting-offset"
                   style={
                     Object {
-                      "width": "30px",
+                      "width": "60px",
                     }
                   }
                 />
@@ -2094,7 +2094,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   className="iot--list-item--nesting-offset"
                   style={
                     Object {
-                      "width": "30px",
+                      "width": "60px",
                     }
                   }
                 />
@@ -2186,7 +2186,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   className="iot--list-item--nesting-offset"
                   style={
                     Object {
-                      "width": "30px",
+                      "width": "60px",
                     }
                   }
                 />
@@ -2278,7 +2278,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   className="iot--list-item--nesting-offset"
                   style={
                     Object {
-                      "width": "30px",
+                      "width": "60px",
                     }
                   }
                 />
@@ -2370,7 +2370,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   className="iot--list-item--nesting-offset"
                   style={
                     Object {
-                      "width": "30px",
+                      "width": "60px",
                     }
                   }
                 />
@@ -2462,7 +2462,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   className="iot--list-item--nesting-offset"
                   style={
                     Object {
-                      "width": "30px",
+                      "width": "60px",
                     }
                   }
                 />
@@ -2554,7 +2554,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   className="iot--list-item--nesting-offset"
                   style={
                     Object {
-                      "width": "30px",
+                      "width": "60px",
                     }
                   }
                 />
@@ -2646,7 +2646,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   className="iot--list-item--nesting-offset"
                   style={
                     Object {
-                      "width": "30px",
+                      "width": "60px",
                     }
                   }
                 />
@@ -4228,7 +4228,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -4268,7 +4268,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -4308,7 +4308,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -4348,7 +4348,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -4388,7 +4388,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -4428,7 +4428,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -4468,7 +4468,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -4508,7 +4508,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -4548,7 +4548,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -4639,7 +4639,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -4679,7 +4679,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -4719,7 +4719,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -4759,7 +4759,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -4799,7 +4799,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -4839,7 +4839,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -4879,7 +4879,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -4919,7 +4919,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -4959,7 +4959,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -4999,7 +4999,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -6036,7 +6036,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -6076,7 +6076,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -6116,7 +6116,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -6156,7 +6156,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -6196,7 +6196,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -6236,7 +6236,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -6276,7 +6276,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -6316,7 +6316,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -6356,7 +6356,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -6425,6 +6425,553 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                       title="Washington Nationals"
                     >
                       Washington Nationals
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--page"
+        >
+          <div
+            className="iot-simple-pagination-container"
+          >
+            <span
+              className="iot-simple-pagination-page-label"
+              maxpage={1}
+            >
+              Page 1
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/HierarchyList with mixed hierarchies 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="bx--modal iot--hierarchy-list-bulk-modal iot--composed-modal"
+        data-floating-menu-container={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onClose={[Function]}
+        onKeyDown={[Function]}
+        open={false}
+        role="presentation"
+      >
+        <span
+          className="bx--visually-hidden"
+          role="link"
+          tabIndex="0"
+        >
+          Focus sentinel
+        </span>
+        <div
+          className="bx--modal-container"
+          role="dialog"
+        >
+          <div
+            className="bx--modal-header"
+          >
+            <p
+              className="bx--modal-header__heading bx--type-beta"
+            >
+              Move 1 item underneath
+            </p>
+            <button
+              aria-label="Close"
+              className="bx--modal-close"
+              onClick={[Function]}
+              title="Close"
+              type="button"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--modal-close__icon"
+                fill="currentColor"
+                focusable="false"
+                height={20}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            className="bx--modal-content"
+          >
+            <div
+              className="iot--hierarchy-list-bulk-modal--title"
+            >
+              Select a destination
+            </div>
+            <div
+              className="breadcrumb--container"
+              data-testid="overflow"
+            >
+              <nav
+                aria-label="Breadcrumb"
+                className={null}
+                data-testid="modal-breadcrumb"
+              >
+                <ol
+                  className="bx--breadcrumb bx--breadcrumb--no-trailing-slash"
+                >
+                  <li
+                    className="bx--breadcrumb-item bx--breadcrumb-item--current iot--hierarchy-list-bulk-modal--breadcrumb"
+                    title="All rows"
+                  >
+                    <button
+                      className="bx--link"
+                      kind="ghost"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      All rows
+                    </button>
+                  </li>
+                </ol>
+              </nav>
+            </div>
+            <div
+              className="iot--hierarchy-list-bulk-modal--list"
+            >
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id33"
+                    name="Tasks"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="Tasks"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id33"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      Tasks
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    Tasks
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id34"
+                    name="My Reports"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="My Reports"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id34"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      My Reports
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    My Reports
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--hierarchy-list-bulk-modal--list-item"
+              >
+                <div
+                  className="iot--hierarchy-list-bulk-modal--radio bx--radio-button-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--radio-button"
+                    id="id35"
+                    name="Requests"
+                    onChange={[Function]}
+                    tabIndex={0}
+                    type="radio"
+                    value="Requests"
+                  />
+                  <label
+                    className="bx--radio-button__label"
+                    htmlFor="id35"
+                  >
+                    <span
+                      className="bx--radio-button__appearance"
+                    />
+                    <span
+                      className="bx--visually-hidden"
+                    >
+                      Requests
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="iot--hierarchy-list-bulk-modal--list-item-button"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <div
+                    className="iot--hierarchy-list-bulk-modal--list-item-value"
+                  >
+                    Requests
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="bx--modal-footer iot--composed-modal-footer"
+          >
+            <button
+              className="iot--btn bx--btn bx--btn--secondary"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Cancel
+            </button>
+            <button
+              className="iot--btn bx--btn bx--btn--primary"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+        <span
+          className="bx--visually-hidden"
+          role="link"
+          tabIndex="0"
+        >
+          Focus sentinel
+        </span>
+      </div>
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              Items with mixed nested hierarchies
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            />
+          </div>
+          <div
+            className="iot--list-header--search"
+          >
+            <div
+              aria-labelledby="iot--list-header--search-search"
+              className="bx--search bx--search--sm"
+              role="search"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--search-magnifier"
+                fill="currentColor"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                />
+              </svg>
+              <label
+                className="bx--label"
+                htmlFor="iot--list-header--search"
+                id="iot--list-header--search-search"
+              >
+                Enter a value
+              </label>
+              <input
+                autoComplete="off"
+                className="bx--search-input"
+                id="iot--list-header--search"
+                onChange={[Function]}
+                placeholder="Enter a value"
+                role="searchbox"
+                type="text"
+                value=""
+              />
+              <button
+                aria-label="Clear search input"
+                className="bx--search-close bx--search-close--hidden"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  fill="currentColor"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  fill="currentColor"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Tasks"
+                    >
+                      Tasks
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item iot--list-item__selectable"
+              data_testid={null}
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value"
+                      title="My Reports"
+                    >
+                      My Reports
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item-parent"
+            data-floating-menu-container={true}
+          >
+            <div
+              className="iot--list-item"
+            >
+              <div
+                className="iot--list-item--expand-icon"
+                data-testid="expand-icon"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="Close"
+                  fill="currentColor"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content"
+              >
+                <div
+                  className="iot--list-item--content--values"
+                >
+                  <div
+                    className="iot--list-item--content--values--main"
+                  >
+                    <div
+                      className="iot--list-item--content--values--value iot--list-item--category"
+                      title="Requests"
+                    >
+                      Requests
                     </div>
                   </div>
                 </div>

--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -158,7 +158,7 @@ const List = forwardRef((props, ref) => {
           id={item.id}
           index={index}
           key={`${item.id}-list-item-${level}-${value}`}
-          nestingLevel={level}
+          nestingLevel={isCategory ? level - 1 : level}
           value={value}
           icon={
             editingStyleIsMultiple(editingStyle) ? (
@@ -202,7 +202,14 @@ const List = forwardRef((props, ref) => {
     ];
   };
 
-  const listItems = items.map((item, index) => renderItemAndChildren(item, index, null, 0));
+  // If there is a mix of categories and non-categories, we should indent non-category items by 1
+  const hasCategories = items.filter(item => item?.children && item.children.length > 0);
+  // const hasNonCategories = items.filter(item => !item?.children);
+  const baseIndentLevel = hasCategories ? 1 : 0;
+
+  const listItems = items.map((item, index) =>
+    renderItemAndChildren(item, index, null, baseIndentLevel)
+  );
 
   return (
     <div

--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -202,10 +202,9 @@ const List = forwardRef((props, ref) => {
     ];
   };
 
-  // If there is a mix of categories and non-categories, we should indent non-category items by 1
-  const hasCategories = items.filter(item => item?.children && item.children.length > 0);
-  // const hasNonCategories = items.filter(item => !item?.children);
-  const baseIndentLevel = hasCategories ? 1 : 0;
+  // If the root level contains a category item, the base indent level should be increased by 1 to
+  // account for the caret on non-category items.
+  const baseIndentLevel = items.filter(item => item?.children && item.children.length > 0) ? 1 : 0;
 
   const listItems = items.map((item, index) =>
     renderItemAndChildren(item, index, null, baseIndentLevel)

--- a/src/components/List/ListItem/_list-item.scss
+++ b/src/components/List/ListItem/_list-item.scss
@@ -130,7 +130,6 @@
     cursor: pointer;
     padding: $spacing-01;
     margin-right: $spacing-04;
-    transform: rotate(180deg);
   }
 
   &--content {

--- a/src/components/List/__snapshots__/List.story.storyshot
+++ b/src/components/List/__snapshots__/List.story.storyshot
@@ -49,6 +49,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -75,6 +83,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -103,6 +119,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -129,6 +153,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -157,6 +189,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -183,6 +223,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -211,6 +259,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -237,6 +293,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -265,6 +329,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -291,6 +363,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -527,7 +607,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -568,7 +648,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -609,7 +689,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -650,7 +730,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -691,7 +771,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -732,7 +812,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -773,7 +853,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -814,7 +894,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -855,7 +935,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -896,7 +976,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -1039,7 +1119,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -1080,7 +1160,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -1121,7 +1201,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -1162,7 +1242,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -1203,7 +1283,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -1244,7 +1324,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -1285,7 +1365,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -1326,7 +1406,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -1367,7 +1447,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -2215,6 +2295,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--expand-icon"
                 data-testid="expand-icon"
                 onClick={[Function]}
@@ -2269,7 +2357,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -2367,7 +2455,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "60px",
+                    "width": "90px",
                   }
                 }
               />
@@ -2476,7 +2564,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "60px",
+                    "width": "90px",
                   }
                 }
               />
@@ -2585,7 +2673,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "90px",
+                    "width": "120px",
                   }
                 }
               />
@@ -2644,7 +2732,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "90px",
+                    "width": "120px",
                   }
                 }
               />
@@ -2703,7 +2791,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "90px",
+                    "width": "120px",
                   }
                 }
               />
@@ -2762,7 +2850,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "90px",
+                    "width": "120px",
                   }
                 }
               />
@@ -2821,7 +2909,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "90px",
+                    "width": "120px",
                   }
                 }
               />
@@ -2880,7 +2968,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "90px",
+                    "width": "120px",
                   }
                 }
               />
@@ -2939,7 +3027,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "90px",
+                    "width": "120px",
                   }
                 }
               />
@@ -2998,7 +3086,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "90px",
+                    "width": "120px",
                   }
                 }
               />
@@ -3057,7 +3145,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "90px",
+                    "width": "120px",
                   }
                 }
               />
@@ -3116,7 +3204,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "90px",
+                    "width": "120px",
                   }
                 }
               />
@@ -3175,7 +3263,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "60px",
+                    "width": "90px",
                   }
                 }
               />
@@ -3284,7 +3372,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "30px",
+                    "width": "60px",
                   }
                 }
               />
@@ -3382,7 +3470,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "60px",
+                    "width": "90px",
                   }
                 }
               />
@@ -3491,7 +3579,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "60px",
+                    "width": "90px",
                   }
                 }
               />
@@ -3600,7 +3688,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--list-item--nesting-offset"
                 style={
                   Object {
-                    "width": "60px",
+                    "width": "90px",
                   }
                 }
               />
@@ -3777,6 +3865,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item iot--list-item__large"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content iot--list-item--content__large"
               >
                 <div
@@ -3827,6 +3923,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item iot--list-item__large"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content iot--list-item--content__large"
               >
@@ -3879,6 +3983,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item iot--list-item__large"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content iot--list-item--content__large"
               >
                 <div
@@ -3929,6 +4041,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item iot--list-item__large"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content iot--list-item--content__large"
               >
@@ -3981,6 +4101,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item iot--list-item__large"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content iot--list-item--content__large"
               >
                 <div
@@ -4031,6 +4159,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item iot--list-item__large"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content iot--list-item--content__large"
               >
@@ -4083,6 +4219,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item iot--list-item__large"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content iot--list-item--content__large"
               >
                 <div
@@ -4133,6 +4277,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item iot--list-item__large"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content iot--list-item--content__large"
               >
@@ -4185,6 +4337,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item iot--list-item__large"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content iot--list-item--content__large"
               >
                 <div
@@ -4235,6 +4395,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item iot--list-item__large"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content iot--list-item--content__large"
               >
@@ -4358,6 +4526,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -4440,6 +4616,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -4524,6 +4708,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -4606,6 +4798,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -4690,6 +4890,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -4772,6 +4980,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -4856,6 +5072,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -4938,6 +5162,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -5022,6 +5254,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -5104,6 +5344,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -5259,6 +5507,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -5330,6 +5586,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -5403,6 +5667,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -5474,6 +5746,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -5547,6 +5827,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -5618,6 +5906,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -5691,6 +5987,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -5762,6 +6066,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -5835,6 +6147,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -5906,6 +6226,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -6050,6 +6378,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -6082,6 +6418,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -6116,6 +6460,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -6148,6 +6500,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -6182,6 +6542,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -6214,6 +6582,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -6248,6 +6624,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -6280,6 +6664,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -6314,6 +6706,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -6346,6 +6746,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -6451,6 +6859,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -6485,6 +6901,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -6521,6 +6945,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -6555,6 +6987,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -6591,6 +7031,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -6625,6 +7073,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -6661,6 +7117,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -6695,6 +7159,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >
@@ -6731,6 +7203,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
+              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -6765,6 +7245,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
+              <div
+                className="iot--list-item--nesting-offset"
+                style={
+                  Object {
+                    "width": "30px",
+                  }
+                }
+              />
               <div
                 className="iot--list-item--content"
               >

--- a/src/components/Table/TableManageViewsModal/__snapshots__/TableManageViewsModal.story.storyshot
+++ b/src/components/Table/TableManageViewsModal/__snapshots__/TableManageViewsModal.story.storyshot
@@ -188,6 +188,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item iot--list-item__large"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content iot--list-item--content__large"
                   >
                     <div
@@ -289,6 +297,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item iot--list-item__large"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content iot--list-item--content__large"
                   >
@@ -400,6 +416,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item iot--list-item__large"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content iot--list-item--content__large"
                   >
                     <div
@@ -501,6 +525,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item iot--list-item__large"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content iot--list-item--content__large"
                   >
@@ -604,6 +636,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item iot--list-item__large"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content iot--list-item--content__large"
                   >
                     <div
@@ -705,6 +745,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item iot--list-item__large"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content iot--list-item--content__large"
                   >
@@ -808,6 +856,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item iot--list-item__large"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content iot--list-item--content__large"
                   >
                     <div
@@ -909,6 +965,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item iot--list-item__large"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content iot--list-item--content__large"
                   >
@@ -1012,6 +1076,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item iot--list-item__large"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content iot--list-item--content__large"
                   >
                     <div
@@ -1113,6 +1185,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item iot--list-item__large"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content iot--list-item--content__large"
                   >
@@ -1497,6 +1577,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -1640,6 +1728,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -1791,6 +1887,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -1934,6 +2038,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -2079,6 +2191,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -2222,6 +2342,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -2367,6 +2495,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -2510,6 +2646,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -2655,6 +2799,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -2798,6 +2950,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -2943,6 +3103,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -3086,6 +3254,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -3231,6 +3407,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -3374,6 +3558,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -3519,6 +3711,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -3662,6 +3862,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -3807,6 +4015,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -3950,6 +4166,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -4095,6 +4319,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -4238,6 +4470,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -4383,6 +4623,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -4526,6 +4774,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -4671,6 +4927,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -4814,6 +5078,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -4959,6 +5231,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -5102,6 +5382,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -5247,6 +5535,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -5390,6 +5686,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -5535,6 +5839,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -5678,6 +5990,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -5823,6 +6143,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -5966,6 +6294,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -6111,6 +6447,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -6254,6 +6598,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -6399,6 +6751,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -6542,6 +6902,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -6687,6 +7055,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -6830,6 +7206,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -6975,6 +7359,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -7118,6 +7510,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -7263,6 +7663,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -7406,6 +7814,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -7551,6 +7967,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -7694,6 +8118,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -7839,6 +8271,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -7982,6 +8422,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -8127,6 +8575,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -8270,6 +8726,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -8415,6 +8879,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -8558,6 +9030,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -8703,6 +9183,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -8846,6 +9334,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -8991,6 +9487,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -9134,6 +9638,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -9279,6 +9791,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -9422,6 +9942,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -9567,6 +10095,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -9710,6 +10246,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -9855,6 +10399,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -9998,6 +10550,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -10143,6 +10703,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -10286,6 +10854,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -10431,6 +11007,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -10574,6 +11158,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -10719,6 +11311,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -10862,6 +11462,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -11007,6 +11615,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -11150,6 +11766,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -11295,6 +11919,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -11438,6 +12070,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -11583,6 +12223,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -11726,6 +12374,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -11871,6 +12527,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -12014,6 +12678,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -12159,6 +12831,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -12302,6 +12982,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -12447,6 +13135,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -12590,6 +13286,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -12735,6 +13439,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -12878,6 +13590,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -13023,6 +13743,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -13166,6 +13894,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -13311,6 +14047,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -13454,6 +14198,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -13599,6 +14351,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -13742,6 +14502,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -13887,6 +14655,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -14030,6 +14806,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -14175,6 +14959,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -14318,6 +15110,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -14463,6 +15263,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -14606,6 +15414,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -14751,6 +15567,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -14894,6 +15718,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -15039,6 +15871,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -15182,6 +16022,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -15327,6 +16175,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -15470,6 +16326,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -15615,6 +16479,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
+                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -15758,6 +16630,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
+                  <div
+                    className="iot--list-item--nesting-offset"
+                    style={
+                      Object {
+                        "width": "30px",
+                      }
+                    }
+                  />
                   <div
                     className="iot--list-item--content"
                   >


### PR DESCRIPTION
Closes #1568

**Summary**

- HierarchyList indentation is improved for when there's a mix of category and non-category items.

![image](https://user-images.githubusercontent.com/3360588/93821956-08cf1500-fc25-11ea-95fe-e6fad359c84c.png)



**Change List (commits, features, bugs, etc)**

- Root level items with no children align with items that have children
- Children items have slightly more indentation than their parent
- Flipped the caret direction to be consistent with sidenav and accordion. When the section is closed, the arrow points down.

**Acceptance Test (how to verify the PR)**

- View and validate the new [`HierarchyList \ with mixed hierarchies`](https://deploy-preview-1617--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-experimental-hierarchylist--with-mixed-hierarchies) story
- Check the other HierarchyList stories to ensure no visual regressions
