### PR TITLE
1761 create a new color dropdown component

### DIFF
--- a/.storybook/__snapshots__/Welcome.story.storyshot
+++ b/.storybook/__snapshots__/Welcome.story.storyshot
@@ -3513,6 +3513,18 @@ exports[`Storybook Snapshot tests and console checks Storyshots 0/Getting Starte
                   <div
                     className="bx--structured-list-td"
                   >
+                    ColorDropdown
+                  </div>
+                </div>
+                <div
+                  className="bx--structured-list-row"
+                >
+                  <div
+                    className="bx--structured-list-td"
+                  />
+                  <div
+                    className="bx--structured-list-td"
+                  >
                     determineCardRange
                   </div>
                 </div>

--- a/src/components/ColorDropdown/ColorDropdown.jsx
+++ b/src/components/ColorDropdown/ColorDropdown.jsx
@@ -26,15 +26,21 @@ const colorPropType = PropTypes.shape({
 });
 
 const propTypes = {
+  /** Array of colors to be shown */
   colors: PropTypes.arrayOf(colorPropType),
-  /** Internationalisation strings */
+  /** The label of the Dropdown, defaults to 'Select a color' */
   label: PropTypes.string,
+  /** The title of the Dropdown, defaults to 'Color' */
   titleText: PropTypes.string,
+  /** Required Id string */
   id: PropTypes.string.isRequired,
+  /** True if the light theme is to be used, defaults to false */
   light: PropTypes.bool,
   /** Callback for when any of the Dropdown color value changes */
   onChange: PropTypes.func.isRequired,
+  /** The selected color, use to set initial color */
   selectedColor: colorPropType,
+  /** Id used if needed for testing */
   testID: PropTypes.string,
 };
 
@@ -75,13 +81,15 @@ const ColorDropdown = ({
       <div
         title={`${item.name}`}
         className={`${iotPrefix}--color-dropdown__item`}>
-        <div
-          title={`${item.carbonColor}`}
-          className={`${iotPrefix}--color-dropdown__color-sample`}
-          style={{ backgroundColor: item.carbonColor }}
-        />
-        <div className={`${iotPrefix}--color-dropdown__color-name`}>
-          {item.name}
+        <div className={`${iotPrefix}--color-dropdown__item-border`}>
+          <div
+            title={`${item.carbonColor}`}
+            className={`${iotPrefix}--color-dropdown__color-sample`}
+            style={{ backgroundColor: item.carbonColor }}
+          />
+          <div className={`${iotPrefix}--color-dropdown__color-name`}>
+            {item.name}
+          </div>
         </div>
       </div>
     );

--- a/src/components/ColorDropdown/ColorDropdown.jsx
+++ b/src/components/ColorDropdown/ColorDropdown.jsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Dropdown } from 'carbon-components-react';
+import {
+  purple70,
+  cyan50,
+  teal70,
+  magenta70,
+  red50,
+  red90,
+  green60,
+  blue80,
+  magenta50,
+  purple50,
+  teal50,
+  cyan90,
+} from '@carbon/colors';
+
+import { settings } from '../../constants/Settings';
+
+const { iotPrefix } = settings;
+
+const colorPropType = PropTypes.shape({
+  carbonColor: PropTypes.string,
+  name: PropTypes.string,
+});
+
+const propTypes = {
+  colors: PropTypes.arrayOf(colorPropType),
+  /** Internationalisation strings */
+  label: PropTypes.string,
+  titleText: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  light: PropTypes.bool,
+  /** Callback for when any of the Dropdown color value changes */
+  onChange: PropTypes.func.isRequired,
+  selectedColor: colorPropType,
+  testID: PropTypes.string,
+};
+
+const defaultProps = {
+  colors: [
+    { carbonColor: purple70, name: 'purple70' },
+    { carbonColor: cyan50, name: 'cyan50' },
+    { carbonColor: teal70, name: 'teal70' },
+    { carbonColor: magenta70, name: 'magenta70' },
+    { carbonColor: red50, name: 'red50' },
+    { carbonColor: red90, name: 'red90' },
+    { carbonColor: green60, name: 'green60' },
+    { carbonColor: blue80, name: 'blue80' },
+    { carbonColor: magenta50, name: 'magenta50' },
+    { carbonColor: purple50, name: 'purple50' },
+    { carbonColor: teal50, name: 'teal50' },
+    { carbonColor: cyan90, name: 'cyan90' },
+  ],
+  label: 'Select a color',
+  light: false,
+  selectedColor: undefined,
+  testID: undefined,
+  titleText: 'Color',
+};
+
+const ColorDropdown = ({
+  colors,
+  id,
+  label,
+  light,
+  onChange,
+  selectedColor,
+  titleText,
+  testID,
+}) => {
+  const renderColorItem = (item) => {
+    return (
+      <div
+        title={`${item.name}`}
+        className={`${iotPrefix}--color-dropdown__item`}>
+        <div
+          title={`${item.carbonColor}`}
+          className={`${iotPrefix}--color-dropdown__color-sample`}
+          style={{ backgroundColor: item.carbonColor }}
+        />
+        <div className={`${iotPrefix}--color-dropdown__color-name`}>
+          {item.name}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <Dropdown
+      className={`${iotPrefix}--color-dropdown`}
+      id={id}
+      itemToString={renderColorItem}
+      items={colors}
+      label={label}
+      light={light}
+      onChange={(change) => {
+        onChange({ color: change.selectedItem });
+      }}
+      selectedItem={selectedColor}
+      titleText={titleText}
+      type="default"
+      test-id={testID}
+    />
+  );
+};
+
+ColorDropdown.propTypes = propTypes;
+ColorDropdown.defaultProps = defaultProps;
+
+export default ColorDropdown;

--- a/src/components/ColorDropdown/ColorDropdown.story.jsx
+++ b/src/components/ColorDropdown/ColorDropdown.story.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { red50, blue50, green50, teal70 } from '@carbon/colors';
+
+import ColorDropdown from './ColorDropdown';
+
+export default {
+  title: 'Watson IoT Experimental/ColorDropdown',
+  decorators: [withKnobs],
+  parameters: {
+    component: ColorDropdown,
+  },
+  excludeStories: [],
+};
+
+export const DefaultExample = () => (
+  <div style={{ width: '200px' }}>
+    <ColorDropdown
+      id="myColorDropdown"
+      label={text('label', 'Select a color')}
+      light={boolean('light', false)}
+      titleText={text('titleText', 'Color')}
+      onChange={action('onChange')}
+    />
+  </div>
+);
+
+export const PresetSelectionExample = () => (
+  <div style={{ width: '200px' }}>
+    <ColorDropdown
+      id="myColorDropdown"
+      label={text('label', 'Select a color')}
+      titleText={text('titleText', 'Color')}
+      onChange={action('onChange')}
+      selectedColor={{ carbonColor: teal70, name: 'teal70' }}
+    />
+  </div>
+);
+
+export const CustomColorsExample = () => (
+  <div style={{ width: '200px' }}>
+    <ColorDropdown
+      id="myColorDropdown"
+      label={text('label', 'Select a color')}
+      titleText={text('titleText', 'Color')}
+      colors={[
+        { carbonColor: red50, name: 'red' },
+        { carbonColor: green50, name: 'green' },
+        { carbonColor: blue50, name: 'blue' },
+      ]}
+      onChange={action('onChange')}
+    />
+  </div>
+);
+
+DefaultExample.story = {
+  parameters: {
+    info: {
+      propTables: [ColorDropdown],
+      propTablesExclude: [],
+    },
+  },
+};

--- a/src/components/ColorDropdown/ColorDropdown.test.jsx
+++ b/src/components/ColorDropdown/ColorDropdown.test.jsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { red50, blue50, green50 } from '@carbon/colors';
+
+import { settings } from '../../constants/Settings';
+
+import ColorDropdown from './ColorDropdown';
+
+const { iotPrefix } = settings;
+
+describe('ColorDropdown', () => {
+  const getColors = () => [
+    { carbonColor: red50, name: 'red' },
+    { carbonColor: green50, name: 'green' },
+    { carbonColor: blue50, name: 'blue' },
+  ];
+
+  const getHexColor = (name) =>
+    getColors().find((obj) => obj.name === name).carbonColor;
+
+  const hexToRgbStyle = (hexColor) => {
+    const regexResult = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(
+      hexColor
+    );
+    const radix = 16;
+    const r = parseInt(regexResult[1], radix);
+    const g = parseInt(regexResult[2], radix);
+    const b = parseInt(regexResult[3], radix);
+    return `rgb(${r}, ${g}, ${b})`;
+  };
+
+  it('renders default labels', () => {
+    render(<ColorDropdown id="myColorDropdown" onChange={() => {}} />);
+
+    expect(
+      within(screen.getByRole('button')).getByText('Select a color')
+    ).toBeTruthy();
+
+    expect(screen.getByText('Color')).toBeVisible();
+  });
+
+  it('renders custom labels', () => {
+    const label = 'my label';
+    const titleText = 'My title text';
+    render(
+      <ColorDropdown
+        id="myColorDropdown"
+        label={label}
+        titleText={titleText}
+        onChange={() => {}}
+      />
+    );
+
+    expect(within(screen.getByRole('button')).getByText(label)).toBeTruthy();
+    expect(screen.getByText(titleText)).toBeVisible();
+  });
+
+  it('renders preset color and shows selected color sample', () => {
+    render(
+      <ColorDropdown
+        colors={getColors()}
+        selectedColor={{ carbonColor: green50, name: 'green' }}
+        id="myColorDropdown"
+        onChange={() => {}}
+      />
+    );
+    const button = screen.getByRole('button');
+    expect(within(button).getByText('green')).toBeVisible();
+    expect(within(button).getByTitle(getHexColor('green'))).toHaveClass(
+      `${iotPrefix}--color-dropdown__color-sample`
+    );
+  });
+
+  it('renders the selected value correctly', () => {
+    const onChange = jest.fn();
+    render(
+      <ColorDropdown
+        id="myColorDropdown"
+        colors={getColors()}
+        onChange={onChange}
+      />
+    );
+    userEvent.click(screen.getByText('Select a color'));
+
+    const firstItem = screen.getAllByRole('option')[0];
+    expect(within(firstItem).getByText('red')).toBeVisible();
+    userEvent.click(firstItem);
+
+    const button = screen.getByRole('button');
+    expect(within(button).getByText('red')).toBeVisible();
+    const colorSample = within(button).getByTitle(getHexColor('red'));
+    expect(colorSample).toHaveClass(
+      `${iotPrefix}--color-dropdown__color-sample`
+    );
+    expect(colorSample).toHaveStyle({
+      backgroundColor: hexToRgbStyle(getHexColor('red')),
+    });
+  });
+
+  it('renders the selectable items correctly', () => {
+    const onChange = jest.fn();
+    render(
+      <ColorDropdown
+        id="myColorDropdown"
+        colors={getColors()}
+        onChange={onChange}
+      />
+    );
+    userEvent.click(screen.getByText('Select a color'));
+
+    const firstItem = screen.getAllByRole('option')[0];
+    const firstColorSample = within(firstItem).getByTitle(getHexColor('red'));
+    expect(within(firstItem).getByText('red')).toBeVisible();
+    expect(firstColorSample).toHaveClass(
+      `${iotPrefix}--color-dropdown__color-sample`
+    );
+    expect(firstColorSample).toHaveStyle({
+      backgroundColor: hexToRgbStyle(getHexColor('red')),
+    });
+
+    const secondItem = screen.getAllByRole('option')[1];
+    const secondColorSample = within(secondItem).getByTitle(
+      getHexColor('green')
+    );
+    expect(within(secondItem).getByText('green')).toBeVisible();
+    expect(secondColorSample).toHaveClass(
+      `${iotPrefix}--color-dropdown__color-sample`
+    );
+    expect(secondColorSample).toHaveStyle({
+      backgroundColor: hexToRgbStyle(getHexColor('green')),
+    });
+  });
+
+  it('calls onChange with the selected color when a color is selected', () => {
+    const onChange = jest.fn();
+    render(
+      <ColorDropdown
+        colors={getColors()}
+        id="myColorDropdown"
+        onChange={onChange}
+      />
+    );
+    userEvent.click(screen.getByText('Select a color'));
+    const firstItem = screen.getAllByRole('option')[0];
+    userEvent.click(firstItem);
+
+    expect(onChange).toHaveBeenCalledWith({
+      color: { carbonColor: getHexColor('red'), name: 'red' },
+    });
+  });
+});

--- a/src/components/ColorDropdown/__snapshots__/ColorDropdown.story.storyshot
+++ b/src/components/ColorDropdown/__snapshots__/ColorDropdown.story.storyshot
@@ -287,18 +287,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 title="teal70"
               >
                 <div
-                  className="iot--color-dropdown__color-sample"
-                  style={
-                    Object {
-                      "backgroundColor": "#005d5d",
-                    }
-                  }
-                  title="#005d5d"
-                />
-                <div
-                  className="iot--color-dropdown__color-name"
+                  className="iot--color-dropdown__item-border"
                 >
-                  teal70
+                  <div
+                    className="iot--color-dropdown__color-sample"
+                    style={
+                      Object {
+                        "backgroundColor": "#005d5d",
+                      }
+                    }
+                    title="#005d5d"
+                  />
+                  <div
+                    className="iot--color-dropdown__color-name"
+                  >
+                    teal70
+                  </div>
                 </div>
               </div>
             </span>

--- a/src/components/ColorDropdown/__snapshots__/ColorDropdown.story.storyshot
+++ b/src/components/ColorDropdown/__snapshots__/ColorDropdown.story.storyshot
@@ -1,0 +1,367 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ColorDropdown Custom Colors Example 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "200px",
+        }
+      }
+    >
+      <div
+        className="bx--dropdown__wrapper bx--list-box__wrapper"
+      >
+        <label
+          className="bx--label"
+          htmlFor="downshift-7-toggle-button"
+          id="downshift-7-label"
+        >
+          Color
+        </label>
+        <div
+          className="bx--dropdown iot--color-dropdown bx--list-box"
+          id="myColorDropdown"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          <button
+            aria-disabled={false}
+            aria-expanded={false}
+            aria-haspopup="listbox"
+            aria-labelledby="downshift-7-label downshift-7-toggle-button"
+            className="bx--list-box__field"
+            disabled={false}
+            id="downshift-7-toggle-button"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            type="button"
+          >
+            <span
+              className="bx--list-box__label"
+            >
+              Select a color
+            </span>
+            <div
+              className="bx--list-box__menu-icon"
+            >
+              <svg
+                aria-label="Open menu"
+                fill="currentColor"
+                focusable="false"
+                height={16}
+                name="chevron--down"
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+                <title>
+                  Open menu
+                </title>
+              </svg>
+            </div>
+          </button>
+          <div
+            aria-labelledby="downshift-7-label"
+            className="bx--list-box__menu"
+            id="downshift-7-menu"
+            onBlur={[Function]}
+            onKeyDown={[Function]}
+            onMouseLeave={[Function]}
+            role="listbox"
+            tabIndex={-1}
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ColorDropdown Default Example 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "200px",
+        }
+      }
+    >
+      <div
+        className="bx--dropdown__wrapper bx--list-box__wrapper"
+      >
+        <label
+          className="bx--label"
+          htmlFor="downshift-5-toggle-button"
+          id="downshift-5-label"
+        >
+          Color
+        </label>
+        <div
+          className="bx--dropdown iot--color-dropdown bx--list-box"
+          id="myColorDropdown"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          <button
+            aria-disabled={false}
+            aria-expanded={false}
+            aria-haspopup="listbox"
+            aria-labelledby="downshift-5-label downshift-5-toggle-button"
+            className="bx--list-box__field"
+            disabled={false}
+            id="downshift-5-toggle-button"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            type="button"
+          >
+            <span
+              className="bx--list-box__label"
+            >
+              Select a color
+            </span>
+            <div
+              className="bx--list-box__menu-icon"
+            >
+              <svg
+                aria-label="Open menu"
+                fill="currentColor"
+                focusable="false"
+                height={16}
+                name="chevron--down"
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+                <title>
+                  Open menu
+                </title>
+              </svg>
+            </div>
+          </button>
+          <div
+            aria-labelledby="downshift-5-label"
+            className="bx--list-box__menu"
+            id="downshift-5-menu"
+            onBlur={[Function]}
+            onKeyDown={[Function]}
+            onMouseLeave={[Function]}
+            role="listbox"
+            tabIndex={-1}
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ColorDropdown Preset Selection Example 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "200px",
+        }
+      }
+    >
+      <div
+        className="bx--dropdown__wrapper bx--list-box__wrapper"
+      >
+        <label
+          className="bx--label"
+          htmlFor="downshift-6-toggle-button"
+          id="downshift-6-label"
+        >
+          Color
+        </label>
+        <div
+          className="bx--dropdown iot--color-dropdown bx--list-box"
+          id="myColorDropdown"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          <button
+            aria-disabled={false}
+            aria-expanded={false}
+            aria-haspopup="listbox"
+            aria-labelledby="downshift-6-label downshift-6-toggle-button"
+            className="bx--list-box__field"
+            disabled={false}
+            id="downshift-6-toggle-button"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            type="button"
+          >
+            <span
+              className="bx--list-box__label"
+            >
+              <div
+                className="iot--color-dropdown__item"
+                title="teal70"
+              >
+                <div
+                  className="iot--color-dropdown__color-sample"
+                  style={
+                    Object {
+                      "backgroundColor": "#005d5d",
+                    }
+                  }
+                  title="#005d5d"
+                />
+                <div
+                  className="iot--color-dropdown__color-name"
+                >
+                  teal70
+                </div>
+              </div>
+            </span>
+            <div
+              className="bx--list-box__menu-icon"
+            >
+              <svg
+                aria-label="Open menu"
+                fill="currentColor"
+                focusable="false"
+                height={16}
+                name="chevron--down"
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+                <title>
+                  Open menu
+                </title>
+              </svg>
+            </div>
+          </button>
+          <div
+            aria-labelledby="downshift-6-label"
+            className="bx--list-box__menu"
+            id="downshift-6-menu"
+            onBlur={[Function]}
+            onKeyDown={[Function]}
+            onMouseLeave={[Function]}
+            role="listbox"
+            tabIndex={-1}
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/ColorDropdown/_color-dropdown.scss
+++ b/src/components/ColorDropdown/_color-dropdown.scss
@@ -1,0 +1,50 @@
+// We want to make sure the title attribute of the carbon option element
+// is not shown on hover, since that will be "[obj obj]" when we are
+// using itemToString. Hence, we remove margins and padding here and add them
+// to the child iot--color-dropdown__item instead.
+.#{$iot-prefix}--color-dropdown {
+  .#{$prefix}--list-box__menu-item__option {
+    margin: 0;
+    padding: 0;
+  }
+
+  .#{$iot-prefix}--color-dropdown__item {
+    display: flex;
+    align-items: center;
+    height: 100%;
+    padding-left: 1rem;
+    padding-right: 1.5rem;
+  }
+
+  // When showing selected item we must remove the padding.
+  .#{$prefix}--list-box__label .#{$iot-prefix}--color-dropdown__item {
+    padding-left: 0;
+  }
+}
+
+.#{$iot-prefix}--color-dropdown__color-sample {
+  width: 1.5rem;
+  height: 1.5rem;
+  margin-right: $spacing-04;
+  flex-shrink: 0;
+}
+
+.#{$iot-prefix}--color-dropdown__color-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+html[dir='rtl'] {
+  .#{$iot-prefix}--color-dropdown__color-sample {
+    margin-left: $spacing-04;
+  }
+
+  .#{$iot-prefix}--color-dropdown__item {
+    padding-right: 2rem;
+  }
+
+  // When showing selected item we must remove the padding.
+  .#{$prefix}--list-box__label .#{$iot-prefix}--color-dropdown__item {
+    padding-right: 0;
+  }
+}

--- a/src/components/ColorDropdown/_color-dropdown.scss
+++ b/src/components/ColorDropdown/_color-dropdown.scss
@@ -8,6 +8,7 @@
   .#{$prefix}--list-box__menu-item__option {
     margin: 0;
     padding: 0;
+    border-top: none;
   }
 
   .#{$iot-prefix}--color-dropdown__item {
@@ -19,9 +20,6 @@
 
   // We need to recreate the border so that it doesn't stretch all the way
   // to the end of the container
-  .#{$prefix}--list-box__menu-item__option {
-    border-top: none;
-  }
   .#{$iot-prefix}--color-dropdown__item-border {
     display: flex;
     align-items: center;

--- a/src/components/ColorDropdown/_color-dropdown.scss
+++ b/src/components/ColorDropdown/_color-dropdown.scss
@@ -1,3 +1,5 @@
+@import '../../globals/vars';
+
 // We want to make sure the title attribute of the carbon option element
 // is not shown on hover, since that will be "[obj obj]" when we are
 // using itemToString. Hence, we remove margins and padding here and add them
@@ -10,15 +12,47 @@
 
   .#{$iot-prefix}--color-dropdown__item {
     display: flex;
-    align-items: center;
     height: 100%;
     padding-left: 1rem;
-    padding-right: 1.5rem;
+    padding-right: 1rem;
   }
 
-  // When showing selected item we must remove the padding.
+  // We need to recreate the border so that it doesn't stretch all the way
+  // to the end of the container
+  .#{$prefix}--list-box__menu-item__option {
+    border-top: none;
+  }
+  .#{$iot-prefix}--color-dropdown__item-border {
+    display: flex;
+    align-items: center;
+    height: 100%;
+    width: 100%;
+    border-top: 1px solid $decorative-01;
+  }
+  // The new borders must be hidded on :hover, :active & .highlighted
+  .#{$prefix}--list-box__menu-item:hover,
+  .#{$prefix}--list-box__menu-item:active,
+  .#{$prefix}--list-box__menu-item--highlighted {
+    .#{$iot-prefix}--color-dropdown__item-border {
+      border-color: transparent;
+    }
+    & + .bx--list-box__menu-item .#{$iot-prefix}--color-dropdown__item-border {
+      border-color: transparent;
+    }
+  }
+
+  // The new borders must be hidded for the topmost item
+  .#{$prefix}--list-box__menu-item:first-of-type
+    .#{$iot-prefix}--color-dropdown__item-border {
+    border-color: transparent;
+  }
+
+  // When showing selected item we must remove the padding and border.
   .#{$prefix}--list-box__label .#{$iot-prefix}--color-dropdown__item {
     padding-left: 0;
+    .#{$iot-prefix}--color-dropdown__item-border {
+      border-color: transparent;
+    }
   }
 }
 

--- a/src/components/ComboBox/__snapshots__/ComboBox.story.storyshot
+++ b/src/components/ComboBox/__snapshots__/ComboBox.story.storyshot
@@ -30,7 +30,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         <div
           aria-expanded={false}
           aria-haspopup="listbox"
-          aria-labelledby="downshift-10-label"
+          aria-labelledby="downshift-13-label"
           aria-owns={null}
           className="bx--list-box__wrapper"
           role="combobox"
@@ -38,7 +38,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           <label
             className="bx--label"
             htmlFor="carbon-combobox-example"
-            id="downshift-10-label"
+            id="downshift-13-label"
           >
             Combobox title
           </label>
@@ -65,7 +65,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 aria-activedescendant={null}
                 aria-autocomplete="list"
                 aria-controls={null}
-                aria-labelledby="downshift-10-label"
+                aria-labelledby="downshift-13-label"
                 autoComplete="off"
                 className="bx--text-input"
                 data-testid="combo-box"
@@ -208,7 +208,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         <div
           aria-expanded={false}
           aria-haspopup="listbox"
-          aria-labelledby="downshift-5-label"
+          aria-labelledby="downshift-8-label"
           aria-owns={null}
           className="bx--list-box__wrapper"
           role="combobox"
@@ -216,7 +216,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           <label
             className="bx--label"
             htmlFor="carbon-combobox-example"
-            id="downshift-5-label"
+            id="downshift-8-label"
           >
             Combobox title
           </label>
@@ -243,7 +243,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 aria-activedescendant={null}
                 aria-autocomplete="list"
                 aria-controls={null}
-                aria-labelledby="downshift-5-label"
+                aria-labelledby="downshift-8-label"
                 autoComplete="off"
                 className="bx--text-input bx--text-input--empty"
                 data-testid="combo-box"
@@ -349,7 +349,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         <div
           aria-expanded={false}
           aria-haspopup="listbox"
-          aria-labelledby="downshift-9-label"
+          aria-labelledby="downshift-12-label"
           aria-owns={null}
           className="bx--list-box__wrapper"
           role="combobox"
@@ -357,7 +357,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           <label
             className="bx--label"
             htmlFor="carbon-combobox-example"
-            id="downshift-9-label"
+            id="downshift-12-label"
           >
             Combobox title
           </label>
@@ -384,7 +384,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 aria-activedescendant={null}
                 aria-autocomplete="list"
                 aria-controls={null}
-                aria-labelledby="downshift-9-label"
+                aria-labelledby="downshift-12-label"
                 autoComplete="off"
                 className="bx--text-input bx--text-input--empty"
                 data-testid="combo-box"
@@ -490,7 +490,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         <div
           aria-expanded={false}
           aria-haspopup="listbox"
-          aria-labelledby="downshift-8-label"
+          aria-labelledby="downshift-11-label"
           aria-owns={null}
           className="bx--list-box__wrapper"
           role="combobox"
@@ -498,7 +498,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           <label
             className="bx--label"
             htmlFor="carbon-combobox-example"
-            id="downshift-8-label"
+            id="downshift-11-label"
           >
             Combobox title
           </label>
@@ -525,7 +525,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 aria-activedescendant={null}
                 aria-autocomplete="list"
                 aria-controls={null}
-                aria-labelledby="downshift-8-label"
+                aria-labelledby="downshift-11-label"
                 autoComplete="off"
                 className="bx--text-input bx--text-input--empty"
                 data-testid="combo-box"
@@ -635,7 +635,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         <div
           aria-expanded={false}
           aria-haspopup="listbox"
-          aria-labelledby="downshift-6-label"
+          aria-labelledby="downshift-9-label"
           aria-owns={null}
           className="bx--list-box__wrapper"
           role="combobox"
@@ -643,7 +643,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           <label
             className="bx--label"
             htmlFor="carbon-combobox-example"
-            id="downshift-6-label"
+            id="downshift-9-label"
           >
             Combobox title
           </label>
@@ -670,7 +670,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 aria-activedescendant={null}
                 aria-autocomplete="list"
                 aria-controls={null}
-                aria-labelledby="downshift-6-label"
+                aria-labelledby="downshift-9-label"
                 autoComplete="off"
                 className="bx--text-input bx--text-input--empty"
                 data-testid="combo-box"
@@ -768,7 +768,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
       <div
         aria-expanded={false}
         aria-haspopup="listbox"
-        aria-labelledby="downshift-7-label"
+        aria-labelledby="downshift-10-label"
         aria-owns={null}
         className="bx--list-box__wrapper"
         role="combobox"
@@ -776,7 +776,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         <label
           className="bx--label"
           htmlFor="carbon-combobox-example"
-          id="downshift-7-label"
+          id="downshift-10-label"
         >
           Combobox title
         </label>
@@ -803,7 +803,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls={null}
-              aria-labelledby="downshift-7-label"
+              aria-labelledby="downshift-10-label"
               autoComplete="off"
               className="bx--text-input"
               data-testid="combo-box"

--- a/src/components/Dropdown/__snapshots__/Dropdown.story.storyshot
+++ b/src/components/Dropdown/__snapshots__/Dropdown.story.storyshot
@@ -26,8 +26,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dropd
       >
         <label
           className="bx--label"
-          htmlFor="downshift-11-toggle-button"
-          id="downshift-11-label"
+          htmlFor="downshift-14-toggle-button"
+          id="downshift-14-label"
         >
           Dropdown label
         </label>
@@ -41,10 +41,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dropd
             aria-disabled={false}
             aria-expanded={false}
             aria-haspopup="listbox"
-            aria-labelledby="downshift-11-label downshift-11-toggle-button"
+            aria-labelledby="downshift-14-label downshift-14-toggle-button"
             className="bx--list-box__field"
             disabled={false}
-            id="downshift-11-toggle-button"
+            id="downshift-14-toggle-button"
             onClick={[Function]}
             onKeyDown={[Function]}
             type="button"
@@ -76,9 +76,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dropd
             </div>
           </button>
           <div
-            aria-labelledby="downshift-11-label"
+            aria-labelledby="downshift-14-label"
             className="bx--list-box__menu"
-            id="downshift-11-menu"
+            id="downshift-14-menu"
             onBlur={[Function]}
             onKeyDown={[Function]}
             onMouseLeave={[Function]}
@@ -146,8 +146,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dropd
       >
         <label
           className="bx--label"
-          htmlFor="downshift-12-toggle-button"
-          id="downshift-12-label"
+          htmlFor="downshift-15-toggle-button"
+          id="downshift-15-label"
         >
           Inline dropdown label
         </label>
@@ -161,10 +161,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dropd
             aria-disabled={false}
             aria-expanded={false}
             aria-haspopup="listbox"
-            aria-labelledby="downshift-12-label downshift-12-toggle-button"
+            aria-labelledby="downshift-15-label downshift-15-toggle-button"
             className="bx--list-box__field"
             disabled={false}
-            id="downshift-12-toggle-button"
+            id="downshift-15-toggle-button"
             onClick={[Function]}
             onKeyDown={[Function]}
             type="button"
@@ -196,9 +196,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dropd
             </div>
           </button>
           <div
-            aria-labelledby="downshift-12-label"
+            aria-labelledby="downshift-15-label"
             className="bx--list-box__menu"
-            id="downshift-12-menu"
+            id="downshift-15-menu"
             onBlur={[Function]}
             onKeyDown={[Function]}
             onMouseLeave={[Function]}
@@ -261,8 +261,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dropd
       >
         <label
           className="bx--label"
-          htmlFor="downshift-13-toggle-button"
-          id="downshift-13-label"
+          htmlFor="downshift-16-toggle-button"
+          id="downshift-16-label"
         >
           Dropdown label
         </label>
@@ -277,10 +277,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dropd
             aria-disabled={false}
             aria-expanded={false}
             aria-haspopup="listbox"
-            aria-labelledby="downshift-13-label downshift-13-toggle-button"
+            aria-labelledby="downshift-16-label downshift-16-toggle-button"
             className="bx--list-box__field"
             disabled={false}
-            id="downshift-13-toggle-button"
+            id="downshift-16-toggle-button"
             onClick={[Function]}
             onKeyDown={[Function]}
             type="button"
@@ -312,9 +312,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dropd
             </div>
           </button>
           <div
-            aria-labelledby="downshift-13-label"
+            aria-labelledby="downshift-16-label"
             className="bx--list-box__menu"
-            id="downshift-13-menu"
+            id="downshift-16-menu"
             onBlur={[Function]}
             onKeyDown={[Function]}
             onMouseLeave={[Function]}
@@ -440,8 +440,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dropd
       >
         <label
           className="bx--label"
-          htmlFor="downshift-14-toggle-button"
-          id="downshift-14-label"
+          htmlFor="downshift-17-toggle-button"
+          id="downshift-17-label"
         >
           Dropdown label
         </label>
@@ -456,10 +456,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dropd
             aria-disabled={false}
             aria-expanded={false}
             aria-haspopup="listbox"
-            aria-labelledby="downshift-14-label downshift-14-toggle-button"
+            aria-labelledby="downshift-17-label downshift-17-toggle-button"
             className="bx--list-box__field"
             disabled={false}
-            id="downshift-14-toggle-button"
+            id="downshift-17-toggle-button"
             onClick={[Function]}
             onKeyDown={[Function]}
             type="button"
@@ -491,9 +491,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dropd
             </div>
           </button>
           <div
-            aria-labelledby="downshift-14-label"
+            aria-labelledby="downshift-17-label"
             className="bx--list-box__menu"
-            id="downshift-14-menu"
+            id="downshift-17-menu"
             onBlur={[Function]}
             onKeyDown={[Function]}
             onMouseLeave={[Function]}

--- a/src/components/IconDropdown/__snapshots__/IconDropdown.story.storyshot
+++ b/src/components/IconDropdown/__snapshots__/IconDropdown.story.storyshot
@@ -36,8 +36,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         >
           <label
             className="bx--label"
-            htmlFor="downshift-15-toggle-button"
-            id="downshift-15-label"
+            htmlFor="downshift-18-toggle-button"
+            id="downshift-18-label"
           >
             Dropdown label
           </label>
@@ -52,10 +52,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               aria-disabled={false}
               aria-expanded={false}
               aria-haspopup="listbox"
-              aria-labelledby="downshift-15-label downshift-15-toggle-button"
+              aria-labelledby="downshift-18-label downshift-18-toggle-button"
               className="bx--list-box__field"
               disabled={false}
-              id="downshift-15-toggle-button"
+              id="downshift-18-toggle-button"
               onClick={[Function]}
               onKeyDown={[Function]}
               type="button"
@@ -90,9 +90,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               </div>
             </button>
             <div
-              aria-labelledby="downshift-15-label"
+              aria-labelledby="downshift-18-label"
               className="bx--list-box__menu"
-              id="downshift-15-menu"
+              id="downshift-18-menu"
               onBlur={[Function]}
               onKeyDown={[Function]}
               onMouseLeave={[Function]}

--- a/src/components/Table/TableViewDropdown/__snapshots__/TableViewDropdown.story.storyshot
+++ b/src/components/Table/TableViewDropdown/__snapshots__/TableViewDropdown.story.storyshot
@@ -38,10 +38,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               aria-disabled={false}
               aria-expanded={false}
               aria-haspopup="listbox"
-              aria-labelledby="downshift-24-label downshift-24-toggle-button"
+              aria-labelledby="downshift-27-label downshift-27-toggle-button"
               className="bx--list-box__field"
               disabled={false}
-              id="downshift-24-toggle-button"
+              id="downshift-27-toggle-button"
               onClick={[Function]}
               onKeyDown={[Function]}
               type="button"
@@ -108,9 +108,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               </div>
             </button>
             <div
-              aria-labelledby="downshift-24-label"
+              aria-labelledby="downshift-27-label"
               className="bx--list-box__menu"
-              id="downshift-24-menu"
+              id="downshift-27-menu"
               onBlur={[Function]}
               onKeyDown={[Function]}
               onMouseLeave={[Function]}

--- a/src/components/Table/TableViewDropdown/__snapshots__/TableViewDropdown.story.storyshot
+++ b/src/components/Table/TableViewDropdown/__snapshots__/TableViewDropdown.story.storyshot
@@ -38,10 +38,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               aria-disabled={false}
               aria-expanded={false}
               aria-haspopup="listbox"
-              aria-labelledby="downshift-29-label downshift-29-toggle-button"
+              aria-labelledby="downshift-32-label downshift-32-toggle-button"
               className="bx--list-box__field"
               disabled={false}
-              id="downshift-29-toggle-button"
+              id="downshift-32-toggle-button"
               onClick={[Function]}
               onKeyDown={[Function]}
               type="button"
@@ -108,9 +108,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               </div>
             </button>
             <div
-              aria-labelledby="downshift-29-label"
+              aria-labelledby="downshift-32-label"
               className="bx--list-box__menu"
-              id="downshift-29-menu"
+              id="downshift-32-menu"
               onBlur={[Function]}
               onKeyDown={[Function]}
               onMouseLeave={[Function]}

--- a/src/index.js
+++ b/src/index.js
@@ -108,6 +108,7 @@ export AccordionItemDefer from './components/Accordion/AccordionItemDefer';
 export ComboBox from './components/ComboBox';
 export FlyoutMenu from './components/FlyoutMenu';
 export FilterTags from './components/FilterTags/FilterTags';
+export ColorDropdown from './components/ColorDropdown/ColorDropdown';
 
 // Carbon proxy
 export {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -155,6 +155,8 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 // 🔬 Experimental
 //-------------------------------------
 @import 'components/UIShell/ui-shell';
+@import 'components/ColorDropdown/color-dropdown';
+@import 'components/HotspotEditorModal/hotspot-editor-modal';
 
 //-------------------------------------
 // 🙈 Hidden (Not exposed on website)

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -156,7 +156,6 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 //-------------------------------------
 @import 'components/UIShell/ui-shell';
 @import 'components/ColorDropdown/color-dropdown';
-@import 'components/HotspotEditorModal/hotspot-editor-modal';
 
 //-------------------------------------
 // 🙈 Hidden (Not exposed on website)

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -17566,6 +17566,118 @@ Map {
       },
     },
   },
+  "ColorDropdown" => Object {
+    "defaultProps": Object {
+      "colors": Array [
+        Object {
+          "carbonColor": "#6929c4",
+          "name": "purple70",
+        },
+        Object {
+          "carbonColor": "#1192e8",
+          "name": "cyan50",
+        },
+        Object {
+          "carbonColor": "#005d5d",
+          "name": "teal70",
+        },
+        Object {
+          "carbonColor": "#9f1853",
+          "name": "magenta70",
+        },
+        Object {
+          "carbonColor": "#fa4d56",
+          "name": "red50",
+        },
+        Object {
+          "carbonColor": "#520408",
+          "name": "red90",
+        },
+        Object {
+          "carbonColor": "#198038",
+          "name": "green60",
+        },
+        Object {
+          "carbonColor": "#002d9c",
+          "name": "blue80",
+        },
+        Object {
+          "carbonColor": "#ee5396",
+          "name": "magenta50",
+        },
+        Object {
+          "carbonColor": "#a56eff",
+          "name": "purple50",
+        },
+        Object {
+          "carbonColor": "#009d9a",
+          "name": "teal50",
+        },
+        Object {
+          "carbonColor": "#012749",
+          "name": "cyan90",
+        },
+      ],
+      "label": "Select a color",
+      "light": false,
+      "selectedColor": undefined,
+      "testID": undefined,
+      "titleText": "Color",
+    },
+    "propTypes": Object {
+      "colors": Object {
+        "args": Array [
+          Object {
+            "args": Array [
+              Object {
+                "carbonColor": Object {
+                  "type": "string",
+                },
+                "name": Object {
+                  "type": "string",
+                },
+              },
+            ],
+            "type": "shape",
+          },
+        ],
+        "type": "arrayOf",
+      },
+      "id": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "label": Object {
+        "type": "string",
+      },
+      "light": Object {
+        "type": "bool",
+      },
+      "onChange": Object {
+        "isRequired": true,
+        "type": "func",
+      },
+      "selectedColor": Object {
+        "args": Array [
+          Object {
+            "carbonColor": Object {
+              "type": "string",
+            },
+            "name": Object {
+              "type": "string",
+            },
+          },
+        ],
+        "type": "shape",
+      },
+      "testID": Object {
+        "type": "string",
+      },
+      "titleText": Object {
+        "type": "string",
+      },
+    },
+  },
   "Accordion" => Object {
     "defaultProps": Object {
       "align": "end",


### PR DESCRIPTION
Closes #1761

**Summary**
A color dropdown component for the HotSpotEditorModal.

**Change List (commits, features, bugs, etc)**
- Extended the carbon Dropdown to show color squares per item and for the selection
- Added default colors
- Added option to pass in custom colors
- Added callback for when color selection change
- Added a new story
- Added unit tests
- Verified RL

**Acceptance Test (how to verify the PR)**
Check out the stories at
https://deploy-preview-1765--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-experimental-colordropdown--default-example
