### PR TITLE
feat(table): added option alwaysTruncate

### DIFF
--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -77,6 +77,12 @@ const propTypes = {
     hasUserViewManagement: PropTypes.bool,
     /** If true removes the "table-layout: fixed" for resizable tables  */
     useAutoTableLayoutForResize: PropTypes.bool,
+    /**
+     * auto - Wrap for tables with dynamic columns widths and truncate for tables with fixed or resizable columns
+     * always - Wrap if needed for all table column configurations
+     * never - Tables with dynamic columns widths grow larger and tables with fixed or resizable columns truncate.
+     * alwaysTruncate - Alwyas truncate if needed for all table column configurations
+     */
     wrapCellText: PropTypes.oneOf(['always', 'never', 'auto', 'alwaysTruncate']),
   }),
 

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -55,7 +55,7 @@ const STATUS = {
   BROKEN: 'BROKEN',
 };
 
-const selectTextWrapping = ['always', 'never', 'auto'];
+const selectTextWrapping = ['always', 'never', 'auto', 'alwaysTruncate'];
 
 const renderStatusIcon = ({ value: status }) => {
   switch (status) {
@@ -700,7 +700,7 @@ storiesOf('Watson IoT/Table', module)
             ...initialState.options,
             hasResize: true,
             hasFilter: select('hasFilter', ['onKeyPress', 'onEnterAndBlur'], 'onKeyPress'),
-            wrapCellText: select('wrapCellText', selectTextWrapping, 'always'),
+            wrapCellText: select('wrapCellText', selectTextWrapping, 'alwaysTruncate'),
             hasSingleRowEdit: true,
           }}
         />

--- a/src/components/Table/TableBody/TableBody.jsx
+++ b/src/components/Table/TableBody/TableBody.jsx
@@ -4,6 +4,7 @@ import { DataTable } from 'carbon-components-react';
 import VisibilitySensor from 'react-visibility-sensor';
 import pick from 'lodash/pick';
 
+import { handleOverflowDeprecation } from '../../../internal/deprecate';
 import {
   ExpandedRowsPropTypes,
   TableRowPropTypes,
@@ -52,6 +53,8 @@ const propTypes = {
     }),
   ]),
   hasRowActions: PropTypes.bool,
+  wrapCellText: PropTypes.oneOf(['always', 'never', 'auto']),
+  truncateCellText: PropTypes.bool,
   cellTextOverflow: CellTextOverflowPropType,
   /** the current state of the row actions */
   rowActionsState: RowActionsStatePropTypes,
