### PR TITLE
fix(hierarchylist): need to useDeepCompareEffect to stop infinite loop

### DIFF
--- a/src/components/List/HierarchyList/HierarchyList.jsx
+++ b/src/components/List/HierarchyList/HierarchyList.jsx
@@ -244,7 +244,8 @@ const HierarchyList = ({
     cancelMoveClicked();
   };
 
-  useEffect(
+  useDeepCompareEffect(
+    // have to use deep compare to accurately compare items
     () => {
       // Expand the parent elements of the defaultSelectedId
       if (defaultSelectedId) {

--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { DragDropContext } from 'react-dnd';
@@ -144,7 +144,7 @@ const List = forwardRef((props, ref) => {
     itemWillMove,
     emptyState,
   } = props;
-  const mergedI18n = { ...defaultProps.i18n, i18n };
+  const mergedI18n = useMemo(() => ({ ...defaultProps.i18n, i18n }), [i18n]);
   const selectedItemRef = ref;
   const ListHeader = overrides?.header?.component || DefaultListHeader;
   const renderItemAndChildren = (item, index, parentId, level) => {


### PR DESCRIPTION
Closes # internal bug: https://github.ibm.com/wiotp/monitoring-dashboard/issues/1633

**Summary**

- Because of the useEffect comparison, objects that come from redux can cause infinite render loops to happen.

**Change List (commits, features, bugs, etc)**

-fix(List): memoize i18n as well.

**Acceptance Test (how to verify the PR)**

- Verify searching within HierarchyList still works
