### PR TITLE
fix(table): checkbox alignment when expandable rows

### DIFF
--- a/src/components/Table/TableHead/_table-head.scss
+++ b/src/components/Table/TableHead/_table-head.scss
@@ -98,10 +98,6 @@
   }
 }
 
-.#{$prefix}--data-table--sort thead tr:first-child th {
-  padding: 0 $spacing-05;
-}
-
 .#{$iot-prefix}--table-head {
   &--overflow {
     margin: auto 0;


### PR DESCRIPTION
Closes #1597
Closes #1587 

**Summary**

- One more fix for the table select all checkbox

**Change List (commits, features, bugs, etc)**

- Remove unnecessary padding on the first (empty) `th` that was previously added to patch a modification from a Carbon release ~5 months ago.

**Acceptance Test (how to verify the PR)**

- View the [`Table \ Stateful Example with expansion, maxPages, and column resize`](https://deploy-preview-1619--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-table--stateful-example-with-expansion-maxpages-and-column-resize) story 
  - The checkbox should be aligned
- Check _all other table stories_ to ensure checkbox is aligned across various states.
