### PR TITLE
fix(dashboardeditor): create onLayoutChange callback and pass layouts to grid

### DIFF
--- a/src/components/DashboardEditor/DashboardEditor.jsx
+++ b/src/components/DashboardEditor/DashboardEditor.jsx
@@ -77,8 +77,14 @@ const propTypes = {
    * this prop will be ignored if getValidDataItems is defined
    */
   dataItems: DataItemsPropTypes,
-  /** if provided, will update the dashboard json according to its own logic */
+  /** if provided, will update the dashboard json according to its own logic. Can return a valid card to be rendered
+   * onCardChange(updatedCard, template): Card
+   */
   onCardChange: PropTypes.func,
+  /** if provided, will return the updated layout and layouts
+   * onLayoutChange(newLayout, newLayouts)
+   */
+  onLayoutChange: PropTypes.func,
   /** if provided, renders import button linked to this callback
    * onImport(data, setNotification?)
    */
@@ -144,6 +150,7 @@ const defaultProps = {
   getValidTimeRanges: null,
   dataItems: [],
   onCardChange: null,
+  onLayoutChange: null,
   onDelete: null,
   onImport: null,
   onExport: null,
@@ -196,6 +203,7 @@ const DashboardEditor = ({
   headerBreadcrumbs,
   notification,
   onCardChange,
+  onLayoutChange,
   onEditTitle,
   onImport,
   onExport,
@@ -369,12 +377,16 @@ const DashboardEditor = ({
                   onBreakpointChange={(newBreakpoint) => {
                     setCurrentBreakpoint(newBreakpoint);
                   }}
-                  onLayoutChange={(newLayout, newLayouts) =>
+                  layouts={dashboardJson.layouts}
+                  onLayoutChange={(newLayout, newLayouts) => {
+                    if (onLayoutChange) {
+                      onLayoutChange(newLayout, newLayouts);
+                    }
                     setDashboardJson({
                       ...dashboardJson,
                       layouts: newLayouts,
-                    })
-                  }
+                    });
+                  }}
                   supportedLayouts={['xl', 'lg', 'md']}>
                   {dashboardJson.cards.map((cardConfig) => {
                     const isSelected = cardConfig.id === selectedCardId;

--- a/src/components/DashboardEditor/DashboardEditor.story.jsx
+++ b/src/components/DashboardEditor/DashboardEditor.story.jsx
@@ -143,7 +143,62 @@ export const WithInitialValue = () => (
             interval: 'day',
           },
         ],
-        layouts: {},
+        layouts: {
+          lg: [
+            { h: 4, i: 'Table', w: 8, x: 0, y: 0 },
+            { h: 2, i: 'Custom', w: 4, x: 8, y: 0 },
+            {
+              h: 2,
+              i: 'Standard',
+              w: 4,
+              x: 12,
+              y: 0,
+            },
+            {
+              h: 2,
+              i: 'Timeseries',
+              w: 8,
+              x: 1,
+              y: 4,
+            },
+          ],
+          md: [
+            { h: 4, i: 'Table', w: 8, x: 0, y: 0 },
+            { h: 2, i: 'Custom', w: 4, x: 8, y: 0 },
+            {
+              h: 2,
+              i: 'Standard',
+              w: 4,
+              x: 12,
+              y: 0,
+            },
+            {
+              h: 2,
+              i: 'Timeseries',
+              w: 8,
+              x: 1,
+              y: 4,
+            },
+          ],
+          xl: [
+            { h: 4, i: 'Table', w: 8, x: 0, y: 0 },
+            { h: 2, i: 'Custom', w: 4, x: 8, y: 0 },
+            {
+              h: 2,
+              i: 'Standard',
+              w: 4,
+              x: 12,
+              y: 0,
+            },
+            {
+              h: 2,
+              i: 'Timeseries',
+              w: 8,
+              x: 1,
+              y: 4,
+            },
+          ],
+        },
       }}
       onEditTitle={action('onEditTitle')}
       onImport={action('onImport')}

--- a/src/components/DashboardEditor/DashboardEditor.story.jsx
+++ b/src/components/DashboardEditor/DashboardEditor.story.jsx
@@ -41,6 +41,7 @@ export const Default = () => (
       onDelete={action('onDelete')}
       onCancel={action('onCancel')}
       onSubmit={action('onSubmit')}
+      onLayoutChange={action('onLayoutChange')}
       submitDisabled={boolean('submitDisabled', false)}
       supportedCardTypes={array('supportedCardTypes', [
         'TIMESERIES',
@@ -150,6 +151,7 @@ export const WithInitialValue = () => (
       onDelete={action('onDelete')}
       onCancel={action('onCancel')}
       onSubmit={action('onSubmit')}
+      onLayoutChange={action('onLayoutChange')}
       supportedCardTypes={[
         'TIMESERIES',
         'SIMPLE_BAR',
@@ -216,9 +218,10 @@ export const WithCustomOnCardChange = () => (
       onCancel={action('onCancel')}
       onSubmit={action('onSubmit')}
       onCardChange={(card) => {
-        console.log('onCardChange');
+        action('onCardChange');
         return card;
       }}
+      onLayoutChange={action('onLayoutChange')}
       supportedCardTypes={[
         'TIMESERIES',
         'SIMPLE_BAR',
@@ -308,6 +311,7 @@ export const WithBreakpointSwitcher = () => (
       onDelete={action('onDelete')}
       onCancel={action('onCancel')}
       onSubmit={action('onSubmit')}
+      onLayoutChange={action('onLayoutChange')}
       supportedCardTypes={array('supportedCardTypes', [
         'TIMESERIES',
         'SIMPLE_BAR',
@@ -372,6 +376,7 @@ export const CustomCardPreviewRenderer = () => (
       onDelete={action('onDelete')}
       onCancel={action('onCancel')}
       onSubmit={action('onSubmit')}
+      onLayoutChange={action('onLayoutChange')}
       supportedCardTypes={array('supportedCardTypes', [
         'TIMESERIES',
         'SIMPLE_BAR',

--- a/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -5462,7 +5462,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     onDrop={[Function]}
                     style={
                       Object {
-                        "height": "624px",
+                        "height": "944px",
                       }
                     }
                   >
@@ -6819,9 +6819,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                         Object {
                           "--card-default-height": "304px",
                           "height": "304px",
-                          "left": "50.625%",
+                          "left": "6.328125%",
                           "position": "absolute",
-                          "top": "320px",
+                          "top": "640px",
                           "width": "49.375%",
                         }
                       }

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -8129,6 +8129,7 @@ Map {
       "onEditTitle": null,
       "onExport": null,
       "onImport": null,
+      "onLayoutChange": null,
       "onSubmit": null,
       "onValidateCardJson": null,
       "renderCardPreview": [Function],
@@ -8290,6 +8291,9 @@ Map {
         "type": "func",
       },
       "onImport": Object {
+        "type": "func",
+      },
+      "onLayoutChange": Object {
         "type": "func",
       },
       "onSubmit": Object {


### PR DESCRIPTION
Closes #1774 

**Summary**

- DashboardEditor was not passing template layouts to DashboardGrid, meaning it would never respect the given layouts

**Change List (commits, features, bugs, etc)**

- Added an `onLayoutChange(newLayout, newLayouts)` callback for consumers
- Passed `layouts` to DashboardGrid correctly
- Added `onLayoutChange` action to stories

**Acceptance Test (how to verify the PR)**

1. Go to any DashboardEditor story, add cards, then move them around. Open up the actions tab and see that `onLayoutChange` is being fired with the correct layouts
2. Open the DashboardEditor - initialValue story and see that the layout is not in the classic default state. (they're not perfectly aligned)
