### PR TITLE
feat(table-card): add multiselect filter to threshold columns

### DIFF
--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -1370,7 +1370,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   }
                 >
                   <div
-                    className="TableCard__StyledStatefulTable-q9l5bz-0 jnbqeq iot--table-container bx--data-table-container"
+                    className="TableCard__StyledStatefulTable-q9l5bz-0 hSSXGi iot--table-container bx--data-table-container"
                   >
                     <section
                       aria-label="data table toolbar"
@@ -3742,7 +3742,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   }
                 >
                   <div
-                    className="TableCard__StyledStatefulTable-q9l5bz-0 jnbqeq iot--table-container bx--data-table-container"
+                    className="TableCard__StyledStatefulTable-q9l5bz-0 hSSXGi iot--table-container bx--data-table-container"
                   >
                     <section
                       aria-label="data table toolbar"
@@ -6142,7 +6142,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   }
                 >
                   <div
-                    className="TableCard__StyledStatefulTable-q9l5bz-0 jnbqeq iot--table-container bx--data-table-container"
+                    className="TableCard__StyledStatefulTable-q9l5bz-0 hSSXGi iot--table-container bx--data-table-container"
                   >
                     <section
                       aria-label="data table toolbar"
@@ -7893,7 +7893,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   }
                 >
                   <div
-                    className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+                    className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
                   >
                     <section
                       aria-label="data table toolbar"
@@ -11112,7 +11112,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   }
                 >
                   <div
-                    className="TableCard__StyledStatefulTable-q9l5bz-0 jnbqeq iot--table-container bx--data-table-container"
+                    className="TableCard__StyledStatefulTable-q9l5bz-0 hSSXGi iot--table-container bx--data-table-container"
                   >
                     <section
                       aria-label="data table toolbar"
@@ -25887,7 +25887,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   }
                 >
                   <div
-                    className="TableCard__StyledStatefulTable-q9l5bz-0 jnbqeq iot--table-container bx--data-table-container"
+                    className="TableCard__StyledStatefulTable-q9l5bz-0 hSSXGi iot--table-container bx--data-table-container"
                   >
                     <section
                       aria-label="data table toolbar"

--- a/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
@@ -1028,7 +1028,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
               }
             >
               <div
-                className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+                className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
               >
                 <section
                   aria-label="data table toolbar"

--- a/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -5554,7 +5554,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                         }
                       >
                         <div
-                          className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+                          className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
                         >
                           <section
                             aria-label="data table toolbar"

--- a/src/components/TableCard/TableCard.jsx
+++ b/src/components/TableCard/TableCard.jsx
@@ -114,10 +114,7 @@ const StyledStatefulTable = styled(
         }
       }
       th div.bx--list-box {
-        height: auto;
-        .bx--list-box__selection {
-          height: inherit;
-        }
+        height: 2rem;
       }
     }
   }
@@ -495,18 +492,19 @@ const TableCard = ({
       renderDataFunction: renderThresholdIcon,
       priority: 1,
       filter: {
+        isMultiselect: true,
         placeholderText: mergedI18n.selectSeverityPlaceholder,
         options: [
           {
-            id: 1,
+            id: mergedI18n.criticalLabel,
             text: mergedI18n.criticalLabel,
           },
           {
-            id: 2,
+            id: mergedI18n.moderateLabel,
             text: mergedI18n.moderateLabel,
           },
           {
-            id: 3,
+            id: mergedI18n.lowLabel,
             text: mergedI18n.lowLabel,
           },
         ],
@@ -616,6 +614,13 @@ const TableCard = ({
     [columns]
   );
 
+  // Map from threshold severity number to label
+  const thresholdSeverityLabelsMap = {
+    1: mergedI18n.criticalLabel,
+    2: mergedI18n.moderateLabel,
+    3: mergedI18n.lowLabel,
+  };
+
   // if we're in editable mode, generate fake data
   const tableDataWithTimestamp = useMemo(
     () =>
@@ -650,7 +655,7 @@ const TableCard = ({
             const iconColumns = matchingThresholds
               ? matchingThresholds.reduce((thresholdData, threshold) => {
                   thresholdData[`iconColumn-${threshold.dataSourceId}`] = // eslint-disable-line no-param-reassign
-                    threshold.severity;
+                    thresholdSeverityLabelsMap[threshold.severity];
                   return thresholdData;
                 }, {})
               : null;
@@ -698,6 +703,7 @@ const TableCard = ({
       filteredPrecisionColumns,
       thresholds,
       tableData,
+      thresholdSeverityLabelsMap,
       locale,
     ]
   );

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -40,7 +40,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           }
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -2528,7 +2528,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           }
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -3745,7 +3745,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           }
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -6502,7 +6502,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           }
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -7933,7 +7933,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           }
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -9698,7 +9698,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           }
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 jnbqeq iot--table-container bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-0 hSSXGi iot--table-container bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -10321,7 +10321,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           }
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -13009,7 +13009,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           }
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -14474,7 +14474,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           }
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -16179,7 +16179,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           }
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -17644,7 +17644,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           }
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -19704,7 +19704,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           }
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -21503,7 +21503,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           }
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -23302,7 +23302,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           }
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -25101,7 +25101,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           }
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -26941,7 +26941,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           }
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -29629,7 +29629,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           }
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -31779,7 +31779,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           }
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -34521,7 +34521,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           }
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 cSTvat iot--table-container bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"


### PR DESCRIPTION
Closes #1779 

**Summary**

Threshold columns in `TableCards` should filter on a multiselect

**Change List (commits, features, bugs, etc)**

Add the `isMultiselect` flag and fix styling.

**Acceptance Test (how to verify the PR)**

Go to `TableCard` "table with thresholds" story, click the filter icon, and see that you can filter on multiple selections.

![Screen Shot 2020-11-10 at 2 50 17 PM](https://user-images.githubusercontent.com/53092833/98731924-115de500-2364-11eb-92a5-ca58ea5e702c.png)

