### PR TITLE
[PageTitleBar] update style to match new spec

### DIFF
--- a/src/components/NavigationBar/__snapshots__/NavigationBar.story.storyshot
+++ b/src/components/NavigationBar/__snapshots__/NavigationBar.story.storyshot
@@ -26,7 +26,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Navig
         <div
           className="page-title-bar-header"
         >
-          <div>
+          <div
+            className="page-title-bar-header-left"
+          >
             <div
               className="page-title-bar-title"
             >
@@ -45,13 +47,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Navig
             </p>
           </div>
           <div
-            style={
-              Object {
-                "flex": 1,
-              }
-            }
-          />
-          <div>
+            className="page-title-bar-header-right"
+          >
             <div>
               Extra Content
             </div>
@@ -238,7 +235,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Navig
         <div
           className="page-title-bar-header"
         >
-          <div>
+          <div
+            className="page-title-bar-header-left"
+          >
             <div
               className="page-title-bar-title"
             >
@@ -257,13 +256,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Navig
             </p>
           </div>
           <div
-            style={
-              Object {
-                "flex": 1,
-              }
-            }
-          />
-          <div>
+            className="page-title-bar-header-right"
+          >
             <div>
               Extra Content
             </div>
@@ -437,7 +431,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Navig
         <div
           className="page-title-bar-header"
         >
-          <div>
+          <div
+            className="page-title-bar-header-left"
+          >
             <div
               className="page-title-bar-title"
             >
@@ -456,13 +452,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Navig
             </p>
           </div>
           <div
-            style={
-              Object {
-                "flex": 1,
-              }
-            }
-          />
-          <div>
+            className="page-title-bar-header-right"
+          >
             <div>
               Extra Content
             </div>
@@ -636,7 +627,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Navig
         <div
           className="page-title-bar-header"
         >
-          <div>
+          <div
+            className="page-title-bar-header-left"
+          >
             <div
               className="page-title-bar-title"
             >
@@ -655,13 +648,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Navig
             </p>
           </div>
           <div
-            style={
-              Object {
-                "flex": 1,
-              }
-            }
-          />
-          <div>
+            className="page-title-bar-header-right"
+          >
             <div>
               Extra Content
             </div>

--- a/src/components/PageTitleBar/PageTitleBar.jsx
+++ b/src/components/PageTitleBar/PageTitleBar.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Fragment } from 'react';
+import React from 'react';
 import classnames from 'classnames';
 import { Information20, Edit20 } from '@carbon/icons-react';
 import { Breadcrumb, BreadcrumbItem, Tooltip, SkeletonText, Tabs } from 'carbon-components-react';
