### PR TITLE
fix(table): single nested parents should have bold font weight

### DIFF
--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -177,6 +177,17 @@ const StyledTableExpandRow = styled(({ hasRowSelection, ...props }) => (
   <TableExpandRow {...props} />
 ))`
   &&& {
+    ${
+      // if single nested hierarchy AND there are children rows (meaning this is a parent),
+      // bolden all cells of this row
+      props =>
+        props.hasRowNesting?.hasSingleNestedHierarchy && props['data-child-count'] > 0
+          ? `td {
+        font-weight: bold
+      }`
+          : ``
+    }
+
     ${props =>
       props['data-child-count'] === 0 && props['data-row-nesting']
         ? `
@@ -245,6 +256,17 @@ const StyledTableExpandRowExpanded = styled(({ hasRowSelection, ...props }) => (
 ))`
   &&& {
     cursor: pointer;
+
+    ${
+      // if single nested hierarchy, bolden all cells of this row
+      props =>
+        props.hasRowNesting?.hasSingleNestedHierarchy
+          ? `td {
+        font-weight: bold
+      }`
+          : ``
+    }
+
     ${props =>
       props['data-row-nesting']
         ? `
@@ -296,6 +318,7 @@ const StyledExpansionTableRow = styled(({ hasRowSelection, ...props }) => <Table
       border-left: 4px solid ${COLORS.blue};
       border-width: 0 0 0 4px;
       padding: 0;
+      font-weight: bold;
     }
 
     :hover {
@@ -511,6 +534,7 @@ const TableBodyRow = ({
               onRowClicked(id);
             }
           }}
+          hasRowNesting={hasRowNesting}
         >
           {tableCells}
         </StyledTableExpandRowExpanded>
@@ -544,6 +568,7 @@ const TableBodyRow = ({
             onRowClicked(id);
           }
         }}
+        hasRowNesting={hasRowNesting}
       >
         {tableCells}
       </StyledTableExpandRow>

--- a/src/components/Table/TableBody/TableBodyRow/__snapshots__/TableBodyRow.story.storyshot
+++ b/src/components/Table/TableBody/TableBodyRow/__snapshots__/TableBodyRow.story.storyshot
@@ -416,7 +416,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
             aria-live="polite"
           >
             <tr
-              className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+              className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
               data-child-count={0}
               data-nesting-offset={0}
               data-parent-row={true}
@@ -571,7 +571,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
             aria-live="polite"
           >
             <tr
-              className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+              className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
               data-child-count={0}
               data-nesting-offset={0}
               data-parent-row={true}
@@ -774,7 +774,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
             aria-live="polite"
           >
             <tr
-              className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+              className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
               data-child-count={0}
               data-nesting-offset={0}
               data-parent-row={true}
@@ -939,7 +939,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
             aria-live="polite"
           >
             <tr
-              className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+              className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
               data-child-count={0}
               data-nesting-offset={0}
               data-parent-row={true}

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -8430,11 +8430,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     aria-live="polite"
                   >
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -8528,11 +8529,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -8626,11 +8628,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -8724,11 +8727,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -8822,11 +8826,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -8920,11 +8925,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -9018,11 +9024,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -9116,11 +9123,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -9214,11 +9222,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -9312,11 +9321,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -20226,11 +20236,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     aria-live="polite"
                   >
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -20324,11 +20335,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -20422,11 +20434,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -20520,11 +20533,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -20618,11 +20632,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -20716,11 +20731,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -20814,11 +20830,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -20912,11 +20929,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -21010,11 +21028,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -21108,11 +21127,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -22025,11 +22045,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     aria-live="polite"
                   >
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -22123,11 +22144,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -22221,11 +22243,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -22319,11 +22342,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -22417,11 +22441,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -22515,11 +22540,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -22613,11 +22639,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -22711,11 +22738,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -22809,11 +22837,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -22907,11 +22936,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -23824,11 +23854,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     aria-live="polite"
                   >
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -23922,11 +23953,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -24020,11 +24052,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -24118,11 +24151,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -24216,11 +24250,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -24314,11 +24349,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -24412,11 +24448,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -24510,11 +24547,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -24608,11 +24646,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -24706,11 +24745,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -32479,11 +32519,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     aria-live="polite"
                   >
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -32631,11 +32672,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -32783,11 +32825,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -32935,11 +32978,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -33087,11 +33131,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -33314,11 +33359,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -33496,11 +33542,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -33648,11 +33695,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -33845,11 +33893,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -33997,11 +34046,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -35112,11 +35162,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     aria-live="polite"
                   >
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -35274,11 +35325,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -35434,11 +35486,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -35596,11 +35649,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -35758,11 +35812,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -35918,11 +35973,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -36078,11 +36134,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -36238,11 +36295,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -36398,11 +36456,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td
@@ -36513,11 +36572,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       </td>
                     </tr>
                     <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 jiOXXf"
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
                       data-child-count={0}
                       data-nesting-offset={0}
                       data-parent-row={true}
                       data-row-nesting={false}
+                      hasRowNesting={false}
                       onClick={[Function]}
                     >
                       <td


### PR DESCRIPTION
Closes #1647 

**Summary**

- To meet the proper design of single-nested hierarchy Table's, this PR adds `font-weight: bold` to parent category/rows

**Change List (commits, features, bugs, etc)**

- Add the font-weight based off whether `hasRowNesting: { hasSingleNestedHierarchy: true}` and whether there is children or not (AKA is the row a parent)

**Acceptance Test (how to verify the PR)**

- Go to ?path=/story/watson-iot-table--stateful-example-with-single-nested-hierarchy and see that all parents are bold, while all children are regular font-weight
