### PR TITLE
fix(table): auto select the select all checkbox

### DIFF
--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -241,7 +241,7 @@ export const defaultProps = baseProps => ({
     },
     table: {
       expandedIds: [],
-      isSelectAllSelected: false,
+      isSelectAllSelected: undefined,
       selectedIds: [],
       rowActions: [],
       sort: {},
@@ -432,6 +432,18 @@ const Table = props => {
   const rowEditMode = view.toolbar.activeBar === 'rowEdit';
   const singleRowEditMode = !!view.table.rowActions.find(action => action.isEditMode);
 
+  const allRowsAreSelected = view.table.selectedIds.length === visibleData.length;
+  const someRowsAreSelected = view.table.selectedIds.length > 0 && !allRowsAreSelected;
+
+  const noSelectAllProp = view.table.isSelectAllSelected === undefined;
+  const isSelectAllSelected = noSelectAllProp ? allRowsAreSelected : view.table.isSelectAllSelected;
+
+  const noIndeterminateProp = view.table.isSelectAllIndeterminate === undefined;
+  const isSelectAllIndeterminate =
+    noIndeterminateProp && noSelectAllProp
+      ? someRowsAreSelected
+      : view.table.isSelectAllIndeterminate;
+
   return (
     <TableContainer
       style={style}
@@ -569,10 +581,7 @@ const Table = props => {
               activeBar: view.toolbar.activeBar,
               filters: view.filters,
               ...view.table,
-              selection: {
-                isSelectAllSelected: view.table.isSelectAllSelected,
-                isSelectAllIndeterminate: view.table.isSelectAllIndeterminate,
-              },
+              selection: { isSelectAllSelected, isSelectAllIndeterminate },
             }}
             hasFastFilter={options?.hasFilter === 'onKeyPress'}
           />

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -2213,39 +2213,48 @@ storiesOf('Watson IoT/Table', module)
       },
     }
   )
