### PR TITLE
feat(suiteheader): Implementation of i18n support and fixing of a redirect issue

### DIFF
--- a/src/components/SuiteHeader/SuiteHeader.jsx
+++ b/src/components/SuiteHeader/SuiteHeader.jsx
@@ -185,7 +185,7 @@ const SuiteHeader = ({
                       ),
                       onClick: () => {
                         window.location.href = isAdminView
-                          ? document.referrer !== ''
+                          ? document.referrer !== '' && document.referrer.indexOf('auth') < 0
                             ? document.referrer
                             : routes.navigator
                           : routes.admin;

--- a/src/components/SuiteHeader/SuiteHeader.story.jsx
+++ b/src/components/SuiteHeader/SuiteHeader.story.jsx
@@ -8,6 +8,7 @@ import Group from '@carbon/icons-react/lib/group/24';
 
 import SuiteHeader from './SuiteHeader';
 import SuiteHeaderI18N from './i18n';
+// import useSuiteHeaderData from './hooks/useSuiteHeaderData';
 
 const sideNavLinks = [
   {
@@ -103,6 +104,7 @@ const HeaderWithHook = () => {
       delayIntervalDays: 30,
       frequencyDays: 90,
     },
+    lang: 'en',
   });
   const surveyLink = data.showSurvey ? 'https://www.ibm.com' : '';
   return (
@@ -116,6 +118,7 @@ const HeaderWithHook = () => {
       sideNavProps={{
         links: sideNavLinks,
       }}
+      i18n={data.i18n}
       surveyLink={surveyLink}
     />
   );
@@ -236,3 +239,4 @@ storiesOf('Watson IoT/SuiteHeader', module)
       />
     );
   });
+// .add('Header with data hook', () => <HeaderWithHook />);

--- a/src/components/SuiteHeader/hooks/suiteHeaderData.fixture.js
+++ b/src/components/SuiteHeader/hooks/suiteHeaderData.fixture.js
@@ -299,6 +299,32 @@ const fixture = {
     lastPromptTimestamp: '2020-08-22T17:15:28Z',
     userId: 'mas-admin',
   },
+  '/i18n/header/en': {
+    about: 'About',
+    administrationIcon: 'Administration',
+    documentation: 'Documentation',
+    gettingStarted: 'Getting started',
+    help: 'Help',
+    logout: 'Logout',
+    profileLogoutButton: 'Log out',
+    profileLogoutModalBody:
+      'You are logged in to {solutionName} as {userName}.  Logging out also logs you out of each application that is open in the same browser.  To ensure a secure log out, close all open browser windows.',
+    profileLogoutModalHeading: 'Do you wish to log out?',
+    profileLogoutModalPrimaryButton: 'Log out',
+    profileLogoutModalSecondaryButton: 'Cancel',
+    profileManageButton: 'Manage profile',
+    profileTitle: 'Profile PT-BR',
+    requestEnhancement: 'Request enhancement',
+    settingsIcon: 'Settings',
+    support: 'Support',
+    surveyText: 'Click here to help us improve the product',
+    surveyTitle: 'Enjoying {solutionName}?',
+    switcherLearnMoreLink: 'Learn more',
+    switcherNavigatorLink: 'All applications',
+    switcherRequestAccess: 'Contact your administrator to request application access',
+    userIcon: 'User',
+    whatsNew: "What's new",
+  },
 };
 
 export default fixture;

--- a/src/components/SuiteHeader/hooks/useSuiteHeaderData.js
+++ b/src/components/SuiteHeader/hooks/useSuiteHeaderData.js
@@ -214,7 +214,7 @@ const useSuiteHeaderData = ({
         setIsLoading(false);
       }
     },
-    [baseApiUrl, domain, isTest, setIsLoading]
+    [baseApiUrl, domain, lang, isTest, setIsLoading]
   );
 
   useEffect(

--- a/src/components/SuiteHeader/hooks/useSuiteHeaderData.js
+++ b/src/components/SuiteHeader/hooks/useSuiteHeaderData.js
@@ -1,10 +1,10 @@
 import { useState, useEffect, useCallback } from 'react';
 import moment from 'moment';
 
+import SuiteHeaderI18N from '../i18n';
+
 // eslint-disable-next-line import/extensions
 import testApiData from './suiteHeaderData.fixture.js';
-
-import SuiteHeaderI18N from '../i18n';
 
 // default route calculation logic
 const calcRoutes = (domain, user, workspaces, applications) => {


### PR DESCRIPTION
**Summary**

- Adding another API call to `useSuiteHeaderData` hook to load the translated strings that will be passed to `SuiteHeader` component.
- Fixing an issue where the settings button in `SuiteHeader` would redirect to the login page instead of the last accessed page when `isAdminView` is set to `true`.
- Please don't mind the changes in `SuiteHeader.story.jsx`, the changes are in a story that is commented out because it is using the useSuiteHeaderData hook (and we had decided to comment out this story because of "missing required prop" errors in tests, caused by async data loading, which causes the component to be loaded without some required props in the first render).

**Change List (commits, features, bugs, etc)**

- fixed settings button redirect issue
- added `GET /i18n/header/<lang>` API call
- included the `lang` to a `useCallback`'s watch list 
- fixing an "import order" lint error

**Acceptance Test (how to verify the PR)**

- No new tests have been added (as it has been decided that data hooks don't need to comply with minimum coverage policy at this moment).
