### PR TITLE
fix(tablecard): remove invalid SCSS code

### DIFF
--- a/src/components/TableCard/_table-card.scss
+++ b/src/components/TableCard/_table-card.scss
@@ -1,6 +1,6 @@
 @import '../../globals/vars';
 
-.#{$iot-prefix}--table-card--overflow-menu & {
+.#{$iot-prefix}--table-card--overflow-menu {
   margin-left: $spacing-03;
   opacity: 1;
   overflow-y: hidden;


### PR DESCRIPTION
Closes #1714 

**Summary**

- Table card has some invalid scss code that breaks dart sass on downstream compile

**Change List (commits, features, bugs, etc)**

- Remove the parent selector

**Acceptance Test (how to verify the PR)**

- Verify the overflow menu in the table card still works successfully
