### PR TITLE
feat(card): add onFocus, onBlur, tabIndex

### DIFF
--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -44,6 +44,9 @@ const CardWrapper = ({
   onMouseUp,
   onTouchEnd,
   onTouchStart,
+  onFocus,
+  onBlur,
+  tabIndex,
   testID,
   ...others
 }) => {
@@ -59,6 +62,9 @@ const CardWrapper = ({
       onTouchEnd={onTouchEnd}
       onTouchStart={onTouchStart}
       onScroll={onScroll}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      tabIndex={tabIndex}
       className={classnames(className, `${iotPrefix}--card--wrapper`)}
       {...validOthers}>
       {children}
@@ -111,15 +117,28 @@ CardWrapper.propTypes = {
   id: CardPropTypes.id,
   style: PropTypes.objectOf(PropTypes.string),
   testID: CardPropTypes.testID,
-  /* eslint-disable react/require-default-props */
   onMouseDown: PropTypes.func,
   onMouseUp: PropTypes.func,
   onTouchEnd: PropTypes.func,
   onTouchStart: PropTypes.func,
   onScroll: PropTypes.func,
-  /* eslint-enable react/require-default-props  */
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
+  tabIndex: PropTypes.number
 };
-CardWrapper.defaultProps = { id: undefined, style: undefined, testID: 'Card' };
+CardWrapper.defaultProps = { 
+  id: undefined, 
+  style: undefined, 
+  testID: 'Card',
+  onMouseDown: undefined,
+  onMouseUp: undefined,
+  onTouchEnd: undefined,
+  onTouchStart: undefined,
+  onScroll: undefined,
+  onFocus: undefined,
+  onBlur: undefined, 
+  tabIndex: undefined 
+};
 CardContent.propTypes = {
   children: PropTypes.node,
   dimensions: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number })
@@ -194,6 +213,9 @@ export const defaultProps = {
   onTouchEnd: undefined,
   onTouchStart: undefined,
   onScroll: undefined,
+  onFocus: undefined,
+  onBlur: undefined, 
+  tabIndex: undefined,
   testID: CardWrapper.defaultProps.testID,
 };
 

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -124,11 +124,11 @@ CardWrapper.propTypes = {
   onScroll: PropTypes.func,
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
-  tabIndex: PropTypes.number
+  tabIndex: PropTypes.number,
 };
-CardWrapper.defaultProps = { 
-  id: undefined, 
-  style: undefined, 
+CardWrapper.defaultProps = {
+  id: undefined,
+  style: undefined,
   testID: 'Card',
   onMouseDown: undefined,
   onMouseUp: undefined,
@@ -136,8 +136,8 @@ CardWrapper.defaultProps = {
   onTouchStart: undefined,
   onScroll: undefined,
   onFocus: undefined,
-  onBlur: undefined, 
-  tabIndex: undefined 
+  onBlur: undefined,
+  tabIndex: undefined,
 };
 CardContent.propTypes = {
   children: PropTypes.node,
@@ -214,7 +214,7 @@ export const defaultProps = {
   onTouchStart: undefined,
   onScroll: undefined,
   onFocus: undefined,
-  onBlur: undefined, 
+  onBlur: undefined,
   tabIndex: undefined,
   testID: CardWrapper.defaultProps.testID,
 };

--- a/src/components/Card/Card.story.jsx
+++ b/src/components/Card/Card.story.jsx
@@ -46,7 +46,7 @@ storiesOf('Watson IoT/Card', module)
           breakpoint="lg"
           availableActions={{ range: true, expand: true }}
           onCardAction={action('onCardAction')}
-          onFocus={() => console.log('onFocus')}
+          onFocus={action('onFocus')}
           onBlur={() => console.log('onBlur')}
           tabIndex={0}
         />

--- a/src/components/Card/Card.story.jsx
+++ b/src/components/Card/Card.story.jsx
@@ -46,6 +46,9 @@ storiesOf('Watson IoT/Card', module)
           breakpoint="lg"
           availableActions={{ range: true, expand: true }}
           onCardAction={action('onCardAction')}
+          onFocus={action('onFocus')}
+          onBlur={action('onBlur')}
+          tabIndex={0}
         />
       </div>
     );

--- a/src/components/Card/Card.story.jsx
+++ b/src/components/Card/Card.story.jsx
@@ -47,7 +47,7 @@ storiesOf('Watson IoT/Card', module)
           availableActions={{ range: true, expand: true }}
           onCardAction={action('onCardAction')}
           onFocus={action('onFocus')}
-          onBlur={() => console.log('onBlur')}
+          onBlur={action('onBlur')}
           tabIndex={0}
         />
       </div>

--- a/src/components/Card/Card.story.jsx
+++ b/src/components/Card/Card.story.jsx
@@ -46,8 +46,8 @@ storiesOf('Watson IoT/Card', module)
           breakpoint="lg"
           availableActions={{ range: true, expand: true }}
           onCardAction={action('onCardAction')}
-          onFocus={action('onFocus')}
-          onBlur={action('onBlur')}
+          onFocus={() => console.log('onFocus')}
+          onBlur={() => console.log('onBlur')}
           tabIndex={0}
         />
       </div>

--- a/src/components/Card/__snapshots__/Card.story.storyshot
+++ b/src/components/Card/__snapshots__/Card.story.storyshot
@@ -24,12 +24,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Card 
         className="iot--card iot--card--wrapper"
         data-testid="Card"
         id="facilitycard-basic"
+        onBlur={[Function]}
+        onFocus={[Function]}
         role="presentation"
         style={
           Object {
             "--card-default-height": "304px",
           }
         }
+        tabIndex={0}
       >
         <div
           className="iot--card--header"

--- a/src/constants/CardPropTypes.js
+++ b/src/constants/CardPropTypes.js
@@ -573,6 +573,11 @@ export const CardPropTypes = {
   onTouchEnd: PropTypes.func,
   onTouchStart: PropTypes.func,
   onScroll: PropTypes.func,
+  /** Optional event handlers */
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
+  /** Optionally adds tab index to card container */
+  tabIndex: PropTypes.number,
   /** For testing */
   testID: PropTypes.string,
   /** the locale of the card, needed for number and date formatting */

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -5184,6 +5184,12 @@ Map {
       "locale": Object {
         "type": "string",
       },
+      "onBlur": Object {
+        "type": "func",
+      },
+      "onFocus": Object {
+        "type": "func",
+      },
       "onMouseDown": Object {
         "type": "func",
       },
@@ -5239,6 +5245,9 @@ Map {
         "type": "bool",
       },
       "size": [Function],
+      "tabIndex": Object {
+        "type": "number",
+      },
       "testID": Object {
         "type": "string",
       },
@@ -8295,6 +8304,8 @@ Map {
       "isLazyLoading": false,
       "isLoading": false,
       "layout": "HORIZONTAL",
+      "onBlur": undefined,
+      "onFocus": undefined,
       "onMouseDown": undefined,
       "onMouseUp": undefined,
       "onScroll": undefined,
@@ -8310,6 +8321,7 @@ Map {
         "xs": 144,
       },
       "size": "MEDIUM",
+      "tabIndex": undefined,
       "testID": "Card",
       "timeRange": undefined,
       "title": undefined,
@@ -8930,6 +8942,12 @@ Map {
       "locale": Object {
         "type": "string",
       },
+      "onBlur": Object {
+        "type": "func",
+      },
+      "onFocus": Object {
+        "type": "func",
+      },
       "onMouseDown": Object {
         "type": "func",
       },
@@ -9000,6 +9018,9 @@ Map {
           ],
         ],
         "type": "oneOf",
+      },
+      "tabIndex": Object {
+        "type": "number",
       },
       "testID": Object {
         "type": "string",
@@ -9669,6 +9690,12 @@ Map {
       "locale": Object {
         "type": "string",
       },
+      "onBlur": Object {
+        "type": "func",
+      },
+      "onFocus": Object {
+        "type": "func",
+      },
       "onMouseDown": Object {
         "type": "func",
       },
@@ -9815,6 +9842,9 @@ Map {
           ],
         ],
         "type": "oneOf",
+      },
+      "tabIndex": Object {
+        "type": "number",
       },
       "testID": Object {
         "type": "string",
@@ -10659,6 +10689,12 @@ Map {
       "locale": Object {
         "type": "string",
       },
+      "onBlur": Object {
+        "type": "func",
+      },
+      "onFocus": Object {
+        "type": "func",
+      },
       "onMouseDown": Object {
         "type": "func",
       },
@@ -10729,6 +10765,9 @@ Map {
           ],
         ],
         "type": "oneOf",
+      },
+      "tabIndex": Object {
+        "type": "number",
       },
       "testID": Object {
         "type": "string",
@@ -11517,6 +11556,12 @@ Map {
       "locale": Object {
         "type": "string",
       },
+      "onBlur": Object {
+        "type": "func",
+      },
+      "onFocus": Object {
+        "type": "func",
+      },
       "onMouseDown": Object {
         "type": "func",
       },
@@ -11590,6 +11635,9 @@ Map {
           ],
         ],
         "type": "oneOf",
+      },
+      "tabIndex": Object {
+        "type": "number",
       },
       "testID": Object {
         "type": "string",
@@ -12279,6 +12327,12 @@ Map {
       "locale": Object {
         "type": "string",
       },
+      "onBlur": Object {
+        "type": "func",
+      },
+      "onFocus": Object {
+        "type": "func",
+      },
       "onMouseDown": Object {
         "type": "func",
       },
@@ -12349,6 +12403,9 @@ Map {
           ],
         ],
         "type": "oneOf",
+      },
+      "tabIndex": Object {
+        "type": "number",
       },
       "testID": Object {
         "type": "string",
@@ -13148,6 +13205,12 @@ Map {
       "locale": Object {
         "type": "string",
       },
+      "onBlur": Object {
+        "type": "func",
+      },
+      "onFocus": Object {
+        "type": "func",
+      },
       "onMouseDown": Object {
         "type": "func",
       },
@@ -13207,6 +13270,9 @@ Map {
           ],
         ],
         "type": "oneOf",
+      },
+      "tabIndex": Object {
+        "type": "number",
       },
       "testID": Object {
         "type": "string",
@@ -14055,6 +14121,12 @@ Map {
       "locale": Object {
         "type": "string",
       },
+      "onBlur": Object {
+        "type": "func",
+      },
+      "onFocus": Object {
+        "type": "func",
+      },
       "onMouseDown": Object {
         "type": "func",
       },
@@ -14125,6 +14197,9 @@ Map {
           ],
         ],
         "type": "oneOf",
+      },
+      "tabIndex": Object {
+        "type": "number",
       },
       "testID": Object {
         "type": "string",
@@ -14863,6 +14938,12 @@ Map {
       "locale": Object {
         "type": "string",
       },
+      "onBlur": Object {
+        "type": "func",
+      },
+      "onFocus": Object {
+        "type": "func",
+      },
       "onMouseDown": Object {
         "type": "func",
       },
@@ -14933,6 +15014,9 @@ Map {
           ],
         ],
         "type": "oneOf",
+      },
+      "tabIndex": Object {
+        "type": "number",
       },
       "testID": Object {
         "type": "string",


### PR DESCRIPTION
Closes #1687

**Summary**

- `onFocus`, `onBlur`, `tabIndex` are now attached to the CardWrapper div for event handling

**Change List (commits, features, bugs, etc)**

- Added each to the CardWrapper
- Added each to the propTypes

**Acceptance Test (how to verify the PR)**

- Go to Card - basic story and attempt to 'tab' into the Card wrapper. See that `onFocus` is fired when focused. Tab out of the Card wrapper, and see the `onBlur` is fired