@@ -104,6 +107,8 @@ const defaultProps = {
   singleRowEditButtons: null,
   langDir: 'ltr',
   cellTextOverflow: null,
+  wrapCellText: null,
+  truncateCellText: null,
 };
 
 const TableBody = ({
@@ -131,6 +136,8 @@ const TableBody = ({
   shouldExpandOnRowClick,
   shouldLazyRender,
   ordering,
+  wrapCellText,
+  truncateCellText,
   cellTextOverflow,
   locale,
   rowEditMode,
@@ -148,6 +155,14 @@ const TableBody = ({
   );
 
   const someRowHasSingleRowEditMode = rowActionsState.some(rowAction => rowAction.isEditMode);
+
+  // Temporary deprecation code to map the deprectated wrapCellText & truncateCellText
+  // to the new cellTextOverflow
+  const myCellTextOverflow = handleOverflowDeprecation(
+    cellTextOverflow,
+    wrapCellText,
+    truncateCellText
+  );
 
   const renderRow = (row, nestingLevel = 0) => {
     const isRowExpanded = expandedIds.includes(row.id);
@@ -194,7 +209,7 @@ const TableBody = ({
           hasRowNesting,
           hasRowActions,
           shouldExpandOnRowClick,
-          cellTextOverflow,
+          cellTextOverflow: myCellTextOverflow,
         }}
         nestingLevel={nestingLevel}
         nestingChildCount={row.children ? row.children.length : 0}

--- a/src/components/Table/TableBody/TableBody.jsx
+++ b/src/components/Table/TableBody/TableBody.jsx
@@ -9,6 +9,7 @@ import {
   TableRowPropTypes,
   TableColumnsPropTypes,
   RowActionsStatePropTypes,
+  CellTextOverflowPropType,
 } from '../TablePropTypes';
 
 import TableBodyRow from './TableBodyRow/TableBodyRow';
@@ -51,8 +52,7 @@ const propTypes = {
     }),
   ]),
   hasRowActions: PropTypes.bool,
-  wrapCellText: PropTypes.oneOf(['always', 'never', 'auto']).isRequired,
-  truncateCellText: PropTypes.bool.isRequired,
+  cellTextOverflow: CellTextOverflowPropType,
   /** the current state of the row actions */
   rowActionsState: RowActionsStatePropTypes,
   shouldExpandOnRowClick: PropTypes.bool,
@@ -103,6 +103,7 @@ const defaultProps = {
   rowEditMode: false,
   singleRowEditButtons: null,
   langDir: 'ltr',
+  cellTextOverflow: null,
 };
 
 const TableBody = ({
@@ -130,8 +131,7 @@ const TableBody = ({
   shouldExpandOnRowClick,
   shouldLazyRender,
   ordering,
-  wrapCellText,
-  truncateCellText,
+  cellTextOverflow,
   locale,
   rowEditMode,
   singleRowEditButtons,
@@ -194,8 +194,7 @@ const TableBody = ({
           hasRowNesting,
           hasRowActions,
           shouldExpandOnRowClick,
-          wrapCellText,
-          truncateCellText,
+          cellTextOverflow,
         }}
         nestingLevel={nestingLevel}
         nestingChildCount={row.children ? row.children.length : 0}

--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -11,6 +11,7 @@ import {
   RowActionPropTypes,
   RowActionErrorPropTypes,
   TableColumnsPropTypes,
+  CellTextOverflowPropType,
 } from '../../TablePropTypes';
 import { stopPropagationAndCallback } from '../../../../utils/componentUtilityFunctions';
 import { COLORS } from '../../../../styles/styles';
@@ -57,8 +58,7 @@ const propTypes = {
       }),
     ]),
     shouldExpandOnRowClick: PropTypes.bool,
-    wrapCellText: PropTypes.oneOf(['always', 'never', 'auto']).isRequired,
-    truncateCellText: PropTypes.bool.isRequired,
+    cellTextOverflow: CellTextOverflowPropType,
   }),
 
   /** The unique row id */
@@ -123,7 +123,7 @@ const defaultProps = {
   rowDetails: null,
   nestingLevel: 0,
   nestingChildCount: 0,
-  options: {},
+  options: { cellTextOverflow: null },
   rowEditMode: false,
   singleRowEditMode: false,
   singleRowEditButtons: null,
@@ -352,8 +352,7 @@ const TableBodyRow = ({
     hasRowActions,
     hasRowNesting,
     shouldExpandOnRowClick,
-    wrapCellText,
-    truncateCellText,
+    cellTextOverflow,
   },
   tableActions: { onRowSelected, onRowExpanded, onRowClicked, onApplyRowAction, onClearRowError },
   isExpanded,
@@ -433,7 +432,7 @@ const TableBodyRow = ({
             offset={offset}
             align={align}
             className={classnames(`data-table-${align}`, {
-              [`${iotPrefix}--table__cell--truncate`]: truncateCellText,
+              [`${iotPrefix}--table__cell--truncate`]: cellTextOverflow === 'truncate',
             })}
             width={initialColumnWidth}
           >
@@ -447,8 +446,7 @@ const TableBodyRow = ({
                 })
               ) : (
                 <TableCellRenderer
-                  wrapText={wrapCellText}
-                  truncateCellText={truncateCellText}
+                  cellTextOverflow={cellTextOverflow}
                   locale={locale}
                   renderDataFunction={col.renderDataFunction}
                   columnId={col.columnId}

--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.story.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.story.jsx
@@ -24,8 +24,7 @@ const tableBodyRowProps = {
     'onClearRowError'
   ),
   options: {
-    wrapCellText: 'never',
-    truncateCellText: false,
+    cellTextOverflow: 'prevent-wrap',
   },
 };
 

--- a/src/components/Table/TableCellRenderer/TableCellRenderer.jsx
+++ b/src/components/Table/TableCellRenderer/TableCellRenderer.jsx
@@ -4,13 +4,13 @@ import classnames from 'classnames';
 import { Tooltip } from 'carbon-components-react';
 
 import { settings } from '../../../constants/Settings';
+import { CellTextOverflowPropType } from '../TablePropTypes';
 
 const { iotPrefix } = settings;
 
 const propTypes = {
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.bool]),
-  wrapText: PropTypes.oneOf(['always', 'never', 'auto']).isRequired,
-  truncateCellText: PropTypes.bool.isRequired,
+  cellTextOverflow: CellTextOverflowPropType,
   allowTooltip: PropTypes.bool,
   /** What locale should the number be rendered in */
   locale: PropTypes.string,
@@ -28,6 +28,7 @@ const defaultProps = {
   renderDataFunction: null,
   columnId: null,
   rowId: null,
+  cellTextOverflow: null,
 };
 
 const isElementTruncated = element => element.offsetWidth < element.scrollWidth;
@@ -45,9 +46,8 @@ const renderCustomCell = (renderDataFunction, args, className) => {
 /** Supports our default render decisions for primitive values */
 const TableCellRenderer = ({
   children,
-  wrapText,
   allowTooltip,
-  truncateCellText,
+  cellTextOverflow,
   locale,
   renderDataFunction,
   columnId,
@@ -56,8 +56,8 @@ const TableCellRenderer = ({
 }) => {
   const mySpanRef = React.createRef();
   const myClasses = classnames({
-    [`${iotPrefix}--table__cell-text--truncate`]: wrapText !== 'always' && truncateCellText,
-    [`${iotPrefix}--table__cell-text--no-wrap`]: wrapText === 'never',
+    [`${iotPrefix}--table__cell-text--truncate`]: cellTextOverflow === 'truncate',
+    [`${iotPrefix}--table__cell-text--no-wrap`]: cellTextOverflow === 'prevent-wrap',
   });
 
   const [useTooltip, setUseTooltip] = useState(false);
@@ -81,11 +81,11 @@ const TableCellRenderer = ({
         typeof children === 'string' ||
         typeof children === 'number' ||
         typeof children === 'boolean';
-      if (canBeTruncated && truncateCellText && allowTooltip && mySpanRef && mySpanRef.current) {
+      if (canBeTruncated && cellTextOverflow === 'truncate' && allowTooltip && mySpanRef?.current) {
         setUseTooltip(isElementTruncated(mySpanRef.current));
       }
     },
-    [mySpanRef, children, wrapText, truncateCellText, allowTooltip]
+    [mySpanRef, children, cellTextOverflow, allowTooltip]
   );
 
   const cellContent = renderDataFunction ? (

--- a/src/components/Table/TableCellRenderer/TableCellRenderer.test.jsx
+++ b/src/components/Table/TableCellRenderer/TableCellRenderer.test.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
 
 import { settings } from '../../../constants/Settings';
 
@@ -9,6 +11,8 @@ const { iotPrefix, prefix } = settings;
 
 describe('TableCellRenderer', () => {
   const cellText = 'This text is not actually measured';
+  const textTruncateClassName = `${iotPrefix}--table__cell-text--truncate`;
+  const textNoWrapClassName = `${iotPrefix}--table__cell-text--no-wrap`;
 
   const originalOffsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
   const originalScrollWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollWidth');
@@ -34,71 +38,43 @@ describe('TableCellRenderer', () => {
     Object.defineProperty(HTMLElement.prototype, 'scrollWidth', originalScrollWidth);
   });
 
-  it('truncates only for truncateCellText={true}', () => {
-    const wrapper = mount(
-      <TableCellRenderer wrapText="never" truncateCellText>
-        {cellText}
-      </TableCellRenderer>
+  it('truncates only for cellTextOverflow:"truncate"', () => {
+    const { rerender } = render(
+      <TableCellRenderer cellTextOverflow="truncate">{cellText}</TableCellRenderer>
     );
-    expect(wrapper.find(`.${iotPrefix}--table__cell-text--truncate`)).toHaveLength(1);
+    expect(screen.getByText(cellText)).toHaveClass(textTruncateClassName);
 
-    const wrapper2 = mount(
-      <TableCellRenderer wrapText="never" truncateCellText={false}>
-        {cellText}
-      </TableCellRenderer>
-    );
-    expect(wrapper2.find(`.${iotPrefix}--table__cell-text--truncate`)).toHaveLength(0);
+    rerender(<TableCellRenderer>{cellText}</TableCellRenderer>);
+    expect(screen.getByText(cellText)).not.toHaveClass(textTruncateClassName);
   });
 
-  it('does not truncat when wrapText={always}', () => {
-    const wrapper = mount(
-      <TableCellRenderer wrapText="always" truncateCellText>
-        {cellText}
-      </TableCellRenderer>
-    );
-    expect(wrapper.find(`.${iotPrefix}--table__cell-text--truncate`)).toHaveLength(0);
+  it('does not allow wrapping for cellTextOverflow:"prevent-wrap"', () => {
+    render(<TableCellRenderer cellTextOverflow="prevent-wrap">{cellText}</TableCellRenderer>);
+    expect(screen.getByText(cellText)).toHaveClass(textNoWrapClassName);
   });
 
-  it('does not allow wrap when wrapText={never}', () => {
-    const wrapper = mount(
-      <TableCellRenderer wrapText="never" truncateCellText={false}>
-        {cellText}
-      </TableCellRenderer>
-    );
-    expect(wrapper.find(`.${iotPrefix}--table__cell-text--no-wrap`)).toHaveLength(1);
-  });
-
-  it('allows wrap when wrapText={always}', () => {
-    const wrapper = mount(
-      <TableCellRenderer wrapText="always" truncateCellText={false}>
-        {cellText}
-      </TableCellRenderer>
-    );
-    expect(wrapper.find(`.${iotPrefix}--table__cell-text--no-wrap`)).toHaveLength(0);
+  it('allows wrapping by default', () => {
+    render(<TableCellRenderer>{cellText}</TableCellRenderer>);
+    expect(screen.getByText(cellText)).not.toHaveClass(textNoWrapClassName);
+    expect(screen.getByText(cellText)).not.toHaveClass(textTruncateClassName);
   });
 
   it('only truncates children that are strings, numbers or booleans', () => {
-    const wrapper = mount(
+    render(
       <table>
         <tbody>
           <tr>
             <td>
-              <TableCellRenderer wrapText="never" truncateCellText>
-                {'my string'}
-              </TableCellRenderer>
+              <TableCellRenderer cellTextOverflow="truncate">my string</TableCellRenderer>
             </td>
             <td>
-              <TableCellRenderer wrapText="never" truncateCellText>
-                {true}
-              </TableCellRenderer>
+              <TableCellRenderer cellTextOverflow="truncate">{true}</TableCellRenderer>
             </td>
             <td>
-              <TableCellRenderer wrapText="never" truncateCellText>
-                {127}
-              </TableCellRenderer>
+              <TableCellRenderer cellTextOverflow="truncate">{127}</TableCellRenderer>
             </td>
             <td>
-              <TableCellRenderer wrapText="never" truncateCellText>
+              <TableCellRenderer cellTextOverflow="truncate">
                 <div>a div</div>
               </TableCellRenderer>
             </td>
@@ -106,7 +82,10 @@ describe('TableCellRenderer', () => {
         </tbody>
       </table>
     );
-    expect(wrapper.find(`.${iotPrefix}--table__cell-text--truncate`)).toHaveLength(3);
+    expect(screen.getByText('my string')).toHaveClass(textTruncateClassName);
+    expect(screen.getByText('true')).toHaveClass(textTruncateClassName);
+    expect(screen.getByText('127')).toHaveClass(textTruncateClassName);
+    expect(screen.getByText('a div').parentNode).not.toHaveClass(textTruncateClassName);
   });
 
   it('only shows tooltip if text is actually truncated', () => {
@@ -114,24 +93,18 @@ describe('TableCellRenderer', () => {
     setScrollWidth(20);
 
     const wrapper = mount(
-      <TableCellRenderer wrapText="never" truncateCellText>
-        {cellText}
-      </TableCellRenderer>
+      <TableCellRenderer cellTextOverflow="truncate">{cellText}</TableCellRenderer>
     );
     expect(wrapper.find(`.${prefix}--tooltip__label`)).toHaveLength(1);
     expect(wrapper.find(`.${iotPrefix}--table__cell-text--truncate`)).toHaveLength(1);
-    expect(wrapper.find(`.${iotPrefix}--table__cell-text--no-wrap`)).toHaveLength(1);
 
     setOffsetWidth(20);
     setScrollWidth(10);
     const wrapper2 = mount(
-      <TableCellRenderer wrapText="never" truncateCellText>
-        {cellText}
-      </TableCellRenderer>
+      <TableCellRenderer cellTextOverflow="truncate">{cellText}</TableCellRenderer>
     );
     expect(wrapper2.find(`.${prefix}--tooltip__label`)).toHaveLength(0);
     expect(wrapper2.find(`.${iotPrefix}--table__cell-text--truncate`)).toHaveLength(1);
-    expect(wrapper2.find(`.${iotPrefix}--table__cell-text--no-wrap`)).toHaveLength(1);
 
     setOffsetWidth(0);
     setScrollWidth(0);
@@ -143,13 +116,12 @@ describe('TableCellRenderer', () => {
 
     const cellText = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit';
     const wrapper = mount(
-      <TableCellRenderer wrapText="never" truncateCellText allowTooltip={false}>
+      <TableCellRenderer cellTextOverflow="truncate" allowTooltip={false}>
         {cellText}
       </TableCellRenderer>
     );
     expect(wrapper.find(`.${prefix}--tooltip__label`)).toHaveLength(0);
     expect(wrapper.find(`.${iotPrefix}--table__cell-text--truncate`)).toHaveLength(1);
-    expect(wrapper.find(`.${iotPrefix}--table__cell-text--no-wrap`)).toHaveLength(1);
 
     setOffsetWidth(0);
     setScrollWidth(0);

--- a/src/components/Table/TableHead/TableHead.jsx
+++ b/src/components/Table/TableHead/TableHead.jsx
@@ -20,6 +20,7 @@ import TableCellRenderer from '../TableCellRenderer/TableCellRenderer';
 import { tableTranslateWithId } from '../../../utils/componentUtilityFunctions';
 import { settings } from '../../../constants/Settings';
 import { OverflowMenu, OverflowMenuItem } from '../../../index';
+import { handleOverflowDeprecation } from '../../../internal/deprecate';
 
 import ColumnHeaderRow from './ColumnHeaderRow/ColumnHeaderRow';
 import FilterHeaderRow from './FilterHeaderRow/FilterHeaderRow';
@@ -50,6 +51,8 @@ const propTypes = {
     hasRowActions: PropTypes.bool,
     hasResize: PropTypes.bool,
     hasSingleRowEdit: PropTypes.bool,
+    wrapCellText: PropTypes.oneOf(['always', 'never', 'auto']),
+    truncateCellText: PropTypes.bool,
     cellTextOverflow: CellTextOverflowPropType,
   }),
   /** List of columns */
@@ -138,7 +141,15 @@ const PADDING_WITH_OVERFLOW_AND_SORT = 58;
 const TableHead = ({
   tableId,
   options,
-  options: { hasRowExpansion, hasRowSelection, hasResize, cellTextOverflow, hasSingleRowEdit },
+  options: {
+    hasRowExpansion,
+    hasRowSelection,
+    hasResize,
+    cellTextOverflow,
+    hasSingleRowEdit,
+    wrapCellText,
+    truncateCellText,
+  },
   columns,
   tableState: {
     selection: { isSelectAllIndeterminate, isSelectAllSelected },
@@ -172,6 +183,14 @@ const TableHead = ({
   const columnRef = generateOrderedColumnRefs(ordering);
   const columnResizeRefs = generateOrderedColumnRefs(ordering);
   const [currentColumnWidths, setCurrentColumnWidths] = useState({});
+
+  // Temporary deprecation code to map the deprectated wrapCellText & truncateCellText
+  // to the new cellTextOverflow
+  const myCellTextOverflow = handleOverflowDeprecation(
+    cellTextOverflow,
+    wrapCellText,
+    truncateCellText
+  );
 
   if (isEmpty(currentColumnWidths)) {
     columns.forEach(col => {
@@ -374,7 +393,7 @@ const TableHead = ({
             >
               <TableCellRenderer
                 className={`${iotPrefix}--table-head--text`}
-                cellTextOverflow={cellTextOverflow}
+                cellTextOverflow={myCellTextOverflow}
                 allowTooltip={false}
               >
                 {matchingColumnMeta.name}

--- a/src/components/Table/TableHead/TableHead.jsx
+++ b/src/components/Table/TableHead/TableHead.jsx
@@ -14,6 +14,7 @@ import {
   I18NPropTypes,
   defaultI18NPropTypes,
   ActiveTableToolbarPropType,
+  CellTextOverflowPropType,
 } from '../TablePropTypes';
 import TableCellRenderer from '../TableCellRenderer/TableCellRenderer';
 import { tableTranslateWithId } from '../../../utils/componentUtilityFunctions';
@@ -49,8 +50,7 @@ const propTypes = {
     hasRowActions: PropTypes.bool,
     hasResize: PropTypes.bool,
     hasSingleRowEdit: PropTypes.bool,
-    wrapCellText: PropTypes.oneOf(['always', 'never', 'auto']).isRequired,
-    truncateCellText: PropTypes.bool.isRequired,
+    cellTextOverflow: CellTextOverflowPropType,
   }),
   /** List of columns */
   columns: TableColumnsPropTypes.isRequired,
@@ -138,14 +138,7 @@ const PADDING_WITH_OVERFLOW_AND_SORT = 58;
 const TableHead = ({
   tableId,
   options,
-  options: {
-    hasRowExpansion,
-    hasRowSelection,
-    hasResize,
-    wrapCellText,
-    truncateCellText,
-    hasSingleRowEdit,
-  },
+  options: { hasRowExpansion, hasRowSelection, hasResize, cellTextOverflow, hasSingleRowEdit },
   columns,
   tableState: {
     selection: { isSelectAllIndeterminate, isSelectAllSelected },
@@ -381,8 +374,7 @@ const TableHead = ({
             >
               <TableCellRenderer
                 className={`${iotPrefix}--table-head--text`}
-                wrapText={wrapCellText}
-                truncateCellText={truncateCellText}
+                cellTextOverflow={cellTextOverflow}
                 allowTooltip={false}
               >
                 {matchingColumnMeta.name}

--- a/src/components/Table/TablePropTypes.js
+++ b/src/components/Table/TablePropTypes.js
@@ -244,3 +244,6 @@ export const TableSearchPropTypes = PropTypes.shape({
 
 /** Which toolbar is currently active */
 export const ActiveTableToolbarPropType = PropTypes.oneOf(['column', 'filter', 'rowEdit']);
+
+/** How should long cell texts be handled, the implicit default is wrapping */
+export const CellTextOverflowPropType = PropTypes.oneOf(['prevent-wrap', 'truncate']);

--- a/src/internal/deprecate.js
+++ b/src/internal/deprecate.js
@@ -31,3 +31,24 @@ export default function deprecate(propType, message) {
 
   return checker;
 }
+
+const mapToCellTextOverflow = (wrapCellText, truncateCellText) => {
+  const truncate = wrapCellText === 'alwaysTruncate' || truncateCellText;
+  return truncate ? 'truncate' : wrapCellText === 'never' ? 'prevent-wrap' : undefined;
+};
+
+/**
+ * Temporary deprecation function that can be removed when the
+ * TableHead and TableBody are removed, see issue #1650, or when the
+ * deprectaed 'wrapCellText' and 'truncateCellText' are removed.
+ * @param {*} cellTextOverflow
+ * @param {*} wrapCellText
+ * @param {*} truncateCellText
+ */
+export const handleOverflowDeprecation = (cellTextOverflow, wrapCellText, truncateCellText) => {
+  const mapDeprecatedProps = !cellTextOverflow && (wrapCellText || truncateCellText);
+
+  return mapDeprecatedProps
+    ? mapToCellTextOverflow(wrapCellText, truncateCellText)
+    : cellTextOverflow;
+};

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -1721,6 +1721,19 @@ Map {
             "hasSingleRowEdit": Object {
               "type": "bool",
             },
+            "truncateCellText": Object {
+              "type": "bool",
+            },
+            "wrapCellText": Object {
+              "args": Array [
+                Array [
+                  "always",
+                  "never",
+                  "auto",
+                ],
+              ],
+              "type": "oneOf",
+            },
           },
         ],
         "type": "shape",
@@ -1868,6 +1881,8 @@ Map {
       "shouldLazyRender": false,
       "singleRowEditButtons": null,
       "totalColumns": 0,
+      "truncateCellText": null,
+      "wrapCellText": null,
     },
     "propTypes": Object {
       "actionFailedText": Object {
@@ -2331,6 +2346,19 @@ Map {
       },
       "totalColumns": Object {
         "type": "number",
+      },
+      "truncateCellText": Object {
+        "type": "bool",
+      },
+      "wrapCellText": Object {
+        "args": Array [
+          Array [
+            "always",
+            "never",
+            "auto",
+          ],
+        ],
+        "type": "oneOf",
       },
     },
   },

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -1022,6 +1022,7 @@ Map {
                   "always",
                   "never",
                   "auto",
+                  "alwaysTruncate",
                 ],
               ],
               "type": "oneOf",
@@ -1689,6 +1690,15 @@ Map {
       "options": Object {
         "args": Array [
           Object {
+            "cellTextOverflow": Object {
+              "args": Array [
+                Array [
+                  "prevent-wrap",
+                  "truncate",
+                ],
+              ],
+              "type": "oneOf",
+            },
             "hasResize": Object {
               "type": "bool",
             },
@@ -1710,21 +1720,6 @@ Map {
             },
             "hasSingleRowEdit": Object {
               "type": "bool",
-            },
-            "truncateCellText": Object {
-              "isRequired": true,
-              "type": "bool",
-            },
-            "wrapCellText": Object {
-              "args": Array [
-                Array [
-                  "always",
-                  "never",
-                  "auto",
-                ],
-              ],
-              "isRequired": true,
-              "type": "oneOf",
             },
           },
         ],
@@ -1851,6 +1846,7 @@ Map {
   },
   "TableBody" => Object {
     "defaultProps": Object {
+      "cellTextOverflow": null,
       "clickToCollapseAria": "Click to collapse.",
       "clickToExpandAria": "Click to expand.",
       "columns": Array [],
@@ -1896,6 +1892,15 @@ Map {
         ],
         "isRequired": true,
         "type": "shape",
+      },
+      "cellTextOverflow": Object {
+        "args": Array [
+          Array [
+            "prevent-wrap",
+            "truncate",
+          ],
+        ],
+        "type": "oneOf",
       },
       "clickToCollapseAria": Object {
         "type": "string",
@@ -2326,21 +2331,6 @@ Map {
       },
       "totalColumns": Object {
         "type": "number",
-      },
-      "truncateCellText": Object {
-        "isRequired": true,
-        "type": "bool",
-      },
-      "wrapCellText": Object {
-        "args": Array [
-          Array [
-            "always",
-            "never",
-            "auto",
-          ],
-        ],
-        "isRequired": true,
-        "type": "oneOf",
       },
     },
   },


### PR DESCRIPTION
After discussion we will close this PR and use #1651 instead. The code refactoring will go in a separate issue for the next major release where we also remove the export of TableHead and TableBody.


**Summary**
The wrapCellText prop could have the values:
• ‘auto’ we apply wrapping only for tables with normal columns. For tables with fixed or resizable columns we use truncation.
• ‘always’ we wrap in all scenarios including tables with fixed or resizable columns (i.e. current situation).
• ‘never’ we never wrap and as a consequence the tables with normal columns* get wide cells and more often horizontal scrolling. For tables with fixed or resizable columns we use truncation.

Feedback and questions shows to some confusion where app developers want to force text truncation for non resizable/fixed width tables. So we added the option `alwaysTruncate` to support this.

See #1196 for more context

**Change List (commits, features, bugs, etc)**
- added the option 'alwaysTruncate' to the table prop `options.wrapCellText`.
- refactored the unit tests to use React Testing Library and made them more robust
- added additional unit tests
- merged the internal props wrapText && truncateCellText into a new prop called cellTextOverflow since they now were overlapping. Removed unused values for the new cellTextOverflow prop.
- improved and refactored the memoized function that calculates the value of the `cellTextOverflow`. Hopefully this code is easier to understand and more aligned with the unit tests.

**Acceptance Test (how to verify the PR)**
Nota bene! You might have to decrease the width of your browser window in order to trigger truncation of the table cell texts.

1. In general, verify that the table stories that have a `wrapCellText` knob will use truncation if the new 'alwaysTruncate' option us selected.

2. Especially, verify that stories that don't use `hasResize` and don't have fixed column widths still will truncate when the new 'alwaysTruncate' option us selected.
E.g. /story/watson-iot-table--stateful-example-with-multiselect-filtering

3. If you are ambitious (which you of course are), verify that the old stories work the same way for the old `wrapCellText` knob alternatives.