### PR TITLE
fix(table): fix variable that was not being interpolated

### DIFF
--- a/src/components/Table/_table.scss
+++ b/src/components/Table/_table.scss
@@ -45,7 +45,7 @@ html[dir='rtl'] {
 }
 
 .#{$iot-prefix}--empty-table--table-row {
-  height: calc(100% - $spacing-09);
+  height: calc(100% - #{$spacing-09});
   &:hover td {
     background: inherit;
   }


### PR DESCRIPTION
Closes #1638 

**Summary**

Small fix to add interpolation of a sass variable inside a calc function

**Change List (commits, features, bugs, etc)**

- changed _table.scss

**Acceptance Test (how to verify the PR)**

- Open up story with empty state and look at the row with class `.iot--empty-table--table-row`. You should see a calc statement for height that has rem value and not the variable. 
