### PR TITLE
1023 error boundary

### DIFF
--- a/.storybook/__snapshots__/Welcome.story.storyshot
+++ b/.storybook/__snapshots__/Welcome.story.storyshot
@@ -658,7 +658,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 0/Getting Starte
                   </div>
                   <div
                     className="bx--structured-list-td"
-                  />
+                  >
+                    ErrorBoundary
+                  </div>
                 </div>
                 <div
                   className="bx--structured-list-row"
@@ -670,7 +672,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 0/Getting Starte
                   </div>
                   <div
                     className="bx--structured-list-td"
-                  />
+                  >
+                    ErrorBoundaryContext
+                  </div>
                 </div>
                 <div
                   className="bx--structured-list-row"

--- a/src/components/ErrorBoundry/ErrorBoundry.story.jsx
+++ b/src/components/ErrorBoundry/ErrorBoundry.story.jsx
@@ -1,0 +1,3 @@
+export {
+  default as ErrorBoundaryStory,
+} from 'carbon-components-react/lib/components/ErrorBoundary/ErrorBoundary-story';

--- a/src/index.js
+++ b/src/index.js
@@ -141,6 +141,8 @@ export {
   DatePicker,
   DatePickerInput,
   Dropdown,
+  ErrorBoundary,
+  ErrorBoundaryContext,
   Filename,
   FileUploader,
   FileUploaderButton,

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -18230,6 +18230,43 @@ Map {
     },
     "render": [Function],
   },
+  "ErrorBoundary" => Object {
+    "contextType": Object {
+      "$$typeof": Symbol(react.context),
+      "Consumer": Object {
+        "$$typeof": Symbol(react.context),
+        "_calculateChangedBits": null,
+        "_context": [Circular],
+      },
+      "Provider": Object {
+        "$$typeof": Symbol(react.provider),
+        "_context": [Circular],
+      },
+      "_calculateChangedBits": null,
+      "_currentRenderer": null,
+      "_currentRenderer2": null,
+      "_currentValue": Object {
+        "log": [Function],
+      },
+      "_currentValue2": Object {
+        "log": [Function],
+      },
+      "_threadCount": 0,
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "fallback": Object {
+        "type": "node",
+      },
+    },
+  },
+  "ErrorBoundaryContext" => Object {
+    "$$typeof": Symbol(react.context),
+    "Consumer": "React.Consumer",
+    "Provider": "React.Provider",
+  },
   "Filename" => Object {
     "defaultProps": Object {
       "iconDescription": "Uploading file",


### PR DESCRIPTION
Closes #1023

**Summary**

We were previously not exporting Carbon's `ErrorBoundary` and `ErrorBoundaryContext` component. This PR exports and adds the stories to our storybook

- Added `ErrorBoundary`  folder that holds story
- updated index.js to include export for `ErrorBoundary` and `ErrorBoundaryContext`

**Acceptance Test (how to verify the PR)**

- Go to ErrorBoundary story and make sure they work. Open up the welcome story dropdown and see that these two components are on the list of Exports. 