@@ -75,16 +75,15 @@ const PageTitleBar = ({
   tabs,
   content,
 }) => {
-  //
   const titleBarContent = content || tabs;
   return (
     <div className={classnames(className, 'page-title-bar')}>
       {isLoading ? (
         <SkeletonText className="page-title-bar-loading" heading width="30%" />
       ) : (
-        <Fragment>
+        <>
           <div className="page-title-bar-header">
-            <div>
+            <div className="page-title-bar-header-left">
               {breadcrumb ? (
                 <div className="page-title-bar-breadcrumb">
                   <Breadcrumb>
@@ -113,7 +112,7 @@ const PageTitleBar = ({
                     <Button
                       className="page-title-bar-title--edit"
                       kind="ghost"
-                      size="small"
+                      size="field"
                       hasIconOnly
                       renderIcon={Edit20}
                       iconDescription={editIconDescription}
@@ -129,14 +128,11 @@ const PageTitleBar = ({
               ) : null}
             </div>
             {extraContent || rightContent ? (
-              <Fragment>
-                <div style={{ flex: 1 }} />
-                <div>{extraContent || rightContent}</div>
-              </Fragment>
+              <div className="page-title-bar-header-right">{extraContent || rightContent}</div>
             ) : null}
           </div>
           {titleBarContent ? <div className="page-title-bar-content">{titleBarContent}</div> : null}
-        </Fragment>
+        </>
       )}
     </div>
   );

--- a/src/components/PageTitleBar/PageTitleBar.story.jsx
+++ b/src/components/PageTitleBar/PageTitleBar.story.jsx
@@ -120,6 +120,8 @@ storiesOf('Watson IoT/PageTitleBar', module)
               hasIconOnly
               iconDescription="Add"
               kind="ghost"
+              tooltipPosition="bottom"
+              tooltipAlignment="center"
             />
             <Button
               renderIcon={TrashCan24}
@@ -128,6 +130,8 @@ storiesOf('Watson IoT/PageTitleBar', module)
               hasIconOnly
               iconDescription="Remove"
               kind="ghost"
+              tooltipPosition="bottom"
+              tooltipAlignment="center"
             />
             <Button onClick={action('click')} size="field">
               Take an action

--- a/src/components/PageTitleBar/PageTitleBar.story.jsx
+++ b/src/components/PageTitleBar/PageTitleBar.story.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { Add24 } from '@carbon/icons-react';
+import { Add24, TrashCan24 } from '@carbon/icons-react';
 import { spacing05 } from '@carbon/layout';
 import { Tabs, Tab } from 'carbon-components-react';
 
@@ -104,7 +104,37 @@ storiesOf('Watson IoT/PageTitleBar', module)
       title={commonPageTitleBarProps.title}
       description={commonPageTitleBarProps.description}
       breadcrumb={pageTitleBarBreadcrumb}
-      extraContent={commonPageTitleBarProps.extraContent}
+      extraContent={
+        <div>
+          <div
+            className="top"
+            style={{ marginBottom: '8px', display: 'flex', flexDirection: 'row-reverse' }}
+          >
+            <span>Last updated: yesterday</span>
+          </div>
+          <div className="bottom">
+            <Button
+              renderIcon={Add24}
+              onClick={action('click')}
+              size="field"
+              hasIconOnly
+              iconDescription="Add"
+              kind="ghost"
+            />
+            <Button
+              renderIcon={TrashCan24}
+              onClick={action('click')}
+              size="field"
+              hasIconOnly
+              iconDescription="Remove"
+              kind="ghost"
+            />
+            <Button onClick={action('click')} size="field">
+              Take an action
+            </Button>
+          </div>
+        </div>
+      }
       editable
       content={
         <Tabs>

--- a/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
+++ b/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
@@ -875,7 +875,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
                 className="bottom"
               >
                 <button
-                  className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                  className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
                   disabled={false}
                   onClick={[Function]}
                   tabIndex={0}
@@ -905,7 +905,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
                   </svg>
                 </button>
                 <button
-                  className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                  className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
                   disabled={false}
                   onClick={[Function]}
                   tabIndex={0}

--- a/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
+++ b/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
@@ -25,7 +25,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
         <div
           className="page-title-bar-header"
         >
-          <div>
+          <div
+            className="page-title-bar-header-left"
+          >
             <div
               className="page-title-bar-title"
             >
@@ -152,7 +154,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
         <div
           className="page-title-bar-header"
         >
-          <div>
+          <div
+            className="page-title-bar-header-left"
+          >
             <div
               className="page-title-bar-breadcrumb"
             >
@@ -261,7 +265,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
         <div
           className="page-title-bar-header"
         >
-          <div>
+          <div
+            className="page-title-bar-header-left"
+          >
             <div
               className="page-title-bar-breadcrumb"
             >
@@ -542,7 +548,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
         <div
           className="page-title-bar-header"
         >
-          <div>
+          <div
+            className="page-title-bar-header-left"
+          >
             <div
               className="page-title-bar-title"
             >
@@ -615,7 +623,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
         <div
           className="page-title-bar-header"
         >
-          <div>
+          <div
+            className="page-title-bar-header-left"
+          >
             <div
               className="page-title-bar-title"
             >
@@ -626,7 +636,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
                   Page title
                 </h2>
                 <button
-                  className="page-title-bar-title--edit iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                  className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
                   disabled={false}
                   onClick={[Function]}
                   tabIndex={0}
@@ -718,7 +728,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
         <div
           className="page-title-bar-header"
         >
-          <div>
+          <div
+            className="page-title-bar-header-left"
+          >
             <div
               className="page-title-bar-breadcrumb"
             >
@@ -809,7 +821,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
                   </div>
                 </div>
                 <button
-                  className="page-title-bar-title--edit iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                  className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
                   disabled={false}
                   onClick={[Function]}
                   tabIndex={0}
@@ -842,57 +854,99 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
             </div>
           </div>
           <div
-            style={
-              Object {
-                "flex": 1,
-              }
-            }
-          />
-          <div>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                }
-              }
-            >
-              <span
+            className="page-title-bar-header-right"
+          >
+            <div>
+              <div
+                className="top"
                 style={
                   Object {
-                    "marginRight": "1rem",
+                    "display": "flex",
+                    "flexDirection": "row-reverse",
+                    "marginBottom": "8px",
                   }
                 }
               >
-                <b>
-                  Last updated:
-                </b>
-                 yesterday
-              </span>
-              <button
-                className="some-right-content iot--btn bx--btn bx--btn--primary"
-                disabled={false}
-                onClick={[Function]}
-                tabIndex={0}
-                type="button"
+                <span>
+                  Last updated: yesterday
+                </span>
+              </div>
+              <div
+                className="bottom"
               >
-                Take an action
-                <svg
-                  aria-hidden={true}
-                  className="bx--btn__icon"
-                  fill="currentColor"
-                  focusable="false"
-                  height={24}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 32 32"
-                  width={24}
-                  xmlns="http://www.w3.org/2000/svg"
+                <button
+                  className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  type="button"
                 >
-                  <path
-                    d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
-                  />
-                </svg>
-              </button>
+                  <span
+                    className="bx--assistive-text"
+                  >
+                    Add
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Add"
+                    className="bx--btn__icon"
+                    fill="currentColor"
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  type="button"
+                >
+                  <span
+                    className="bx--assistive-text"
+                  >
+                    Remove
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Remove"
+                    className="bx--btn__icon"
+                    fill="currentColor"
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M12 12H14V24H12zM18 12H20V24H18z"
+                    />
+                    <path
+                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  className="iot--btn bx--btn bx--btn--field bx--btn--primary"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  type="button"
+                >
+                  Take an action
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -1083,7 +1137,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
         <div
           className="page-title-bar-header"
         >
-          <div>
+          <div
+            className="page-title-bar-header-left"
+          >
             <div
               className="page-title-bar-title"
             >
@@ -1136,13 +1192,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
             </div>
           </div>
           <div
-            style={
-              Object {
-                "flex": 1,
-              }
-            }
-          />
-          <div>
+            className="page-title-bar-header-right"
+          >
             <div
               style={
                 Object {
@@ -1244,7 +1295,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
         <div
           className="page-title-bar-header"
         >
-          <div>
+          <div
+            className="page-title-bar-header-left"
+          >
             <div
               className="page-title-bar-breadcrumb"
             >

--- a/src/components/PageTitleBar/_page-title-bar.scss
+++ b/src/components/PageTitleBar/_page-title-bar.scss
@@ -14,6 +14,10 @@
       h2 {
         @include type-style('productive-heading-04');
       }
+
+      & #tooltip {
+        fill: $icon-01;
+      }
     }
 
     &--edit {

--- a/src/components/PageTitleBar/_page-title-bar.scss
+++ b/src/components/PageTitleBar/_page-title-bar.scss
@@ -2,8 +2,6 @@
 @import '~carbon-components/scss/globals/scss/typography';
 
 .page-title-bar {
-  padding: $spacing-06 $spacing-07 $spacing-03 $spacing-07;
-
   &-title {
     display: flex;
     align-items: center;
@@ -14,8 +12,12 @@
       display: flex;
 
       h2 {
-        @include type-style('productive-heading-03');
+        @include type-style('productive-heading-04');
       }
+    }
+
+    &--edit {
+      margin-left: $spacing-05;
     }
   }
   .#{$prefix}--tab-content {
@@ -26,6 +28,16 @@
   &-header {
     display: flex;
     align-items: center;
+    justify-content: space-between;
+    height: 100px;
+    padding: $spacing-05 $spacing-07 $spacing-06 $spacing-07;
+
+    &-left {
+      margin-right: $spacing-05;
+    }
+    &-right {
+      margin-left: $spacing-05;
+    }
   }
 
   &-description {
@@ -41,12 +53,10 @@
 
   &-loading {
     height: carbon--rem(20px);
-    margin-top: carbon--rem(8.5px);
-    margin-bottom: carbon--rem(7px);
-    margin-left: carbon--rem(2.5px);
+    margin: $spacing-05 0 0 $spacing-07;
   }
 
   &-content {
-    margin-top: $spacing-05;
+    padding: 0 $spacing-07;
   }
 }

--- a/src/components/PageWizard/__snapshots__/PageWizard.story.storyshot
+++ b/src/components/PageWizard/__snapshots__/PageWizard.story.storyshot
@@ -625,7 +625,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageW
         <div
           className="page-title-bar-header"
         >
-          <div>
+          <div
+            className="page-title-bar-header-left"
+          >
             <div
               className="page-title-bar-breadcrumb"
             >
@@ -1030,7 +1032,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageW
         <div
           className="page-title-bar-header"
         >
-          <div>
+          <div
+            className="page-title-bar-header-left"
+          >
             <div
               className="page-title-bar-breadcrumb"
             >
@@ -1443,7 +1447,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageW
         <div
           className="page-title-bar-header"
         >
-          <div>
+          <div
+            className="page-title-bar-header-left"
+          >
             <div
               className="page-title-bar-breadcrumb"
             >
@@ -2271,7 +2277,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageW
         <div
           className="page-title-bar-header"
         >
-          <div>
+          <div
+            className="page-title-bar-header-left"
+          >
             <div
               className="page-title-bar-breadcrumb"
             >
@@ -3282,7 +3290,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageW
         <div
           className="page-title-bar-header"
         >
-          <div>
+          <div
+            className="page-title-bar-header-left"
+          >
             <div
               className="page-title-bar-breadcrumb"
             >

--- a/src/components/SideNav/__snapshots__/SideNav.story.storyshot
+++ b/src/components/SideNav/__snapshots__/SideNav.story.storyshot
@@ -396,7 +396,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/SideN
           <div
             className="page-title-bar-header"
           >
-            <div>
+            <div
+              className="page-title-bar-header-left"
+            >
               <div
                 className="page-title-bar-title"
               >

--- a/src/components/TileGallery/TileGallery.story.jsx
+++ b/src/components/TileGallery/TileGallery.story.jsx
@@ -8,7 +8,7 @@ import {
   Rocket32,
   StarFilled16,
   Activity32,
-  Sunny32,
+  Light32,
 } from '@carbon/icons-react';
 import { green40 } from '@carbon/colors';
 import { spacing07 } from '@carbon/layout';
@@ -61,7 +61,7 @@ export const content = (
         description="card description"
         moreInfoLink="https://www.ibm.com/br-pt/cloud/internet-of-things?mhsrc=ibmsearch_a&mhq=iot"
         mode="grid"
-        thumbnail={<Sunny32 fill="black" description="Icon" width={50} height={50} />}
+        thumbnail={<Light32 fill="black" description="Icon" width={50} height={50} />}
         icon={<CheckmarkFilled16 fill={green40} onClick={action('clicked')} />}
         afterContent={overflowComponent}
       />
@@ -72,7 +72,7 @@ export const content = (
         description="card description"
         moreInfoLink="https://www.ibm.com/br-pt/cloud/internet-of-things?mhsrc=ibmsearch_a&mhq=iot"
         mode="grid"
-        thumbnail={<Sunny32 fill="black" description="Icon" width={50} height={50} />}
+        thumbnail={<Light32 fill="black" description="Icon" width={50} height={50} />}
         icon={<CheckmarkFilled16 fill={green40} onClick={action('clicked')} />}
         afterContent={overflowComponent}
       />
@@ -98,7 +98,7 @@ export const galleryData = [
         description: 'More about your dashboard',
         icon: <StarFilled16 />,
         afterContent: overflowComponent,
-        thumbnail: <Sunny32 />,
+        thumbnail: <Light32 />,
         onClick: action('Card Clicked'),
       },
       {
@@ -128,7 +128,7 @@ export const galleryData = [
         description: 'More about your dashboard',
         icon: <StarFilled16 />,
         afterContent: overflowComponent,
-        thumbnail: <Sunny32 />,
+        thumbnail: <Light32 />,
         onClick: action('Card Clicked'),
       },
       {

--- a/src/components/TileGallery/__snapshots__/TileGallery.story.storyshot
+++ b/src/components/TileGallery/__snapshots__/TileGallery.story.storyshot
@@ -25,7 +25,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         <div
           className="page-title-bar-header"
         >
-          <div>
+          <div
+            className="page-title-bar-header-left"
+          >
             <div
               className="page-title-bar-title"
             >
@@ -39,13 +41,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            style={
-              Object {
-                "flex": 1,
-              }
-            }
-          />
-          <div>
+            className="page-title-bar-header-right"
+          >
             <div
               className="extra-content"
             >
@@ -355,36 +352,35 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M16,12a4,4,0,1,1-4,4,4.0045,4.0045,0,0,1,4-4m0-2a6,6,0,1,0,6,6,6,6,0,0,0-6-6Z"
-                                  transform="translate(0 .005)"
-                                />
-                                <path
-                                  d="M6.854 5.375H8.854V10.333H6.854z"
-                                  transform="rotate(-45 7.86 7.856)"
-                                />
-                                <path
-                                  d="M2 15.005H7V17.005000000000003H2z"
-                                />
-                                <path
-                                  d="M5.375 23.147H10.333V25.147H5.375z"
-                                  transform="rotate(-45 7.86 24.149)"
-                                />
-                                <path
-                                  d="M15 25.005H17V30.005H15z"
-                                />
-                                <path
-                                  d="M23.147 21.668H25.147V26.625999999999998H23.147z"
-                                  transform="rotate(-45 24.152 24.149)"
-                                />
-                                <path
-                                  d="M25 15.005H30V17.005000000000003H25z"
+                                  d="M15 2H17V7H15z"
                                 />
                                 <path
                                   d="M21.668 6.854H26.625999999999998V8.854H21.668z"
-                                  transform="rotate(-45 24.152 7.856)"
+                                  transform="rotate(-45 24.147 7.853)"
                                 />
                                 <path
-                                  d="M15 2.005H17V7.005H15z"
+                                  d="M25 15H30V17H25z"
+                                />
+                                <path
+                                  d="M23.147 21.668H25.147V26.625999999999998H23.147z"
+                                  transform="rotate(-45 24.147 24.146)"
+                                />
+                                <path
+                                  d="M15 25H17V30H15z"
+                                />
+                                <path
+                                  d="M5.375 23.147H10.333V25.147H5.375z"
+                                  transform="rotate(-45 7.853 24.146)"
+                                />
+                                <path
+                                  d="M2 15H7V17H2z"
+                                />
+                                <path
+                                  d="M6.854 5.375H8.854V10.333H6.854z"
+                                  transform="rotate(-45 7.854 7.853)"
+                                />
+                                <path
+                                  d="M16,12a4,4,0,1,1-4,4,4.0045,4.0045,0,0,1,4-4m0-2a6,6,0,1,0,6,6,6,6,0,0,0-6-6Z"
                                 />
                               </svg>
                             </div>
@@ -786,36 +782,35 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M16,12a4,4,0,1,1-4,4,4.0045,4.0045,0,0,1,4-4m0-2a6,6,0,1,0,6,6,6,6,0,0,0-6-6Z"
-                                  transform="translate(0 .005)"
-                                />
-                                <path
-                                  d="M6.854 5.375H8.854V10.333H6.854z"
-                                  transform="rotate(-45 7.86 7.856)"
-                                />
-                                <path
-                                  d="M2 15.005H7V17.005000000000003H2z"
-                                />
-                                <path
-                                  d="M5.375 23.147H10.333V25.147H5.375z"
-                                  transform="rotate(-45 7.86 24.149)"
-                                />
-                                <path
-                                  d="M15 25.005H17V30.005H15z"
-                                />
-                                <path
-                                  d="M23.147 21.668H25.147V26.625999999999998H23.147z"
-                                  transform="rotate(-45 24.152 24.149)"
-                                />
-                                <path
-                                  d="M25 15.005H30V17.005000000000003H25z"
+                                  d="M15 2H17V7H15z"
                                 />
                                 <path
                                   d="M21.668 6.854H26.625999999999998V8.854H21.668z"
-                                  transform="rotate(-45 24.152 7.856)"
+                                  transform="rotate(-45 24.147 7.853)"
                                 />
                                 <path
-                                  d="M15 2.005H17V7.005H15z"
+                                  d="M25 15H30V17H25z"
+                                />
+                                <path
+                                  d="M23.147 21.668H25.147V26.625999999999998H23.147z"
+                                  transform="rotate(-45 24.147 24.146)"
+                                />
+                                <path
+                                  d="M15 25H17V30H15z"
+                                />
+                                <path
+                                  d="M5.375 23.147H10.333V25.147H5.375z"
+                                  transform="rotate(-45 7.853 24.146)"
+                                />
+                                <path
+                                  d="M2 15H7V17H2z"
+                                />
+                                <path
+                                  d="M6.854 5.375H8.854V10.333H6.854z"
+                                  transform="rotate(-45 7.854 7.853)"
+                                />
+                                <path
+                                  d="M16,12a4,4,0,1,1-4,4,4.0045,4.0045,0,0,1,4-4m0-2a6,6,0,1,0,6,6,6,6,0,0,0-6-6Z"
                                 />
                               </svg>
                             </div>
@@ -1411,7 +1406,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         <div
           className="page-title-bar-header"
         >
-          <div>
+          <div
+            className="page-title-bar-header-left"
+          >
             <div
               className="page-title-bar-title"
             >
@@ -1425,13 +1422,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
           <div
-            style={
-              Object {
-                "flex": 1,
-              }
-            }
-          />
-          <div>
+            className="page-title-bar-header-right"
+          >
             <div
               className="extra-content"
             >
@@ -2102,36 +2094,35 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <path
-                              d="M16,12a4,4,0,1,1-4,4,4.0045,4.0045,0,0,1,4-4m0-2a6,6,0,1,0,6,6,6,6,0,0,0-6-6Z"
-                              transform="translate(0 .005)"
-                            />
-                            <path
-                              d="M6.854 5.375H8.854V10.333H6.854z"
-                              transform="rotate(-45 7.86 7.856)"
-                            />
-                            <path
-                              d="M2 15.005H7V17.005000000000003H2z"
-                            />
-                            <path
-                              d="M5.375 23.147H10.333V25.147H5.375z"
-                              transform="rotate(-45 7.86 24.149)"
-                            />
-                            <path
-                              d="M15 25.005H17V30.005H15z"
-                            />
-                            <path
-                              d="M23.147 21.668H25.147V26.625999999999998H23.147z"
-                              transform="rotate(-45 24.152 24.149)"
-                            />
-                            <path
-                              d="M25 15.005H30V17.005000000000003H25z"
+                              d="M15 2H17V7H15z"
                             />
                             <path
                               d="M21.668 6.854H26.625999999999998V8.854H21.668z"
-                              transform="rotate(-45 24.152 7.856)"
+                              transform="rotate(-45 24.147 7.853)"
                             />
                             <path
-                              d="M15 2.005H17V7.005H15z"
+                              d="M25 15H30V17H25z"
+                            />
+                            <path
+                              d="M23.147 21.668H25.147V26.625999999999998H23.147z"
+                              transform="rotate(-45 24.147 24.146)"
+                            />
+                            <path
+                              d="M15 25H17V30H15z"
+                            />
+                            <path
+                              d="M5.375 23.147H10.333V25.147H5.375z"
+                              transform="rotate(-45 7.853 24.146)"
+                            />
+                            <path
+                              d="M2 15H7V17H2z"
+                            />
+                            <path
+                              d="M6.854 5.375H8.854V10.333H6.854z"
+                              transform="rotate(-45 7.854 7.853)"
+                            />
+                            <path
+                              d="M16,12a4,4,0,1,1-4,4,4.0045,4.0045,0,0,1,4-4m0-2a6,6,0,1,0,6,6,6,6,0,0,0-6-6Z"
                             />
                           </svg>
                         </div>
@@ -2306,36 +2297,35 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <path
-                              d="M16,12a4,4,0,1,1-4,4,4.0045,4.0045,0,0,1,4-4m0-2a6,6,0,1,0,6,6,6,6,0,0,0-6-6Z"
-                              transform="translate(0 .005)"
-                            />
-                            <path
-                              d="M6.854 5.375H8.854V10.333H6.854z"
-                              transform="rotate(-45 7.86 7.856)"
-                            />
-                            <path
-                              d="M2 15.005H7V17.005000000000003H2z"
-                            />
-                            <path
-                              d="M5.375 23.147H10.333V25.147H5.375z"
-                              transform="rotate(-45 7.86 24.149)"
-                            />
-                            <path
-                              d="M15 25.005H17V30.005H15z"
-                            />
-                            <path
-                              d="M23.147 21.668H25.147V26.625999999999998H23.147z"
-                              transform="rotate(-45 24.152 24.149)"
-                            />
-                            <path
-                              d="M25 15.005H30V17.005000000000003H25z"
+                              d="M15 2H17V7H15z"
                             />
                             <path
                               d="M21.668 6.854H26.625999999999998V8.854H21.668z"
-                              transform="rotate(-45 24.152 7.856)"
+                              transform="rotate(-45 24.147 7.853)"
                             />
                             <path
-                              d="M15 2.005H17V7.005H15z"
+                              d="M25 15H30V17H25z"
+                            />
+                            <path
+                              d="M23.147 21.668H25.147V26.625999999999998H23.147z"
+                              transform="rotate(-45 24.147 24.146)"
+                            />
+                            <path
+                              d="M15 25H17V30H15z"
+                            />
+                            <path
+                              d="M5.375 23.147H10.333V25.147H5.375z"
+                              transform="rotate(-45 7.853 24.146)"
+                            />
+                            <path
+                              d="M2 15H7V17H2z"
+                            />
+                            <path
+                              d="M6.854 5.375H8.854V10.333H6.854z"
+                              transform="rotate(-45 7.854 7.853)"
+                            />
+                            <path
+                              d="M16,12a4,4,0,1,1-4,4,4.0045,4.0045,0,0,1,4-4m0-2a6,6,0,1,0,6,6,6,6,0,0,0-6-6Z"
                             />
                           </svg>
                         </div>
@@ -2903,36 +2893,35 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
-                                d="M16,12a4,4,0,1,1-4,4,4.0045,4.0045,0,0,1,4-4m0-2a6,6,0,1,0,6,6,6,6,0,0,0-6-6Z"
-                                transform="translate(0 .005)"
-                              />
-                              <path
-                                d="M6.854 5.375H8.854V10.333H6.854z"
-                                transform="rotate(-45 7.86 7.856)"
-                              />
-                              <path
-                                d="M2 15.005H7V17.005000000000003H2z"
-                              />
-                              <path
-                                d="M5.375 23.147H10.333V25.147H5.375z"
-                                transform="rotate(-45 7.86 24.149)"
-                              />
-                              <path
-                                d="M15 25.005H17V30.005H15z"
-                              />
-                              <path
-                                d="M23.147 21.668H25.147V26.625999999999998H23.147z"
-                                transform="rotate(-45 24.152 24.149)"
-                              />
-                              <path
-                                d="M25 15.005H30V17.005000000000003H25z"
+                                d="M15 2H17V7H15z"
                               />
                               <path
                                 d="M21.668 6.854H26.625999999999998V8.854H21.668z"
-                                transform="rotate(-45 24.152 7.856)"
+                                transform="rotate(-45 24.147 7.853)"
                               />
                               <path
-                                d="M15 2.005H17V7.005H15z"
+                                d="M25 15H30V17H25z"
+                              />
+                              <path
+                                d="M23.147 21.668H25.147V26.625999999999998H23.147z"
+                                transform="rotate(-45 24.147 24.146)"
+                              />
+                              <path
+                                d="M15 25H17V30H15z"
+                              />
+                              <path
+                                d="M5.375 23.147H10.333V25.147H5.375z"
+                                transform="rotate(-45 7.853 24.146)"
+                              />
+                              <path
+                                d="M2 15H7V17H2z"
+                              />
+                              <path
+                                d="M6.854 5.375H8.854V10.333H6.854z"
+                                transform="rotate(-45 7.854 7.853)"
+                              />
+                              <path
+                                d="M16,12a4,4,0,1,1-4,4,4.0045,4.0045,0,0,1,4-4m0-2a6,6,0,1,0,6,6,6,6,0,0,0-6-6Z"
                               />
                             </svg>
                           </div>
@@ -3107,36 +3096,35 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
-                                d="M16,12a4,4,0,1,1-4,4,4.0045,4.0045,0,0,1,4-4m0-2a6,6,0,1,0,6,6,6,6,0,0,0-6-6Z"
-                                transform="translate(0 .005)"
-                              />
-                              <path
-                                d="M6.854 5.375H8.854V10.333H6.854z"
-                                transform="rotate(-45 7.86 7.856)"
-                              />
-                              <path
-                                d="M2 15.005H7V17.005000000000003H2z"
-                              />
-                              <path
-                                d="M5.375 23.147H10.333V25.147H5.375z"
-                                transform="rotate(-45 7.86 24.149)"
-                              />
-                              <path
-                                d="M15 25.005H17V30.005H15z"
-                              />
-                              <path
-                                d="M23.147 21.668H25.147V26.625999999999998H23.147z"
-                                transform="rotate(-45 24.152 24.149)"
-                              />
-                              <path
-                                d="M25 15.005H30V17.005000000000003H25z"
+                                d="M15 2H17V7H15z"
                               />
                               <path
                                 d="M21.668 6.854H26.625999999999998V8.854H21.668z"
-                                transform="rotate(-45 24.152 7.856)"
+                                transform="rotate(-45 24.147 7.853)"
                               />
                               <path
-                                d="M15 2.005H17V7.005H15z"
+                                d="M25 15H30V17H25z"
+                              />
+                              <path
+                                d="M23.147 21.668H25.147V26.625999999999998H23.147z"
+                                transform="rotate(-45 24.147 24.146)"
+                              />
+                              <path
+                                d="M15 25H17V30H15z"
+                              />
+                              <path
+                                d="M5.375 23.147H10.333V25.147H5.375z"
+                                transform="rotate(-45 7.853 24.146)"
+                              />
+                              <path
+                                d="M2 15H7V17H2z"
+                              />
+                              <path
+                                d="M6.854 5.375H8.854V10.333H6.854z"
+                                transform="rotate(-45 7.854 7.853)"
+                              />
+                              <path
+                                d="M16,12a4,4,0,1,1-4,4,4.0045,4.0045,0,0,1,4-4m0-2a6,6,0,1,0,6,6,6,6,0,0,0-6-6Z"
                               />
                             </svg>
                           </div>

--- a/src/components/WizardInline/__snapshots__/WizardInline.story.storyshot
+++ b/src/components/WizardInline/__snapshots__/WizardInline.story.storyshot
@@ -25,7 +25,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Wizar
           <div
             className="page-title-bar-header"
           >
-            <div>
+            <div
+              className="page-title-bar-header-left"
+            >
               <div
                 className="page-title-bar-title"
               >
@@ -44,13 +46,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Wizar
               </p>
             </div>
             <div
-              style={
-                Object {
-                  "flex": 1,
-                }
-              }
-            />
-            <div>
+              className="page-title-bar-header-right"
+            >
               <button
                 className="bx--modal-close iot--btn bx--btn bx--btn--primary"
                 disabled={false}
@@ -452,7 +449,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Wizar
           <div
             className="page-title-bar-header"
           >
-            <div>
+            <div
+              className="page-title-bar-header-left"
+            >
               <div
                 className="page-title-bar-title"
               >
@@ -466,13 +465,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Wizar
               </div>
             </div>
             <div
-              style={
-                Object {
-                  "flex": 1,
-                }
-              }
-            />
-            <div>
+              className="page-title-bar-header-right"
+            >
               <button
                 className="bx--modal-close iot--btn bx--btn bx--btn--primary"
                 disabled={false}
@@ -853,7 +847,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Wizar
           <div
             className="page-title-bar-header"
           >
-            <div>
+            <div
+              className="page-title-bar-header-left"
+            >
               <div
                 className="page-title-bar-title"
               >
@@ -867,13 +863,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Wizar
               </div>
             </div>
             <div
-              style={
-                Object {
-                  "flex": 1,
-                }
-              }
-            />
-            <div>
+              className="page-title-bar-header-right"
+            >
               <button
                 className="bx--modal-close iot--btn bx--btn bx--btn--primary"
                 disabled={false}
@@ -1253,7 +1244,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Wizar
           <div
             className="page-title-bar-header"
           >
-            <div>
+            <div
+              className="page-title-bar-header-left"
+            >
               <div
                 className="page-title-bar-title"
               >
@@ -1267,13 +1260,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Wizar
               </div>
             </div>
             <div
-              style={
-                Object {
-                  "flex": 1,
-                }
-              }
-            />
-            <div>
+              className="page-title-bar-header-right"
+            >
               <button
                 className="bx--modal-close iot--btn bx--btn bx--btn--primary"
                 disabled={false}
@@ -1666,7 +1654,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Wizar
           <div
             className="page-title-bar-header"
           >
-            <div>
+            <div
+              className="page-title-bar-header-left"
+            >
               <div
                 className="page-title-bar-title"
               >
@@ -1680,13 +1670,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Wizar
               </div>
             </div>
             <div
-              style={
-                Object {
-                  "flex": 1,
-                }
-              }
-            />
-            <div>
+              className="page-title-bar-header-right"
+            >
               <button
                 className="bx--modal-close iot--btn bx--btn bx--btn--primary"
                 disabled={false}
@@ -2067,7 +2052,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Wizar
           <div
             className="page-title-bar-header"
           >
-            <div>
+            <div
+              className="page-title-bar-header-left"
+            >
               <div
                 className="page-title-bar-title"
               >
@@ -2081,13 +2068,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Wizar
               </div>
             </div>
             <div
-              style={
-                Object {
-                  "flex": 1,
-                }
-              }
-            />
-            <div>
+              className="page-title-bar-header-right"
+            >
               <button
                 className="bx--modal-close iot--btn bx--btn bx--btn--primary"
                 disabled={false}


### PR DESCRIPTION
Closes #1661 

**Summary**

- As part of the new DashboardEditor, a new design spec has been created for the header (PageTitleBar). This PR updates the styling to match those new specs

**Change List (commits, features, bugs, etc)**

- Updated styles to match spec
- Updated story to match a common DashboardEditor header
- Changed a deprecated icon in the TileGallery stories to a similar valid icon to remove warning in console

**Acceptance Test (how to verify the PR)**

- Go to each PageTitleBar story and ensure they match the specified design seen in the above issue
