### PR TITLE
Hotfix to Master -- fix(table): fixed left alignment of table headers

### DIFF
--- a/src/components/DataTable/_data-table.scss
+++ b/src/components/DataTable/_data-table.scss
@@ -73,6 +73,11 @@ html[dir='rtl'] {
   .#{$prefix}--table-sort {
     padding-left: $spacing-04;
     padding-right: $spacing-04;
+
+    .#{$prefix}--table-header-label {
+      padding-left: 0;
+      padding-right: 0;
+    }
   }
 }
 


### PR DESCRIPTION
**Summary**

- Hotfix #1789 to `master` so consumers can get it now
