### PR TITLE
fix(datetimepicker): fix setting absolute value

### DIFF
--- a/src/components/DateTimePicker/DateTimePicker.jsx
+++ b/src/components/DateTimePicker/DateTimePicker.jsx
@@ -361,15 +361,21 @@ const DateTimePicker = ({
           startDate.minutes(value.absolute.startTime.split(':')[1]);
         }
         returnValue.absolute.start = new Date(startDate.valueOf());
-        const endDate = moment(value.absolute.end);
-        if (value.absolute.endTime) {
-          endDate.hours(value.absolute.endTime.split(':')[0]);
-          endDate.minutes(value.absolute.endTime.split(':')[1]);
+        if (value.absolute.end) {
+          const endDate = moment(value.absolute.end);
+          if (value.absolute.endTime) {
+            endDate.hours(value.absolute.endTime.split(':')[0]);
+            endDate.minutes(value.absolute.endTime.split(':')[1]);
+          }
+          returnValue.absolute.end = new Date(endDate.valueOf());
+          readableValue = `${moment(startDate).format(dateTimeMask)} ${strings.toLabel} ${moment(
+            endDate
+          ).format(dateTimeMask)}`;
+        } else {
+          readableValue = `${moment(startDate).format(dateTimeMask)} ${strings.toLabel} ${moment(
+            startDate
+          ).format(dateTimeMask)}`;
         }
-        returnValue.absolute.end = new Date(endDate.valueOf());
-        readableValue = `${moment(startDate).format(dateTimeMask)} ${strings.toLabel} ${moment(
-          endDate
-        ).format(dateTimeMask)}`;
         break;
       }
       default:
@@ -442,15 +448,19 @@ const DateTimePicker = ({
   );
 
   const onDatePickerChange = range => {
-    if (range.length > 1) {
+    const newAbsolute = { ...absoluteValue };
+
+    if (range[1]) {
       setFocusOnFirstField(!focusOnFirstField);
+      newAbsolute.start = range[0]; // eslint-disable-line prefer-destructuring
+      newAbsolute.startDate = moment(newAbsolute.start).format('MM/DD/YYYY');
+      newAbsolute.end = range[1]; // eslint-disable-line prefer-destructuring
+      newAbsolute.endDate = moment(newAbsolute.end).format('MM/DD/YYYY');
     }
 
-    const newAbsolute = { ...absoluteValue };
-    [newAbsolute.start] = range;
+    newAbsolute.start = range[0]; // eslint-disable-line prefer-destructuring
     newAbsolute.startDate = moment(newAbsolute.start).format('MM/DD/YYYY');
-    newAbsolute.end = range[range.length - 1];
-    newAbsolute.endDate = moment(newAbsolute.end).format('MM/DD/YYYY');
+
     setAbsoluteValue(newAbsolute);
   };
 


### PR DESCRIPTION
Closes #1592 

**Summary**

Somewhere along the line we lost the ability to add an absolute value. This PR fixes this regression. 

**Change List (commits, features, bugs, etc)**

- Change in DateTimePicker.jsx

**Acceptance Test (how to verify the PR)**

- go to default story and click on custom. choose absolute and pick a date range. You will see the date range update. 
