### PR TITLE
fix(listitem): rowActions should be null by default

### DIFF
--- a/src/components/List/ListItem/ListItem.jsx
+++ b/src/components/List/ListItem/ListItem.jsx
@@ -78,7 +78,7 @@ const ListItemDefaultProps = {
   selected: false,
   expanded: false,
   secondaryValue: null,
-  rowActions: [],
+  rowActions: null,
   icon: null,
   iconPosition: 'left',
   nestingLevel: 0,


### PR DESCRIPTION
Closes #

**Summary**

- Change to the default propTypes for rowActions to stop the warning message
