### PR TITLE
fix(table): fixed left alignment of table headers

### DIFF
--- a/src/components/DataTable/_data-table.scss
+++ b/src/components/DataTable/_data-table.scss
@@ -73,6 +73,11 @@ html[dir='rtl'] {
   .#{$prefix}--table-sort {
     padding-left: $spacing-04;
     padding-right: $spacing-04;
+
+    .#{$prefix}--table-header-label {
+      padding-left: 0;
+      padding-right: 0;
+    }
   }
 }
 


### PR DESCRIPTION
Closes #1784

**Summary**

- Removes double padding on header items when embedded in a button.

**Change List (commits, features, bugs, etc)**

- Small scss fix.

**Acceptance Test (how to verify the PR)**

- Go to https://deploy-preview-1789--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-table--simple-stateful-example and observe the headers that are left aligned.
