### PR TITLE
fix(tablecard): last column duplicated on resize

### DIFF
--- a/src/components/TableCard/TableCard.jsx
+++ b/src/components/TableCard/TableCard.jsx
@@ -566,26 +566,7 @@ const TableCard = ({
             ? i.filter
             : { placeholderText: mergedI18n.defaultFilterStringPlaceholdText }, // if filter not send we send empty object
         }))
-        .concat(hasActionColumn ? actionColumn : [])
-        .map((column) => {
-          const columnPriority = column.priority || 1; // default to 1 if not provided
-          switch (newSize) {
-            case CARD_SIZES.LARGETHIN:
-              return columnPriority === 1 ? column : null;
-
-            case CARD_SIZES.LARGE:
-              return columnPriority === 1 || columnPriority === 2
-                ? column
-                : null;
-
-            case CARD_SIZES.LARGEWIDE:
-              return column;
-
-            default:
-              return column;
-          }
-        })
-        .filter((i) => i),
+        .concat(hasActionColumn ? actionColumn : []),
     [
       actionColumn,
       hasActionColumn,
@@ -593,6 +574,19 @@ const TableCard = ({
       newColumns,
       newSize,
     ]
+  );
+
+  const ordering = useMemo(
+    () =>
+      columnsToRender.map(({ id: columnId, priority }) => {
+        const prio = priority || 1; // default to 1 if not provided
+        const isHidden =
+          (newSize === CARD_SIZES.LARGETHIN && prio !== 1) ||
+          (newSize === CARD_SIZES.LARGE && !(prio === 1 || prio === 2));
+
+        return { columnId, isHidden };
+      }),
+    [columnsToRender, newSize]
   );
 
   const filteredTimestampColumns = useMemo(
@@ -784,11 +778,7 @@ const TableCard = ({
   );
 
   // is columns recieved is different from the columnsToRender show card expand
-  const isExpandable =
-    columns.length !==
-    columnsToRender.filter(
-      (item) => item.id !== 'actionColumn' && !item.id.includes('iconColumn')
-    ).length;
+  const isExpandable = !!ordering.find((col) => col.isHidden);
 
   const hasFilter = newSize !== CARD_SIZES.LARGETHIN;
 
@@ -892,6 +882,7 @@ const TableCard = ({
                 emptyState: {
                   message: emptyMessage || mergedI18n.emptyMessage,
                 },
+                ordering,
               },
             }}
             showHeader={showHeader !== undefined ? showHeader : true}

--- a/src/components/TableCard/TableCard.test.jsx
+++ b/src/components/TableCard/TableCard.test.jsx
@@ -625,4 +625,104 @@ describe('TableCard', () => {
 
     expect(screen.getByText('Testing resize')).toBeInTheDocument();
   });
+
+  it('last column is not dublicated when changeing sizes', () => {
+    const { rerender } = render(
+      <TableCard
+        id="table-list"
+        title="Testing resize"
+        content={{
+          columns: tableColumns,
+        }}
+        values={tableData}
+        size={CARD_SIZES.LARGE}
+      />
+    );
+
+    rerender(
+      <TableCard
+        id="table-list"
+        title="Testing resize"
+        content={{
+          columns: tableColumns,
+        }}
+        values={tableData}
+        size={CARD_SIZES.LARGEWIDE}
+      />
+    );
+
+    rerender(
+      <TableCard
+        id="table-list"
+        title="Testing resize"
+        content={{
+          columns: tableColumns,
+        }}
+        values={tableData}
+        size={CARD_SIZES.LARGE}
+      />
+    );
+
+    expect(screen.queryAllByText('Pressure')).toHaveLength(1);
+  });
+
+  it('hides low priority columns for LARGE and LARGETHIN sizes', () => {
+    const { rerender } = render(
+      <TableCard
+        id="table-list"
+        title="Testing resize"
+        content={{
+          columns: tableColumns,
+        }}
+        values={tableData}
+        size={CARD_SIZES.LARGE}
+      />
+    );
+
+    // Column Count has priority 3 so it should be hidden
+    expect(screen.queryAllByTitle('Count')).toHaveLength(0);
+
+    rerender(
+      <TableCard
+        id="table-list"
+        title="Testing resize"
+        content={{
+          columns: tableColumns,
+        }}
+        values={tableData}
+        size={CARD_SIZES.LARGEWIDE}
+      />
+    );
+
+    expect(screen.queryAllByTitle('Count')).toHaveLength(1);
+  });
+
+  it('shows toolbar expand button only when low priority columns are hidden', () => {
+    const { rerender } = render(
+      <TableCard
+        id="table-list"
+        title="Testing resize"
+        content={{
+          columns: tableColumns,
+        }}
+        values={tableData}
+        size={CARD_SIZES.LARGE}
+      />
+    );
+    expect(screen.getByTitle('Expand to fullscreen')).toBeVisible();
+
+    rerender(
+      <TableCard
+        id="table-list"
+        title="Testing resize"
+        content={{
+          columns: tableColumns,
+        }}
+        values={tableData}
+        size={CARD_SIZES.LARGEWIDE}
+      />
+    );
+
+    expect(screen.queryAllByTitle('Expand to fullscreen')).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Closes #1701

**Summary**
I've been all over the place with this one trying to figure out where to add the fix. The core problem was that the CardTable was using the StatefulTable and at the same time modifying the number of columns externally (for smaller sizes some columns should not be shown). When a column was removed the StatefulTable could be sending a `columns` prop of length 6 and an `ordering` prop of length 5 to the Table in a render call before the state had synced the two props. The `columns` prop is used in the Table to create the default `ordering` prop of length 6 and since the Table merges default props with normal props a duplication could occur. 

I was unable to reproduce this behaviour anywhere else then in the CardTable scenario, so I finally settled to fix the issue there.

**Change List (commits, features, bugs, etc)**
- Updated CardTable to hide columns instead of removing them
- Added unit tests

**Acceptance Test (how to verify the PR)**
1. Go to https://deploy-preview-####--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-tablecard--table-with-thresholds
2. Change the size to Large and make sure the Toolbar icon for "Expand to full screen" is showing
3. Change the size to LargeWide
4. Make sure the pressure column is only shown once and make sure the Toolbar icon for "Expand to full screen" is not showing
