### PR TITLE
fix(barchartcard): add classname to top container, allow empty series prop

### DIFF
--- a/src/components/BarChartCard/BarChartCard.jsx
+++ b/src/components/BarChartCard/BarChartCard.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import SimpleBarChart from '@carbon/charts-react/bar-chart-simple';
 import StackedBarChart from '@carbon/charts-react/bar-chart-stacked';
 import GroupedBarChart from '@carbon/charts-react/bar-chart-grouped';
-import classnames from 'classnames';
+import classNames from 'classnames';
 import isEmpty from 'lodash/isEmpty';
 import memoize from 'lodash/memoize';
 
@@ -78,14 +78,16 @@ const BarChartCard = ({
   const size = increaseSmallCardSize(sizeProp, 'BarChartCard');
 
   // If editable, show sample presentation data
-  const values = isEditable
-    ? memoizedGenerateSampleValues(
-        series,
-        timeDataSourceId,
-        interval,
-        categoryDataSourceId
-      )
-    : valuesProp;
+  // If there is no series defined, there is no datasets to make sample data from
+  const values =
+    isEditable && !isEmpty(series)
+      ? memoizedGenerateSampleValues(
+          series,
+          timeDataSourceId,
+          interval,
+          categoryDataSourceId
+        )
+      : valuesProp;
 
   const chartData = formatChartData(
     series,
@@ -117,7 +119,9 @@ const BarChartCard = ({
   const uniqueDatasets = [
     ...new Set(chartData.map((dataset) => dataset.group)),
   ];
-  const colors = formatColors(series, uniqueDatasets, isEditable);
+  const colors = !isAllValuesEmpty
+    ? formatColors(series, uniqueDatasets, isEditable)
+    : null;
 
   let tableColumns = [];
   let tableData = [];
@@ -147,7 +151,7 @@ const BarChartCard = ({
   return (
     <Card
       title={title}
-      className={`${iotPrefix}--bar-chart-card`}
+      className={classNames(className, `${iotPrefix}--bar-chart-card`)}
       size={size}
       i18n={i18n}
       isExpanded={isExpanded}
@@ -158,14 +162,10 @@ const BarChartCard = ({
       {...others}>
       {!isAllValuesEmpty ? (
         <div
-          className={classnames(
-            `${iotPrefix}--bar-chart-container`,
-            {
-              [`${iotPrefix}--bar-chart-container--expanded`]: isExpanded,
-              [`${iotPrefix}--bar-chart-container--editable`]: isEditable,
-            },
-            className
-          )}>
+          className={classNames(`${iotPrefix}--bar-chart-container`, {
+            [`${iotPrefix}--bar-chart-container--expanded`]: isExpanded,
+            [`${iotPrefix}--bar-chart-container--editable`]: isEditable,
+          })}>
           <ChartComponent
             data={chartData}
             options={{
@@ -236,7 +236,7 @@ const BarChartCard = ({
               (ZOOM_BAR_ENABLED_CARD_SIZES.includes(size) || isExpanded)
                 ? {
                     zoomBar: {
-                      // [zoomBar.axes]: {    TODO: the top axes is the only one support at the moment so default to top
+                      // [zoomBar.axes]: {    TODO: the top axes is the only one supported at the moment so default to top
                       top: {
                         enabled: zoomBar.enabled,
                         initialZoomDomain: zoomBar.initialZoomDomain,
@@ -309,6 +309,7 @@ BarChartCard.defaultProps = {
   locale: 'en',
   showTimeInGMT: false,
   tooltipDateFormatPattern: 'L HH:mm:ss',
+  values: null,
 };
 
 export default BarChartCard;

--- a/src/components/BarChartCard/BarChartCard.jsx
+++ b/src/components/BarChartCard/BarChartCard.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import SimpleBarChart from '@carbon/charts-react/bar-chart-simple';
 import StackedBarChart from '@carbon/charts-react/bar-chart-stacked';
 import GroupedBarChart from '@carbon/charts-react/bar-chart-grouped';
-import classNames from 'classnames';
+import classnames from 'classnames';
 import isEmpty from 'lodash/isEmpty';
 import memoize from 'lodash/memoize';
 
@@ -151,7 +151,7 @@ const BarChartCard = ({
   return (
     <Card
       title={title}
-      className={classNames(className, `${iotPrefix}--bar-chart-card`)}
+      className={classnames(className, `${iotPrefix}--bar-chart-card`)}
       size={size}
       i18n={i18n}
       isExpanded={isExpanded}
@@ -162,7 +162,7 @@ const BarChartCard = ({
       {...others}>
       {!isAllValuesEmpty ? (
         <div
-          className={classNames(`${iotPrefix}--bar-chart-container`, {
+          className={classnames(`${iotPrefix}--bar-chart-container`, {
             [`${iotPrefix}--bar-chart-container--expanded`]: isExpanded,
             [`${iotPrefix}--bar-chart-container--editable`]: isEditable,
           })}>

--- a/src/components/BarChartCard/barChartUtils.js
+++ b/src/components/BarChartCard/barChartUtils.js
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import isNil from 'lodash/isNil';
+import isEmpty from 'lodash/isEmpty';
 import capitalize from 'lodash/capitalize';
 import cheerio from 'cheerio';
 import { blue, cyan, green, magenta, purple, red, teal } from '@carbon/colors';
@@ -104,7 +105,7 @@ export const formatChartData = (
   type
 ) => {
   const data = [];
-  if (!isNil(values)) {
+  if (!isNil(values) || !isEmpty(series)) {
     // grouped or stacked
     if (type === BAR_CHART_TYPES.GROUPED || type === BAR_CHART_TYPES.STACKED) {
       let uniqueDatasetNames;

--- a/src/components/BarChartCard/barChartUtils.test.js
+++ b/src/components/BarChartCard/barChartUtils.test.js
@@ -363,6 +363,21 @@ describe('barChartUtils', () => {
     ]);
   });
 
+  it('formatChartData returns empty array is series is empty', () => {
+    const series = [];
+    const emptyData = [];
+    // check horizontal layout
+    expect(
+      formatChartData(
+        series,
+        emptyData,
+        undefined,
+        null,
+        BAR_CHART_TYPES.SIMPLE
+      )
+    ).toEqual([]);
+  });
+
   it('formatColors returns correct format if color is string', () => {
     const series = [
       {

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -255,7 +255,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                 </div>
               </div>
               <div
-                className="iot--card iot--bar-chart-card iot--card--wrapper"
+                className="iot--card react-grid-item react-resizable-hide react-resizable iot--bar-chart-card iot--card--wrapper"
                 data-testid="Card"
                 id="barchartcard"
                 onMouseDown={[Function]}
@@ -330,7 +330,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   }
                 >
                   <div
-                    className="iot--bar-chart-container react-grid-item react-resizable-hide react-resizable"
+                    className="iot--bar-chart-container"
                   >
                     <div
                       className="chart-holder"
@@ -2582,7 +2582,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                 </div>
               </div>
               <div
-                className="iot--card iot--bar-chart-card iot--card--wrapper"
+                className="iot--card react-grid-item react-resizable-hide react-resizable iot--bar-chart-card iot--card--wrapper"
                 data-testid="Card"
                 id="barchartcard"
                 onMouseDown={[Function]}
@@ -2657,7 +2657,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   }
                 >
                   <div
-                    className="iot--bar-chart-container react-grid-item react-resizable-hide react-resizable"
+                    className="iot--bar-chart-container"
                   >
                     <div
                       className="chart-holder"
@@ -4937,7 +4937,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                 </div>
               </div>
               <div
-                className="iot--card iot--bar-chart-card iot--card--wrapper"
+                className="iot--card react-grid-item react-resizable-hide react-resizable iot--bar-chart-card iot--card--wrapper"
                 data-testid="Card"
                 id="barchartcard"
                 onMouseDown={[Function]}
@@ -5012,7 +5012,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   }
                 >
                   <div
-                    className="iot--bar-chart-container react-grid-item react-resizable-hide react-resizable"
+                    className="iot--bar-chart-container"
                   >
                     <div
                       className="chart-holder"
@@ -7074,7 +7074,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             }
           >
             <div
-              className="iot--card iot--bar-chart-card iot--card--wrapper"
+              className="iot--card react-grid-item react-resizable-hide react-resizable iot--bar-chart-card iot--card--wrapper"
               data-testid="Card"
               id="expandedcard"
               onMouseDown={[Function]}
@@ -7149,7 +7149,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                 }
               >
                 <div
-                  className="iot--bar-chart-container react-grid-item react-resizable-hide react-resizable"
+                  className="iot--bar-chart-container"
                 >
                   <div
                     className="chart-holder"
@@ -9846,7 +9846,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                 </div>
               </div>
               <div
-                className="iot--card iot--bar-chart-card iot--card--wrapper"
+                className="iot--card react-grid-item react-resizable-hide react-resizable iot--bar-chart-card iot--card--wrapper"
                 data-testid="Card"
                 id="barchartcard"
                 onMouseDown={[Function]}
@@ -9921,7 +9921,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   }
                 >
                   <div
-                    className="iot--bar-chart-container react-grid-item react-resizable-hide react-resizable"
+                    className="iot--bar-chart-container"
                   >
                     <div
                       className="chart-holder"
@@ -24576,7 +24576,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                 </div>
               </div>
               <div
-                className="iot--card iot--bar-chart-card iot--card--wrapper"
+                className="iot--card react-grid-item react-resizable-hide react-resizable iot--bar-chart-card iot--card--wrapper"
                 data-testid="Card"
                 id="barchartcard"
                 onMouseDown={[Function]}
@@ -24651,7 +24651,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   }
                 >
                   <div
-                    className="iot--bar-chart-container react-grid-item react-resizable-hide react-resizable"
+                    className="iot--bar-chart-container"
                   >
                     <div
                       className="chart-holder"

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -4511,6 +4511,7 @@ Map {
       "showTimeInGMT": false,
       "size": "MEDIUMWIDE",
       "tooltipDateFormatPattern": "L HH:mm:ss",
+      "values": null,
     },
     "propTypes": Object {
       "availableActions": Object {


### PR DESCRIPTION
Closes #1685 
Closes #1684 

**Summary**

- `className` prop is now added to the top container in BarChartCard
- If `series` is an empty array, show the empty card state
- If `values` is empty, do not generate colors, as theres nothing to add colors to

**Change List (commits, features, bugs, etc)**

- Updated tests
- Updated stories
- Added `values: null` to defaultProps to be more explicit

**Acceptance Test (how to verify the PR)**

- Add a custom className and see that its attached to the top BarChartCard container
- Set `series: []` and `isEditable: true` and see that the empty state renders
