### PR TITLE
fix(list): correct non-hierarchical list indentation level

### DIFF
--- a/src/components/CardEditor/__snapshots__/CardEditor.story.storyshot
+++ b/src/components/CardEditor/__snapshots__/CardEditor.story.storyshot
@@ -775,14 +775,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -862,14 +854,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -951,14 +935,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -1038,14 +1014,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -1129,14 +1097,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >

--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -204,7 +204,7 @@ const List = forwardRef((props, ref) => {
 
   // If the root level contains a category item, the base indent level should be increased by 1 to
   // account for the caret on non-category items.
-  const baseIndentLevel = items.filter(item => item?.children && item.children.length > 0) ? 1 : 0;
+  const baseIndentLevel = items.some(item => item?.children && item.children.length > 0) ? 1 : 0;
 
   const listItems = items.map((item, index) =>
     renderItemAndChildren(item, index, null, baseIndentLevel)

--- a/src/components/List/__snapshots__/List.story.storyshot
+++ b/src/components/List/__snapshots__/List.story.storyshot
@@ -49,14 +49,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -83,14 +75,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -119,14 +103,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -153,14 +129,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -189,14 +157,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -223,14 +183,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -259,14 +211,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -293,14 +237,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -329,14 +265,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -363,14 +291,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -3865,14 +3785,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item iot--list-item__large"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content iot--list-item--content__large"
               >
                 <div
@@ -3923,14 +3835,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item iot--list-item__large"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content iot--list-item--content__large"
               >
@@ -3983,14 +3887,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item iot--list-item__large"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content iot--list-item--content__large"
               >
                 <div
@@ -4041,14 +3937,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item iot--list-item__large"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content iot--list-item--content__large"
               >
@@ -4101,14 +3989,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item iot--list-item__large"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content iot--list-item--content__large"
               >
                 <div
@@ -4159,14 +4039,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item iot--list-item__large"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content iot--list-item--content__large"
               >
@@ -4219,14 +4091,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item iot--list-item__large"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content iot--list-item--content__large"
               >
                 <div
@@ -4277,14 +4141,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item iot--list-item__large"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content iot--list-item--content__large"
               >
@@ -4337,14 +4193,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item iot--list-item__large"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content iot--list-item--content__large"
               >
                 <div
@@ -4395,14 +4243,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item iot--list-item__large"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content iot--list-item--content__large"
               >
@@ -4526,14 +4366,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -4616,14 +4448,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -4708,14 +4532,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -4798,14 +4614,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -4890,14 +4698,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -4980,14 +4780,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -5072,14 +4864,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -5162,14 +4946,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -5254,14 +5030,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -5344,14 +5112,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -5507,14 +5267,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -5586,14 +5338,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -5667,14 +5411,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -5746,14 +5482,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -5827,14 +5555,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -5906,14 +5626,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -5987,14 +5699,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -6066,14 +5770,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -6147,14 +5843,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -6226,14 +5914,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -6378,14 +6058,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -6418,14 +6090,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -6460,14 +6124,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -6500,14 +6156,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -6542,14 +6190,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -6582,14 +6222,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -6624,14 +6256,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -6664,14 +6288,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -6706,14 +6322,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -6746,14 +6354,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -6859,14 +6459,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -6901,14 +6493,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -6945,14 +6529,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -6987,14 +6563,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -7031,14 +6599,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -7073,14 +6633,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -7117,14 +6669,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -7159,14 +6703,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >
@@ -7203,14 +6739,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-item"
             >
               <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
-              <div
                 className="iot--list-item--content"
               >
                 <div
@@ -7245,14 +6773,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-item"
             >
-              <div
-                className="iot--list-item--nesting-offset"
-                style={
-                  Object {
-                    "width": "30px",
-                  }
-                }
-              />
               <div
                 className="iot--list-item--content"
               >

--- a/src/components/Table/TableManageViewsModal/__snapshots__/TableManageViewsModal.story.storyshot
+++ b/src/components/Table/TableManageViewsModal/__snapshots__/TableManageViewsModal.story.storyshot
@@ -188,14 +188,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item iot--list-item__large"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content iot--list-item--content__large"
                   >
                     <div
@@ -297,14 +289,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item iot--list-item__large"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content iot--list-item--content__large"
                   >
@@ -416,14 +400,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item iot--list-item__large"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content iot--list-item--content__large"
                   >
                     <div
@@ -525,14 +501,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item iot--list-item__large"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content iot--list-item--content__large"
                   >
@@ -636,14 +604,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item iot--list-item__large"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content iot--list-item--content__large"
                   >
                     <div
@@ -745,14 +705,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item iot--list-item__large"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content iot--list-item--content__large"
                   >
@@ -856,14 +808,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item iot--list-item__large"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content iot--list-item--content__large"
                   >
                     <div
@@ -965,14 +909,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item iot--list-item__large"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content iot--list-item--content__large"
                   >
@@ -1076,14 +1012,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item iot--list-item__large"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content iot--list-item--content__large"
                   >
                     <div
@@ -1185,14 +1113,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item iot--list-item__large"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content iot--list-item--content__large"
                   >
@@ -1577,14 +1497,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -1728,14 +1640,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -1887,14 +1791,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -2038,14 +1934,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -2191,14 +2079,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -2342,14 +2222,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -2495,14 +2367,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -2646,14 +2510,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -2799,14 +2655,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -2950,14 +2798,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -3103,14 +2943,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -3254,14 +3086,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -3407,14 +3231,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -3558,14 +3374,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -3711,14 +3519,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -3862,14 +3662,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -4015,14 +3807,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -4166,14 +3950,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -4319,14 +4095,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -4470,14 +4238,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -4623,14 +4383,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -4774,14 +4526,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -4927,14 +4671,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -5078,14 +4814,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -5231,14 +4959,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -5382,14 +5102,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -5535,14 +5247,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -5686,14 +5390,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -5839,14 +5535,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -5990,14 +5678,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -6143,14 +5823,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -6294,14 +5966,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -6447,14 +6111,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -6598,14 +6254,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -6751,14 +6399,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -6902,14 +6542,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -7055,14 +6687,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -7206,14 +6830,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -7359,14 +6975,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -7510,14 +7118,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -7663,14 +7263,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -7814,14 +7406,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -7967,14 +7551,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -8118,14 +7694,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -8271,14 +7839,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -8422,14 +7982,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -8575,14 +8127,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -8726,14 +8270,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -8879,14 +8415,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -9030,14 +8558,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -9183,14 +8703,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -9334,14 +8846,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -9487,14 +8991,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -9638,14 +9134,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -9791,14 +9279,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -9942,14 +9422,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -10095,14 +9567,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -10246,14 +9710,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -10399,14 +9855,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -10550,14 +9998,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -10703,14 +10143,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -10854,14 +10286,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -11007,14 +10431,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -11158,14 +10574,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -11311,14 +10719,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -11462,14 +10862,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -11615,14 +11007,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -11766,14 +11150,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -11919,14 +11295,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -12070,14 +11438,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -12223,14 +11583,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -12374,14 +11726,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -12527,14 +11871,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -12678,14 +12014,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -12831,14 +12159,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -12982,14 +12302,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -13135,14 +12447,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -13286,14 +12590,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -13439,14 +12735,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -13590,14 +12878,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -13743,14 +13023,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -13894,14 +13166,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -14047,14 +13311,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -14198,14 +13454,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -14351,14 +13599,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -14502,14 +13742,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -14655,14 +13887,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -14806,14 +14030,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -14959,14 +14175,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -15110,14 +14318,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -15263,14 +14463,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -15414,14 +14606,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -15567,14 +14751,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -15718,14 +14894,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -15871,14 +15039,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -16022,14 +15182,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -16175,14 +15327,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -16326,14 +15470,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >
@@ -16479,14 +15615,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--list-item"
                 >
                   <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
-                  <div
                     className="iot--list-item--content"
                   >
                     <div
@@ -16630,14 +15758,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <div
                   className="iot--list-item"
                 >
-                  <div
-                    className="iot--list-item--nesting-offset"
-                    style={
-                      Object {
-                        "width": "30px",
-                      }
-                    }
-                  />
                   <div
                     className="iot--list-item--content"
                   >

--- a/src/components/WizardModal/WizardModal.test.jsx
+++ b/src/components/WizardModal/WizardModal.test.jsx
@@ -156,32 +156,36 @@ describe('WizardModal', () => {
     expect(wrapper.find(Loading)).toHaveLength(1);
   });
   it('clicking on progressIndicator steps will render related content', () => {
-    render(<WizardModal {...commonWizardProps} steps={[
-      { label: 'step1', content: 'page 1' },
-      { label: 'step2', content: 'page 2', onValidate: () => false },
-      { label: 'step3', content: 'page 3' },
-    ]} />);
+    render(
+      <WizardModal
+        {...commonWizardProps}
+        steps={[
+          { label: 'step1', content: 'page 1' },
+          { label: 'step2', content: 'page 2', onValidate: () => false },
+          { label: 'step3', content: 'page 3' },
+        ]}
+      />
+    );
 
-      // analogue to ProgressIndicator test we check if clicking step will show related content
-      const [ beforeClick1 ] = screen.getByTitle('step1').children;
-    
-      screen.getByTestId('iot--progress-step-button-main-step2').click();
-    
-      // content should be page2
-      expect(screen.getByTitle('step1').children[0]).not.toContain(beforeClick1);
-      expect(screen.getByText('page 2')).toBeDefined();
+    // analogue to ProgressIndicator test we check if clicking step will show related content
+    const [beforeClick1] = screen.getByTitle('step1').children;
 
-      // clicking on step3 should not progress the modal
-      const [ beforeClick2 ] = screen.getByTitle('step2').children;
-      screen.getByTestId('iot--progress-step-button-main-step3').click();
-      
-      expect(screen.getByTitle('step2').children[0]).toEqual(beforeClick2);
-      expect(screen.getByText('page 2')).toBeDefined();
+    screen.getByTestId('iot--progress-step-button-main-step2').click();
 
-      // clicking on page 1 should go back to step 1
-      screen.getByTestId('iot--progress-step-button-main-step1').click();
-      expect(screen.getByTitle('step1').children[0]).toEqual(beforeClick1);
-      expect(screen.getByText('page 1')).toBeDefined();
+    // content should be page2
+    expect(screen.getByTitle('step1').children[0]).not.toContain(beforeClick1);
+    expect(screen.getByText('page 2')).toBeDefined();
 
+    // clicking on step3 should not progress the modal
+    const [beforeClick2] = screen.getByTitle('step2').children;
+    screen.getByTestId('iot--progress-step-button-main-step3').click();
+
+    expect(screen.getByTitle('step2').children[0]).toEqual(beforeClick2);
+    expect(screen.getByText('page 2')).toBeDefined();
+
+    // clicking on page 1 should go back to step 1
+    screen.getByTestId('iot--progress-step-button-main-step1').click();
+    expect(screen.getByTitle('step1').children[0]).toEqual(beforeClick1);
+    expect(screen.getByText('page 1')).toBeDefined();
   });
 });


### PR DESCRIPTION
Closes #1657 

**Summary**

- Small fix to ensure that non-hierarchical list items have no indent

**Change List (commits, features, bugs, etc)**

- modify base indentation logic for list items

**Acceptance Test (how to verify the PR)**

- The [`List \ basic single column` story](https://deploy-preview-1660--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-experimental-list--basic-single-column) should now have no indentation as it used to be before the changes in #1617 
  - The PR #1608 was merged right before #1617. [The 1608 deploy preview](https://deploy-preview-1608--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-experimental-list--basic-single-column) shows the original to compare
