### PR TITLE
feat(dashboardgrid): allow resizing by dragging the border

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,11 +13,16 @@ module.exports = {
       functions: 80,
       lines: 80,
     },
-    './src/components/**/!(ColumnHeaderSelect|FilterHeaderRow|TableToolbar|RowActionsCell|RowActionsError|StatefulTable|StatefulTableDetailWizard|CatalogContent|FileDrop|HeaderMenu|Dashboard|CardRenderer|Attribute|UnitRenderer|ImageHotspots|ImageControls|PageHero|PageTitle|EditPage|AsyncTable|ImageCard|WizardHeader|TableHead|ColumnResize|DateTimePicker|TimeSeriesCard|BarChartCard).jsx': {
+    './src/components/**/!(ColumnHeaderSelect|FilterHeaderRow|TableToolbar|RowActionsCell|RowActionsError|StatefulTable|StatefulTableDetailWizard|CatalogContent|FileDrop|HeaderMenu|Dashboard|CardRenderer|Attribute|UnitRenderer|ImageHotspots|ImageControls|PageHero|PageTitle|EditPage|AsyncTable|ImageCard|WizardHeader|TableHead|ColumnResize|DateTimePicker|TimeSeriesCard|BarChartCard|DashboardGrid).jsx': {
       statements: 80,
       branches: 80,
       functions: 80,
       lines: 80,
+    },
+    './src/components/Dashboard/DashboardGrid.jsx': {
+      statements: 74,
+      branches: 61,
+      lines: 74,
     },
     './src/components/BarChartCard/BarChartCard.jsx': {
       // TODO: Add tests for tooltip interaction and formatting when below issue is solved

--- a/jest.config.js
+++ b/jest.config.js
@@ -20,9 +20,9 @@ module.exports = {
       lines: 80,
     },
     './src/components/Dashboard/DashboardGrid.jsx': {
-      statements: 74,
+      statements: 73,
       branches: 61,
-      lines: 74,
+      lines: 73,
     },
     './src/components/BarChartCard/BarChartCard.jsx': {
       // TODO: Add tests for tooltip interaction and formatting when below issue is solved

--- a/src/components/BarChartCard/BarChartCard.jsx
+++ b/src/components/BarChartCard/BarChartCard.jsx
@@ -20,6 +20,7 @@ import Card from '../Card/Card';
 import { settings } from '../../constants/Settings';
 import {
   chartValueFormatter,
+  getResizeHandles,
   handleCardVariables,
   increaseSmallCardSize,
 } from '../../utils/cardUtilityFunctions';
@@ -43,6 +44,7 @@ const memoizedGenerateSampleValues = memoize(generateSampleValues);
 const BarChartCard = ({
   title: titleProp,
   content,
+  children,
   size: sizeProp,
   values: initialValues,
   locale,
@@ -51,6 +53,7 @@ const BarChartCard = ({
   isLazyLoading,
   isEditable,
   isLoading,
+  isResizable,
   interval,
   className,
   domainRange,
@@ -76,6 +79,8 @@ const BarChartCard = ({
   } = handleCardVariables(titleProp, content, initialValues, others);
 
   const size = increaseSmallCardSize(sizeProp, 'BarChartCard');
+
+  const resizeHandles = isResizable ? getResizeHandles(children) : [];
 
   // If editable, show sample presentation data
   // If there is no series defined, there is no datasets to make sample data from
@@ -159,6 +164,8 @@ const BarChartCard = ({
       isLazyLoading={isLazyLoading}
       isEditable={isEditable}
       isLoading={isLoading}
+      isResizable={isResizable}
+      resizeHandles={resizeHandles}
       {...others}>
       {!isAllValuesEmpty ? (
         <div

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -22,7 +22,10 @@ import {
   getCardMinSize,
   filterValidAttributes,
 } from '../../utils/componentUtilityFunctions';
-import { getUpdatedCardSize } from '../../utils/cardUtilityFunctions';
+import {
+  getUpdatedCardSize,
+  useCardResizing,
+} from '../../utils/cardUtilityFunctions';
 
 import CardToolbar from './CardToolbar';
 
@@ -232,6 +235,8 @@ const Card = (props) => {
     isEditable,
     isExpanded,
     isLazyLoading,
+    isResizable,
+    resizeHandles: wrappingCardResizeHandles,
     error,
     hideHeader,
     id,
@@ -312,6 +317,12 @@ const Card = (props) => {
     }
   });
 
+  const { resizeHandles, isResizing } = useCardResizing(
+    wrappingCardResizeHandles,
+    children,
+    isResizable
+  );
+
   const card = (
     <VisibilitySensor partialVisibility offset={{ top: 10 }}>
       {({ isVisible }) => (
@@ -347,7 +358,9 @@ const Card = (props) => {
                         width: 'calc(100% - 50px)',
                       }
                 }
-                className={classnames(`${iotPrefix}--card`, className)}>
+                className={classnames(`${iotPrefix}--card`, className, {
+                  [`${iotPrefix}--card--resizing`]: isResizing,
+                })}>
                 {!hideHeader && (
                   <CardHeader>
                     <CardTitle title={title}>
@@ -419,6 +432,7 @@ const Card = (props) => {
                     children
                   )}
                 </CardContent>
+                {resizeHandles}
               </CardWrapper>
             );
           }}

--- a/src/components/Card/_card.scss
+++ b/src/components/Card/_card.scss
@@ -15,7 +15,7 @@ $iot-header-padding: $spacing-05;
 }
 
 .#{$iot-prefix}--card--resizing {
-  border: $spacing-01 solid $interactive-04;
+  border: $spacing-01 solid $interactive-02;
   box-sizing: content-box;
   margin: -$spacing-01;
 }

--- a/src/components/Card/_card.scss
+++ b/src/components/Card/_card.scss
@@ -14,6 +14,12 @@ $iot-header-padding: $spacing-05;
   overflow: hidden;
 }
 
+.#{$iot-prefix}--card--resizing {
+  border: $spacing-01 solid $interactive-04;
+  box-sizing: content-box;
+  margin: -$spacing-01;
+}
+
 .#{$iot-prefix}--card--title {
   flex: 1;
   // min-width value is required to ensure flex child with text properly truncates

--- a/src/components/Dashboard/DashboardGrid.jsx
+++ b/src/components/Dashboard/DashboardGrid.jsx
@@ -13,6 +13,7 @@ import {
   DASHBOARD_BREAKPOINTS,
   DASHBOARD_COLUMNS,
   DASHBOARD_CONTAINER_PADDING,
+  CARD_SIZES,
 } from '../../constants/LayoutConstants';
 import { DashboardLayoutPropTypes } from '../../constants/CardPropTypes';
 
@@ -63,6 +64,10 @@ export const DashboardGridPropTypes = {
   onLayoutChange: PropTypes.func,
   /** Optionally listen to window resize events to update a dashboard template */
   onBreakpointChange: PropTypes.func,
+  /** Callback for when a card has been resized */
+  onResizeStop: PropTypes.func,
+  /** Callback for when a card has been resized by drag */
+  onCardSizeChange: PropTypes.func,
 };
 
 const defaultProps = {
@@ -71,6 +76,67 @@ const defaultProps = {
   layouts: {},
   onLayoutChange: null,
   onBreakpointChange: null,
+  onResizeStop: null,
+  onCardSizeChange: null,
+};
+
+const getClosestMatchingSizes = ({ sortedSizes, value, dimension }) => {
+  const closestLargerSize = sortedSizes.find((size) => size[dimension] > value);
+  const closestDimensionValue = closestLargerSize
+    ? closestLargerSize[dimension]
+    : sortedSizes[sortedSizes.length - 1][dimension];
+  return sortedSizes.filter(
+    (size) => size[dimension] === closestDimensionValue
+  );
+};
+
+const getMatchingCardSizesByDimension = ({ breakpointSizes, ...rest }) => {
+  const { value, dimension } = rest;
+  const sortedSizes = breakpointSizes.sort(
+    (a, b) => a[dimension] - b[dimension]
+  );
+  const matchingSizes = sortedSizes.filter((size) => size[dimension] === value);
+  return matchingSizes.length
+    ? matchingSizes
+    : getClosestMatchingSizes({ sortedSizes, ...rest });
+};
+
+/**
+ * Returns the closest larger matching card size (SMALL, MEDIUM etc) based on the
+ * dimensions (height first) of a layoutItems.
+ * @param {*} layoutItem a layoutItem with modified dimensions
+ * @param {*} breakpointSizes list of card size objects for a specific breakpoint
+ */
+export const getMatchingCardSize = (layoutItem, breakpointSizes) => {
+  const sizesMatchingHeight = getMatchingCardSizesByDimension({
+    breakpointSizes,
+    value: layoutItem.h,
+    dimension: 'h',
+  });
+  return getMatchingCardSizesByDimension({
+    breakpointSizes: sizesMatchingHeight,
+    value: layoutItem.w,
+    dimension: 'w',
+  })[0];
+};
+
+/**
+ * Used to generate a list card size objects for a specific breakpoint.
+ * The list objects have the props 'h', 'w' and 'name' where name is the card size name.
+ * @param {*} breakpoint
+ * @param {*} cardDimensions see CARD_DIMENSIONS
+ * @param {*} cardSizes see CARD_SIZES
+ */
+export const getBreakPointSizes = (breakpoint, cardDimensions, cardSizes) => {
+  return (
+    Object.entries(cardDimensions)
+      .map(([name, breakpoints]) => ({
+        ...breakpoints[breakpoint],
+        name,
+      }))
+      // Filter out legacy sizes
+      .filter((entry) => cardSizes[entry.name])
+  );
 };
 
 /**
@@ -100,6 +166,8 @@ export const findLayoutOrGenerate = (layouts, cards) => {
             updatedLayout.push({
               ...cardFromLayout,
               ...CARD_DIMENSIONS[matchingCard.size][layoutName],
+              // Let thet card isResizable prop automatically set the layout prop accordingly
+              isResizable: matchingCard.isResizable,
             });
           return updatedLayout;
         }, []);
@@ -115,6 +183,15 @@ export const findLayoutOrGenerate = (layouts, cards) => {
     };
   }, {});
 };
+
+const formatResizeResponse = (params) => ({
+  layout: params[0],
+  oldItem: params[1],
+  newItem: params[2],
+  placeholder: params[3],
+  event: params[4],
+  element: params[5],
+});
 
 /**
  * Renders the grid of cards according to the standardized PAL patterns for IoT.
@@ -141,6 +218,8 @@ const DashboardGrid = ({
   layouts,
   onLayoutChange,
   onBreakpointChange,
+  onCardSizeChange,
+  onResizeStop: onResizeStopCallback, // TODO: remove?
   ...others
 }) => {
   // Unfortunately can't use React.Children.map because it breaks the original key which breaks react-grid-layout
@@ -184,6 +263,53 @@ const DashboardGrid = ({
     });
   }, [isEditable]);
 
+  const breakpointSizes = useMemo(
+    () => getBreakPointSizes(breakpoint, CARD_DIMENSIONS, CARD_SIZES),
+    [breakpoint]
+  );
+
+  const onCardResize = (...params) => {
+    const [, , layoutItem, placeholder] = params;
+    const matchedSize = getMatchingCardSize(layoutItem, breakpointSizes);
+    const renderedCardSizeName = cards.find(
+      (card) => card.props.id === layoutItem.i
+    ).props.size;
+    placeholder.h = matchedSize.h;
+    placeholder.w = matchedSize.w;
+    layoutItem.h = matchedSize.h;
+    layoutItem.w = matchedSize.w;
+    if (renderedCardSizeName !== matchedSize.name && onCardSizeChange) {
+      const gridResponse = formatResizeResponse(params);
+      onCardSizeChange(
+        {
+          id: layoutItem.i,
+          size: matchedSize.name,
+        },
+        gridResponse
+      );
+    }
+  };
+
+  const onResizeStop = (...params) => {
+    const [, oldLayoutItem, layoutItem] = params;
+    const newSize = getMatchingCardSize(layoutItem, breakpointSizes);
+    const oldSize = getMatchingCardSize(oldLayoutItem, breakpointSizes);
+    if (newSize !== oldSize) {
+      layoutItem.h = newSize.h;
+      layoutItem.w = newSize.w;
+      if (onResizeStopCallback) {
+        const gridResponse = formatResizeResponse(params);
+        onResizeStopCallback(
+          {
+            id: layoutItem.i,
+            size: newSize.name,
+          },
+          gridResponse
+        );
+      }
+    }
+  };
+
   return (
     <div style={{ flex: 1 }}>
       <StyledGridLayout
@@ -199,6 +325,8 @@ const DashboardGrid = ({
         shouldAnimate={animationState}
         onLayoutChange={handleLayoutChange}
         onBreakpointChange={onBreakpointChange}
+        onResize={onCardResize}
+        onResizeStop={onResizeStop}
         isResizable={false}
         isDraggable={isEditable}
         {...others}>

--- a/src/components/Dashboard/DashboardGrid.jsx
+++ b/src/components/Dashboard/DashboardGrid.jsx
@@ -222,7 +222,7 @@ const DashboardGrid = ({
   onLayoutChange,
   onBreakpointChange,
   onCardSizeChange,
-  onResizeStop: onResizeStopCallback, // TODO: remove?
+  onResizeStop: onResizeStopCallback,
   ...others
 }) => {
   // Unfortunately can't use React.Children.map because it breaks the original key which breaks react-grid-layout
@@ -272,8 +272,21 @@ const DashboardGrid = ({
   );
 
   const onCardResize = (...params) => {
-    const [, , layoutItem, placeholder] = params;
-    const matchedSize = getMatchingCardSize(layoutItem, breakpointSizes);
+    const [, oldLayoutItem, layoutItem, placeholder] = params;
+    const rowsJumped = layoutItem.y - oldLayoutItem.y;
+    const colsJumped = layoutItem.x - oldLayoutItem.x;
+
+    const jumpAdjustedlayoutItem = {
+      ...layoutItem,
+      h: layoutItem.h + rowsJumped,
+      w: layoutItem.w + colsJumped,
+    };
+
+    const matchedSize = getMatchingCardSize(
+      jumpAdjustedlayoutItem,
+      breakpointSizes
+    );
+
     const renderedCardSizeName = cards.find(
       (card) => card.props.id === layoutItem.i
     ).props.size;

--- a/src/components/Dashboard/DashboardGrid.jsx
+++ b/src/components/Dashboard/DashboardGrid.jsx
@@ -166,8 +166,6 @@ export const findLayoutOrGenerate = (layouts, cards) => {
             updatedLayout.push({
               ...cardFromLayout,
               ...CARD_DIMENSIONS[matchingCard.size][layoutName],
-              // Let thet card isResizable prop automatically set the layout prop accordingly
-              isResizable: matchingCard.isResizable,
             });
           return updatedLayout;
         }, []);
@@ -177,9 +175,14 @@ export const findLayoutOrGenerate = (layouts, cards) => {
       layout = getLayout(layoutName, cards, DASHBOARD_COLUMNS, CARD_DIMENSIONS);
     }
 
+    const layoutWithResizableItems = layout.map((cardFromLayout) => {
+      const matchingCard = find(cards, { id: cardFromLayout.i });
+      return { ...cardFromLayout, isResizable: matchingCard.isResizable };
+    });
+
     return {
       ...acc,
-      [layoutName]: layout,
+      [layoutName]: layoutWithResizableItems,
     };
   }, {});
 };

--- a/src/components/Dashboard/DashboardGrid.story.jsx
+++ b/src/components/Dashboard/DashboardGrid.story.jsx
@@ -1,11 +1,24 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { boolean } from '@storybook/addon-knobs';
 
 import FullWidthWrapper from '../../internal/FullWidthWrapper';
 import Card from '../Card/Card';
-import { CARD_SIZES, CARD_TYPES } from '../../constants/LayoutConstants';
+import {
+  CARD_DIMENSIONS,
+  CARD_SIZES,
+  CARD_TYPES,
+} from '../../constants/LayoutConstants';
+import { chartData, tableColumns, tableData } from '../../utils/sample';
+import PieChartCard from '../PieChartCard/PieChartCard';
+import ValueCard from '../ValueCard/ValueCard';
+import BarChartCard from '../BarChartCard/BarChartCard';
+import TableCard from '../TableCard/TableCard';
+import ImageCard from '../ImageCard/ImageCard';
+import TimeSeriesCard from '../TimeSeriesCard/TimeSeriesCard';
+import GaugeCard from '../GaugeCard/GaugeCard';
+import ListCard from '../ListCard/ListCard';
 
 import DashboardGrid from './DashboardGrid';
 
@@ -305,6 +318,558 @@ storiesOf('Watson IoT/Dashboard Grid', module)
         text: `
       This is the simplest way to use the dashboard grid, just pass it a set of cards and let it figure out it's own layout to use.
       # Component Overview
+      `,
+      },
+    }
+  )
+  .add(
+    'dashboard, resizable card',
+    () => {
+      return React.createElement(() => {
+        const [currentSize, setCurrentSize] = useState(CARD_SIZES.SMALL);
+        const [currentBreakpoint, setCurrentBreakpoint] = useState('lg');
+        const isEditable = boolean('isEditable', true);
+        const isResizable = boolean('isResizable', true);
+        const layouts = {
+          max: [{ i: 'card', x: 0, y: 0, w: 2, h: 1 }],
+          xl: [{ i: 'card', x: 0, y: 0, w: 2, h: 1 }],
+          lg: [{ i: 'card', x: 0, y: 0, w: 4, h: 1 }],
+          md: [{ i: 'card', x: 0, y: 0, w: 4, h: 1 }],
+          sm: [{ i: 'card', x: 0, y: 0, w: 2, h: 1 }],
+          xs: [{ i: 'card', x: 0, y: 0, w: 4, h: 1 }],
+        };
+
+        return (
+          <Fragment>
+            The card is resizable by dragging and the card size prop is
+            automatically updated to match the new size during the drag process.
+            <FullWidthWrapper>
+              <DashboardGrid
+                {...commonGridProps}
+                layouts={layouts}
+                breakpoint={currentBreakpoint}
+                isEditable={isEditable}
+                onBreakpointChange={(newBreakpoint) =>
+                  setCurrentBreakpoint(newBreakpoint)
+                }
+                onCardSizeChange={(cardSizeData, gridData) => {
+                  const { size } = cardSizeData;
+                  action('onCardSizeChange')(cardSizeData, gridData);
+                  setCurrentSize(size);
+                }}
+                onResizeStop={action('onResizeStop')}>
+                {[
+                  <Card
+                    title={`Card - ${currentSize}`}
+                    id="card"
+                    isEditable={isEditable}
+                    isResizable={isResizable}
+                    key="card"
+                    size={currentSize}
+                  />,
+                ]}
+              </DashboardGrid>
+            </FullWidthWrapper>
+          </Fragment>
+        );
+      });
+    },
+    {
+      info: {
+        source: true,
+        text: `
+        This story demonstrates how a card can be resizable by dragging. During reszie the cards' size prop is
+        automatically updated to match the new size.
+        See the source code for the full example.
+
+        ~~~js
+        const [currentSize, setCurrentSize] = useState(CARD_SIZES.SMALL);
+        const [currentBreakpoint, setCurrentBreakpoint] = useState('lg');
+        const isEditable = boolean('isEditable', true);
+        const isResizable = boolean('isResizable', false);
+        const layouts = {
+          max: [{ i: 'card', x: 0, y: 0, w: 2, h: 1 }],
+          xl: [{ i: 'card', x: 0, y: 0, w: 2, h: 1 }],
+          lg: [{ i: 'card', x: 0, y: 0, w: 4, h: 1 }],
+          md: [{ i: 'card', x: 0, y: 0, w: 4, h: 1 }],
+          sm: [{ i: 'card', x: 0, y: 0, w: 2, h: 1 }],
+          xs: [{ i: 'card', x: 0, y: 0, w: 4, h: 1 }],
+        };
+
+        return (
+          <Fragment>
+            The card is resizable by dragging and the cards' size prop is
+            automatically updated to match the new size during the drag process.
+            <FullWidthWrapper>
+              <DashboardGrid
+                layouts={layouts}
+                breakpoint={currentBreakpoint}
+                isEditable={isEditable}
+                onBreakpointChange={(newBreakpoint) =>
+                  setCurrentBreakpoint(newBreakpoint)
+                }
+                onCardSizeChange={(cardSizeData, gridData) => {
+                  const { size } = cardSizeData;
+                  setCurrentSize(size);
+                }}
+                onResizeStop={() => {}}>
+                <Card
+                  title={'Card -' + currentSize}
+                  id="card"
+                  isEditable={isEditable}
+                  isResizable={isResizable}
+                  key="card"
+                  size={currentSize}></Card>
+              </DashboardGrid>
+            </FullWidthWrapper>
+          </Fragment>
+        );
+        ~~~           
+      `,
+      },
+    }
+  )
+  .add(
+    'dashboard, all cards as resizable',
+    () => {
+      const barChartCardValues = [
+        {
+          city: 'A',
+          particles: 447,
+        },
+        {
+          city: 'B',
+          particles: 528,
+        },
+        {
+          city: 'C',
+          particles: 435,
+        },
+        {
+          city: 'D',
+          particles: 388,
+        },
+      ];
+
+      const pieChartCardValues = [
+        {
+          category: 'A',
+          group: '2V2N 9KYPM',
+          value: 1,
+        },
+        {
+          category: 'B',
+          group: 'L22I P66EP L22I P66EP',
+          value: 10,
+        },
+        {
+          category: 'C',
+          group: 'JQAI 2M4L1',
+          value: 20,
+        },
+      ];
+
+      const timeSeriesCardContent = {
+        includeZeroOnXaxis: true,
+        includeZeroOnYaxis: true,
+        series: [
+          {
+            dataSourceId: 'temperature',
+            label: 'Temperature',
+          },
+        ],
+        timeDataSourceId: 'timestamp',
+        xLabel: 'Time',
+        yLabel: 'Temperature (˚F)',
+      };
+
+      const imageCardValues = {
+        hotspots: [
+          {
+            color: 'purple',
+            content: {
+              attributes: [
+                {
+                  dataSourceId: 'temperature',
+                  label: 'Temp',
+                  precision: 2,
+                },
+              ],
+              description: 'Description',
+              title: 'My Device',
+              values: {
+                deviceid: '73000',
+                temperature: 35.05,
+              },
+            },
+            icon: 'arrowDown',
+            x: 35,
+            y: 65,
+          },
+        ],
+      };
+
+      const gaugeCardContent = {
+        gauges: [
+          {
+            backgroundColor: '#e0e0e0',
+            color: 'orange',
+            dataSourceId: 'usage',
+            maximumValue: 100,
+            minimumValue: 0,
+            shape: 'circle',
+            thresholds: [
+              {
+                color: 'red',
+                comparison: '>',
+                label: 'Poor',
+                value: 0,
+              },
+              {
+                color: '#f1c21b',
+                comparison: '>',
+                label: 'Fair',
+                value: 60,
+              },
+              {
+                color: 'green',
+                comparison: '>',
+                label: 'Good',
+                value: 80,
+              },
+            ],
+            trend: {
+              color: '',
+              dataSourceId: 'usageTrend',
+              trend: 'up',
+            },
+            units: '%',
+          },
+        ],
+      };
+
+      const listCardData = [
+        {
+          id: 'row-1',
+          value: 'Row content 1',
+          link: 'https://internetofthings.ibmcloud.com/',
+        },
+        {
+          id: 'row-2',
+          value: 'Row content 2',
+          link: 'https://internetofthings.ibmcloud.com/',
+        },
+        { id: 'row-3', value: 'Row content 3' },
+        {
+          id: 'row-4',
+          value: 'Row content 4',
+          link: 'https://internetofthings.ibmcloud.com/',
+          extraContent: (
+            <svg height="10" width="30">
+              <circle
+                cx="5"
+                cy="5"
+                r="3"
+                stroke="none"
+                strokeWidth="1"
+                fill="red"
+              />
+            </svg>
+          ),
+        },
+        { id: 'row-5', value: 'Row content 5' },
+        { id: 'row-6', value: 'Row content 6' },
+        { id: 'row-7', value: 'Row content 7' },
+        { id: 'row-8', value: 'Row content 8' },
+      ];
+
+      return React.createElement(() => {
+        const [currentSizes, setCurrentSizes] = useState({
+          card: CARD_SIZES.SMALL,
+          valueCard: CARD_SIZES.SMALLWIDE,
+          gaugeCard: CARD_SIZES.MEDIUMTHIN,
+          pieChartCard: CARD_SIZES.MEDIUM,
+          tableCard: CARD_SIZES.LARGE,
+          imageCard: CARD_SIZES.LARGE,
+          timeSeriesCard: CARD_SIZES.LARGETHIN,
+          listCard: CARD_SIZES.LARGETHIN,
+          barChartCard: CARD_SIZES.LARGEWIDE,
+        });
+        const [currentBreakpoint, setCurrentBreakpoint] = useState('lg');
+        const isEditable = boolean('isEditable', true);
+        const isResizable = boolean('isResizable', true);
+
+        const CARDS_ALL_SIZES = [
+          <Card
+            title={`Card - ${currentSizes.card}`}
+            id="card"
+            isEditable={isEditable}
+            isResizable={isResizable}
+            key="card"
+            size={currentSizes.card}
+            availableActions={{
+              delete: true,
+            }}>
+            <p>This is a basic card</p>
+          </Card>,
+          <ValueCard
+            title={`ValueCard - ${currentSizes.valueCard}`}
+            id="valueCard"
+            key="valueCard"
+            size={currentSizes.valueCard}
+            isEditable={isEditable}
+            isResizable={isResizable}
+            content={{
+              attributes: [
+                {
+                  dataSourceId: 'occupancy',
+                  unit: '%',
+                  secondaryValue: {
+                    dataSourceId: 'trend',
+                    trend: 'down',
+                    color: 'red',
+                  },
+                },
+              ],
+            }}
+            values={{ occupancy: 88 }}
+          />,
+          <GaugeCard
+            id="gaugeCard"
+            key="gaugeCard"
+            isEditable={isEditable}
+            isResizable={isResizable}
+            size={currentSizes.gaugeCard}
+            title={`GaugeCard - ${currentSizes.gaugeCard}`}
+            content={gaugeCardContent}
+            tooltip={<p>Health - of floor 8</p>}
+            values={{
+              usage: 81,
+              usageTrend: '12%',
+            }}
+          />,
+          <PieChartCard
+            content={{
+              groupDataSourceId: 'category',
+              legendPosition: 'bottom',
+            }}
+            title={`PieChartCard - ${currentSizes.pieChartCard}`}
+            key="pieChartCard"
+            id="pieChartCard"
+            size={currentSizes.pieChartCard}
+            isEditable={isEditable}
+            isResizable={isResizable}
+            values={pieChartCardValues}
+          />,
+          <TableCard
+            title={`TableCard - ${currentSizes.tableCard}`}
+            id="tableCard"
+            key="tableCard"
+            content={{
+              columns: tableColumns,
+            }}
+            values={tableData}
+            onCardAction={() => {}}
+            size={currentSizes.tableCard}
+            isEditable={isEditable}
+            isResizable={isResizable}
+          />,
+          <ImageCard
+            title={`ImageCard - ${currentSizes.imageCard}`}
+            id="imageCard"
+            isEditable={isEditable}
+            isResizable={isResizable}
+            key="imageCard"
+            size={currentSizes.imageCard}
+            content={{
+              alt: 'Sample image',
+              src: 'static/media/landscape.013ce39d.jpg',
+              zoomMax: 10,
+            }}
+            values={imageCardValues}
+          />,
+          <TimeSeriesCard
+            id="timeSeriesCard"
+            isEditable={isEditable}
+            isResizable={isResizable}
+            size={currentSizes.timeSeriesCard}
+            title={`TimeSeriesCard - ${currentSizes.timeSeriesCard}`}
+            chartType="LINE"
+            content={timeSeriesCardContent}
+            key="timeSeriesCard"
+            interval="hour"
+            values={chartData.events.slice(0, 5)}
+          />,
+          <ListCard
+            id="listCard"
+            isEditable={isEditable}
+            isResizable={isResizable}
+            key="listCard"
+            title={`ListCard - ${currentSizes.listCard}`}
+            size={currentSizes.listCard}
+            data={listCardData}
+            hasMoreData={false}
+            loadData={() => {}}
+          />,
+          <BarChartCard
+            id="barChartCard"
+            key="barChartCard"
+            size={currentSizes.barChartCard}
+            isEditable={isEditable}
+            isResizable={isResizable}
+            title={`BarChartCard - ${currentSizes.barChartCard}`}
+            content={{
+              categoryDataSourceId: 'city',
+              layout: 'VERTICAL',
+              series: [
+                {
+                  dataSourceId: 'particles',
+                },
+              ],
+              type: 'SIMPLE',
+              unit: 'P',
+              xLabel: 'Cities',
+              yLabel: 'Particles',
+            }}
+            values={barChartCardValues}
+          />,
+        ];
+
+        const layouts = {
+          max: [
+            { i: 'card', x: 0, y: 0, w: 2, h: 1 },
+            { i: 'valueCard', x: 2, y: 0, w: 4, h: 1 },
+            { i: 'gaugeCard', x: 0, y: 2, w: 2, h: 2 },
+            { i: 'pieChartCard', x: 2, y: 0, w: 4, h: 2 },
+            { i: 'imageCard', x: 6, y: 2, w: 8, h: 2 },
+            { i: 'timeSeriesCard', x: 0, y: 4, w: 4, h: 4 },
+            { i: 'listCard', x: 4, y: 4, w: 4, h: 4 },
+            { i: 'tableCard', x: 4, y: 4, w: 8, h: 4 },
+            { i: 'barChartCard', x: 8, y: 8, w: 16, h: 4 },
+          ],
+          xl: [
+            { i: 'card', x: 0, y: 0, w: 2, h: 1 },
+            { i: 'valueCard', x: 4, y: 0, w: 4, h: 1 },
+            { i: 'gaugeCard', x: 0, y: 2, w: 4, h: 2 },
+            { i: 'pieChartCard', x: 4, y: 0, w: 4, h: 2 },
+            { i: 'imageCard', x: 8, y: 2, w: 8, h: 2 },
+            { i: 'timeSeriesCard', x: 0, y: 4, w: 4, h: 4 },
+            { i: 'listCard', x: 4, y: 4, w: 4, h: 4 },
+            { i: 'tableCard', x: 4, y: 4, w: 8, h: 4 },
+            { i: 'barChartCard', x: 8, y: 8, w: 16, h: 4 },
+          ],
+          lg: [
+            { i: 'card', x: 0, y: 0, w: 4, h: 1 },
+            { i: 'valueCard', x: 4, y: 0, w: 4, h: 1 },
+            { i: 'gaugeCard', x: 0, y: 2, w: 4, h: 2 },
+            { i: 'pieChartCard', x: 4, y: 0, w: 4, h: 2 },
+            { i: 'imageCard', x: 8, y: 2, w: 8, h: 2 },
+            { i: 'timeSeriesCard', x: 0, y: 4, w: 4, h: 4 },
+            { i: 'listCard', x: 4, y: 4, w: 4, h: 4 },
+            { i: 'tableCard', x: 4, y: 4, w: 8, h: 4 },
+            { i: 'barChartCard', x: 8, y: 8, w: 16, h: 4 },
+          ],
+          md: [
+            { i: 'card', x: 0, y: 0, w: 4, h: 1 },
+            { i: 'valueCard', x: 4, y: 0, w: 4, h: 1 },
+            { i: 'gaugeCard', x: 0, y: 2, w: 2, h: 2 },
+            { i: 'pieChartCard', x: 2, y: 0, w: 4, h: 2 },
+            { i: 'imageCard', x: 8, y: 2, w: 8, h: 2 },
+            { i: 'timeSeriesCard', x: 0, y: 4, w: 4, h: 4 },
+            { i: 'listCard', x: 4, y: 4, w: 4, h: 4 },
+            { i: 'tableCard', x: 4, y: 4, w: 8, h: 4 },
+            { i: 'barChartCard', x: 8, y: 8, w: 8, h: 4 },
+          ],
+          sm: [
+            { i: 'card', x: 0, y: 0, w: 2, h: 1 },
+            { i: 'valueCard', x: 4, y: 0, w: 4, h: 2 },
+            { i: 'gaugeCard', x: 0, y: 0, w: 2, h: 2 },
+            { i: 'pieChartCard', x: 2, y: 0, w: 4, h: 2 },
+            { i: 'imageCard', x: 8, y: 0, w: 4, h: 2 },
+            { i: 'timeSeriesCard', x: 0, y: 0, w: 4, h: 4 },
+            { i: 'listCard', x: 0, y: 0, w: 4, h: 4 },
+            { i: 'tableCard', x: 4, y: 0, w: 4, h: 4 },
+            { i: 'barChartCard', x: 8, y: 0, w: 4, h: 4 },
+          ],
+          xs: [
+            { i: 'card', x: 0, y: 0, w: 4, h: 1 },
+            { i: 'valueCard', x: 4, y: 0, w: 4, h: 1 },
+            { i: 'gaugeCard', x: 0, y: 0, w: 4, h: 2 },
+            { i: 'pieChartCard', x: 2, y: 0, w: 4, h: 2 },
+            { i: 'imageCard', x: 8, y: 0, w: 4, h: 2 },
+            { i: 'timeSeriesCard', x: 0, y: 0, w: 4, h: 4 },
+            { i: 'listCard', x: 0, y: 0, w: 4, h: 4 },
+            { i: 'tableCard', x: 4, y: 0, w: 4, h: 4 },
+            { i: 'barChartCard', x: 8, y: 0, w: 4, h: 4 },
+          ],
+        };
+
+        // Set minimum sizes for the cards that requires it
+        const minWidthLayouts = {};
+        Object.entries(layouts).forEach(([breakpoint, breakpointLayout]) => {
+          minWidthLayouts[breakpoint] = breakpointLayout.map((cardLayout) => {
+            const cardLayoutCopy = { ...cardLayout };
+            switch (cardLayoutCopy.i) {
+              case 'pieChartCard':
+                cardLayoutCopy.minW = CARD_DIMENSIONS.MEDIUMTHIN.max.w;
+                cardLayoutCopy.minH = CARD_DIMENSIONS.MEDIUMTHIN.max.h;
+                break;
+              case 'barChartCard':
+                cardLayoutCopy.minW = CARD_DIMENSIONS.MEDIUMTHIN.max.w;
+                cardLayoutCopy.minH = CARD_DIMENSIONS.MEDIUMTHIN.max.h;
+                break;
+              case 'tableCard':
+                cardLayoutCopy.minW = CARD_DIMENSIONS.LARGE.max.w;
+                cardLayoutCopy.minH = CARD_DIMENSIONS.LARGE.max.h;
+                break;
+              case 'imageCard':
+                cardLayoutCopy.minW = CARD_DIMENSIONS.MEDIUMTHIN.max.w;
+                cardLayoutCopy.minH = CARD_DIMENSIONS.MEDIUMTHIN.max.h;
+                break;
+              default:
+                break;
+            }
+            return cardLayoutCopy;
+          });
+        });
+
+        return (
+          <Fragment>
+            <p>
+              All cards are resizable by dragging and the card size prop is
+              automatically updated to match the new size during the drag
+              process. Some cards have a minimal size defined.
+            </p>
+            <FullWidthWrapper>
+              <DashboardGrid
+                {...commonGridProps}
+                layouts={minWidthLayouts}
+                breakpoint={currentBreakpoint}
+                isEditable={isEditable}
+                onBreakpointChange={(newBreakpoint) => {
+                  action('onBreakpointChange')(newBreakpoint);
+                  setCurrentBreakpoint(newBreakpoint);
+                }}
+                onCardSizeChange={(...[{ id, size }, rest]) => {
+                  action('onCardSizeChange')({ id, size }, rest);
+                  setCurrentSizes((old) => ({ ...old, [id]: size }));
+                }}
+                onResizeStop={action('onResizeStop')}>
+                {CARDS_ALL_SIZES}
+              </DashboardGrid>
+            </FullWidthWrapper>
+          </Fragment>
+        );
+      });
+    },
+    {
+      info: {
+        source: true,
+        text: `
+        This story demonstrates how all cards can be resizable by dragging. During reszie the cards' size prop is
+        automatically updated to match the new size. Some cards have a minimal size defined. 
+
+        See the source code for the full example.
       `,
       },
     }

--- a/src/components/Dashboard/DashboardGrid.story.jsx
+++ b/src/components/Dashboard/DashboardGrid.story.jsx
@@ -96,8 +96,7 @@ storiesOf('Watson IoT/Dashboard Grid', module)
           <FullWidthWrapper>
             <DashboardGrid
               {...commonGridProps}
-              isEditable={boolean('isEditable', true)}
-              isResizable={boolean('isResizable', true)}>
+              isEditable={boolean('isEditable', true)}>
               {Cards}
             </DashboardGrid>
           </FullWidthWrapper>
@@ -328,7 +327,6 @@ storiesOf('Watson IoT/Dashboard Grid', module)
       return React.createElement(() => {
         const [currentSize, setCurrentSize] = useState(CARD_SIZES.SMALL);
         const [currentBreakpoint, setCurrentBreakpoint] = useState('lg');
-        const isEditable = boolean('isEditable', true);
         const isResizable = boolean('isResizable', true);
         const layouts = {
           max: [{ i: 'card', x: 0, y: 0, w: 2, h: 1 }],
@@ -348,7 +346,6 @@ storiesOf('Watson IoT/Dashboard Grid', module)
                 {...commonGridProps}
                 layouts={layouts}
                 breakpoint={currentBreakpoint}
-                isEditable={isEditable}
                 onBreakpointChange={(newBreakpoint) =>
                   setCurrentBreakpoint(newBreakpoint)
                 }
@@ -362,7 +359,6 @@ storiesOf('Watson IoT/Dashboard Grid', module)
                   <Card
                     title={`Card - ${currentSize}`}
                     id="card"
-                    isEditable={isEditable}
                     isResizable={isResizable}
                     key="card"
                     size={currentSize}
@@ -385,7 +381,6 @@ storiesOf('Watson IoT/Dashboard Grid', module)
         ~~~js
         const [currentSize, setCurrentSize] = useState(CARD_SIZES.SMALL);
         const [currentBreakpoint, setCurrentBreakpoint] = useState('lg');
-        const isEditable = boolean('isEditable', true);
         const isResizable = boolean('isResizable', false);
         const layouts = {
           max: [{ i: 'card', x: 0, y: 0, w: 2, h: 1 }],
@@ -404,7 +399,6 @@ storiesOf('Watson IoT/Dashboard Grid', module)
               <DashboardGrid
                 layouts={layouts}
                 breakpoint={currentBreakpoint}
-                isEditable={isEditable}
                 onBreakpointChange={(newBreakpoint) =>
                   setCurrentBreakpoint(newBreakpoint)
                 }
@@ -416,7 +410,6 @@ storiesOf('Watson IoT/Dashboard Grid', module)
                 <Card
                   title={'Card -' + currentSize}
                   id="card"
-                  isEditable={isEditable}
                   isResizable={isResizable}
                   key="card"
                   size={currentSize}></Card>
@@ -596,14 +589,12 @@ storiesOf('Watson IoT/Dashboard Grid', module)
           barChartCard: CARD_SIZES.LARGEWIDE,
         });
         const [currentBreakpoint, setCurrentBreakpoint] = useState('lg');
-        const isEditable = boolean('isEditable', true);
         const isResizable = boolean('isResizable', true);
 
         const CARDS_ALL_SIZES = [
           <Card
             title={`Card - ${currentSizes.card}`}
             id="card"
-            isEditable={isEditable}
             isResizable={isResizable}
             key="card"
             size={currentSizes.card}
@@ -617,7 +608,6 @@ storiesOf('Watson IoT/Dashboard Grid', module)
             id="valueCard"
             key="valueCard"
             size={currentSizes.valueCard}
-            isEditable={isEditable}
             isResizable={isResizable}
             content={{
               attributes: [
@@ -637,7 +627,6 @@ storiesOf('Watson IoT/Dashboard Grid', module)
           <GaugeCard
             id="gaugeCard"
             key="gaugeCard"
-            isEditable={isEditable}
             isResizable={isResizable}
             size={currentSizes.gaugeCard}
             title={`GaugeCard - ${currentSizes.gaugeCard}`}
@@ -657,7 +646,6 @@ storiesOf('Watson IoT/Dashboard Grid', module)
             key="pieChartCard"
             id="pieChartCard"
             size={currentSizes.pieChartCard}
-            isEditable={isEditable}
             isResizable={isResizable}
             values={pieChartCardValues}
           />,
@@ -671,13 +659,11 @@ storiesOf('Watson IoT/Dashboard Grid', module)
             values={tableData}
             onCardAction={() => {}}
             size={currentSizes.tableCard}
-            isEditable={isEditable}
             isResizable={isResizable}
           />,
           <ImageCard
             title={`ImageCard - ${currentSizes.imageCard}`}
             id="imageCard"
-            isEditable={isEditable}
             isResizable={isResizable}
             key="imageCard"
             size={currentSizes.imageCard}
@@ -690,7 +676,6 @@ storiesOf('Watson IoT/Dashboard Grid', module)
           />,
           <TimeSeriesCard
             id="timeSeriesCard"
-            isEditable={isEditable}
             isResizable={isResizable}
             size={currentSizes.timeSeriesCard}
             title={`TimeSeriesCard - ${currentSizes.timeSeriesCard}`}
@@ -702,7 +687,6 @@ storiesOf('Watson IoT/Dashboard Grid', module)
           />,
           <ListCard
             id="listCard"
-            isEditable={isEditable}
             isResizable={isResizable}
             key="listCard"
             title={`ListCard - ${currentSizes.listCard}`}
@@ -715,7 +699,6 @@ storiesOf('Watson IoT/Dashboard Grid', module)
             id="barChartCard"
             key="barChartCard"
             size={currentSizes.barChartCard}
-            isEditable={isEditable}
             isResizable={isResizable}
             title={`BarChartCard - ${currentSizes.barChartCard}`}
             content={{
@@ -845,7 +828,6 @@ storiesOf('Watson IoT/Dashboard Grid', module)
                 {...commonGridProps}
                 layouts={minWidthLayouts}
                 breakpoint={currentBreakpoint}
-                isEditable={isEditable}
                 onBreakpointChange={(newBreakpoint) => {
                   action('onBreakpointChange')(newBreakpoint);
                   setCurrentBreakpoint(newBreakpoint);

--- a/src/components/Dashboard/DashboardGrid.test.jsx
+++ b/src/components/Dashboard/DashboardGrid.test.jsx
@@ -1,24 +1,51 @@
-import { CARD_SIZES } from '../../constants/LayoutConstants';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
 
-import { findLayoutOrGenerate } from './DashboardGrid';
+import { CARD_DIMENSIONS, CARD_SIZES } from '../../constants/LayoutConstants';
+import Card from '../Card/Card';
+import ValueCard from '../ValueCard/ValueCard';
+import GaugeCard from '../GaugeCard/GaugeCard';
+import PieChartCard from '../PieChartCard/PieChartCard';
+import TableCard from '../TableCard/TableCard';
+import ImageCard from '../ImageCard/ImageCard';
+import TimeSeriesCard from '../TimeSeriesCard/TimeSeriesCard';
+import ListCard from '../ListCard/ListCard';
+import BarChartCard from '../BarChartCard/BarChartCard';
 
-jest.mock('../../utils/componentUtilityFunctions.js'); // this happens automatically with automocking
-const componentUtilityFunctions = require('../../utils/componentUtilityFunctions.js');
+import DashboardGrid, {
+  getMatchingCardSize,
+  getBreakPointSizes,
+  findLayoutOrGenerate,
+} from './DashboardGrid';
 
 describe('DashboardGrid', () => {
   it('findLayoutOrGenerate', () => {
+    const layouts = {
+      max: [{ i: 'mycard', x: 0, y: 0, w: 4, h: 2 }],
+      xl: [{ i: 'mycard', x: 0, y: 0, w: 4, h: 2 }],
+      lg: [{ i: 'mycard', x: 0, y: 0, w: 4, h: 2 }],
+      md: [{ i: 'mycard', x: 0, y: 0, w: 4, h: 2 }],
+      sm: [{ i: 'mycard', x: 0, y: 0, w: 4, h: 2 }],
+      xs: [{ i: 'mycard', x: 0, y: 0, w: 4, h: 2 }],
+    };
+
     // if no layouts exist they should be generated
-    findLayoutOrGenerate({}, [{ id: 'mycard', size: CARD_SIZES.MEDIUM }]);
-    expect(componentUtilityFunctions.getLayout).toHaveBeenCalled();
-    componentUtilityFunctions.getLayout.mockClear();
-    // if layout is missing card it should be regenerated
-    findLayoutOrGenerate({ max: [], xl: [], lg: [], md: [], sm: [], xs: [] }, [
+    const generated = findLayoutOrGenerate({}, [
       { id: 'mycard', size: CARD_SIZES.MEDIUM },
     ]);
-    expect(componentUtilityFunctions.getLayout).toHaveBeenCalled();
-    componentUtilityFunctions.getLayout.mockClear();
+
+    expect(generated).toEqual(layouts);
+
+    // if layout is missing card it should be regenerated
+    const regenerated = findLayoutOrGenerate(
+      { max: [], xl: [], lg: [], md: [], sm: [], xs: [] },
+      [{ id: 'mycard', size: CARD_SIZES.MEDIUM }]
+    );
+    expect(regenerated).toEqual(layouts);
+
     // if every layout already exists, the card should have dimensions added
-    const newLayouts = findLayoutOrGenerate(
+    const addedDimensions = findLayoutOrGenerate(
       {
         max: [{ i: 'mycard', x: 0, y: 0 }],
         xl: [{ i: 'mycard', x: 0, y: 0 }],
@@ -29,9 +56,8 @@ describe('DashboardGrid', () => {
       },
       [{ id: 'mycard', size: CARD_SIZES.MEDIUM }]
     );
-    expect(componentUtilityFunctions.getLayout).not.toHaveBeenCalled();
-    expect(newLayouts.max[0]).toHaveProperty('w');
-    expect(newLayouts.max[0]).toHaveProperty('h');
+    expect(addedDimensions).toEqual(layouts);
+
     // handle old layouts with bogus cards
     const emptyLayouts = findLayoutOrGenerate(
       {
@@ -49,5 +75,245 @@ describe('DashboardGrid', () => {
     );
     // the bogus card was quietly removed from the layout
     expect(emptyLayouts.max).toHaveLength(1);
+  });
+
+  describe('resizing', () => {
+    const BREAKPOINT = 'lg';
+    const layouts = {
+      [BREAKPOINT]: [
+        { i: 'card', x: 0, y: 0, w: 4, h: 1 },
+        { i: 'valueCard', x: 4, y: 0, w: 4, h: 1 },
+        { i: 'gaugeCard', x: 0, y: 2, w: 4, h: 2 },
+        { i: 'pieChartCard', x: 4, y: 0, w: 4, h: 2 },
+        { i: 'imageCard', x: 8, y: 2, w: 8, h: 2 },
+        { i: 'timeSeriesCard', x: 0, y: 4, w: 4, h: 4 },
+        { i: 'listCard', x: 4, y: 4, w: 4, h: 4 },
+        { i: 'tableCard', x: 4, y: 4, w: 8, h: 4 },
+        { i: 'barChartCard', x: 8, y: 8, w: 16, h: 4 },
+      ],
+    };
+
+    const callbackMocks = {
+      onBreakpointChange: jest.fn(),
+      onLayoutChange: jest.fn(),
+      onCardSizeChange: jest.fn(),
+      onResizeStop: jest.fn(),
+    };
+
+    const getCards = ({ isResizable }) => [
+      <Card
+        testID="test-card"
+        title="Card"
+        id="card"
+        key="card"
+        isResizable={isResizable}
+        size={CARD_SIZES.SMALL}
+      />,
+      <ValueCard
+        testID="test-valueCard"
+        title="ValueCard"
+        id="valueCard"
+        key="valueCard"
+        size={CARD_SIZES.SMALLWIDE}
+        isResizable={isResizable}
+        content={{
+          attributes: [],
+        }}
+        values={{}}
+      />,
+      <GaugeCard
+        testID="test-gaugeCard"
+        title="GaugeCard"
+        id="gaugeCard"
+        key="gaugeCard"
+        isResizable={isResizable}
+        size={CARD_SIZES.MEDIUMTHIN}
+        content={{ gauges: [] }}
+        values={{}}
+      />,
+      <PieChartCard
+        testID="test-pieChartCard"
+        title="PieChartCard"
+        key="pieChartCard"
+        id="pieChartCard"
+        content={{}}
+        size={CARD_SIZES.MEDIUM}
+        isResizable={isResizable}
+        values={[]}
+      />,
+      <TableCard
+        testID="test-tableCard"
+        title="TableCard"
+        id="tableCard"
+        key="tableCard"
+        content={{
+          columns: [],
+        }}
+        values={[]}
+        onCardAction={() => {}}
+        size={CARD_SIZES.LARGE}
+        isResizable={isResizable}
+      />,
+      <ImageCard
+        testID="test-imageCard"
+        title="ImageCard"
+        id="imageCard"
+        key="imageCard"
+        isResizable={isResizable}
+        size={CARD_SIZES.LARGE}
+        content={{}}
+        values={{
+          hotspots: [],
+        }}
+      />,
+      <TimeSeriesCard
+        testID="test-timeSeriesCard"
+        title="TimeSeriesCard"
+        id="timeSeriesCard"
+        isResizable={isResizable}
+        size={CARD_SIZES.LARGETHIN}
+        chartType="LINE"
+        content={{
+          series: [
+            {
+              dataSourceId: 'temperature',
+              label: 'Temperature',
+            },
+          ],
+        }}
+        key="timeSeriesCard"
+        interval="hour"
+        values={[]}
+      />,
+      <ListCard
+        testID="test-listCard"
+        title="ListCard"
+        id="listCard"
+        key="listCard"
+        isResizable={isResizable}
+        size={CARD_SIZES.LARGETHIN}
+        data={[]}
+        hasMoreData={false}
+        loadData={() => {}}
+      />,
+      <BarChartCard
+        testID="test-barChartCard"
+        title="BarChartCard"
+        id="barChartCard"
+        key="barChartCard"
+        size={CARD_SIZES.LARGEWIDE}
+        isResizable={isResizable}
+        content={{
+          categoryDataSourceId: 'city',
+          layout: 'VERTICAL',
+          series: [
+            {
+              dataSourceId: 'particles',
+            },
+          ],
+          type: 'SIMPLE',
+        }}
+        values={[]}
+      />,
+    ];
+
+    it('adds resize handles for all cards with isResizable: true', () => {
+      const resizeHandleClass = 'react-resizable-handle';
+      const expectToBeResizable = (testId, resizeHandleIndex = 2) => {
+        expect(
+          screen.getByTestId(testId).childNodes[resizeHandleIndex]
+        ).toHaveClass(resizeHandleClass);
+      };
+
+      render(
+        <DashboardGrid
+          {...callbackMocks}
+          layouts={layouts}
+          breakpoint={BREAKPOINT}>
+          {getCards({ isResizable: true })}
+        </DashboardGrid>
+      );
+
+      expectToBeResizable('test-card');
+      expectToBeResizable('test-valueCard');
+      expectToBeResizable('test-gaugeCard');
+      expectToBeResizable('test-pieChartCard');
+      expectToBeResizable('test-tableCard', 1);
+      expectToBeResizable('test-imageCard');
+      expectToBeResizable('test-timeSeriesCard');
+      expectToBeResizable('test-listCard');
+      expectToBeResizable('test-barChartCard');
+    });
+
+    it('prevents resize handles for all cards with isResizable: false', () => {
+      const resizeHandleClass = 'react-resizable-handle';
+      const expectNotToBeResizable = (testId, resizeHandleIndex = 2) => {
+        const element = screen.getByTestId(testId).childNodes[
+          resizeHandleIndex
+        ];
+        if (element) {
+          expect(element).not.toHaveClass(resizeHandleClass);
+        } else {
+          expect(element).toBeUndefined();
+        }
+      };
+
+      render(
+        <DashboardGrid
+          {...callbackMocks}
+          layouts={layouts}
+          breakpoint={BREAKPOINT}>
+          {getCards({ isResizable: false })}
+        </DashboardGrid>
+      );
+
+      expectNotToBeResizable('test-card');
+      expectNotToBeResizable('test-valueCard');
+      expectNotToBeResizable('test-gaugeCard');
+      expectNotToBeResizable('test-pieChartCard');
+      expectNotToBeResizable('test-tableCard', 1);
+      expectNotToBeResizable('test-imageCard');
+      expectNotToBeResizable('test-timeSeriesCard');
+      expectNotToBeResizable('test-listCard');
+      expectNotToBeResizable('test-barChartCard');
+    });
+
+    it('it matches dimensions (height first) to closest larger or equally large card size', () => {
+      const breakpointSizes = getBreakPointSizes(
+        'xl',
+        CARD_DIMENSIONS,
+        CARD_SIZES
+      );
+
+      const size = getMatchingCardSize({ w: 1, h: 1 }, breakpointSizes);
+      expect(size.name).toEqual(CARD_SIZES.SMALL);
+
+      const sizeA = getMatchingCardSize({ w: 2, h: 1 }, breakpointSizes);
+      expect(sizeA.name).toEqual(CARD_SIZES.SMALL);
+
+      const sizeB = getMatchingCardSize({ w: 3, h: 1 }, breakpointSizes);
+      expect(sizeB.name).toEqual(CARD_SIZES.SMALLWIDE);
+
+      const sizeC = getMatchingCardSize({ w: 4, h: 1 }, breakpointSizes);
+      expect(sizeC.name).toEqual(CARD_SIZES.SMALLWIDE);
+
+      const sizeD = getMatchingCardSize({ w: 4, h: 2 }, breakpointSizes);
+      expect(sizeD.name).toEqual(CARD_SIZES.MEDIUM);
+
+      const sizeE = getMatchingCardSize({ w: 3, h: 2 }, breakpointSizes);
+      expect(sizeE.name).toEqual(CARD_SIZES.MEDIUM);
+
+      const sizeF = getMatchingCardSize({ w: 2, h: 2 }, breakpointSizes);
+      expect(sizeF.name).toEqual(CARD_SIZES.MEDIUMTHIN);
+
+      const sizeG = getMatchingCardSize({ w: 5, h: 2 }, breakpointSizes);
+      expect(sizeG.name).toEqual(CARD_SIZES.MEDIUMWIDE);
+
+      const sizeH = getMatchingCardSize({ w: 18, h: 5 }, breakpointSizes);
+      expect(sizeH.name).toEqual(CARD_SIZES.LARGEWIDE);
+
+      const sizeI = getMatchingCardSize({ w: 16, h: 2 }, breakpointSizes);
+      expect(sizeI.name).toEqual(CARD_SIZES.MEDIUMWIDE);
+    });
   });
 });

--- a/src/components/Dashboard/DashboardGrid.test.jsx
+++ b/src/components/Dashboard/DashboardGrid.test.jsx
@@ -79,7 +79,7 @@ describe('DashboardGrid', () => {
 
   describe('resizing', () => {
     const BREAKPOINT = 'lg';
-    const layouts = {
+    const getLayouts = () => ({
       [BREAKPOINT]: [
         { i: 'card', x: 0, y: 0, w: 4, h: 1 },
         { i: 'valueCard', x: 4, y: 0, w: 4, h: 1 },
@@ -91,7 +91,7 @@ describe('DashboardGrid', () => {
         { i: 'tableCard', x: 4, y: 4, w: 8, h: 4 },
         { i: 'barChartCard', x: 8, y: 8, w: 16, h: 4 },
       ],
-    };
+    });
 
     const callbackMocks = {
       onBreakpointChange: jest.fn(),
@@ -220,20 +220,23 @@ describe('DashboardGrid', () => {
     it('adds resize handles for all cards with isResizable: true', () => {
       const resizeHandleClass = 'react-resizable-handle';
       const expectToBeResizable = (testId, resizeHandleIndex = 2) => {
-        expect(
-          screen.getByTestId(testId).childNodes[resizeHandleIndex]
-        ).toHaveClass(resizeHandleClass);
+        const resizeHandle = screen.getByTestId(testId).childNodes[
+          resizeHandleIndex
+        ];
+        expect(resizeHandle).toHaveClass(resizeHandleClass);
+        expect(resizeHandle).toBeVisible();
       };
 
-      render(
+      const { rerender } = render(
         <DashboardGrid
           {...callbackMocks}
-          layouts={layouts}
+          layouts={getLayouts()}
           breakpoint={BREAKPOINT}>
           {getCards({ isResizable: true })}
         </DashboardGrid>
       );
 
+      // We test all cards
       expectToBeResizable('test-card');
       expectToBeResizable('test-valueCard');
       expectToBeResizable('test-gaugeCard');
@@ -243,6 +246,34 @@ describe('DashboardGrid', () => {
       expectToBeResizable('test-timeSeriesCard');
       expectToBeResizable('test-listCard');
       expectToBeResizable('test-barChartCard');
+
+      const emptyLayouts = {};
+      rerender(
+        <DashboardGrid
+          {...callbackMocks}
+          layouts={emptyLayouts}
+          breakpoint={BREAKPOINT}>
+          {getCards({ isResizable: true })}
+        </DashboardGrid>
+      );
+      expectToBeResizable('test-card'); // base card
+      expectToBeResizable('test-valueCard'); // card wrapping base card
+      expectToBeResizable('test-imageCard'); // card wrapping base card with children as a function
+
+      const layoutwithMissingCards = {
+        [BREAKPOINT]: [{ i: 'nonExistingCard', x: 0, y: 0, w: 4, h: 1 }],
+      };
+      rerender(
+        <DashboardGrid
+          {...callbackMocks}
+          layouts={layoutwithMissingCards}
+          breakpoint={BREAKPOINT}>
+          {getCards({ isResizable: true })}
+        </DashboardGrid>
+      );
+      expectToBeResizable('test-card');
+      expectToBeResizable('test-valueCard');
+      expectToBeResizable('test-imageCard');
     });
 
     it('prevents resize handles for all cards with isResizable: false', () => {
@@ -258,10 +289,10 @@ describe('DashboardGrid', () => {
         }
       };
 
-      render(
+      const { rerender } = render(
         <DashboardGrid
           {...callbackMocks}
-          layouts={layouts}
+          layouts={getLayouts()}
           breakpoint={BREAKPOINT}>
           {getCards({ isResizable: false })}
         </DashboardGrid>
@@ -276,6 +307,34 @@ describe('DashboardGrid', () => {
       expectNotToBeResizable('test-timeSeriesCard');
       expectNotToBeResizable('test-listCard');
       expectNotToBeResizable('test-barChartCard');
+
+      const emptyLayouts = {};
+      rerender(
+        <DashboardGrid
+          {...callbackMocks}
+          layouts={emptyLayouts}
+          breakpoint={BREAKPOINT}>
+          {getCards({ isResizable: false })}
+        </DashboardGrid>
+      );
+      expectNotToBeResizable('test-card'); // base card
+      expectNotToBeResizable('test-valueCard'); // card wrapping base card
+      expectNotToBeResizable('test-imageCard'); // card wrapping base card with children as a function
+
+      const layoutwithMissingCards = {
+        [BREAKPOINT]: [{ i: 'nonExistingCard', x: 0, y: 0, w: 4, h: 1 }],
+      };
+      rerender(
+        <DashboardGrid
+          {...callbackMocks}
+          layouts={layoutwithMissingCards}
+          breakpoint={BREAKPOINT}>
+          {getCards({ isResizable: false })}
+        </DashboardGrid>
+      );
+      expectNotToBeResizable('test-card');
+      expectNotToBeResizable('test-valueCard');
+      expectNotToBeResizable('test-imageCard');
     });
 
     it('it matches dimensions (height first) to closest larger or equally large card size', () => {

--- a/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
@@ -541,6 +541,2295 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashboard Grid dashboard, all cards as resizable 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <p>
+      All cards are resizable by dragging and the card size prop is automatically updated to match the new size during the drag process. Some cards have a minimal size defined.
+    </p>
+    <div
+      style={
+        Object {
+          "width": "calc(100vw - 6rem)",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <div
+          className="react-grid-layout DashboardGrid__StyledGridLayout-vxs00g-0 ANzdO"
+          onDragEnter={[Function]}
+          onDragLeave={[Function]}
+          onDragOver={[Function]}
+          onDrop={[Function]}
+          style={
+            Object {
+              "height": "2544px",
+            }
+          }
+        >
+          <div
+            className="iot--card react-grid-item react-draggable react-resizable iot--card--wrapper"
+            data-testid="Card"
+            id="card"
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            role="presentation"
+            style={
+              Object {
+                "--card-default-height": "144px",
+                "height": "144px",
+                "left": "0%",
+                "position": "absolute",
+                "top": "0px",
+                "width": "24.0625%",
+              }
+            }
+          >
+            <div
+              className="iot--card--header"
+            >
+              <span
+                className="iot--card--title"
+                title="Card - SMALL"
+              >
+                <div
+                  className="iot--card--title--text"
+                >
+                  Card - SMALL
+                </div>
+              </span>
+              <div
+                className="iot--card--toolbar"
+              >
+                <button
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  aria-label="Menu"
+                  className="bx--overflow-menu"
+                  onClick={[Function]}
+                  onClose={[Function]}
+                  onKeyDown={[Function]}
+                  open={false}
+                  tabIndex={0}
+                  title="Open and close list of options"
+                  type="button"
+                >
+                  <svg
+                    aria-label="open and close list of options"
+                    className="bx--overflow-menu__icon"
+                    fill="currentColor"
+                    focusable="false"
+                    height={16}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 32 32"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <circle
+                      cx="16"
+                      cy="8"
+                      r="2"
+                    />
+                    <circle
+                      cx="16"
+                      cy="16"
+                      r="2"
+                    />
+                    <circle
+                      cx="16"
+                      cy="24"
+                      r="2"
+                    />
+                    <title>
+                      open and close list of options
+                    </title>
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              className="iot--card--content"
+              style={
+                Object {
+                  "--card-content-height": "96px",
+                }
+              }
+            >
+              <p>
+                This is a basic card
+              </p>
+              <span
+                className="react-resizable-handle react-resizable-handle-se"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "touchAction": "none",
+                  }
+                }
+              />
+            </div>
+            <span
+              className="react-resizable-handle react-resizable-handle-se"
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+            />
+          </div>
+          <div
+            className="iot--card react-grid-item react-draggable react-resizable iot--card--wrapper"
+            data-testid="Card"
+            id="valueCard"
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            role="presentation"
+            style={
+              Object {
+                "--card-default-height": "144px",
+                "height": "144px",
+                "left": "25.3125%",
+                "position": "absolute",
+                "top": "0px",
+                "width": "24.0625%",
+              }
+            }
+          >
+            <div
+              className="iot--card--header"
+            >
+              <span
+                className="iot--card--title"
+                title="ValueCard - SMALLWIDE"
+              >
+                <div
+                  className="iot--card--title--text"
+                >
+                  ValueCard - SMALLWIDE
+                </div>
+              </span>
+            </div>
+            <div
+              className="iot--card--content"
+              style={
+                Object {
+                  "--card-content-height": "96px",
+                }
+              }
+            >
+              <div
+                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+              >
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
+                  size="SMALLWIDE"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                    label={null}
+                    size="SMALLWIDE"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 kmAyHP"
+                        size="SMALLWIDE"
+                        title="-- %"
+                        value="--"
+                      >
+                        --
+                      </span>
+                    </div>
+                    <span
+                      className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                      style={
+                        Object {
+                          "--default-font-size": "1.25rem",
+                        }
+                      }
+                    >
+                      %
+                    </span>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
+                    size="SMALLWIDE"
+                  />
+                </div>
+              </div>
+              <span
+                className="react-resizable-handle react-resizable-handle-se"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "touchAction": "none",
+                  }
+                }
+              />
+            </div>
+            <span
+              className="react-resizable-handle react-resizable-handle-se"
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+            />
+          </div>
+          <div
+            className="iot--card iot--gauge-card iot--card--wrapper"
+            data-testid="Card"
+            id="gaugeCard"
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            role="presentation"
+            style={
+              Object {
+                "--card-default-height": "304px",
+                "height": "304px",
+                "left": "0%",
+                "position": "absolute",
+                "top": "160px",
+                "width": "24.0625%",
+              }
+            }
+          >
+            <div
+              className="iot--card--header"
+            >
+              <span
+                className="iot--card--title"
+                title="GaugeCard - MEDIUMTHIN"
+              >
+                <div
+                  className="iot--card--title--text"
+                >
+                  GaugeCard - MEDIUMTHIN
+                </div>
+                <div
+                  className="bx--tooltip__label"
+                  id="card-tooltip-trigger-gaugeCard"
+                >
+                  
+                  <div
+                    aria-describedby={null}
+                    className="bx--tooltip__trigger"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      description={null}
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role={null}
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
+                      />
+                      <path
+                        d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </span>
+            </div>
+            <div
+              className="iot--card--content"
+              style={
+                Object {
+                  "--card-content-height": "256px",
+                }
+              }
+            >
+              <div
+                className="iot--gauge-container react-grid-item react-draggable react-resizable"
+                style={
+                  Object {
+                    "paddingBottom": 0,
+                    "paddingLeft": 16,
+                    "paddingRight": 16,
+                    "paddingTop": 0,
+                  }
+                }
+              >
+                <svg
+                  aria-labelledby="gauge-label"
+                  className="iot--gauge react-grid-item react-draggable react-resizable"
+                  percent="0"
+                  style={
+                    Object {
+                      "--gauge-bg": "#e0e0e0",
+                      "--gauge-colors": "green",
+                      "--gauge-max-value": 100,
+                      "--gauge-size": "80px",
+                      "--gauge-trend-color": "",
+                      "--gauge-value": 81,
+                      "--stroke-dash": 183.21768355735674,
+                      "--stroke-dash-array": 226.1946710584651,
+                    }
+                  }
+                >
+                  <circle
+                    className="iot--gauge-bg"
+                    cx={40}
+                    cy={40}
+                    r={36}
+                  />
+                  <circle
+                    className="iot--gauge-fg"
+                    cx={40}
+                    cy={40}
+                    r={36}
+                  />
+                  <text
+                    className="iot--gauge-value iot--gauge-value__centered iot--gauge-value-lg"
+                    id="gauge-label"
+                    textAnchor="middle"
+                    x={40}
+                    y="33"
+                  >
+                    <tspan>
+                      81
+                    </tspan>
+                    <tspan>
+                      %
+                    </tspan>
+                  </text>
+                </svg>
+                <div
+                  className="iot--gauge-trend iot--gauge-trend__up"
+                >
+                  <p
+                    style={
+                      Object {
+                        "--gauge-trend-color": "",
+                      }
+                    }
+                  >
+                    12%
+                  </p>
+                </div>
+              </div>
+            </div>
+            <span
+              className="react-resizable-handle react-resizable-handle-se"
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+            />
+          </div>
+          <div
+            className="iot--card react-grid-item react-draggable react-resizable iot--card--wrapper"
+            data-testid="Card"
+            id="pieChartCard"
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            role="presentation"
+            style={
+              Object {
+                "--card-default-height": "304px",
+                "height": "304px",
+                "left": "25.3125%",
+                "position": "absolute",
+                "top": "160px",
+                "width": "24.0625%",
+              }
+            }
+          >
+            <div
+              className="iot--card--header"
+            >
+              <span
+                className="iot--card--title"
+                title="PieChartCard - MEDIUM"
+              >
+                <div
+                  className="iot--card--title--text"
+                >
+                  PieChartCard - MEDIUM
+                </div>
+              </span>
+            </div>
+            <div
+              className="iot--card--content"
+              style={
+                Object {
+                  "--card-content-height": "256px",
+                }
+              }
+            >
+              <div
+                className="iot--pie-chart-container"
+              >
+                <div
+                  className="chart-holder"
+                />
+              </div>
+              <span
+                className="react-resizable-handle react-resizable-handle-se"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "touchAction": "none",
+                  }
+                }
+              />
+            </div>
+            <span
+              className="react-resizable-handle react-resizable-handle-se"
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+            />
+          </div>
+          <div
+            className="iot--card react-grid-item react-draggable react-resizable iot--card--wrapper"
+            data-testid="Card"
+            id="tableCard"
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            role="presentation"
+            style={
+              Object {
+                "--card-default-height": "624px",
+                "height": "624px",
+                "left": "25.3125%",
+                "position": "absolute",
+                "top": "640px",
+                "width": "49.375%",
+              }
+            }
+          >
+            <div
+              className="iot--card--content"
+              style={
+                Object {
+                  "--card-content-height": "576px",
+                }
+              }
+            >
+              <div
+                className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+              >
+                <section
+                  aria-label="data table toolbar"
+                  className="bx--table-toolbar"
+                >
+                  <div
+                    className="bx--batch-actions iot--table-batch-actions"
+                  >
+                    <div
+                      className="bx--batch-summary"
+                    >
+                      <p
+                        className="bx--batch-summary__para"
+                      >
+                        <span>
+                          0 item selected
+                        </span>
+                      </p>
+                    </div>
+                    <div
+                      className="bx--action-list"
+                    >
+                      <button
+                        className="bx--batch-summary__cancel bx--btn bx--btn--primary"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={-1}
+                        type="button"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                  <label
+                    className="iot--table-toolbar-secondary-title"
+                  >
+                    TableCard - LARGE
+                  </label>
+                  <div
+                    className="bx--toolbar-content iot--table-toolbar-content"
+                  >
+                    <div
+                      className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      tabIndex="0"
+                    >
+                      <div
+                        aria-labelledby="table-for-card-tableCard-toolbar-search-search"
+                        className="bx--search bx--search--sm table-toolbar-search"
+                        role="search"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="bx--search-magnifier"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                          />
+                        </svg>
+                        <label
+                          className="bx--label"
+                          htmlFor="table-for-card-tableCard-toolbar-search"
+                          id="table-for-card-tableCard-toolbar-search-search"
+                        >
+                          Search
+                        </label>
+                        <input
+                          aria-hidden={true}
+                          autoComplete="off"
+                          className="bx--search-input"
+                          disabled={true}
+                          id="table-for-card-tableCard-toolbar-search"
+                          onChange={[Function]}
+                          placeholder="Search"
+                          role="searchbox"
+                          tabIndex="-1"
+                          type="text"
+                          value=""
+                        />
+                        <button
+                          aria-label="Clear search input"
+                          className="bx--search-close bx--search-close--hidden"
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden={true}
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                    <button
+                      className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost bx--btn--disabled"
+                      data-testid="download-button"
+                      disabled={true}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      title="Download table content"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="Download table content"
+                        className="bx--btn__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                        />
+                        <path
+                          d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
+                        />
+                      </svg>
+                    </button>
+                    <button
+                      className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost bx--btn--disabled"
+                      data-testid="filter-button"
+                      disabled={true}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      title="Filters"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="Filters"
+                        className="bx--btn__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M18,28H14a2,2,0,0,1-2-2V18.41L4.59,11A2,2,0,0,1,4,9.59V6A2,2,0,0,1,6,4H26a2,2,0,0,1,2,2V9.59A2,2,0,0,1,27.41,11L20,18.41V26A2,2,0,0,1,18,28ZM6,6V9.59l8,8V26h4V17.59l8-8V6Z"
+                        />
+                      </svg>
+                    </button>
+                    <div
+                      className="iot--card--toolbar"
+                    />
+                  </div>
+                </section>
+                <div
+                  className="addons-iot-table-container"
+                >
+                  <div
+                    className="bx--data-table-content"
+                  >
+                    <table
+                      className="bx--data-table bx--data-table--no-border"
+                      title={null}
+                    >
+                      <thead
+                        onMouseMove={null}
+                        onMouseUp={null}
+                      >
+                        <tr>
+                          <th
+                            aria-sort="none"
+                            className="table-header-label-start iot--table-head--table-header table-header-sortable"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                            width=""
+                          >
+                            <button
+                              align="start"
+                              className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
+                              data-column="alert"
+                              data-floating-menu-container={true}
+                              id="column-alert"
+                              onClick={[Function]}
+                              style={
+                                Object {
+                                  "--table-header-width": "",
+                                }
+                              }
+                              width=""
+                            >
+                              <span
+                                className="bx--table-header-label"
+                              >
+                                <span
+                                  className=""
+                                  title="Alert"
+                                >
+                                  Alert
+                                </span>
+                              </span>
+                              <svg
+                                aria-label="Sort rows by this header in ascending order"
+                                className="bx--table-sort__icon"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                                />
+                              </svg>
+                              <svg
+                                aria-label="Sort rows by this header in ascending order"
+                                className="bx--table-sort__icon-unsorted"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                />
+                              </svg>
+                            </button>
+                          </th>
+                          <th
+                            aria-sort="none"
+                            className="table-header-label-start iot--table-head--table-header table-header-sortable"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                            width=""
+                          >
+                            <button
+                              align="start"
+                              className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
+                              data-column="hour"
+                              data-floating-menu-container={true}
+                              id="column-hour"
+                              onClick={[Function]}
+                              style={
+                                Object {
+                                  "--table-header-width": "",
+                                }
+                              }
+                              width=""
+                            >
+                              <span
+                                className="bx--table-header-label"
+                              >
+                                <span
+                                  className=""
+                                  title="Hour"
+                                >
+                                  Hour
+                                </span>
+                              </span>
+                              <svg
+                                aria-label="Sort rows by this header in ascending order"
+                                className="bx--table-sort__icon"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                                />
+                              </svg>
+                              <svg
+                                aria-label="Sort rows by this header in ascending order"
+                                className="bx--table-sort__icon-unsorted"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                />
+                              </svg>
+                            </button>
+                          </th>
+                          <th
+                            aria-sort="none"
+                            className="table-header-label-start iot--table-head--table-header table-header-sortable"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                            width=""
+                          >
+                            <button
+                              align="start"
+                              className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
+                              data-column="pressure"
+                              data-floating-menu-container={true}
+                              id="column-pressure"
+                              onClick={[Function]}
+                              style={
+                                Object {
+                                  "--table-header-width": "",
+                                }
+                              }
+                              width=""
+                            >
+                              <span
+                                className="bx--table-header-label"
+                              >
+                                <span
+                                  className=""
+                                  title="Pressure"
+                                >
+                                  Pressure
+                                </span>
+                              </span>
+                              <svg
+                                aria-label="Sort rows by this header in ascending order"
+                                className="bx--table-sort__icon"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                                />
+                              </svg>
+                              <svg
+                                aria-label="Sort rows by this header in ascending order"
+                                className="bx--table-sort__icon-unsorted"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                />
+                              </svg>
+                            </button>
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody
+                        aria-live="polite"
+                      >
+                        <tr
+                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                          onClick={[Function]}
+                        >
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="alert"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-0-alert"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="--"
+                              >
+                                --
+                              </span>
+                            </span>
+                          </td>
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="hour"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-0-hour"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="hh:mm:ss"
+                              >
+                                hh:mm:ss
+                              </span>
+                            </span>
+                          </td>
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="pressure"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-0-pressure"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="--"
+                              >
+                                --
+                              </span>
+                            </span>
+                          </td>
+                        </tr>
+                        <tr
+                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                          onClick={[Function]}
+                        >
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="alert"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-1-alert"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="--"
+                              >
+                                --
+                              </span>
+                            </span>
+                          </td>
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="hour"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-1-hour"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="hh:mm:ss"
+                              >
+                                hh:mm:ss
+                              </span>
+                            </span>
+                          </td>
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="pressure"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-1-pressure"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="--"
+                              >
+                                --
+                              </span>
+                            </span>
+                          </td>
+                        </tr>
+                        <tr
+                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                          onClick={[Function]}
+                        >
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="alert"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-2-alert"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="--"
+                              >
+                                --
+                              </span>
+                            </span>
+                          </td>
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="hour"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-2-hour"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="hh:mm:ss"
+                              >
+                                hh:mm:ss
+                              </span>
+                            </span>
+                          </td>
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="pressure"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-2-pressure"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="--"
+                              >
+                                --
+                              </span>
+                            </span>
+                          </td>
+                        </tr>
+                        <tr
+                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                          onClick={[Function]}
+                        >
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="alert"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-3-alert"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="--"
+                              >
+                                --
+                              </span>
+                            </span>
+                          </td>
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="hour"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-3-hour"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="hh:mm:ss"
+                              >
+                                hh:mm:ss
+                              </span>
+                            </span>
+                          </td>
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="pressure"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-3-pressure"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="--"
+                              >
+                                --
+                              </span>
+                            </span>
+                          </td>
+                        </tr>
+                        <tr
+                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                          onClick={[Function]}
+                        >
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="alert"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-4-alert"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="--"
+                              >
+                                --
+                              </span>
+                            </span>
+                          </td>
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="hour"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-4-hour"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="hh:mm:ss"
+                              >
+                                hh:mm:ss
+                              </span>
+                            </span>
+                          </td>
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="pressure"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-4-pressure"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="--"
+                              >
+                                --
+                              </span>
+                            </span>
+                          </td>
+                        </tr>
+                        <tr
+                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                          onClick={[Function]}
+                        >
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="alert"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-5-alert"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="--"
+                              >
+                                --
+                              </span>
+                            </span>
+                          </td>
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="hour"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-5-hour"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="hh:mm:ss"
+                              >
+                                hh:mm:ss
+                              </span>
+                            </span>
+                          </td>
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="pressure"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-5-pressure"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="--"
+                              >
+                                --
+                              </span>
+                            </span>
+                          </td>
+                        </tr>
+                        <tr
+                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                          onClick={[Function]}
+                        >
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="alert"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-6-alert"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="--"
+                              >
+                                --
+                              </span>
+                            </span>
+                          </td>
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="hour"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-6-hour"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="hh:mm:ss"
+                              >
+                                hh:mm:ss
+                              </span>
+                            </span>
+                          </td>
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="pressure"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-6-pressure"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="--"
+                              >
+                                --
+                              </span>
+                            </span>
+                          </td>
+                        </tr>
+                        <tr
+                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                          onClick={[Function]}
+                        >
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="alert"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-7-alert"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="--"
+                              >
+                                --
+                              </span>
+                            </span>
+                          </td>
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="hour"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-7-hour"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="hh:mm:ss"
+                              >
+                                hh:mm:ss
+                              </span>
+                            </span>
+                          </td>
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="pressure"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-7-pressure"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="--"
+                              >
+                                --
+                              </span>
+                            </span>
+                          </td>
+                        </tr>
+                        <tr
+                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                          onClick={[Function]}
+                        >
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="alert"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-8-alert"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="--"
+                              >
+                                --
+                              </span>
+                            </span>
+                          </td>
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="hour"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-8-hour"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="hh:mm:ss"
+                              >
+                                hh:mm:ss
+                              </span>
+                            </span>
+                          </td>
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="pressure"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-8-pressure"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="--"
+                              >
+                                --
+                              </span>
+                            </span>
+                          </td>
+                        </tr>
+                        <tr
+                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                          onClick={[Function]}
+                        >
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="alert"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-9-alert"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="--"
+                              >
+                                --
+                              </span>
+                            </span>
+                          </td>
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="hour"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-9-hour"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="hh:mm:ss"
+                              >
+                                hh:mm:ss
+                              </span>
+                            </span>
+                          </td>
+                          <td
+                            align="start"
+                            className="data-table-start"
+                            data-column="pressure"
+                            data-offset={0}
+                            id="cell-table-for-card-tableCard-sample-values-tableCard-9-pressure"
+                            offset={0}
+                            width=""
+                          >
+                            <span
+                              className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                            >
+                              <span
+                                className=""
+                                title="--"
+                              >
+                                --
+                              </span>
+                            </span>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+                <div
+                  className="bx--pagination iot--pagination iot--pagination--hide-page"
+                  style={
+                    Object {
+                      "--pagination-text-display": "flex",
+                    }
+                  }
+                >
+                  <div
+                    className="bx--pagination__left"
+                  >
+                    <label
+                      className="bx--pagination__text"
+                      htmlFor="bx-pagination-select-3"
+                      id="bx-pagination-select-3-count-label"
+                    >
+                      Items per page:
+                    </label>
+                    <div
+                      className="bx--form-item"
+                    >
+                      <div
+                        className="bx--select bx--select--inline bx--select__item-count"
+                      >
+                        <div
+                          className="bx--select-input--inline__wrapper"
+                        >
+                          <div
+                            className="bx--select-input__wrapper"
+                            data-invalid={null}
+                          >
+                            <select
+                              className="bx--select-input"
+                              id="bx-pagination-select-3"
+                              onChange={[Function]}
+                              value={10}
+                            >
+                              <option
+                                className="bx--select-option"
+                                disabled={false}
+                                hidden={false}
+                                value={10}
+                              >
+                                10
+                              </option>
+                              <option
+                                className="bx--select-option"
+                                disabled={false}
+                                hidden={false}
+                                value={25}
+                              >
+                                25
+                              </option>
+                              <option
+                                className="bx--select-option"
+                                disabled={false}
+                                hidden={false}
+                                value={100}
+                              >
+                                100
+                              </option>
+                            </select>
+                            <svg
+                              aria-hidden={true}
+                              className="bx--select__arrow"
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <span
+                      className="bx--pagination__text bx--pagination__items-count"
+                    >
+                      1–10 of 10 items
+                    </span>
+                  </div>
+                  <div
+                    className="bx--pagination__right"
+                  >
+                    <div
+                      className="bx--form-item"
+                    >
+                      <div
+                        className="bx--select bx--select--inline bx--select__page-number"
+                      >
+                        <label
+                          className="bx--label bx--visually-hidden"
+                          htmlFor="bx-pagination-select-3-right"
+                        >
+                          Page number, of 1 pages
+                        </label>
+                        <div
+                          className="bx--select-input--inline__wrapper"
+                        >
+                          <div
+                            className="bx--select-input__wrapper"
+                            data-invalid={null}
+                          >
+                            <select
+                              className="bx--select-input"
+                              id="bx-pagination-select-3-right"
+                              onChange={[Function]}
+                              value={1}
+                            >
+                              <option
+                                className="bx--select-option"
+                                disabled={false}
+                                hidden={false}
+                                value={1}
+                              >
+                                1
+                              </option>
+                            </select>
+                            <svg
+                              aria-hidden={true}
+                              className="bx--select__arrow"
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <span
+                      className="bx--pagination__text"
+                    >
+                      1 of 1 pages
+                    </span>
+                    <div
+                      className="bx--pagination__control-buttons"
+                    >
+                      <button
+                        className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index bx--btn bx--btn--ghost bx--btn--disabled bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                        disabled={true}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Previous page
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Previous page"
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M20 24L10 16 20 8z"
+                          />
+                        </svg>
+                      </button>
+                      <button
+                        className="bx--pagination__button bx--pagination__button--forward bx--pagination__button--no-index bx--btn bx--btn--ghost bx--btn--disabled bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-end"
+                        disabled={true}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Next page
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Next page"
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 8L22 16 12 24z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <span
+              className="react-resizable-handle react-resizable-handle-se"
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+            />
+          </div>
+          <div
+            className="iot--card react-grid-item react-draggable react-resizable iot--card--wrapper"
+            data-testid="Card"
+            id="imageCard"
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            role="presentation"
+            style={
+              Object {
+                "--card-default-height": "624px",
+                "height": "624px",
+                "left": "50.625%",
+                "position": "absolute",
+                "top": "0px",
+                "width": "49.375%",
+              }
+            }
+          >
+            <div
+              className="iot--card--header"
+            >
+              <span
+                className="iot--card--title"
+                title="ImageCard - LARGE"
+              >
+                <div
+                  className="iot--card--title--text"
+                >
+                  ImageCard - LARGE
+                </div>
+              </span>
+              <div
+                className="iot--card--toolbar"
+              />
+            </div>
+            <div
+              className="iot--card--content"
+              style={
+                Object {
+                  "--card-content-height": "576px",
+                }
+              }
+            >
+              <div
+                className="ImageCard__ContentWrapper-sc-1p2j9dm-0 bcWqmR"
+              >
+                <div
+                  className="ImageCard__EmptyDiv-sc-1p2j9dm-1 dkLZTG"
+                >
+                  <svg
+                    aria-hidden={true}
+                    fill="gray"
+                    focusable="false"
+                    height={250}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 32 32"
+                    width={250}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M19,14a3,3,0,1,0-3-3A3,3,0,0,0,19,14Zm0-4a1,1,0,1,1-1,1A1,1,0,0,1,19,10Z"
+                    />
+                    <path
+                      d="M26,4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2V6A2,2,0,0,0,26,4Zm0,22H6V20l5-5,5.59,5.59a2,2,0,0,0,2.82,0L21,19l5,5Zm0-4.83-3.59-3.59a2,2,0,0,0-2.82,0L18,19.17l-5.59-5.59a2,2,0,0,0-2.82,0L6,17.17V6H26Z"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </div>
+            <span
+              className="react-resizable-handle react-resizable-handle-se"
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+            />
+          </div>
+          <div
+            className="iot--card react-grid-item react-draggable react-resizable iot--card--wrapper"
+            data-testid="Card"
+            id="timeSeriesCard"
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            role="presentation"
+            style={
+              Object {
+                "--card-default-height": "624px",
+                "height": "624px",
+                "left": "0%",
+                "position": "absolute",
+                "top": "480px",
+                "width": "24.0625%",
+              }
+            }
+          >
+            <div
+              className="iot--card--header"
+            >
+              <span
+                className="iot--card--title"
+                title="TimeSeriesCard - LARGETHIN"
+              >
+                <div
+                  className="iot--card--title--text"
+                >
+                  TimeSeriesCard - LARGETHIN
+                </div>
+              </span>
+            </div>
+            <div
+              className="iot--card--content"
+              style={
+                Object {
+                  "--card-content-height": "576px",
+                }
+              }
+            >
+              <div
+                className="iot--time-series-card--wrapper iot--time-series-card--wrapper__editable"
+              >
+                <div
+                  className="chart-holder"
+                />
+              </div>
+            </div>
+            <span
+              className="react-resizable-handle react-resizable-handle-se"
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+            />
+          </div>
+          <div
+            className="iot--card iot--card--wrapper"
+            data-testid="Card"
+            id="listCard"
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            onScroll={[Function]}
+            onTouchEnd={[Function]}
+            role="presentation"
+            style={
+              Object {
+                "--card-default-height": "624px",
+                "height": "624px",
+                "left": "25.3125%",
+                "position": "absolute",
+                "top": "1280px",
+                "width": "24.0625%",
+              }
+            }
+          >
+            <div
+              className="iot--card--header"
+            >
+              <span
+                className="iot--card--title"
+                title="ListCard - LARGETHIN"
+              >
+                <div
+                  className="iot--card--title--text"
+                >
+                  ListCard - LARGETHIN
+                </div>
+              </span>
+            </div>
+            <div
+              className="iot--card--content"
+              style={
+                Object {
+                  "--card-content-height": "576px",
+                }
+              }
+            >
+              <div
+                className="list-card react-grid-item react-draggable react-resizable"
+                style={
+                  Object {
+                    "paddingBottom": 0,
+                    "paddingLeft": 16,
+                    "paddingRight": 16,
+                    "paddingTop": 0,
+                  }
+                }
+              >
+                <section
+                  aria-label="Structured list section"
+                  className="bx--structured-list"
+                >
+                  <div
+                    className="bx--structured-list-tbody"
+                    onKeyDown={[Function]}
+                  >
+                    <div
+                      className="bx--structured-list-row"
+                    >
+                      <div
+                        className="list-card--item bx--structured-list-td"
+                      >
+                        <div
+                          className="list-card--item--value"
+                        >
+                          <a
+                            className="bx--link"
+                            href="https://internetofthings.ibmcloud.com/"
+                            style={
+                              Object {
+                                "display": "inherit",
+                              }
+                            }
+                            target="_blank"
+                          >
+                            Row content 1
+                          </a>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="bx--structured-list-row"
+                    >
+                      <div
+                        className="list-card--item bx--structured-list-td"
+                      >
+                        <div
+                          className="list-card--item--value"
+                        >
+                          <a
+                            className="bx--link"
+                            href="https://internetofthings.ibmcloud.com/"
+                            style={
+                              Object {
+                                "display": "inherit",
+                              }
+                            }
+                            target="_blank"
+                          >
+                            Row content 2
+                          </a>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="bx--structured-list-row"
+                    >
+                      <div
+                        className="list-card--item bx--structured-list-td"
+                      >
+                        <div
+                          className="list-card--item--value"
+                        >
+                          Row content 3
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="bx--structured-list-row"
+                    >
+                      <div
+                        className="list-card--item bx--structured-list-td"
+                      >
+                        <div
+                          className="list-card--item--value"
+                        >
+                          <a
+                            className="bx--link"
+                            href="https://internetofthings.ibmcloud.com/"
+                            style={
+                              Object {
+                                "display": "inherit",
+                              }
+                            }
+                            target="_blank"
+                          >
+                            Row content 4
+                          </a>
+                        </div>
+                        <div
+                          className="list-card--item--extra-content"
+                        >
+                          <svg
+                            height="10"
+                            width="30"
+                          >
+                            <circle
+                              cx="5"
+                              cy="5"
+                              fill="red"
+                              r="3"
+                              stroke="none"
+                              strokeWidth="1"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="bx--structured-list-row"
+                    >
+                      <div
+                        className="list-card--item bx--structured-list-td"
+                      >
+                        <div
+                          className="list-card--item--value"
+                        >
+                          Row content 5
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="bx--structured-list-row"
+                    >
+                      <div
+                        className="list-card--item bx--structured-list-td"
+                      >
+                        <div
+                          className="list-card--item--value"
+                        >
+                          Row content 6
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="bx--structured-list-row"
+                    >
+                      <div
+                        className="list-card--item bx--structured-list-td"
+                      >
+                        <div
+                          className="list-card--item--value"
+                        >
+                          Row content 7
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="bx--structured-list-row"
+                    >
+                      <div
+                        className="list-card--item bx--structured-list-td"
+                      >
+                        <div
+                          className="list-card--item--value"
+                        >
+                          Row content 8
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </section>
+              </div>
+            </div>
+            <span
+              className="react-resizable-handle react-resizable-handle-se"
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+            />
+          </div>
+          <div
+            className="iot--card react-grid-item react-draggable react-resizable iot--bar-chart-card iot--card--wrapper"
+            data-testid="Card"
+            id="barChartCard"
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            role="presentation"
+            style={
+              Object {
+                "--card-default-height": "624px",
+                "height": "624px",
+                "left": "0%",
+                "position": "absolute",
+                "top": "1920px",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              className="iot--card--header"
+            >
+              <span
+                className="iot--card--title"
+                title="BarChartCard - LARGEWIDE"
+              >
+                <div
+                  className="iot--card--title--text"
+                >
+                  BarChartCard - LARGEWIDE
+                </div>
+              </span>
+            </div>
+            <div
+              className="iot--card--content"
+              style={
+                Object {
+                  "--card-content-height": "576px",
+                }
+              }
+            >
+              <div
+                className="iot--bar-chart-container iot--bar-chart-container--editable"
+              >
+                <div
+                  className="chart-holder"
+                />
+              </div>
+            </div>
+            <span
+              className="react-resizable-handle react-resizable-handle-se"
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashboard Grid dashboard, custom layout 1`] = `
 <div
   className="storybook-container"
@@ -1257,6 +3546,142 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                 }
               />
             </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashboard Grid dashboard, resizable card 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    The card is resizable by dragging and the card size prop is automatically updated to match the new size during the drag process.
+    <div
+      style={
+        Object {
+          "width": "calc(100vw - 6rem)",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <div
+          className="react-grid-layout DashboardGrid__StyledGridLayout-vxs00g-0 ANzdO"
+          onDragEnter={[Function]}
+          onDragLeave={[Function]}
+          onDragOver={[Function]}
+          onDrop={[Function]}
+          style={
+            Object {
+              "height": "144px",
+            }
+          }
+        >
+          <div
+            className="iot--card react-grid-item react-draggable react-resizable iot--card--wrapper"
+            data-testid="Card"
+            id="card"
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            role="presentation"
+            style={
+              Object {
+                "--card-default-height": "144px",
+                "height": "144px",
+                "left": "0%",
+                "position": "absolute",
+                "top": "0px",
+                "width": "24.0625%",
+              }
+            }
+          >
+            <div
+              className="iot--card--header"
+            >
+              <span
+                className="iot--card--title"
+                title="Card - SMALL"
+              >
+                <div
+                  className="iot--card--title--text"
+                >
+                  Card - SMALL
+                </div>
+              </span>
+            </div>
+            <div
+              className="iot--card--content"
+              style={
+                Object {
+                  "--card-content-height": "96px",
+                }
+              }
+            >
+              <span
+                className="react-resizable-handle react-resizable-handle-se"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "touchAction": "none",
+                  }
+                }
+              />
+            </div>
+            <span
+              className="react-resizable-handle react-resizable-handle-se"
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+            />
           </div>
         </div>
       </div>

--- a/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
@@ -583,7 +583,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
           }
         >
           <div
-            className="iot--card react-grid-item react-draggable react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item react-resizable iot--card--wrapper"
             data-testid="Card"
             id="card"
             onMouseDown={[Function]}
@@ -616,55 +616,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
               </span>
               <div
                 className="iot--card--toolbar"
-              >
-                <button
-                  aria-expanded={false}
-                  aria-haspopup={true}
-                  aria-label="Menu"
-                  className="bx--overflow-menu"
-                  onClick={[Function]}
-                  onClose={[Function]}
-                  onKeyDown={[Function]}
-                  open={false}
-                  tabIndex={0}
-                  title="Open and close list of options"
-                  type="button"
-                >
-                  <svg
-                    aria-label="open and close list of options"
-                    className="bx--overflow-menu__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height={16}
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    viewBox="0 0 32 32"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <circle
-                      cx="16"
-                      cy="8"
-                      r="2"
-                    />
-                    <circle
-                      cx="16"
-                      cy="16"
-                      r="2"
-                    />
-                    <circle
-                      cx="16"
-                      cy="24"
-                      r="2"
-                    />
-                    <title>
-                      open and close list of options
-                    </title>
-                  </svg>
-                </button>
-              </div>
+              />
             </div>
             <div
               className="iot--card--content"
@@ -704,7 +656,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             />
           </div>
           <div
-            className="iot--card react-grid-item react-draggable react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item react-resizable iot--card--wrapper"
             data-testid="Card"
             id="valueCard"
             onMouseDown={[Function]}
@@ -761,16 +713,16 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                       color={null}
                     >
                       <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 kmAyHP"
+                        className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                         size="SMALLWIDE"
-                        title="-- %"
-                        value="--"
+                        title="88 %"
+                        value={88}
                       >
-                        --
+                        88
                       </span>
                     </div>
                     <span
-                      className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                      className="iot--value-card__attribute-unit"
                       style={
                         Object {
                           "--default-font-size": "1.25rem",
@@ -892,7 +844,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
               }
             >
               <div
-                className="iot--gauge-container react-grid-item react-draggable react-resizable"
+                className="iot--gauge-container react-grid-item react-resizable"
                 style={
                   Object {
                     "paddingBottom": 0,
@@ -904,7 +856,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
               >
                 <svg
                   aria-labelledby="gauge-label"
-                  className="iot--gauge react-grid-item react-draggable react-resizable"
+                  className="iot--gauge react-grid-item react-resizable"
                   percent="0"
                   style={
                     Object {
@@ -975,7 +927,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             />
           </div>
           <div
-            className="iot--card react-grid-item react-draggable react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item react-resizable iot--card--wrapper"
             data-testid="Card"
             id="pieChartCard"
             onMouseDown={[Function]}
@@ -1049,7 +1001,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             />
           </div>
           <div
-            className="iot--card react-grid-item react-draggable react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item react-resizable iot--card--wrapper"
             data-testid="Card"
             id="tableCard"
             onMouseDown={[Function]}
@@ -1157,7 +1109,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           aria-hidden={true}
                           autoComplete="off"
                           className="bx--search-input"
-                          disabled={true}
                           id="table-for-card-tableCard-toolbar-search"
                           onChange={[Function]}
                           placeholder="Search"
@@ -1190,9 +1141,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                       </div>
                     </div>
                     <button
-                      className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost bx--btn--disabled"
+                      className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
                       data-testid="download-button"
-                      disabled={true}
+                      disabled={false}
                       onClick={[Function]}
                       tabIndex={0}
                       title="Download table content"
@@ -1220,9 +1171,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                       </svg>
                     </button>
                     <button
-                      className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost bx--btn--disabled"
+                      className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
                       data-testid="filter-button"
-                      disabled={true}
+                      disabled={false}
                       onClick={[Function]}
                       tabIndex={0}
                       title="Filters"
@@ -1248,7 +1199,82 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                     </button>
                     <div
                       className="iot--card--toolbar"
-                    />
+                    >
+                      <div
+                        className="iot--card--toolbar-date-range-wrapper"
+                      >
+                        <button
+                          aria-expanded={false}
+                          aria-haspopup={true}
+                          aria-label="Menu"
+                          className="iot--card--toolbar-date-range-action bx--overflow-menu"
+                          onClick={[Function]}
+                          onClose={[Function]}
+                          onKeyDown={[Function]}
+                          open={false}
+                          tabIndex={0}
+                          title="Select time range"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Select time range"
+                            className="bx--overflow-menu__icon"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
+                            />
+                            <path
+                              d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                            />
+                            <path
+                              d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
+                            />
+                            <title>
+                              Select time range
+                            </title>
+                          </svg>
+                        </button>
+                      </div>
+                      <button
+                        className="iot--card--toolbar-action iot--card--toolbar-svg-wrapper bx--btn--icon-only bx--btn bx--btn--ghost"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        title="Expand to fullscreen"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Expand to fullscreen"
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M28,4H10A2.0059,2.0059,0,0,0,8,6V20a2.0059,2.0059,0,0,0,2,2H28a2.0059,2.0059,0,0,0,2-2V6A2.0059,2.0059,0,0,0,28,4Zm0,16H10V6H28Z"
+                          />
+                          <path
+                            d="M18,26H4V16H6V14H4a2.0059,2.0059,0,0,0-2,2V26a2.0059,2.0059,0,0,0,2,2H18a2.0059,2.0059,0,0,0,2-2V24H18Z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </section>
                 <div
@@ -1479,7 +1505,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         aria-live="polite"
                       >
                         <tr
-                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 fAdmMh"
                           onClick={[Function]}
                         >
                           <td
@@ -1487,7 +1513,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="alert"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-0-alert"
+                            id="cell-table-for-card-tableCard-row-10-alert"
                             offset={0}
                             width=""
                           >
@@ -1496,9 +1522,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="--"
+                                title="AHI010 proccess need to optimize adjust Y variables"
                               >
-                                --
+                                AHI010 proccess need to optimize adjust Y variables
                               </span>
                             </span>
                           </td>
@@ -1507,7 +1533,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="hour"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-0-hour"
+                            id="cell-table-for-card-tableCard-row-10-hour"
                             offset={0}
                             width=""
                           >
@@ -1516,9 +1542,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="hh:mm:ss"
+                                title="10/28/2018 07:34"
                               >
-                                hh:mm:ss
+                                10/28/2018 07:34
                               </span>
                             </span>
                           </td>
@@ -1527,7 +1553,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="pressure"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-0-pressure"
+                            id="cell-table-for-card-tableCard-row-10-pressure"
                             offset={0}
                             width=""
                           >
@@ -1536,15 +1562,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="--"
+                                title="0"
                               >
-                                --
+                                0
                               </span>
                             </span>
                           </td>
                         </tr>
                         <tr
-                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 fAdmMh"
                           onClick={[Function]}
                         >
                           <td
@@ -1552,7 +1578,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="alert"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-1-alert"
+                            id="cell-table-for-card-tableCard-row-11-alert"
                             offset={0}
                             width=""
                           >
@@ -1561,9 +1587,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="--"
+                                title="AHI010 proccess need to optimize adjust Y variables"
                               >
-                                --
+                                AHI010 proccess need to optimize adjust Y variables
                               </span>
                             </span>
                           </td>
@@ -1572,7 +1598,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="hour"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-1-hour"
+                            id="cell-table-for-card-tableCard-row-11-hour"
                             offset={0}
                             width=""
                           >
@@ -1581,9 +1607,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="hh:mm:ss"
+                                title="10/28/2018 07:34"
                               >
-                                hh:mm:ss
+                                10/28/2018 07:34
                               </span>
                             </span>
                           </td>
@@ -1592,7 +1618,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="pressure"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-1-pressure"
+                            id="cell-table-for-card-tableCard-row-11-pressure"
                             offset={0}
                             width=""
                           >
@@ -1601,15 +1627,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="--"
+                                title="1"
                               >
-                                --
+                                1
                               </span>
                             </span>
                           </td>
                         </tr>
                         <tr
-                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 fAdmMh"
                           onClick={[Function]}
                         >
                           <td
@@ -1617,7 +1643,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="alert"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-2-alert"
+                            id="cell-table-for-card-tableCard-row-1-alert"
                             offset={0}
                             width=""
                           >
@@ -1626,9 +1652,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="--"
+                                title="AHI005 Asset failure"
                               >
-                                --
+                                AHI005 Asset failure
                               </span>
                             </span>
                           </td>
@@ -1637,7 +1663,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="hour"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-2-hour"
+                            id="cell-table-for-card-tableCard-row-1-hour"
                             offset={0}
                             width=""
                           >
@@ -1646,9 +1672,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="hh:mm:ss"
+                                title="10/28/2018 07:34"
                               >
-                                hh:mm:ss
+                                10/28/2018 07:34
                               </span>
                             </span>
                           </td>
@@ -1657,7 +1683,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="pressure"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-2-pressure"
+                            id="cell-table-for-card-tableCard-row-1-pressure"
                             offset={0}
                             width=""
                           >
@@ -1666,15 +1692,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="--"
+                                title="0"
                               >
-                                --
+                                0
                               </span>
                             </span>
                           </td>
                         </tr>
                         <tr
-                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 fAdmMh"
                           onClick={[Function]}
                         >
                           <td
@@ -1682,7 +1708,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="alert"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-3-alert"
+                            id="cell-table-for-card-tableCard-row-2-alert"
                             offset={0}
                             width=""
                           >
@@ -1691,9 +1717,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="--"
+                                title="AHI003 process need to optimize adjust X variables"
                               >
-                                --
+                                AHI003 process need to optimize adjust X variables
                               </span>
                             </span>
                           </td>
@@ -1702,7 +1728,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="hour"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-3-hour"
+                            id="cell-table-for-card-tableCard-row-2-hour"
                             offset={0}
                             width=""
                           >
@@ -1711,9 +1737,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="hh:mm:ss"
+                                title="10/28/2018 07:34"
                               >
-                                hh:mm:ss
+                                10/28/2018 07:34
                               </span>
                             </span>
                           </td>
@@ -1722,7 +1748,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="pressure"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-3-pressure"
+                            id="cell-table-for-card-tableCard-row-2-pressure"
                             offset={0}
                             width=""
                           >
@@ -1731,15 +1757,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="--"
+                                title="2"
                               >
-                                --
+                                2
                               </span>
                             </span>
                           </td>
                         </tr>
                         <tr
-                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 fAdmMh"
                           onClick={[Function]}
                         >
                           <td
@@ -1747,7 +1773,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="alert"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-4-alert"
+                            id="cell-table-for-card-tableCard-row-6-alert"
                             offset={0}
                             width=""
                           >
@@ -1756,9 +1782,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="--"
+                                title="AHI001 proccess need to optimize."
                               >
-                                --
+                                AHI001 proccess need to optimize.
                               </span>
                             </span>
                           </td>
@@ -1767,7 +1793,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="hour"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-4-hour"
+                            id="cell-table-for-card-tableCard-row-6-hour"
                             offset={0}
                             width=""
                           >
@@ -1776,9 +1802,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="hh:mm:ss"
+                                title="10/28/2018 07:34"
                               >
-                                hh:mm:ss
+                                10/28/2018 07:34
                               </span>
                             </span>
                           </td>
@@ -1787,7 +1813,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="pressure"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-4-pressure"
+                            id="cell-table-for-card-tableCard-row-6-pressure"
                             offset={0}
                             width=""
                           >
@@ -1796,15 +1822,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="--"
+                                title="68"
                               >
-                                --
+                                68
                               </span>
                             </span>
                           </td>
                         </tr>
                         <tr
-                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 fAdmMh"
                           onClick={[Function]}
                         >
                           <td
@@ -1812,7 +1838,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="alert"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-5-alert"
+                            id="cell-table-for-card-tableCard-row-3-alert"
                             offset={0}
                             width=""
                           >
@@ -1821,9 +1847,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="--"
+                                title="AHI001 proccess need to optimize adjust Y variables"
                               >
-                                --
+                                AHI001 proccess need to optimize adjust Y variables
                               </span>
                             </span>
                           </td>
@@ -1832,7 +1858,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="hour"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-5-hour"
+                            id="cell-table-for-card-tableCard-row-3-hour"
                             offset={0}
                             width=""
                           >
@@ -1841,9 +1867,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="hh:mm:ss"
+                                title="10/28/2018 07:34"
                               >
-                                hh:mm:ss
+                                10/28/2018 07:34
                               </span>
                             </span>
                           </td>
@@ -1852,7 +1878,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="pressure"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-5-pressure"
+                            id="cell-table-for-card-tableCard-row-3-pressure"
                             offset={0}
                             width=""
                           >
@@ -1861,15 +1887,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="--"
+                                title="10"
                               >
-                                --
+                                10
                               </span>
                             </span>
                           </td>
                         </tr>
                         <tr
-                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 fAdmMh"
                           onClick={[Function]}
                         >
                           <td
@@ -1877,7 +1903,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="alert"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-6-alert"
+                            id="cell-table-for-card-tableCard-row-4-alert"
                             offset={0}
                             width=""
                           >
@@ -1886,9 +1912,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="--"
+                                title="AHI001 proccess need to optimize adjust Y variables"
                               >
-                                --
+                                AHI001 proccess need to optimize adjust Y variables
                               </span>
                             </span>
                           </td>
@@ -1897,7 +1923,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="hour"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-6-hour"
+                            id="cell-table-for-card-tableCard-row-4-hour"
                             offset={0}
                             width=""
                           >
@@ -1906,9 +1932,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="hh:mm:ss"
+                                title="10/28/2018 07:34"
                               >
-                                hh:mm:ss
+                                10/28/2018 07:34
                               </span>
                             </span>
                           </td>
@@ -1917,7 +1943,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="pressure"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-6-pressure"
+                            id="cell-table-for-card-tableCard-row-4-pressure"
                             offset={0}
                             width=""
                           >
@@ -1926,15 +1952,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="--"
+                                title="0"
                               >
-                                --
+                                0
                               </span>
                             </span>
                           </td>
                         </tr>
                         <tr
-                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 fAdmMh"
                           onClick={[Function]}
                         >
                           <td
@@ -1942,7 +1968,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="alert"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-7-alert"
+                            id="cell-table-for-card-tableCard-row-8-alert"
                             offset={0}
                             width=""
                           >
@@ -1951,9 +1977,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="--"
+                                title="AHI001 proccess need to optimize adjust Y variables"
                               >
-                                --
+                                AHI001 proccess need to optimize adjust Y variables
                               </span>
                             </span>
                           </td>
@@ -1962,7 +1988,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="hour"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-7-hour"
+                            id="cell-table-for-card-tableCard-row-8-hour"
                             offset={0}
                             width=""
                           >
@@ -1971,9 +1997,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="hh:mm:ss"
+                                title="10/28/2018 07:34"
                               >
-                                hh:mm:ss
+                                10/28/2018 07:34
                               </span>
                             </span>
                           </td>
@@ -1982,7 +2008,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="pressure"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-7-pressure"
+                            id="cell-table-for-card-tableCard-row-8-pressure"
                             offset={0}
                             width=""
                           >
@@ -1991,15 +2017,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="--"
+                                title="0"
                               >
-                                --
+                                0
                               </span>
                             </span>
                           </td>
                         </tr>
                         <tr
-                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 fAdmMh"
                           onClick={[Function]}
                         >
                           <td
@@ -2007,7 +2033,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="alert"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-8-alert"
+                            id="cell-table-for-card-tableCard-row-9-alert"
                             offset={0}
                             width=""
                           >
@@ -2016,9 +2042,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="--"
+                                title="AHI001 proccess need to optimize adjust Y variables"
                               >
-                                --
+                                AHI001 proccess need to optimize adjust Y variables
                               </span>
                             </span>
                           </td>
@@ -2027,7 +2053,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="hour"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-8-hour"
+                            id="cell-table-for-card-tableCard-row-9-hour"
                             offset={0}
                             width=""
                           >
@@ -2036,9 +2062,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="hh:mm:ss"
+                                title="10/28/2018 07:34"
                               >
-                                hh:mm:ss
+                                10/28/2018 07:34
                               </span>
                             </span>
                           </td>
@@ -2047,7 +2073,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="pressure"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-8-pressure"
+                            id="cell-table-for-card-tableCard-row-9-pressure"
                             offset={0}
                             width=""
                           >
@@ -2056,15 +2082,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="--"
+                                title="0"
                               >
-                                --
+                                0
                               </span>
                             </span>
                           </td>
                         </tr>
                         <tr
-                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                          className="TableBodyRow__StyledTableRow-sc-103itxu-0 fAdmMh"
                           onClick={[Function]}
                         >
                           <td
@@ -2072,7 +2098,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="alert"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-9-alert"
+                            id="cell-table-for-card-tableCard-row-5-alert"
                             offset={0}
                             width=""
                           >
@@ -2081,9 +2107,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="--"
+                                title="AHI001 proccess need to optimize"
                               >
-                                --
+                                AHI001 proccess need to optimize
                               </span>
                             </span>
                           </td>
@@ -2092,7 +2118,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="hour"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-9-hour"
+                            id="cell-table-for-card-tableCard-row-5-hour"
                             offset={0}
                             width=""
                           >
@@ -2101,9 +2127,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="hh:mm:ss"
+                                title="10/28/2018 07:34"
                               >
-                                hh:mm:ss
+                                10/28/2018 07:34
                               </span>
                             </span>
                           </td>
@@ -2112,7 +2138,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             className="data-table-start"
                             data-column="pressure"
                             data-offset={0}
-                            id="cell-table-for-card-tableCard-sample-values-tableCard-9-pressure"
+                            id="cell-table-for-card-tableCard-row-5-pressure"
                             offset={0}
                             width=""
                           >
@@ -2121,9 +2147,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <span
                                 className=""
-                                title="--"
+                                title="10"
                               >
-                                --
+                                10
                               </span>
                             </span>
                           </td>
@@ -2216,7 +2242,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                     <span
                       className="bx--pagination__text bx--pagination__items-count"
                     >
-                      1–10 of 10 items
+                      1–10 of 11 items
                     </span>
                   </div>
                   <div
@@ -2232,7 +2258,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           className="bx--label bx--visually-hidden"
                           htmlFor="bx-pagination-select-3-right"
                         >
-                          Page number, of 1 pages
+                          Page number, of 2 pages
                         </label>
                         <div
                           className="bx--select-input--inline__wrapper"
@@ -2254,6 +2280,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                 value={1}
                               >
                                 1
+                              </option>
+                              <option
+                                className="bx--select-option"
+                                disabled={false}
+                                hidden={false}
+                                value={2}
+                              >
+                                2
                               </option>
                             </select>
                             <svg
@@ -2278,7 +2312,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                     <span
                       className="bx--pagination__text"
                     >
-                      1 of 1 pages
+                      1 of 2 pages
                     </span>
                     <div
                       className="bx--pagination__control-buttons"
@@ -2314,8 +2348,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         </svg>
                       </button>
                       <button
-                        className="bx--pagination__button bx--pagination__button--forward bx--pagination__button--no-index bx--btn bx--btn--ghost bx--btn--disabled bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-end"
-                        disabled={true}
+                        className="bx--pagination__button bx--pagination__button--forward bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-end"
+                        disabled={false}
                         onClick={[Function]}
                         tabIndex={0}
                         type="button"
@@ -2362,7 +2396,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             />
           </div>
           <div
-            className="iot--card react-grid-item react-draggable react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item react-resizable iot--card--wrapper"
             data-testid="Card"
             id="imageCard"
             onMouseDown={[Function]}
@@ -2395,7 +2429,37 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
               </span>
               <div
                 className="iot--card--toolbar"
-              />
+              >
+                <button
+                  className="iot--card--toolbar-action iot--card--toolbar-svg-wrapper bx--btn--icon-only bx--btn bx--btn--ghost"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  title="Expand to fullscreen"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Expand to fullscreen"
+                    className="bx--btn__icon"
+                    fill="currentColor"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 32 32"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M28,4H10A2.0059,2.0059,0,0,0,8,6V20a2.0059,2.0059,0,0,0,2,2H28a2.0059,2.0059,0,0,0,2-2V6A2.0059,2.0059,0,0,0,28,4Zm0,16H10V6H28Z"
+                    />
+                    <path
+                      d="M18,26H4V16H6V14H4a2.0059,2.0059,0,0,0-2,2V26a2.0059,2.0059,0,0,0,2,2H18a2.0059,2.0059,0,0,0,2-2V24H18Z"
+                    />
+                  </svg>
+                </button>
+              </div>
             </div>
             <div
               className="iot--card--content"
@@ -2409,25 +2473,126 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                 className="ImageCard__ContentWrapper-sc-1p2j9dm-0 bcWqmR"
               >
                 <div
-                  className="ImageCard__EmptyDiv-sc-1p2j9dm-1 dkLZTG"
+                  onBlur={[Function]}
+                  onMouseOut={[Function]}
+                  style={
+                    Object {
+                      "background": "#eee",
+                      "height": "100%",
+                      "overflow": "hidden",
+                      "position": "relative",
+                      "textAlign": "center",
+                      "width": "100%",
+                    }
+                  }
                 >
-                  <svg
-                    aria-hidden={true}
-                    fill="gray"
-                    focusable="false"
-                    height={250}
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width={250}
-                    xmlns="http://www.w3.org/2000/svg"
+                  <img
+                    alt="Sample image"
+                    onLoad={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseMove={[Function]}
+                    onMouseUp={[Function]}
+                    src="static/media/landscape.013ce39d.jpg"
+                    style={
+                      Object {
+                        "left": undefined,
+                        "position": "relative",
+                        "top": undefined,
+                      }
+                    }
+                  />
+                  <div
+                    style={
+                      Object {
+                        "left": undefined,
+                        "margin": "auto",
+                        "pointerEvents": "none",
+                        "position": "absolute",
+                        "right": "auto",
+                        "top": undefined,
+                      }
+                    }
                   >
-                    <path
-                      d="M19,14a3,3,0,1,0-3-3A3,3,0,0,0,19,14Zm0-4a1,1,0,1,1-1,1A1,1,0,0,1,19,10Z"
-                    />
-                    <path
-                      d="M26,4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2V6A2,2,0,0,0,26,4Zm0,22H6V20l5-5,5.59,5.59a2,2,0,0,0,2.82,0L21,19l5,5Zm0-4.83-3.59-3.59a2,2,0,0,0-2.82,0L18,19.17l-5.59-5.59a2,2,0,0,0-2.82,0L6,17.17V6H26Z"
-                    />
-                  </svg>
+                    <div
+                      className="Hotspot__StyledHotspot-nlpwmi-0 fxwZek"
+                    >
+                      <div
+                        aria-describedby={null}
+                        aria-labelledby="hotspot-35-65"
+                        className="bx--tooltip__label"
+                        id="hotspot-35-65"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <svg
+                          aria-hidden={true}
+                          aria-label=""
+                          fill="purple"
+                          focusable="false"
+                          height={25}
+                          preserveAspectRatio="xMidYMid meet"
+                          title=""
+                          viewBox="0 0 16 16"
+                          width={25}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12.3 9.3L8.5 13.1 8.5 1 7.5 1 7.5 13.1 3.7 9.3 3 10 8 15 13 10z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "bottom": 10,
+                        "pointerEvents": "auto",
+                        "position": "absolute",
+                        "right": 10,
+                      }
+                    }
+                  >
+                    <button
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "background": "#fff",
+                          "border": "none",
+                          "boxShadow": "0px 0px 2px 0px rgba(0,0,0,0.5)",
+                          "height": "25px",
+                          "width": "25px",
+                        }
+                      }
+                      title="Zoom in"
+                      type="button"
+                    >
+                      +
+                    </button>
+                    <br />
+                    <button
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "background": "#fff",
+                          "border": "none",
+                          "boxShadow": "0px 0px 2px 0px rgba(0,0,0,0.5)",
+                          "height": "25px",
+                          "width": "25px",
+                        }
+                      }
+                      title="Zoom out"
+                      type="button"
+                    >
+                      -
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
@@ -2445,7 +2610,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             />
           </div>
           <div
-            className="iot--card react-grid-item react-draggable react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item react-resizable iot--card--wrapper"
             data-testid="Card"
             id="timeSeriesCard"
             onMouseDown={[Function]}
@@ -2486,7 +2651,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
               }
             >
               <div
-                className="iot--time-series-card--wrapper iot--time-series-card--wrapper__editable"
+                className="iot--time-series-card--wrapper"
               >
                 <div
                   className="chart-holder"
@@ -2549,7 +2714,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
               }
             >
               <div
-                className="list-card react-grid-item react-draggable react-resizable"
+                className="list-card react-grid-item react-resizable"
                 style={
                   Object {
                     "paddingBottom": 0,
@@ -2739,7 +2904,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             />
           </div>
           <div
-            className="iot--card react-grid-item react-draggable react-resizable iot--bar-chart-card iot--card--wrapper"
+            className="iot--card react-grid-item react-resizable iot--bar-chart-card iot--card--wrapper"
             data-testid="Card"
             id="barChartCard"
             onMouseDown={[Function]}
@@ -2780,7 +2945,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
               }
             >
               <div
-                className="iot--bar-chart-container iot--bar-chart-container--editable"
+                className="iot--bar-chart-container"
               >
                 <div
                   className="chart-holder"
@@ -3368,7 +3533,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
           }
         >
           <div
-            className="iot--card react-grid-item react-draggable react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item react-draggable react-resizable-hide react-resizable iot--card--wrapper"
             content="My Facility Metrics"
             data-testid="Card"
             id="facility"
@@ -3428,7 +3593,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             </div>
           </div>
           <div
-            className="iot--card react-grid-item react-draggable react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item react-draggable react-resizable-hide react-resizable iot--card--wrapper"
             content="My Humidity Values"
             data-testid="Card"
             id="humidity"
@@ -3488,7 +3653,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             </div>
           </div>
           <div
-            className="iot--card react-grid-item react-draggable react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item react-draggable react-resizable-hide react-resizable iot--card--wrapper"
             content="My utilization chart"
             data-testid="Card"
             id="utilization"
@@ -3617,7 +3782,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
           }
         >
           <div
-            className="iot--card react-grid-item react-draggable react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item react-resizable iot--card--wrapper"
             data-testid="Card"
             id="card"
             onMouseDown={[Function]}

--- a/src/components/Dashboard/_dashboard.scss
+++ b/src/components/Dashboard/_dashboard.scss
@@ -64,5 +64,5 @@
 
 .react-grid-item.react-grid-placeholder {
   background: none;
-  border: 3px dashed gray;
+  border: 3px dashed $active-secondary;
 }

--- a/src/components/Dashboard/_dashboard.scss
+++ b/src/components/Dashboard/_dashboard.scss
@@ -1,5 +1,6 @@
 @import '~react-grid-layout/css/styles';
 @import '~react-resizable/css/styles';
+@import '../../globals/vars';
 
 .dashboard {
   &--header {
@@ -59,4 +60,9 @@
       margin-left: $spacing-03;
     }
   }
+}
+
+.react-grid-item.react-grid-placeholder {
+  background: none;
+  border: 3px dashed gray;
 }

--- a/src/components/GaugeCard/GaugeCard.jsx
+++ b/src/components/GaugeCard/GaugeCard.jsx
@@ -10,6 +10,7 @@ import {
 import Card from '../Card/Card';
 import DataStateRenderer from '../Card/DataStateRenderer';
 import { settings } from '../../constants/Settings';
+import { getResizeHandles } from '../../utils/cardUtilityFunctions';
 
 const { iotPrefix } = settings;
 // r value of the circle in SVG
@@ -51,6 +52,7 @@ export const getColor = (gauge, value) => {
   };
 };
 const GaugeCard = ({
+  children,
   id,
   title,
   tooltip,
@@ -58,6 +60,7 @@ const GaugeCard = ({
   values,
   data,
   isLoading,
+  isResizable,
   hasMoreData,
   size,
   className,
@@ -83,12 +86,15 @@ const GaugeCard = ({
         paddingLeft: CARD_CONTENT_PADDING,
       };
 
+  const resizeHandles = isResizable ? getResizeHandles(children) : [];
+
   return (
     <Card
       id={id}
       className={`${iotPrefix}--gauge-card`}
       title={title}
       size={size}
+      resizeHandles={resizeHandles}
       {...others}
       tooltip={tooltip}
       isLoading={isLoading}>

--- a/src/components/ImageCard/ImageCard.jsx
+++ b/src/components/ImageCard/ImageCard.jsx
@@ -10,7 +10,10 @@ import {
 } from '../../constants/CardPropTypes';
 import { CARD_SIZES } from '../../constants/LayoutConstants';
 import Card from '../Card/Card';
-import { getUpdatedCardSize } from '../../utils/cardUtilityFunctions';
+import {
+  getResizeHandles,
+  getUpdatedCardSize,
+} from '../../utils/cardUtilityFunctions';
 
 import ImageHotspots from './ImageHotspots';
 
@@ -40,12 +43,14 @@ const defaultProps = {
 const ImageCard = ({
   title,
   content,
+  children,
   values,
   size,
   onCardAction,
   availableActions,
   isEditable,
   isExpanded,
+  isResizable,
   error,
   isLoading,
   i18n: { loadingDataLabel, ...otherLabels },
@@ -70,6 +75,7 @@ const ImageCard = ({
   const mergedAvailableActions = { expand: supportedSize, ...availableActions };
 
   const isCardLoading = isNil(src) && !isEditable && !error;
+  const resizeHandles = isResizable ? getResizeHandles(children) : [];
 
   return (
     <Card
@@ -80,6 +86,7 @@ const ImageCard = ({
       isLoading={isCardLoading} // only show the spinner if we don't have an image
       isExpanded={isExpanded}
       isEditable={isEditable}
+      resizeHandles={resizeHandles}
       {...others}
       error={error}
       i18n={otherLabels}>

--- a/src/components/ListCard/ListCard.jsx
+++ b/src/components/ListCard/ListCard.jsx
@@ -14,6 +14,7 @@ import isEmpty from 'lodash/isEmpty';
 import { CARD_CONTENT_PADDING } from '../../constants/LayoutConstants';
 import { CardPropTypes } from '../../constants/CardPropTypes';
 import Card from '../Card/Card';
+import { getResizeHandles } from '../../utils/cardUtilityFunctions';
 
 const ListCard = ({
   id,
@@ -21,10 +22,12 @@ const ListCard = ({
   size,
   data,
   isLoading,
+  isResizable,
   loadData,
   hasMoreData,
   layout,
   className,
+  children,
   ...others
 }) => {
   const handleScroll = (e) => {
@@ -39,6 +42,8 @@ const ListCard = ({
     }
   };
 
+  const resizeHandles = isResizable ? getResizeHandles(children) : [];
+
   return (
     <Card
       id={id}
@@ -46,6 +51,7 @@ const ListCard = ({
       size={size}
       onScroll={handleScroll}
       isEmpty={isEmpty(data)}
+      resizeHandles={resizeHandles}
       {...others}>
       <div
         className={classnames('list-card', className)}

--- a/src/components/PieChartCard/PieChartCard.jsx
+++ b/src/components/PieChartCard/PieChartCard.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PieChart from '@carbon/charts-react/pie-chart';
 import classNames from 'classnames';
 import isEmpty from 'lodash/isEmpty';
@@ -8,6 +8,7 @@ import { PieCardPropTypes, CardPropTypes } from '../../constants/CardPropTypes';
 import { CARD_SIZES } from '../../constants/LayoutConstants';
 import { settings } from '../../constants/Settings';
 import {
+  getResizeHandles,
   handleCardVariables,
   increaseSmallCardSize,
 } from '../../utils/cardUtilityFunctions';
@@ -83,6 +84,7 @@ const defaultProps = {
 };
 
 const PieChartCard = ({
+  children,
   content,
   i18n: { noDataLabel },
   i18n,
@@ -90,6 +92,7 @@ const PieChartCard = ({
   isExpanded,
   isEditable,
   isLoading,
+  isResizable,
   overrides,
   size: sizeProp,
   title: titleProp,
@@ -119,14 +122,19 @@ const PieChartCard = ({
     others
   );
 
-  const sampleSlicesCount = colorsProp ? Object.keys(colorsProp).length : 4;
-  const values = isEditable
-    ? generateSampleData(sampleSlicesCount, groupDataSourceId)
-    : valuesProp;
+  const values = useMemo(() => {
+    const sampleSlicesCount = colorsProp ? Object.keys(colorsProp).length : 4;
+    return isEditable
+      ? generateSampleData(sampleSlicesCount, groupDataSourceId)
+      : valuesProp;
+  }, [colorsProp, groupDataSourceId, valuesProp, isEditable]);
+
   const colors =
     isEditable && colorsProp
       ? getColorsForSampleData(colorsProp, values, groupDataSourceId)
       : colorsProp;
+
+  const resizeHandles = isResizable ? getResizeHandles(children) : [];
 
   const chartProps = {
     // Changes to some options does not update the chart so we modify the key for these
@@ -203,6 +211,8 @@ const PieChartCard = ({
       // the loading skeleton from the PieChart instead.
       isEmpty={isAllValuesEmpty && !isLoading}
       isEditable={isEditable}
+      isResizable={isResizable}
+      resizeHandles={resizeHandles}
       testID={testID}
       {...others}
       {...overrides?.card?.props}>
@@ -223,6 +233,7 @@ const PieChartCard = ({
           ) : null}
         </div>
       ) : null}
+      {resizeHandles}
     </MyCard>
   );
 };

--- a/src/components/TableCard/TableCard.jsx
+++ b/src/components/TableCard/TableCard.jsx
@@ -25,6 +25,7 @@ import {
   handleCardVariables,
   formatNumberWithPrecision,
   getVariables,
+  getResizeHandles,
 } from '../../utils/cardUtilityFunctions';
 import icons from '../../utils/bundledIcons';
 
@@ -327,10 +328,12 @@ const TableCard = ({
   title: titleProp,
   isExpanded,
   content: contentProp,
+  children,
   size,
   onCardAction,
   values: valuesProp,
   isEditable,
+  isResizable,
   i18n,
   tooltip,
   locale,
@@ -821,6 +824,8 @@ const TableCard = ({
     />
   );
 
+  const resizeHandles = isResizable ? getResizeHandles(children) : [];
+
   return (
     <Card
       id={id}
@@ -828,8 +833,10 @@ const TableCard = ({
       onCardAction={onCardAction}
       availableActions={{ expand: isExpandable, range: true }}
       isEditable={isEditable}
+      isResizable={isResizable}
       isExpanded={isExpanded}
       i18n={mergedI18n}
+      resizeHandles={resizeHandles}
       hideHeader
       {...others}>
       {({ height }) => {

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -2248,8 +2248,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-31"
-                  id="bx-pagination-select-31-count-label"
+                  htmlFor="bx-pagination-select-32"
+                  id="bx-pagination-select-32-count-label"
                 >
                   Items per page:
                 </label>
@@ -2268,7 +2268,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-31"
+                          id="bx-pagination-select-32"
                           onChange={[Function]}
                           value={10}
                         >
@@ -2333,7 +2333,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-31-right"
+                      htmlFor="bx-pagination-select-32-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -2346,7 +2346,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-31-right"
+                          id="bx-pagination-select-32-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -3465,8 +3465,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-27"
-                  id="bx-pagination-select-27-count-label"
+                  htmlFor="bx-pagination-select-28"
+                  id="bx-pagination-select-28-count-label"
                 >
                   Items per page:
                 </label>
@@ -3485,7 +3485,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-27"
+                          id="bx-pagination-select-28"
                           onChange={[Function]}
                           value={10}
                         >
@@ -3550,7 +3550,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-27-right"
+                      htmlFor="bx-pagination-select-28-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -3563,7 +3563,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-27-right"
+                          id="bx-pagination-select-28-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -6222,8 +6222,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-28"
-                  id="bx-pagination-select-28-count-label"
+                  htmlFor="bx-pagination-select-29"
+                  id="bx-pagination-select-29-count-label"
                 >
                   Items per page:
                 </label>
@@ -6242,7 +6242,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-28"
+                          id="bx-pagination-select-29"
                           onChange={[Function]}
                           value={10}
                         >
@@ -6307,7 +6307,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-28-right"
+                      htmlFor="bx-pagination-select-29-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -6320,7 +6320,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-28-right"
+                          id="bx-pagination-select-29-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -7661,8 +7661,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-41"
-                  id="bx-pagination-select-41-count-label"
+                  htmlFor="bx-pagination-select-42"
+                  id="bx-pagination-select-42-count-label"
                 >
                   Items per page:
                 </label>
@@ -7681,7 +7681,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-41"
+                          id="bx-pagination-select-42"
                           onChange={[Function]}
                           value={10}
                         >
@@ -7746,7 +7746,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-41-right"
+                      htmlFor="bx-pagination-select-42-right"
                     >
                       Page number, of 1 pages
                     </label>
@@ -7759,7 +7759,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-41-right"
+                          id="bx-pagination-select-42-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -9426,8 +9426,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-42"
-                  id="bx-pagination-select-42-count-label"
+                  htmlFor="bx-pagination-select-43"
+                  id="bx-pagination-select-43-count-label"
                 >
                   Items per page:
                 </label>
@@ -9446,7 +9446,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-42"
+                          id="bx-pagination-select-43"
                           onChange={[Function]}
                           value={10}
                         >
@@ -9511,7 +9511,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-42-right"
+                      htmlFor="bx-pagination-select-43-right"
                     >
                       Page number, of 1 pages
                     </label>
@@ -9524,7 +9524,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-42-right"
+                          id="bx-pagination-select-43-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -12729,8 +12729,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-43"
-                  id="bx-pagination-select-43-count-label"
+                  htmlFor="bx-pagination-select-44"
+                  id="bx-pagination-select-44-count-label"
                 >
                   Items per page:
                 </label>
@@ -12749,7 +12749,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-43"
+                          id="bx-pagination-select-44"
                           onChange={[Function]}
                           value={10}
                         >
@@ -12814,7 +12814,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-43-right"
+                      htmlFor="bx-pagination-select-44-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -12827,7 +12827,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-43-right"
+                          id="bx-pagination-select-44-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -14194,8 +14194,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-40"
-                  id="bx-pagination-select-40-count-label"
+                  htmlFor="bx-pagination-select-41"
+                  id="bx-pagination-select-41-count-label"
                 >
                   Items per page:
                 </label>
@@ -14214,7 +14214,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-40"
+                          id="bx-pagination-select-41"
                           onChange={[Function]}
                           value={10}
                         >
@@ -14279,7 +14279,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-40-right"
+                      htmlFor="bx-pagination-select-41-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -14292,7 +14292,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-40-right"
+                          id="bx-pagination-select-41-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -15899,8 +15899,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-35"
-                  id="bx-pagination-select-35-count-label"
+                  htmlFor="bx-pagination-select-36"
+                  id="bx-pagination-select-36-count-label"
                 >
                   Items per page:
                 </label>
@@ -15919,7 +15919,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-35"
+                          id="bx-pagination-select-36"
                           onChange={[Function]}
                           value={10}
                         >
@@ -15984,7 +15984,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-35-right"
+                      htmlFor="bx-pagination-select-36-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -15997,7 +15997,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-35-right"
+                          id="bx-pagination-select-36-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -17364,8 +17364,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-36"
-                  id="bx-pagination-select-36-count-label"
+                  htmlFor="bx-pagination-select-37"
+                  id="bx-pagination-select-37-count-label"
                 >
                   Items per page:
                 </label>
@@ -17384,7 +17384,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-36"
+                          id="bx-pagination-select-37"
                           onChange={[Function]}
                           value={10}
                         >
@@ -17449,7 +17449,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-36-right"
+                      htmlFor="bx-pagination-select-37-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -17462,7 +17462,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-36-right"
+                          id="bx-pagination-select-37-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -19424,8 +19424,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-26"
-                  id="bx-pagination-select-26-count-label"
+                  htmlFor="bx-pagination-select-27"
+                  id="bx-pagination-select-27-count-label"
                 >
                   Items per page:
                 </label>
@@ -19444,7 +19444,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-26"
+                          id="bx-pagination-select-27"
                           onChange={[Function]}
                           value={10}
                         >
@@ -19509,7 +19509,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-26-right"
+                      htmlFor="bx-pagination-select-27-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -19522,7 +19522,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-26-right"
+                          id="bx-pagination-select-27-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -19665,1805 +19665,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
 `;
 
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TableCard table with row expansion 1`] = `
-<div
-  className="storybook-container"
->
-  <div
-    style={
-      Object {
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "margin": "1rem4",
-          "width": "520px",
-        }
-      }
-    >
-      <div
-        className="iot--card iot--card--wrapper"
-        data-testid="Card"
-        id="table-list"
-        role="presentation"
-        style={
-          Object {
-            "--card-default-height": "624px",
-          }
-        }
-      >
-        <div
-          className="iot--card--content"
-          style={
-            Object {
-              "--card-content-height": "576px",
-            }
-          }
-        >
-          <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
-          >
-            <section
-              aria-label="data table toolbar"
-              className="bx--table-toolbar"
-            >
-              <div
-                className="bx--batch-actions iot--table-batch-actions"
-              >
-                <div
-                  className="bx--batch-summary"
-                >
-                  <p
-                    className="bx--batch-summary__para"
-                  >
-                    <span>
-                      0 item selected
-                    </span>
-                  </p>
-                </div>
-                <div
-                  className="bx--action-list"
-                >
-                  <button
-                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </div>
-              <label
-                className="iot--table-toolbar-secondary-title"
-              >
-                Open Alerts
-              </label>
-              <div
-                className="iot--table-tooltip-container"
-              >
-                <div
-                  className="bx--tooltip__label"
-                  id="card-tooltip-trigger-table-for-card-table-list"
-                >
-                  
-                  <div
-                    aria-describedby={null}
-                    className="bx--tooltip__trigger"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
-                    <svg
-                      aria-hidden={true}
-                      description={null}
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role={null}
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
-                      />
-                      <path
-                        d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-content iot--table-toolbar-content"
-              >
-                <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  tabIndex="0"
-                >
-                  <div
-                    aria-labelledby="table-for-card-table-list-toolbar-search-search"
-                    className="bx--search bx--search--sm table-toolbar-search"
-                    role="search"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="bx--search-magnifier"
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                      />
-                    </svg>
-                    <label
-                      className="bx--label"
-                      htmlFor="table-for-card-table-list-toolbar-search"
-                      id="table-for-card-table-list-toolbar-search-search"
-                    >
-                      Search
-                    </label>
-                    <input
-                      aria-hidden={true}
-                      autoComplete="off"
-                      className="bx--search-input"
-                      id="table-for-card-table-list-toolbar-search"
-                      onChange={[Function]}
-                      placeholder="Search"
-                      role="searchbox"
-                      tabIndex="-1"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Clear search input"
-                      className="bx--search-close bx--search-close--hidden"
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-                <button
-                  className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
-                  data-testid="download-button"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Download table content"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Download table content"
-                    className="bx--btn__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
-                    />
-                    <path
-                      d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
-                  data-testid="filter-button"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Filters"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Filters"
-                    className="bx--btn__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M18,28H14a2,2,0,0,1-2-2V18.41L4.59,11A2,2,0,0,1,4,9.59V6A2,2,0,0,1,6,4H26a2,2,0,0,1,2,2V9.59A2,2,0,0,1,27.41,11L20,18.41V26A2,2,0,0,1,18,28ZM6,6V9.59l8,8V26h4V17.59l8-8V6Z"
-                    />
-                  </svg>
-                </button>
-                <div
-                  className="iot--card--toolbar"
-                >
-                  <div
-                    className="iot--card--toolbar-date-range-wrapper"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="iot--card--toolbar-date-range-action bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
-                      title="Select time range"
-                      type="button"
-                    >
-                      <svg
-                        aria-label="Select time range"
-                        className="bx--overflow-menu__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        onClick={[Function]}
-                        onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
-                        />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
-                        />
-                        <path
-                          d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
-                        />
-                        <title>
-                          Select time range
-                        </title>
-                      </svg>
-                    </button>
-                  </div>
-                  <button
-                    className="iot--card--toolbar-action iot--card--toolbar-svg-wrapper bx--btn--icon-only bx--btn bx--btn--ghost"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    title="Expand to fullscreen"
-                    type="button"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      aria-label="Expand to fullscreen"
-                      className="bx--btn__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      viewBox="0 0 32 32"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M28,4H10A2.0059,2.0059,0,0,0,8,6V20a2.0059,2.0059,0,0,0,2,2H28a2.0059,2.0059,0,0,0,2-2V6A2.0059,2.0059,0,0,0,28,4Zm0,16H10V6H28Z"
-                      />
-                      <path
-                        d="M18,26H4V16H6V14H4a2.0059,2.0059,0,0,0-2,2V26a2.0059,2.0059,0,0,0,2,2H18a2.0059,2.0059,0,0,0,2-2V24H18Z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-            </section>
-            <div
-              className="addons-iot-table-container"
-            >
-              <div
-                className="bx--data-table-content"
-              >
-                <table
-                  className="bx--data-table bx--data-table--no-border"
-                  title={null}
-                >
-                  <thead
-                    onMouseMove={null}
-                    onMouseUp={null}
-                  >
-                    <tr>
-                      <th
-                        className="bx--table-expand"
-                        scope="col"
-                      />
-                      <th
-                        aria-sort="none"
-                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
-                        scope="col"
-                        style={
-                          Object {
-                            "width": undefined,
-                          }
-                        }
-                        width=""
-                      >
-                        <button
-                          align="start"
-                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
-                          data-column="alert"
-                          data-floating-menu-container={true}
-                          id="column-alert"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "--table-header-width": "",
-                            }
-                          }
-                          width=""
-                        >
-                          <span
-                            className="bx--table-header-label"
-                          >
-                            <span
-                              className=""
-                              title="Alert"
-                            >
-                              Alert
-                            </span>
-                          </span>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
-                            />
-                          </svg>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon-unsorted"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                            />
-                          </svg>
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="none"
-                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
-                        scope="col"
-                        style={
-                          Object {
-                            "width": undefined,
-                          }
-                        }
-                        width=""
-                      >
-                        <button
-                          align="start"
-                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
-                          data-column="hour"
-                          data-floating-menu-container={true}
-                          id="column-hour"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "--table-header-width": "",
-                            }
-                          }
-                          width=""
-                        >
-                          <span
-                            className="bx--table-header-label"
-                          >
-                            <span
-                              className=""
-                              title="Hour"
-                            >
-                              Hour
-                            </span>
-                          </span>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
-                            />
-                          </svg>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon-unsorted"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                            />
-                          </svg>
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="none"
-                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
-                        scope="col"
-                        style={
-                          Object {
-                            "width": undefined,
-                          }
-                        }
-                        width=""
-                      >
-                        <button
-                          align="start"
-                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
-                          data-column="pressure"
-                          data-floating-menu-container={true}
-                          id="column-pressure"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "--table-header-width": "",
-                            }
-                          }
-                          width=""
-                        >
-                          <span
-                            className="bx--table-header-label"
-                          >
-                            <span
-                              className=""
-                              title="Pressure"
-                            >
-                              Pressure
-                            </span>
-                          </span>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
-                            />
-                          </svg>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon-unsorted"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                            />
-                          </svg>
-                        </button>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody
-                    aria-live="polite"
-                  >
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-10-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI010 proccess need to optimize adjust Y variables"
-                          >
-                            AHI010 proccess need to optimize adjust Y variables
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-10-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="10/28/2018 07:34"
-                          >
-                            10/28/2018 07:34
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-10-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="0"
-                          >
-                            0
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-11-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI010 proccess need to optimize adjust Y variables"
-                          >
-                            AHI010 proccess need to optimize adjust Y variables
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-11-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="10/28/2018 07:34"
-                          >
-                            10/28/2018 07:34
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-11-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="1"
-                          >
-                            1
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-1-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI005 Asset failure"
-                          >
-                            AHI005 Asset failure
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-1-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="10/28/2018 07:34"
-                          >
-                            10/28/2018 07:34
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-1-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="0"
-                          >
-                            0
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-2-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI003 process need to optimize adjust X variables"
-                          >
-                            AHI003 process need to optimize adjust X variables
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-2-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="10/28/2018 07:34"
-                          >
-                            10/28/2018 07:34
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-2-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="2"
-                          >
-                            2
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-6-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI001 proccess need to optimize."
-                          >
-                            AHI001 proccess need to optimize.
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-6-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="10/28/2018 07:34"
-                          >
-                            10/28/2018 07:34
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-6-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="68"
-                          >
-                            68
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-3-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI001 proccess need to optimize adjust Y variables"
-                          >
-                            AHI001 proccess need to optimize adjust Y variables
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-3-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="10/28/2018 07:34"
-                          >
-                            10/28/2018 07:34
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-3-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="10"
-                          >
-                            10
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-4-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI001 proccess need to optimize adjust Y variables"
-                          >
-                            AHI001 proccess need to optimize adjust Y variables
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-4-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="10/28/2018 07:34"
-                          >
-                            10/28/2018 07:34
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-4-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="0"
-                          >
-                            0
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-8-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI001 proccess need to optimize adjust Y variables"
-                          >
-                            AHI001 proccess need to optimize adjust Y variables
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-8-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="10/28/2018 07:34"
-                          >
-                            10/28/2018 07:34
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-8-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="0"
-                          >
-                            0
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-9-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI001 proccess need to optimize adjust Y variables"
-                          >
-                            AHI001 proccess need to optimize adjust Y variables
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-9-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="10/28/2018 07:34"
-                          >
-                            10/28/2018 07:34
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-9-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="0"
-                          >
-                            0
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-5-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI001 proccess need to optimize"
-                          >
-                            AHI001 proccess need to optimize
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-5-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="10/28/2018 07:34"
-                          >
-                            10/28/2018 07:34
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-5-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="10"
-                          >
-                            10
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-            </div>
-            <div
-              className="bx--pagination iot--pagination iot--pagination--hide-page"
-              style={
-                Object {
-                  "--pagination-text-display": "flex",
-                }
-              }
-            >
-              <div
-                className="bx--pagination__left"
-              >
-                <label
-                  className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-37"
-                  id="bx-pagination-select-37-count-label"
-                >
-                  Items per page:
-                </label>
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__item-count"
-                  >
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-37"
-                          onChange={[Function]}
-                          value={10}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={10}
-                          >
-                            10
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={25}
-                          >
-                            25
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={100}
-                          >
-                            100
-                          </option>
-                        </select>
-                        <svg
-                          aria-hidden={true}
-                          className="bx--select__arrow"
-                          fill="currentColor"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text bx--pagination__items-count"
-                >
-                  1–10 of 11 items
-                </span>
-              </div>
-              <div
-                className="bx--pagination__right"
-              >
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__page-number"
-                  >
-                    <label
-                      className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-37-right"
-                    >
-                      Page number, of 2 pages
-                    </label>
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-37-right"
-                          onChange={[Function]}
-                          value={1}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={1}
-                          >
-                            1
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={2}
-                          >
-                            2
-                          </option>
-                        </select>
-                        <svg
-                          aria-hidden={true}
-                          className="bx--select__arrow"
-                          fill="currentColor"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1 of 2 pages
-                </span>
-                <div
-                  className="bx--pagination__control-buttons"
-                >
-                  <button
-                    className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index bx--btn bx--btn--ghost bx--btn--disabled bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
-                    disabled={true}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    type="button"
-                  >
-                    <span
-                      className="bx--assistive-text"
-                    >
-                      Previous page
-                    </span>
-                    <svg
-                      aria-hidden="true"
-                      aria-label="Previous page"
-                      className="bx--btn__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      viewBox="0 0 32 32"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M20 24L10 16 20 8z"
-                      />
-                    </svg>
-                  </button>
-                  <button
-                    className="bx--pagination__button bx--pagination__button--forward bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-end"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    type="button"
-                  >
-                    <span
-                      className="bx--assistive-text"
-                    >
-                      Next page
-                    </span>
-                    <svg
-                      aria-hidden="true"
-                      aria-label="Next page"
-                      className="bx--btn__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      viewBox="0 0 32 32"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M12 8L22 16 12 24z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <button
-    className="info__show-button"
-    onClick={[Function]}
-    style={
-      Object {
-        "background": "#027ac5",
-        "border": "none",
-        "borderRadius": "0 0 0 5px",
-        "color": "#fff",
-        "cursor": "pointer",
-        "display": "block",
-        "fontFamily": "sans-serif",
-        "fontSize": 12,
-        "padding": "5px 15px",
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
-    type="button"
-  >
-    Show Info
-  </button>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TableCard table with row expansion and link variables 1`] = `
 <div
   className="storybook-container"
 >
@@ -23262,7 +21463,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TableCard table with row expansion and row specific link variables 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TableCard table with row expansion and link variables 1`] = `
 <div
   className="storybook-container"
 >
@@ -25061,6 +23262,1805 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TableCard table with row expansion and row specific link variables 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": "1rem4",
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="iot--card iot--card--wrapper"
+        data-testid="Card"
+        id="table-list"
+        role="presentation"
+        style={
+          Object {
+            "--card-default-height": "624px",
+          }
+        }
+      >
+        <div
+          className="iot--card--content"
+          style={
+            Object {
+              "--card-content-height": "576px",
+            }
+          }
+        >
+          <div
+            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+          >
+            <section
+              aria-label="data table toolbar"
+              className="bx--table-toolbar"
+            >
+              <div
+                className="bx--batch-actions iot--table-batch-actions"
+              >
+                <div
+                  className="bx--batch-summary"
+                >
+                  <p
+                    className="bx--batch-summary__para"
+                  >
+                    <span>
+                      0 item selected
+                    </span>
+                  </p>
+                </div>
+                <div
+                  className="bx--action-list"
+                >
+                  <button
+                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={-1}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+              <label
+                className="iot--table-toolbar-secondary-title"
+              >
+                Open Alerts
+              </label>
+              <div
+                className="iot--table-tooltip-container"
+              >
+                <div
+                  className="bx--tooltip__label"
+                  id="card-tooltip-trigger-table-for-card-table-list"
+                >
+                  
+                  <div
+                    aria-describedby={null}
+                    className="bx--tooltip__trigger"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      description={null}
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role={null}
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
+                      />
+                      <path
+                        d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="bx--toolbar-content iot--table-toolbar-content"
+              >
+                <div
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  tabIndex="0"
+                >
+                  <div
+                    aria-labelledby="table-for-card-table-list-toolbar-search-search"
+                    className="bx--search bx--search--sm table-toolbar-search"
+                    role="search"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="bx--search-magnifier"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                      />
+                    </svg>
+                    <label
+                      className="bx--label"
+                      htmlFor="table-for-card-table-list-toolbar-search"
+                      id="table-for-card-table-list-toolbar-search-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      autoComplete="off"
+                      className="bx--search-input"
+                      id="table-for-card-table-list-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      role="searchbox"
+                      tabIndex="-1"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <button
+                  className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
+                  data-testid="download-button"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  title="Download table content"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Download table content"
+                    className="bx--btn__icon"
+                    fill="currentColor"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                    />
+                    <path
+                      d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
+                  data-testid="filter-button"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  title="Filters"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Filters"
+                    className="bx--btn__icon"
+                    fill="currentColor"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M18,28H14a2,2,0,0,1-2-2V18.41L4.59,11A2,2,0,0,1,4,9.59V6A2,2,0,0,1,6,4H26a2,2,0,0,1,2,2V9.59A2,2,0,0,1,27.41,11L20,18.41V26A2,2,0,0,1,18,28ZM6,6V9.59l8,8V26h4V17.59l8-8V6Z"
+                    />
+                  </svg>
+                </button>
+                <div
+                  className="iot--card--toolbar"
+                >
+                  <div
+                    className="iot--card--toolbar-date-range-wrapper"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="iot--card--toolbar-date-range-action bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                      title="Select time range"
+                      type="button"
+                    >
+                      <svg
+                        aria-label="Select time range"
+                        className="bx--overflow-menu__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
+                        />
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        />
+                        <path
+                          d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
+                        />
+                        <title>
+                          Select time range
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                  <button
+                    className="iot--card--toolbar-action iot--card--toolbar-svg-wrapper bx--btn--icon-only bx--btn bx--btn--ghost"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    title="Expand to fullscreen"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Expand to fullscreen"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M28,4H10A2.0059,2.0059,0,0,0,8,6V20a2.0059,2.0059,0,0,0,2,2H28a2.0059,2.0059,0,0,0,2-2V6A2.0059,2.0059,0,0,0,28,4Zm0,16H10V6H28Z"
+                      />
+                      <path
+                        d="M18,26H4V16H6V14H4a2.0059,2.0059,0,0,0-2,2V26a2.0059,2.0059,0,0,0,2,2H18a2.0059,2.0059,0,0,0,2-2V24H18Z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </section>
+            <div
+              className="addons-iot-table-container"
+            >
+              <div
+                className="bx--data-table-content"
+              >
+                <table
+                  className="bx--data-table bx--data-table--no-border"
+                  title={null}
+                >
+                  <thead
+                    onMouseMove={null}
+                    onMouseUp={null}
+                  >
+                    <tr>
+                      <th
+                        className="bx--table-expand"
+                        scope="col"
+                      />
+                      <th
+                        aria-sort="none"
+                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
+                        scope="col"
+                        style={
+                          Object {
+                            "width": undefined,
+                          }
+                        }
+                        width=""
+                      >
+                        <button
+                          align="start"
+                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
+                          data-column="alert"
+                          data-floating-menu-container={true}
+                          id="column-alert"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "--table-header-width": "",
+                            }
+                          }
+                          width=""
+                        >
+                          <span
+                            className="bx--table-header-label"
+                          >
+                            <span
+                              className=""
+                              title="Alert"
+                            >
+                              Alert
+                            </span>
+                          </span>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                            />
+                          </svg>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon-unsorted"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                            />
+                          </svg>
+                        </button>
+                      </th>
+                      <th
+                        aria-sort="none"
+                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
+                        scope="col"
+                        style={
+                          Object {
+                            "width": undefined,
+                          }
+                        }
+                        width=""
+                      >
+                        <button
+                          align="start"
+                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
+                          data-column="hour"
+                          data-floating-menu-container={true}
+                          id="column-hour"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "--table-header-width": "",
+                            }
+                          }
+                          width=""
+                        >
+                          <span
+                            className="bx--table-header-label"
+                          >
+                            <span
+                              className=""
+                              title="Hour"
+                            >
+                              Hour
+                            </span>
+                          </span>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                            />
+                          </svg>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon-unsorted"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                            />
+                          </svg>
+                        </button>
+                      </th>
+                      <th
+                        aria-sort="none"
+                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
+                        scope="col"
+                        style={
+                          Object {
+                            "width": undefined,
+                          }
+                        }
+                        width=""
+                      >
+                        <button
+                          align="start"
+                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
+                          data-column="pressure"
+                          data-floating-menu-container={true}
+                          id="column-pressure"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "--table-header-width": "",
+                            }
+                          }
+                          width=""
+                        >
+                          <span
+                            className="bx--table-header-label"
+                          >
+                            <span
+                              className=""
+                              title="Pressure"
+                            >
+                              Pressure
+                            </span>
+                          </span>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                            />
+                          </svg>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon-unsorted"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                            />
+                          </svg>
+                        </button>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    aria-live="polite"
+                  >
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-10-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI010 proccess need to optimize adjust Y variables"
+                          >
+                            AHI010 proccess need to optimize adjust Y variables
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-10-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="10/28/2018 07:34"
+                          >
+                            10/28/2018 07:34
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-10-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="0"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-11-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI010 proccess need to optimize adjust Y variables"
+                          >
+                            AHI010 proccess need to optimize adjust Y variables
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-11-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="10/28/2018 07:34"
+                          >
+                            10/28/2018 07:34
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-11-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="1"
+                          >
+                            1
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-1-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI005 Asset failure"
+                          >
+                            AHI005 Asset failure
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-1-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="10/28/2018 07:34"
+                          >
+                            10/28/2018 07:34
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-1-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="0"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-2-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI003 process need to optimize adjust X variables"
+                          >
+                            AHI003 process need to optimize adjust X variables
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-2-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="10/28/2018 07:34"
+                          >
+                            10/28/2018 07:34
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-2-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="2"
+                          >
+                            2
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-6-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI001 proccess need to optimize."
+                          >
+                            AHI001 proccess need to optimize.
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-6-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="10/28/2018 07:34"
+                          >
+                            10/28/2018 07:34
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-6-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="68"
+                          >
+                            68
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-3-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI001 proccess need to optimize adjust Y variables"
+                          >
+                            AHI001 proccess need to optimize adjust Y variables
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-3-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="10/28/2018 07:34"
+                          >
+                            10/28/2018 07:34
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-3-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="10"
+                          >
+                            10
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-4-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI001 proccess need to optimize adjust Y variables"
+                          >
+                            AHI001 proccess need to optimize adjust Y variables
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-4-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="10/28/2018 07:34"
+                          >
+                            10/28/2018 07:34
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-4-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="0"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-8-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI001 proccess need to optimize adjust Y variables"
+                          >
+                            AHI001 proccess need to optimize adjust Y variables
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-8-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="10/28/2018 07:34"
+                          >
+                            10/28/2018 07:34
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-8-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="0"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-9-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI001 proccess need to optimize adjust Y variables"
+                          >
+                            AHI001 proccess need to optimize adjust Y variables
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-9-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="10/28/2018 07:34"
+                          >
+                            10/28/2018 07:34
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-9-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="0"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-5-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI001 proccess need to optimize"
+                          >
+                            AHI001 proccess need to optimize
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-5-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="10/28/2018 07:34"
+                          >
+                            10/28/2018 07:34
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-5-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="10"
+                          >
+                            10
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div
+              className="bx--pagination iot--pagination iot--pagination--hide-page"
+              style={
+                Object {
+                  "--pagination-text-display": "flex",
+                }
+              }
+            >
+              <div
+                className="bx--pagination__left"
+              >
+                <label
+                  className="bx--pagination__text"
+                  htmlFor="bx-pagination-select-40"
+                  id="bx-pagination-select-40-count-label"
+                >
+                  Items per page:
+                </label>
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__item-count"
+                  >
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-40"
+                          onChange={[Function]}
+                          value={10}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={10}
+                          >
+                            10
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={25}
+                          >
+                            25
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={100}
+                          >
+                            100
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden={true}
+                          className="bx--select__arrow"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text bx--pagination__items-count"
+                >
+                  1–10 of 11 items
+                </span>
+              </div>
+              <div
+                className="bx--pagination__right"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__page-number"
+                  >
+                    <label
+                      className="bx--label bx--visually-hidden"
+                      htmlFor="bx-pagination-select-40-right"
+                    >
+                      Page number, of 2 pages
+                    </label>
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-40-right"
+                          onChange={[Function]}
+                          value={1}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={1}
+                          >
+                            1
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={2}
+                          >
+                            2
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden={true}
+                          className="bx--select__arrow"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1 of 2 pages
+                </span>
+                <div
+                  className="bx--pagination__control-buttons"
+                >
+                  <button
+                    className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index bx--btn bx--btn--ghost bx--btn--disabled bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                    disabled={true}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Previous page
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Previous page"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M20 24L10 16 20 8z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="bx--pagination__button bx--pagination__button--forward bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-end"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Next page
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Next page"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M12 8L22 16 12 24z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TableCard table with single actions 1`] = `
 <div
   className="storybook-container"
@@ -26661,8 +26661,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-29"
-                  id="bx-pagination-select-29-count-label"
+                  htmlFor="bx-pagination-select-30"
+                  id="bx-pagination-select-30-count-label"
                 >
                   Items per page:
                 </label>
@@ -26681,7 +26681,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-29"
+                          id="bx-pagination-select-30"
                           onChange={[Function]}
                           value={10}
                         >
@@ -26746,7 +26746,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-29-right"
+                      htmlFor="bx-pagination-select-30-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -26759,7 +26759,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-29-right"
+                          id="bx-pagination-select-30-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -29349,8 +29349,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-32"
-                  id="bx-pagination-select-32-count-label"
+                  htmlFor="bx-pagination-select-33"
+                  id="bx-pagination-select-33-count-label"
                 >
                   Items per page:
                 </label>
@@ -29369,7 +29369,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-32"
+                          id="bx-pagination-select-33"
                           onChange={[Function]}
                           value={10}
                         >
@@ -29434,7 +29434,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-32-right"
+                      htmlFor="bx-pagination-select-33-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -29447,7 +29447,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-32-right"
+                          id="bx-pagination-select-33-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -31499,8 +31499,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-33"
-                  id="bx-pagination-select-33-count-label"
+                  htmlFor="bx-pagination-select-34"
+                  id="bx-pagination-select-34-count-label"
                 >
                   Items per page:
                 </label>
@@ -31519,7 +31519,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-33"
+                          id="bx-pagination-select-34"
                           onChange={[Function]}
                           value={10}
                         >
@@ -31584,7 +31584,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-33-right"
+                      htmlFor="bx-pagination-select-34-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -31597,7 +31597,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-33-right"
+                          id="bx-pagination-select-34-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -34241,8 +34241,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-30"
-                  id="bx-pagination-select-30-count-label"
+                  htmlFor="bx-pagination-select-31"
+                  id="bx-pagination-select-31-count-label"
                 >
                   Items per page:
                 </label>
@@ -34261,7 +34261,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-30"
+                          id="bx-pagination-select-31"
                           onChange={[Function]}
                           value={10}
                         >
@@ -34326,7 +34326,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-30-right"
+                      htmlFor="bx-pagination-select-31-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -34339,7 +34339,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-30-right"
+                          id="bx-pagination-select-31-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -36690,8 +36690,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-34"
-                  id="bx-pagination-select-34-count-label"
+                  htmlFor="bx-pagination-select-35"
+                  id="bx-pagination-select-35-count-label"
                 >
                   Items per page:
                 </label>
@@ -36710,7 +36710,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-34"
+                          id="bx-pagination-select-35"
                           onChange={[Function]}
                           value={10}
                         >
@@ -36775,7 +36775,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-34-right"
+                      htmlFor="bx-pagination-select-35-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -36788,7 +36788,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-34-right"
+                          id="bx-pagination-select-35-right"
                           onChange={[Function]}
                           value={1}
                         >

--- a/src/components/TileCatalogNew/__snapshots__/TileCatalogNew.story.storyshot
+++ b/src/components/TileCatalogNew/__snapshots__/TileCatalogNew.story.storyshot
@@ -43,7 +43,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 tabIndex="0"
               >
                 <div
-                  aria-labelledby="37-search"
+                  aria-labelledby="38-search"
                   className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
                   role="search"
                 >
@@ -64,8 +64,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   </svg>
                   <label
                     className="bx--label"
-                    htmlFor="37"
-                    id="37-search"
+                    htmlFor="38"
+                    id="38-search"
                   >
                     Filter table
                   </label>
@@ -73,7 +73,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     aria-hidden={true}
                     autoComplete="off"
                     className="bx--search-input"
-                    id="37"
+                    id="38"
                     onChange={[Function]}
                     placeholder="Enter a value"
                     role="searchbox"
@@ -412,7 +412,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 tabIndex="0"
               >
                 <div
-                  aria-labelledby="38-search"
+                  aria-labelledby="39-search"
                   className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
                   role="search"
                 >
@@ -433,8 +433,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   </svg>
                   <label
                     className="bx--label"
-                    htmlFor="38"
-                    id="38-search"
+                    htmlFor="39"
+                    id="39-search"
                   >
                     Filter table
                   </label>
@@ -442,7 +442,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     aria-hidden={true}
                     autoComplete="off"
                     className="bx--search-input"
-                    id="38"
+                    id="39"
                     onChange={[Function]}
                     placeholder="Enter a value"
                     role="searchbox"
@@ -688,7 +688,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 tabIndex="0"
               >
                 <div
-                  aria-labelledby="40-search"
+                  aria-labelledby="41-search"
                   className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
                   role="search"
                 >
@@ -709,8 +709,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   </svg>
                   <label
                     className="bx--label"
-                    htmlFor="40"
-                    id="40-search"
+                    htmlFor="41"
+                    id="41-search"
                   >
                     Filter table
                   </label>
@@ -718,7 +718,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     aria-hidden={true}
                     autoComplete="off"
                     className="bx--search-input"
-                    id="40"
+                    id="41"
                     onChange={[Function]}
                     placeholder="Enter a value"
                     role="searchbox"
@@ -892,7 +892,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 tabIndex="0"
               >
                 <div
-                  aria-labelledby="39-search"
+                  aria-labelledby="40-search"
                   className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
                   role="search"
                 >
@@ -913,8 +913,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   </svg>
                   <label
                     className="bx--label"
-                    htmlFor="39"
-                    id="39-search"
+                    htmlFor="40"
+                    id="40-search"
                   >
                     Filter table
                   </label>
@@ -922,7 +922,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     aria-hidden={true}
                     autoComplete="off"
                     className="bx--search-input"
-                    id="39"
+                    id="40"
                     onChange={[Function]}
                     placeholder="Enter a value"
                     role="searchbox"
@@ -1120,7 +1120,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 tabIndex="0"
               >
                 <div
-                  aria-labelledby="43-search"
+                  aria-labelledby="44-search"
                   className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
                   role="search"
                 >
@@ -1141,8 +1141,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   </svg>
                   <label
                     className="bx--label"
-                    htmlFor="43"
-                    id="43-search"
+                    htmlFor="44"
+                    id="44-search"
                   >
                     Filter table
                   </label>
@@ -1150,7 +1150,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     aria-hidden={true}
                     autoComplete="off"
                     className="bx--search-input"
-                    id="43"
+                    id="44"
                     onChange={[Function]}
                     placeholder="Enter a value"
                     role="searchbox"
@@ -1602,7 +1602,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 tabIndex="0"
               >
                 <div
-                  aria-labelledby="41-search"
+                  aria-labelledby="42-search"
                   className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
                   role="search"
                 >
@@ -1623,8 +1623,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   </svg>
                   <label
                     className="bx--label"
-                    htmlFor="41"
-                    id="41-search"
+                    htmlFor="42"
+                    id="42-search"
                   >
                     Filter table
                   </label>
@@ -1632,7 +1632,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     aria-hidden={true}
                     autoComplete="off"
                     className="bx--search-input"
-                    id="41"
+                    id="42"
                     onChange={[Function]}
                     placeholder="Enter a value"
                     role="searchbox"
@@ -2205,7 +2205,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 tabIndex="0"
               >
                 <div
-                  aria-labelledby="42-search"
+                  aria-labelledby="43-search"
                   className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
                   role="search"
                 >
@@ -2226,8 +2226,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                   </svg>
                   <label
                     className="bx--label"
-                    htmlFor="42"
-                    id="42-search"
+                    htmlFor="43"
+                    id="43-search"
                   >
                     Filter table
                   </label>
@@ -2235,7 +2235,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     aria-hidden={true}
                     autoComplete="off"
                     className="bx--search-input"
-                    id="42"
+                    id="43"
                     onChange={[Function]}
                     placeholder="Enter a value"
                     role="searchbox"

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -28,6 +28,7 @@ import {
   getUpdatedCardSize,
   handleCardVariables,
   chartValueFormatter,
+  getResizeHandles,
 } from '../../utils/cardUtilityFunctions';
 import deprecate from '../../internal/deprecate';
 
@@ -249,9 +250,11 @@ export const formatColors = (series) => {
 const TimeSeriesCard = ({
   title: titleProp,
   content,
+  children,
   size,
   interval,
   isEditable,
+  isResizable,
   values: initialValues,
   locale,
   i18n: { alertDetected, noDataLabel },
@@ -458,6 +461,8 @@ const TimeSeriesCard = ({
   const ChartComponent =
     chartType === TIME_SERIES_TYPES.BAR ? StackedBarChart : LineChart;
 
+  const resizeHandles = isResizable ? getResizeHandles(children) : [];
+
   return (
     <Card
       title={title}
@@ -468,7 +473,8 @@ const TimeSeriesCard = ({
       isEditable={isEditable}
       isEmpty={isChartDataEmpty}
       isLazyLoading={isLazyLoading || (valueSort && valueSort.length > 200)}
-      isLoading={isLoading}>
+      isLoading={isLoading}
+      resizeHandles={resizeHandles}>
       {!isChartDataEmpty ? (
         <>
           <div

--- a/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -2898,8 +2898,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
                 >
                   <label
                     className="bx--pagination__text"
-                    htmlFor="bx-pagination-select-44"
-                    id="bx-pagination-select-44-count-label"
+                    htmlFor="bx-pagination-select-45"
+                    id="bx-pagination-select-45-count-label"
                   >
                     Items per page:
                   </label>
@@ -2918,7 +2918,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
                         >
                           <select
                             className="bx--select-input"
-                            id="bx-pagination-select-44"
+                            id="bx-pagination-select-45"
                             onChange={[Function]}
                             value={10}
                           >
@@ -2983,7 +2983,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
                     >
                       <label
                         className="bx--label bx--visually-hidden"
-                        htmlFor="bx-pagination-select-44-right"
+                        htmlFor="bx-pagination-select-45-right"
                       >
                         Page number, of 1 pages
                       </label>
@@ -2996,7 +2996,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
                         >
                           <select
                             className="bx--select-input"
-                            id="bx-pagination-select-44-right"
+                            id="bx-pagination-select-45-right"
                             onChange={[Function]}
                             value={1}
                           >

--- a/src/components/ValueCard/ValueCard.jsx
+++ b/src/components/ValueCard/ValueCard.jsx
@@ -19,6 +19,7 @@ import { COLORS } from '../../styles/styles';
 import Card from '../Card/Card';
 import {
   determineMaxValueCardAttributeCount,
+  getResizeHandles,
   getUpdatedCardSize,
   handleCardVariables,
 } from '../../utils/cardUtilityFunctions';
@@ -259,17 +260,21 @@ const ValueCard = ({
   size,
   values: valuesProp,
   isEditable,
+  isResizable,
   i18n,
   dataState,
   id,
   locale,
   customFormatter,
+  children,
   ...others
 }) => {
   const availableActions = {
     expand: false,
     ...others.availableActions,
   };
+
+  const resizeHandles = isResizable ? getResizeHandles(children) : [];
 
   /** Searches for variables and updates the card if it is passed the cardVariables prop */
   const { title, content, values } = handleCardVariables(
@@ -320,6 +325,8 @@ const ValueCard = ({
             availableActions={availableActions}
             isEmpty={isEmpty(values) && !dataState}
             isEditable={isEditable}
+            isResizable={isResizable}
+            resizeHandles={resizeHandles}
             i18n={i18n}
             id={id}
             {...others}>
@@ -415,6 +422,7 @@ const ValueCard = ({
                 ))
               )}
             </ContentWrapper>
+            {resizeHandles}
           </Card>
         );
       }}

--- a/src/constants/CardPropTypes.js
+++ b/src/constants/CardPropTypes.js
@@ -498,6 +498,8 @@ export const CardPropTypes = {
   isEditable: PropTypes.bool,
   /** goes full screen if expanded */
   isExpanded: PropTypes.bool,
+  /** True if the card can be resizable in the DashboardGrid by dragging the borders */
+  isResizable: PropTypes.bool,
   /**
    * Define the icon render to be rendered.
    * Can be a React component class
@@ -587,4 +589,6 @@ export const CardPropTypes = {
   testID: PropTypes.string,
   /** the locale of the card, needed for number and date formatting */
   locale: PropTypes.string,
+  /** a way to pass down dashboard grid resize handles, only used by other card types */
+  resizeHandles: PropTypes.array,
 };

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -5173,6 +5173,9 @@ Map {
       "isLoading": Object {
         "type": "bool",
       },
+      "isResizable": Object {
+        "type": "bool",
+      },
       "layout": Object {
         "args": Array [
           Array [
@@ -5222,6 +5225,9 @@ Map {
       "renderIconByName": Object {
         "type": "func",
       },
+      "resizeHandles": Object {
+        "type": "array",
+      },
       "rowHeight": Object {
         "args": Array [
           Object {
@@ -5240,6 +5246,9 @@ Map {
           },
         ],
         "type": "shape",
+      },
+      "showContentDuringResize": Object {
+        "type": "bool",
       },
       "showOverflow": [Function],
       "showTimeInGMT": Object {
@@ -7503,6 +7512,9 @@ Map {
       "onBreakpointChange": Object {
         "type": "func",
       },
+      "onCardSizeChange": Object {
+        "type": "func",
+      },
       "onDashboardAction": Object {
         "type": "func",
       },
@@ -7510,6 +7522,9 @@ Map {
         "type": "func",
       },
       "onLayoutChange": Object {
+        "type": "func",
+      },
+      "onResizeStop": Object {
         "type": "func",
       },
       "onSetupCard": Object {
@@ -7647,7 +7662,9 @@ Map {
       "isEditable": false,
       "layouts": Object {},
       "onBreakpointChange": null,
+      "onCardSizeChange": null,
       "onLayoutChange": null,
+      "onResizeStop": null,
     },
     "propTypes": Object {
       "breakpoint": Object {
@@ -7847,7 +7864,13 @@ Map {
       "onBreakpointChange": Object {
         "type": "func",
       },
+      "onCardSizeChange": Object {
+        "type": "func",
+      },
       "onLayoutChange": Object {
+        "type": "func",
+      },
+      "onResizeStop": Object {
         "type": "func",
       },
     },
@@ -9101,6 +9124,9 @@ Map {
       "isLoading": Object {
         "type": "bool",
       },
+      "isResizable": Object {
+        "type": "bool",
+      },
       "layout": Object {
         "args": Array [
           Array [
@@ -9150,6 +9176,9 @@ Map {
       "renderIconByName": Object {
         "type": "func",
       },
+      "resizeHandles": Object {
+        "type": "array",
+      },
       "rowHeight": Object {
         "args": Array [
           Object {
@@ -9168,6 +9197,9 @@ Map {
           },
         ],
         "type": "shape",
+      },
+      "showContentDuringResize": Object {
+        "type": "bool",
       },
       "showOverflow": [Function],
       "size": Object {
@@ -9849,6 +9881,9 @@ Map {
       "isLoading": Object {
         "type": "bool",
       },
+      "isResizable": Object {
+        "type": "bool",
+      },
       "layout": Object {
         "args": Array [
           Array [
@@ -9974,6 +10009,9 @@ Map {
       "renderIconByName": Object {
         "type": "func",
       },
+      "resizeHandles": Object {
+        "type": "array",
+      },
       "rowHeight": Object {
         "args": Array [
           Object {
@@ -9992,6 +10030,9 @@ Map {
           },
         ],
         "type": "shape",
+      },
+      "showContentDuringResize": Object {
+        "type": "bool",
       },
       "showOverflow": [Function],
       "size": Object {
@@ -10853,6 +10894,9 @@ Map {
       "isLoading": Object {
         "type": "bool",
       },
+      "isResizable": Object {
+        "type": "bool",
+      },
       "layout": Object {
         "args": Array [
           Array [
@@ -10902,6 +10946,9 @@ Map {
       "renderIconByName": Object {
         "type": "func",
       },
+      "resizeHandles": Object {
+        "type": "array",
+      },
       "rowHeight": Object {
         "args": Array [
           Object {
@@ -10920,6 +10967,9 @@ Map {
           },
         ],
         "type": "shape",
+      },
+      "showContentDuringResize": Object {
+        "type": "bool",
       },
       "showOverflow": [Function],
       "size": Object {
@@ -11720,6 +11770,9 @@ Map {
       "isLoading": Object {
         "type": "bool",
       },
+      "isResizable": Object {
+        "type": "bool",
+      },
       "layout": Object {
         "args": Array [
           Array [
@@ -11769,6 +11822,9 @@ Map {
       "renderIconByName": Object {
         "type": "func",
       },
+      "resizeHandles": Object {
+        "type": "array",
+      },
       "rowHeight": Object {
         "args": Array [
           Object {
@@ -11787,6 +11843,9 @@ Map {
           },
         ],
         "type": "shape",
+      },
+      "showContentDuringResize": Object {
+        "type": "bool",
       },
       "showOverflow": [Function],
       "showTimeInGMT": Object {
@@ -12491,6 +12550,9 @@ Map {
       "isLoading": Object {
         "type": "bool",
       },
+      "isResizable": Object {
+        "type": "bool",
+      },
       "layout": Object {
         "args": Array [
           Array [
@@ -12540,6 +12602,9 @@ Map {
       "renderIconByName": Object {
         "type": "func",
       },
+      "resizeHandles": Object {
+        "type": "array",
+      },
       "rowHeight": Object {
         "args": Array [
           Object {
@@ -12558,6 +12623,9 @@ Map {
           },
         ],
         "type": "shape",
+      },
+      "showContentDuringResize": Object {
+        "type": "bool",
       },
       "showOverflow": [Function],
       "size": Object {
@@ -13369,6 +13437,9 @@ Map {
       "isLoading": Object {
         "type": "bool",
       },
+      "isResizable": Object {
+        "type": "bool",
+      },
       "layout": Object {
         "args": Array [
           Array [
@@ -13418,6 +13489,9 @@ Map {
       "renderIconByName": Object {
         "type": "func",
       },
+      "resizeHandles": Object {
+        "type": "array",
+      },
       "rowHeight": Object {
         "args": Array [
           Object {
@@ -13436,6 +13510,9 @@ Map {
           },
         ],
         "type": "shape",
+      },
+      "showContentDuringResize": Object {
+        "type": "bool",
       },
       "showOverflow": [Function],
       "size": Object {
@@ -14285,6 +14362,9 @@ Map {
       "isLoading": Object {
         "type": "bool",
       },
+      "isResizable": Object {
+        "type": "bool",
+      },
       "layout": Object {
         "args": Array [
           Array [
@@ -14334,6 +14414,9 @@ Map {
       "renderIconByName": Object {
         "type": "func",
       },
+      "resizeHandles": Object {
+        "type": "array",
+      },
       "rowHeight": Object {
         "args": Array [
           Object {
@@ -14352,6 +14435,9 @@ Map {
           },
         ],
         "type": "shape",
+      },
+      "showContentDuringResize": Object {
+        "type": "bool",
       },
       "showOverflow": [Function],
       "size": Object {
@@ -15104,6 +15190,9 @@ Map {
       "isLoading": Object {
         "type": "bool",
       },
+      "isResizable": Object {
+        "type": "bool",
+      },
       "layout": Object {
         "type": "string",
       },
@@ -15151,6 +15240,9 @@ Map {
       "renderIconByName": Object {
         "type": "func",
       },
+      "resizeHandles": Object {
+        "type": "array",
+      },
       "rowHeight": Object {
         "args": Array [
           Object {
@@ -15169,6 +15261,9 @@ Map {
           },
         ],
         "type": "shape",
+      },
+      "showContentDuringResize": Object {
+        "type": "bool",
       },
       "showOverflow": [Function],
       "size": Object {

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -5247,9 +5247,6 @@ Map {
         ],
         "type": "shape",
       },
-      "showContentDuringResize": Object {
-        "type": "bool",
-      },
       "showOverflow": [Function],
       "showTimeInGMT": Object {
         "type": "bool",
@@ -9198,9 +9195,6 @@ Map {
         ],
         "type": "shape",
       },
-      "showContentDuringResize": Object {
-        "type": "bool",
-      },
       "showOverflow": [Function],
       "size": Object {
         "args": Array [
@@ -10030,9 +10024,6 @@ Map {
           },
         ],
         "type": "shape",
-      },
-      "showContentDuringResize": Object {
-        "type": "bool",
       },
       "showOverflow": [Function],
       "size": Object {
@@ -10968,9 +10959,6 @@ Map {
         ],
         "type": "shape",
       },
-      "showContentDuringResize": Object {
-        "type": "bool",
-      },
       "showOverflow": [Function],
       "size": Object {
         "args": Array [
@@ -11844,9 +11832,6 @@ Map {
         ],
         "type": "shape",
       },
-      "showContentDuringResize": Object {
-        "type": "bool",
-      },
       "showOverflow": [Function],
       "showTimeInGMT": Object {
         "type": "bool",
@@ -12623,9 +12608,6 @@ Map {
           },
         ],
         "type": "shape",
-      },
-      "showContentDuringResize": Object {
-        "type": "bool",
       },
       "showOverflow": [Function],
       "size": Object {
@@ -13510,9 +13492,6 @@ Map {
           },
         ],
         "type": "shape",
-      },
-      "showContentDuringResize": Object {
-        "type": "bool",
       },
       "showOverflow": [Function],
       "size": Object {
@@ -14436,9 +14415,6 @@ Map {
         ],
         "type": "shape",
       },
-      "showContentDuringResize": Object {
-        "type": "bool",
-      },
       "showOverflow": [Function],
       "size": Object {
         "args": Array [
@@ -15261,9 +15237,6 @@ Map {
           },
         ],
         "type": "shape",
-      },
-      "showContentDuringResize": Object {
-        "type": "bool",
       },
       "showOverflow": [Function],
       "size": Object {

--- a/src/utils/cardUtilityFunctions.js
+++ b/src/utils/cardUtilityFunctions.js
@@ -431,8 +431,8 @@ export const increaseSmallCardSize = (size, cardName) => {
 const resizeHandleId = 'resizableHandle';
 
 /**
- * Simple helper function to extract the resizeHandles from the react children 
- * @param {} children the react children data structure containing the resizeHandles 
+ * Simple helper function to extract the resizeHandles from the react children
+ * @param {} children the react children data structure containing the resizeHandles
  */
 export const getResizeHandles = (children) =>
   React.Children.toArray(children).filter((child) =>
@@ -441,14 +441,14 @@ export const getResizeHandles = (children) =>
 
 /**
  * Custom hook that manages the isResizable state. It does that by wrapping
- * the onStart/onStop callbacks found in the resizeHandles. The resizeHandles 
+ * the onStart/onStop callbacks found in the resizeHandles. The resizeHandles
  * are created by the external library react-grid-layout.
- * 
- * The hook returns an object with both the modified resizeHandles and 
+ *
+ * The hook returns an object with both the modified resizeHandles and
  * the isResizing state.
- * 
+ *
  * @param {array} wrappingCardResizeHandles resizeHandles optionally passed down by wrapping card
- * @param {} children the react children data structure containing the resizeHandles 
+ * @param {} children the react children data structure containing the resizeHandles
  * @param {boolean} isResizable true if the component using the hook should be resizable
  */
 export const useCardResizing = (

--- a/src/utils/cardUtilityFunctions.js
+++ b/src/utils/cardUtilityFunctions.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import warning from 'warning';
 import isNil from 'lodash/isNil';
 import mapValues from 'lodash/mapValues';
@@ -426,4 +426,64 @@ export const increaseSmallCardSize = (size, cardName) => {
     : size === CARD_SIZES.SMALLWIDE
     ? CARD_SIZES.MEDIUMWIDE
     : size;
+};
+
+const resizeHandleId = 'resizableHandle';
+
+/**
+ * Simple helper function to extract the resizeHandles from the react children 
+ * @param {} children the react children data structure containing the resizeHandles 
+ */
+export const getResizeHandles = (children) =>
+  React.Children.toArray(children).filter((child) =>
+    child.key?.includes(resizeHandleId)
+  );
+
+/**
+ * Custom hook that manages the isResizable state. It does that by wrapping
+ * the onStart/onStop callbacks found in the resizeHandles. The resizeHandles 
+ * are created by the external library react-grid-layout.
+ * 
+ * The hook returns an object with both the modified resizeHandles and 
+ * the isResizing state.
+ * 
+ * @param {array} wrappingCardResizeHandles resizeHandles optionally passed down by wrapping card
+ * @param {} children the react children data structure containing the resizeHandles 
+ * @param {boolean} isResizable true if the component using the hook should be resizable
+ */
+export const useCardResizing = (
+  wrappingCardResizeHandles,
+  children,
+  isResizable
+) => {
+  const [isResizing, setIsResizing] = useState(false);
+  const resizeHandlesWithEventHandling = useMemo(
+    () => {
+      const resizeHandles =
+        wrappingCardResizeHandles ||
+        (isResizable && getResizeHandles(children)) ||
+        [];
+
+      return resizeHandles.map((handleElement) =>
+        React.cloneElement(handleElement, {
+          ...handleElement.props,
+          onStart: (...args) => {
+            setIsResizing(true);
+            if (handleElement.props?.onStart) {
+              handleElement.props.onStart(...args);
+            }
+          },
+          onStop: (...args) => {
+            setIsResizing(false);
+            if (handleElement.props?.onStop) {
+              handleElement.props.onStop(...args);
+            }
+          },
+        })
+      );
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isResizable]
+  );
+  return { resizeHandles: resizeHandlesWithEventHandling, isResizing };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -17907,9 +17907,9 @@ react-redux@^7.0.2:
     react-is "^16.9.0"
 
 react-resizable@^1.9.0:
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/react-resizable/-/react-resizable-1.10.1.tgz#f0c2cf1d83b3470b87676ce6d6b02bbe3f4d8cd4"
-  integrity sha512-Jd/bKOKx6+19NwC4/aMLRu/J9/krfxlDnElP41Oc+oLiUWs/zwV1S9yBfBZRnqAwQb6vQ/HRSk3bsSWGSgVbpw==
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/react-resizable/-/react-resizable-1.11.0.tgz#0b237c4aff16937b7663de1045861749683227ad"
+  integrity sha512-VoGz2ddxUFvildS8r8/29UZJeyiM3QJnlmRZSuXm+FpTqq/eIrMPc796Y9XQLg291n2hFZJtIoP1xC3hSTw/jg==
   dependencies:
     prop-types "15.x"
     react-draggable "^4.0.3"


### PR DESCRIPTION
Closes #1598 

**Summary**
Added resize functionality to all cards when present in a DashboardGrid. The feature is based on the underlying resize functionality of the react-grid-layout which passes down a resize handler to the grid items (cards). The DashboardGrid listens to all resize callbacks and makes sure the only valid card sizes are suggested and available as drop while dragging.

The actual card content is showing during resize and I believe performance is acceptable. In the stories added the card also gets transformed between the defined card sizes during the resize drag process.

**Change List (commits, features, bugs, etc)**
- Modified DashboardGrid to manage card resizing using strict card sizes. It now exposes onCardSizeChange and onResizeStop. Both callbacks include the current name and size of the card + all additional parameters passed from the react-grid-layout that might be needed to manage/store the new state of the grid. 
- Modified Card to wrap the onStart/onStop callbacks of the resize handle so that the card can know when it is resized (and show resize border)
- Modified all the card components to extract the resize handles from children and explicitly pass them via a special prop to the underlying Card component. This was needed since most cards don't pass down the children to the Card and some pass children as a function. 
- All cards (including the base Card) has a isResizable prop that controls if the card is resizable in the DashboardGrid.
- Added useMemo to PieChart so that the sample data isn't regenerated during resize
- Removed the mock in the mock of componentUtilityFunctions.js in the DashboardGrid.test and tested the result instead.
- Created unit tests
- Created a story that shows a single card that can be resized. 
- Created a story that shows all the card in different sizes where some cards have minimum sizes defined.
- adjusted the CSS to be more inline with the PAL design
- adjusted the coverage threshold 

**Acceptance Test (how to verify the PR)**
I tested in Chrome, Safari & Firefox.
Checkout out the two stories and plat around with the resizing and knobs. Verify that performance and functionality is ok.

https://deploy-preview-1722--carbon-addons-iot-react.netlify.app?path=/story/watson-iot-dashboard-grid--dashboard-all-cards-as-resizable

https://deploy-preview-1722--carbon-addons-iot-react.netlify.app?path=/story/watson-iot-dashboard-grid--dashboard-resizable-card

**Note!**
If we upgrade to the latest version (1.1.1) we can use the horizontal (west) & vertical (south) border resize as shown in the PAL design. I've tried it and it works, but since it requires a major upgrade of the react-grid-layout I will create a separate issue for that.