-  .add('with multi select and batch actions', () => (
-    <StatefulTable
-      id="table"
-      secondaryTitle={text('Secondary Title', `Row count: ${initialState.data.length}`)}
-      columns={tableColumns}
-      data={tableData}
-      actions={actions}
-      options={{
-        hasFilter: true,
-        hasPagination: true,
-        hasRowSelection: 'multi',
-      }}
-      view={{
-        filters: [],
-        toolbar: {
-          batchActions: [
-            {
-              id: 'delete',
-              labelText: 'Delete',
-              renderIcon: TrashCan16,
-              iconDescription: 'Delete Item',
-            },
-          ],
-        },
-        table: {
-          ordering: defaultOrdering,
-          isSelectAllSelected: false,
-          isSelectAllIndeterminate: true,
-          selectedIds: ['row-3', 'row-4', 'row-6', 'row-7'],
-        },
-      }}
-    />
-  ))
+  .add('with multi select and batch actions', () => {
+    const selectedTableType = select('Type of Table', ['Table', 'StatefulTable'], 'StatefulTable');
+    const MyTable = selectedTableType === 'StatefulTable' ? StatefulTable : Table;
+
+    return (
+      <MyTable
+        id="table"
+        secondaryTitle={text('Secondary Title', `Row count: ${initialState.data.length}`)}
+        columns={tableColumns}
+        data={tableData.slice(0, 10)}
+        actions={actions}
+        options={{
+          hasFilter: true,
+          hasPagination: true,
+          hasRowSelection: 'multi',
+        }}
+        view={{
+          filters: [],
+          toolbar: {
+            batchActions: [
+              {
+                id: 'delete',
+                labelText: 'Delete',
+                renderIcon: TrashCan16,
+                iconDescription: 'Delete Item',
+              },
+            ],
+          },
+          table: {
+            ordering: defaultOrdering,
+            isSelectAllSelected: select('isSelectAllSelected', [undefined, true, false], undefined),
+            isSelectAllIndeterminate: select(
+              'isSelectAllIndeterminate',
+              [undefined, true, false],
+              undefined
+            ),
+            selectedIds: array('selectedIds', ['row-3', 'row-4', 'row-6', 'row-7']),
+          },
+        }}
+      />
+    );
+  })
   .add('with single select', () => (
     <Table
       id="table"

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -1148,4 +1148,159 @@ describe('Table', () => {
 
     expect(screen.queryAllByTestId('table-head--overflow').length).toBe(5);
   });
+
+  it('automatically checks "select all" if all rows are selected', () => {
+    const rows = tableData.slice(0, 5);
+    const selectedIds = rows.map(row => row.id);
+    const { rerender } = render(
+      <Table
+        id="tableid1"
+        columns={tableColumns}
+        data={rows}
+        options={{ hasRowSelection: 'multi' }}
+        view={{
+          table: { selectedIds },
+        }}
+      />
+    );
+
+    const selectAllCheckbox = screen.getByLabelText('Select all items');
+    expect(selectAllCheckbox).toBeInTheDocument();
+    expect(selectAllCheckbox).toHaveProperty('checked', true);
+
+    rerender(
+      <Table
+        id="tableid2"
+        columns={tableColumns}
+        data={rows}
+        options={{ hasRowSelection: 'multi' }}
+        view={{
+          table: { selectedIds: selectedIds.slice(1, 5) },
+        }}
+      />
+    );
+    expect(screen.getByLabelText('Select all items')).toHaveProperty('checked', false);
+  });
+
+  it('overrides automatic "select all" check if "isSelectAllSelected" is used', () => {
+    const rows = tableData.slice(0, 5);
+    const selectedIds = rows.map(row => row.id);
+    const { rerender } = render(
+      <Table
+        id="tableid1"
+        columns={tableColumns}
+        data={rows}
+        options={{ hasRowSelection: 'multi' }}
+        view={{
+          table: { selectedIds: selectedIds.slice(1, 5), isSelectAllSelected: true },
+        }}
+      />
+    );
+
+    const selectAllCheckbox = screen.getByLabelText('Select all items');
+    expect(selectAllCheckbox).toBeInTheDocument();
+    expect(selectAllCheckbox).toHaveProperty('checked', true);
+
+    rerender(
+      <Table
+        id="tableid2"
+        columns={tableColumns}
+        data={rows}
+        options={{ hasRowSelection: 'multi' }}
+        view={{
+          table: { selectedIds, isSelectAllSelected: false },
+        }}
+      />
+    );
+    expect(screen.getByLabelText('Select all items')).toHaveProperty('checked', false);
+  });
+
+  it('automatically marks "select all" as Indeterminate if some but not all rows are selected', () => {
+    const rows = tableData.slice(0, 5);
+    const selectedIds = rows.map(row => row.id);
+    const { rerender } = render(
+      <Table
+        id="tableid1"
+        columns={tableColumns}
+        data={rows}
+        options={{ hasRowSelection: 'multi' }}
+        view={{
+          table: { selectedIds: selectedIds.slice(1, 5) },
+        }}
+      />
+    );
+
+    const selectAllCheckbox = screen.getByLabelText('Select all items');
+    expect(selectAllCheckbox).toBeInTheDocument();
+    expect(selectAllCheckbox).toHaveProperty('indeterminate', true);
+
+    rerender(
+      <Table
+        id="tableid2"
+        columns={tableColumns}
+        data={rows}
+        options={{ hasRowSelection: 'multi' }}
+        view={{
+          table: { selectedIds },
+        }}
+      />
+    );
+    expect(screen.getByLabelText('Select all items')).toHaveProperty('indeterminate', false);
+  });
+
+  it('overrides automatically indeterminate state for "select all" if "isSelectAllSelected" or "isSelectAllIndeterminate" is used', () => {
+    const rows = tableData.slice(0, 5);
+    const selectedIds = rows.map(row => row.id);
+    const selectionThatWouldCauseAnIndeterminateState = selectedIds.slice(1, 5);
+    const { rerender } = render(
+      <Table
+        id="tableid1"
+        columns={tableColumns}
+        data={rows}
+        options={{ hasRowSelection: 'multi' }}
+        view={{
+          table: {
+            selectedIds: selectionThatWouldCauseAnIndeterminateState,
+            isSelectAllSelected: false,
+          },
+        }}
+      />
+    );
+
+    const selectAllCheckbox = screen.getByLabelText('Select all items');
+    expect(selectAllCheckbox).toBeInTheDocument();
+    expect(selectAllCheckbox).toHaveProperty('indeterminate', false);
+
+    rerender(
+      <Table
+        id="tableid2"
+        columns={tableColumns}
+        data={rows}
+        options={{ hasRowSelection: 'multi' }}
+        view={{
+          table: {
+            selectedIds: selectionThatWouldCauseAnIndeterminateState,
+            isSelectAllSelected: true,
+          },
+        }}
+      />
+    );
+    expect(screen.getByLabelText('Select all items')).toHaveProperty('indeterminate', false);
+
+    rerender(
+      <Table
+        id="tableid3"
+        columns={tableColumns}
+        data={rows}
+        options={{ hasRowSelection: 'multi' }}
+        view={{
+          table: {
+            selectedIds: selectionThatWouldCauseAnIndeterminateState,
+            isSelectAllIndeterminate: false,
+          },
+        }}
+      />
+    );
+    expect(screen.getByLabelText('Select all items')).toHaveProperty('indeterminate', false);
+  });
 });

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -412,7 +412,7 @@ Map {
         },
         "table": Object {
           "expandedIds": Array [],
-          "isSelectAllSelected": false,
+          "isSelectAllSelected": undefined,
           "loadingState": Object {
             "rowCount": 5,
           },


### PR DESCRIPTION
Closes #1464

**Summary**
This fix automatically checks the checkbox if all rows are selected. If some rows are selected, the checkbox gets the Indeterminate state. 

If the `view.table.isSelectAllSelected` is present as a prop then that value will be used instead and if `view.table.isSelectAllIndeterminate` is present that value will be used. See the unit tests for the exact functionality.

Like I commented in the issue itself:
I question if this really is a bug to be fixed? Since the app actually controls the view.table.isSelectAllSelected like the suggested workaround shows I'm not sure it makes sense to handle this value automatically. With this fix implemented, what is the use case of the view.table.isSelectAllSelected (and possibly view.table.isSelectAllIndeterminate) if those values are automatically calculated? So I think we should go with either

a) Don't add this fix
b) Add this fix and if we don't have a use case for overriding the automatically calculated props view.table.isSelectAllSelected and view.table.isSelectAllIndeterminate then we should probably deprecate them.
c) **CURRENT PR -** We combine view.table.isSelectAllSelected and view.table.isSelectAllIndeterminate with a default automatic behaviour like this issue describes.


**Change List (commits, features, bugs, etc)**
1. Removed the default value "false" for the view.table.isSelectAllSelected 
2. Added automatic calculation for isSelectAllSelected and isSelectAllIndeterminate
3. Added unit tests

**Acceptance Test (how to verify the PR)**
1. Go to story ?path=/story/watson-iot-table--with-multi-select-and-batch-actions
2. Select "Table" from the Type of Table knob
3. Add `row-0,row-1,row-2,row-3,row-4,row-5,row-6,row-7,row-8,row-9` to the selectedIds knob
4. Make sure the "Select all is selected"
5. Play with the combination of `isSelectAllSelected` and `isSelectAllIndeterminate` knobs to make sure they override the automatic behaviour