### PR TITLE
feat(imagehotspots): add selecting and creating hotspots

### DIFF
--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -2114,6 +2114,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         src="landscape.jpg"
                         style={
                           Object {
+                            "cursor": "auto",
                             "left": undefined,
                             "position": "relative",
                             "top": undefined,
@@ -2133,7 +2134,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         }
                       >
                         <div
-                          className="Hotspot__StyledHotspot-nlpwmi-0 fxwZek"
+                          className="iot--hotspot-container iot--hotspot-container--has-icon"
+                          data-testid="hotspot-35-65"
+                          icon="arrowDown"
+                          style={
+                            Object {
+                              "--height": 25,
+                              "--width": 25,
+                              "--x-pos": 35,
+                              "--y-pos": 65,
+                            }
+                          }
                         >
                           <div
                             aria-describedby={null}
@@ -2168,7 +2179,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="Hotspot__StyledHotspot-nlpwmi-0 kwumIH"
+                          className="iot--hotspot-container"
+                          data-testid="hotspot-45-25"
+                          icon={null}
+                          style={
+                            Object {
+                              "--height": 25,
+                              "--width": 25,
+                              "--x-pos": 45,
+                              "--y-pos": 25,
+                            }
+                          }
                         >
                           <div
                             aria-describedby={null}
@@ -2209,7 +2230,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="Hotspot__StyledHotspot-nlpwmi-0 eqtfro"
+                          className="iot--hotspot-container"
+                          data-testid="hotspot-45-50"
+                          icon={null}
+                          style={
+                            Object {
+                              "--height": 25,
+                              "--width": 25,
+                              "--x-pos": 45,
+                              "--y-pos": 50,
+                            }
+                          }
                         >
                           <div
                             aria-describedby={null}
@@ -2250,7 +2281,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="Hotspot__StyledHotspot-nlpwmi-0 jjFGEa"
+                          className="iot--hotspot-container iot--hotspot-container--has-icon"
+                          data-testid="hotspot-45-75"
+                          icon="arrowUp"
+                          style={
+                            Object {
+                              "--height": 25,
+                              "--width": 25,
+                              "--x-pos": 45,
+                              "--y-pos": 75,
+                            }
+                          }
                         >
                           <div
                             aria-describedby={null}
@@ -4486,6 +4527,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         src="landscape.jpg"
                         style={
                           Object {
+                            "cursor": "auto",
                             "left": undefined,
                             "position": "relative",
                             "top": undefined,
@@ -4505,7 +4547,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         }
                       >
                         <div
-                          className="Hotspot__StyledHotspot-nlpwmi-0 fxwZek"
+                          className="iot--hotspot-container iot--hotspot-container--has-icon"
+                          data-testid="hotspot-35-65"
+                          icon="arrowDown"
+                          style={
+                            Object {
+                              "--height": 25,
+                              "--width": 25,
+                              "--x-pos": 35,
+                              "--y-pos": 65,
+                            }
+                          }
                         >
                           <div
                             aria-describedby={null}
@@ -4540,7 +4592,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="Hotspot__StyledHotspot-nlpwmi-0 kwumIH"
+                          className="iot--hotspot-container"
+                          data-testid="hotspot-45-25"
+                          icon={null}
+                          style={
+                            Object {
+                              "--height": 25,
+                              "--width": 25,
+                              "--x-pos": 45,
+                              "--y-pos": 25,
+                            }
+                          }
                         >
                           <div
                             aria-describedby={null}
@@ -4581,7 +4643,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="Hotspot__StyledHotspot-nlpwmi-0 eqtfro"
+                          className="iot--hotspot-container"
+                          data-testid="hotspot-45-50"
+                          icon={null}
+                          style={
+                            Object {
+                              "--height": 25,
+                              "--width": 25,
+                              "--x-pos": 45,
+                              "--y-pos": 50,
+                            }
+                          }
                         >
                           <div
                             aria-describedby={null}
@@ -4622,7 +4694,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="Hotspot__StyledHotspot-nlpwmi-0 jjFGEa"
+                          className="iot--hotspot-container iot--hotspot-container--has-icon"
+                          data-testid="hotspot-45-75"
+                          icon="arrowUp"
+                          style={
+                            Object {
+                              "--height": 25,
+                              "--width": 25,
+                              "--x-pos": 45,
+                              "--y-pos": 75,
+                            }
+                          }
                         >
                           <div
                             aria-describedby={null}
@@ -6886,6 +6968,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         src="landscape.jpg"
                         style={
                           Object {
+                            "cursor": "auto",
                             "left": undefined,
                             "position": "relative",
                             "top": undefined,
@@ -6905,7 +6988,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         }
                       >
                         <div
-                          className="Hotspot__StyledHotspot-nlpwmi-0 fxwZek"
+                          className="iot--hotspot-container iot--hotspot-container--has-icon"
+                          data-testid="hotspot-35-65"
+                          icon="arrowDown"
+                          style={
+                            Object {
+                              "--height": 25,
+                              "--width": 25,
+                              "--x-pos": 35,
+                              "--y-pos": 65,
+                            }
+                          }
                         >
                           <div
                             aria-describedby={null}
@@ -6940,7 +7033,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="Hotspot__StyledHotspot-nlpwmi-0 kwumIH"
+                          className="iot--hotspot-container"
+                          data-testid="hotspot-45-25"
+                          icon={null}
+                          style={
+                            Object {
+                              "--height": 25,
+                              "--width": 25,
+                              "--x-pos": 45,
+                              "--y-pos": 25,
+                            }
+                          }
                         >
                           <div
                             aria-describedby={null}
@@ -6981,7 +7084,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="Hotspot__StyledHotspot-nlpwmi-0 eqtfro"
+                          className="iot--hotspot-container"
+                          data-testid="hotspot-45-50"
+                          icon={null}
+                          style={
+                            Object {
+                              "--height": 25,
+                              "--width": 25,
+                              "--x-pos": 45,
+                              "--y-pos": 50,
+                            }
+                          }
                         >
                           <div
                             aria-describedby={null}
@@ -7022,7 +7135,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="Hotspot__StyledHotspot-nlpwmi-0 jjFGEa"
+                          className="iot--hotspot-container iot--hotspot-container--has-icon"
+                          data-testid="hotspot-45-75"
+                          icon="arrowUp"
+                          style={
+                            Object {
+                              "--height": 25,
+                              "--width": 25,
+                              "--x-pos": 45,
+                              "--y-pos": 75,
+                            }
+                          }
                         >
                           <div
                             aria-describedby={null}
@@ -7502,6 +7625,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         src="landscape.jpg"
                         style={
                           Object {
+                            "cursor": "auto",
                             "left": undefined,
                             "position": "relative",
                             "top": undefined,
@@ -11856,6 +11980,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         src="landscape.jpg"
                         style={
                           Object {
+                            "cursor": "auto",
                             "left": undefined,
                             "position": "relative",
                             "top": undefined,
@@ -11875,7 +12000,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         }
                       >
                         <div
-                          className="Hotspot__StyledHotspot-nlpwmi-0 fxwZek"
+                          className="iot--hotspot-container iot--hotspot-container--has-icon"
+                          data-testid="hotspot-35-65"
+                          icon="arrowDown"
+                          style={
+                            Object {
+                              "--height": 25,
+                              "--width": 25,
+                              "--x-pos": 35,
+                              "--y-pos": 65,
+                            }
+                          }
                         >
                           <div
                             aria-describedby={null}
@@ -11910,7 +12045,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="Hotspot__StyledHotspot-nlpwmi-0 kwumIH"
+                          className="iot--hotspot-container"
+                          data-testid="hotspot-45-25"
+                          icon={null}
+                          style={
+                            Object {
+                              "--height": 25,
+                              "--width": 25,
+                              "--x-pos": 45,
+                              "--y-pos": 25,
+                            }
+                          }
                         >
                           <div
                             aria-describedby={null}
@@ -11951,7 +12096,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="Hotspot__StyledHotspot-nlpwmi-0 eqtfro"
+                          className="iot--hotspot-container"
+                          data-testid="hotspot-45-50"
+                          icon={null}
+                          style={
+                            Object {
+                              "--height": 25,
+                              "--width": 25,
+                              "--x-pos": 45,
+                              "--y-pos": 50,
+                            }
+                          }
                         >
                           <div
                             aria-describedby={null}
@@ -11992,7 +12147,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="Hotspot__StyledHotspot-nlpwmi-0 jjFGEa"
+                          className="iot--hotspot-container iot--hotspot-container--has-icon"
+                          data-testid="hotspot-45-75"
+                          icon="arrowUp"
+                          style={
+                            Object {
+                              "--height": 25,
+                              "--width": 25,
+                              "--x-pos": 45,
+                              "--y-pos": 75,
+                            }
+                          }
                         >
                           <div
                             aria-describedby={null}
@@ -26631,6 +26796,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         src="landscape.jpg"
                         style={
                           Object {
+                            "cursor": "auto",
                             "left": undefined,
                             "position": "relative",
                             "top": undefined,
@@ -26650,7 +26816,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         }
                       >
                         <div
-                          className="Hotspot__StyledHotspot-nlpwmi-0 fxwZek"
+                          className="iot--hotspot-container iot--hotspot-container--has-icon"
+                          data-testid="hotspot-35-65"
+                          icon="arrowDown"
+                          style={
+                            Object {
+                              "--height": 25,
+                              "--width": 25,
+                              "--x-pos": 35,
+                              "--y-pos": 65,
+                            }
+                          }
                         >
                           <div
                             aria-describedby={null}
@@ -26685,7 +26861,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="Hotspot__StyledHotspot-nlpwmi-0 kwumIH"
+                          className="iot--hotspot-container"
+                          data-testid="hotspot-45-25"
+                          icon={null}
+                          style={
+                            Object {
+                              "--height": 25,
+                              "--width": 25,
+                              "--x-pos": 45,
+                              "--y-pos": 25,
+                            }
+                          }
                         >
                           <div
                             aria-describedby={null}
@@ -26726,7 +26912,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="Hotspot__StyledHotspot-nlpwmi-0 eqtfro"
+                          className="iot--hotspot-container"
+                          data-testid="hotspot-45-50"
+                          icon={null}
+                          style={
+                            Object {
+                              "--height": 25,
+                              "--width": 25,
+                              "--x-pos": 45,
+                              "--y-pos": 50,
+                            }
+                          }
                         >
                           <div
                             aria-describedby={null}
@@ -26767,7 +26963,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="Hotspot__StyledHotspot-nlpwmi-0 jjFGEa"
+                          className="iot--hotspot-container iot--hotspot-container--has-icon"
+                          data-testid="hotspot-45-75"
+                          icon="arrowUp"
+                          style={
+                            Object {
+                              "--height": 25,
+                              "--width": 25,
+                              "--x-pos": 45,
+                              "--y-pos": 75,
+                            }
+                          }
                         >
                           <div
                             aria-describedby={null}

--- a/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
@@ -2495,6 +2495,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                     src="static/media/landscape.013ce39d.jpg"
                     style={
                       Object {
+                        "cursor": "auto",
                         "left": undefined,
                         "position": "relative",
                         "top": undefined,
@@ -2514,7 +2515,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                     }
                   >
                     <div
-                      className="Hotspot__StyledHotspot-nlpwmi-0 fxwZek"
+                      className="iot--hotspot-container iot--hotspot-container--has-icon"
+                      data-testid="hotspot-35-65"
+                      icon="arrowDown"
+                      style={
+                        Object {
+                          "--height": 25,
+                          "--width": 25,
+                          "--x-pos": 35,
+                          "--y-pos": 65,
+                        }
+                      }
                     >
                       <div
                         aria-describedby={null}

--- a/src/components/ImageCard/Hotspot.jsx
+++ b/src/components/ImageCard/Hotspot.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import classNames from 'classnames';
 import { Tooltip } from 'carbon-components-react';
-import { spacing02 } from '@carbon/layout';
+
+import { settings } from '../../constants/Settings';
 
 import { HotspotContentPropTypes } from './HotspotContent';
 import CardIcon from './CardIcon';
+
+const { iotPrefix } = settings;
 
 export const propTypes = {
   /** percentage from the left of the image to show this hotspot */
@@ -30,6 +33,12 @@ export const propTypes = {
   height: PropTypes.number,
   /** optional function to provide icon based on name */
   renderIconByName: PropTypes.func,
+  /**
+   * onClick callback for when the hotspot is clicked. Returns the event and an
+   * object width the x and y coordinates */
+  onClick: PropTypes.func,
+  /** shows a border with padding when set to true */
+  isSelected: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -39,39 +48,9 @@ const defaultProps = {
   width: 25,
   height: 25,
   renderIconByName: null,
+  onClick: null,
+  isSelected: false,
 };
-
-const StyledHotspot = styled(({ className, children }) => (
-  <div className={className}>{children}</div>
-))`
-  position: absolute;
-  ${(props) => `
-    top: calc(${props.y}% - ${props.height / 2}px);
-    left: calc(${props.x}% - ${props.width / 2}px);
-  `}
-  font-family: Sans-Serif;
-  pointer-events: auto;
-
-  .bx--tooltip__label {
-    ${(props) =>
-      props.icon
-        ? `
-      border: solid 1px #aaa;
-      cursor: pointer;
-      padding: ${spacing02};
-      background: white;
-      opacity: 0.9;
-      border-radius: 4px;
-      box-shadow: 0 0 8px #777;
-    `
-        : `
-      cursor: pointer;
-      box-shadow: 0 0 4px #999;
-      border-radius: 13px;
-      background: none;
-        `}
-  }
-`;
 
 /**
  * This component renders a hotspot with content over an image
@@ -86,6 +65,9 @@ const Hotspot = ({
   width,
   height,
   renderIconByName,
+  onClick,
+  isSelected,
+  className,
   ...others
 }) => {
   const defaultIcon = (
@@ -123,17 +105,36 @@ const Hotspot = ({
     defaultIcon
   );
 
+  const id = `hotspot-${x}-${y}`;
+
   return (
-    <StyledHotspot x={x} y={y} width={width} height={height} icon={icon}>
+    <div
+      data-testid={id}
+      className={classNames(`${iotPrefix}--hotspot-container`, {
+        [`${iotPrefix}--hotspot-container--selected`]: isSelected,
+        [`${iotPrefix}--hotspot-container--has-icon`]: icon,
+      })}
+      style={{
+        '--x-pos': x,
+        '--y-pos': y,
+        '--width': width,
+        '--height': height,
+      }}
+      icon={icon}>
       <Tooltip
         {...others}
         triggerText={iconToRender}
         showIcon={false}
-        triggerId={`hotspot-${x}-${y}`}
-        tooltipId={`hotspot-${x}-${y}`}>
+        triggerId={id}
+        tooltipId={id}
+        onChange={(evt) => {
+          if (evt.type === 'click' && onClick) {
+            onClick(evt, { x, y });
+          }
+        }}>
         {content}
       </Tooltip>
-    </StyledHotspot>
+    </div>
   );
 };
 

--- a/src/components/ImageCard/ImageHotspots.jsx
+++ b/src/components/ImageCard/ImageHotspots.jsx
@@ -482,7 +482,7 @@ const ImageHotspots = ({
     (evt, position) => {
       // It is possible to receive two events here, one Mouse event and one Pointer event.
       // When used in the ImageHotspots component the Pointer event can somehow be from a
-      // previously clicked hotspot. See issue #1803
+      // previously clicked hotspot. See https://github.com/carbon-design-system/carbon-addons-iot-react/issues/1803
       const isPointerEventOfTypeMouse = evt?.pointerType === 'mouse';
       if (!isPointerEventOfTypeMouse && isEditable) {
         onSelectHotspot(position);

--- a/src/components/ImageCard/ImageHotspots.jsx
+++ b/src/components/ImageCard/ImageHotspots.jsx
@@ -449,8 +449,7 @@ const ImageHotspots = ({
     );
   }, [container, zoomMax, image, minimap, options]);
 
-  const { dragging } = cursor;
-  const { dragPrepared } = cursor;
+  const { dragging, dragPrepared } = cursor;
   const { hideZoomControls, hideHotspots, hideMinimap, draggable } = options;
   const imageLoaded = image.initialWidth && image.initialHeight;
 

--- a/src/components/ImageCard/ImageHotspots.jsx
+++ b/src/components/ImageCard/ImageHotspots.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import PropTypes from 'prop-types';
 import { InlineLoading } from 'carbon-components-react';
@@ -19,11 +19,17 @@ const propTypes = {
   hideZoomControls: PropTypes.bool,
   hideHotspots: PropTypes.bool,
   hideMinimap: PropTypes.bool,
+  /** when true activates mouse event based create & select hotspot fuctionality */
+  isEditable: PropTypes.bool,
   isHotspotDataLoading: PropTypes.bool,
   /** Background color to display around the image */
   background: PropTypes.string,
   /** Current height in pixels */
   height: PropTypes.number.isRequired,
+  /** Callback when an editable image is clicked without drag */
+  onAddHotspotPosition: PropTypes.func,
+  /** Callback when a hotspot is clicked in isEditable mode, emits position obj {x, y} */
+  onSelectHotspot: PropTypes.func,
   /** Current width in pixels */
   width: PropTypes.number.isRequired,
   zoomMax: PropTypes.number,
@@ -31,6 +37,10 @@ const propTypes = {
   i18n: PropTypes.objectOf(PropTypes.string),
   /** locale string to pass for formatting */
   locale: PropTypes.string,
+  /** The (unique) positions of the currently selected hotspots */
+  selectedHotspots: PropTypes.arrayOf(
+    PropTypes.shape({ x: PropTypes.number, y: PropTypes.number })
+  ),
 };
 
 const defaultProps = {
@@ -41,6 +51,9 @@ const defaultProps = {
   hideHotspots: false,
   hideMinimap: false,
   isHotspotDataLoading: false,
+  isEditable: false,
+  onAddHotspotPosition: () => {},
+  onSelectHotspot: () => {},
   background: '#eee',
   zoomMax: undefined,
   renderIconByName: null,
@@ -50,6 +63,18 @@ const defaultProps = {
     zoomToFit: 'Zoom to fit',
   },
   locale: null,
+  selectedHotspots: [],
+};
+
+export const prepareDrag = (event, element, cursor, setCursor) => {
+  if (element === 'image') {
+    setCursor({
+      ...cursor,
+      dragging: false,
+      dragPrepared: true,
+    });
+  }
+  event.preventDefault();
 };
 
 export const startDrag = (event, element, cursor, setCursor) => {
@@ -61,6 +86,7 @@ export const startDrag = (event, element, cursor, setCursor) => {
       cursorX,
       cursorY,
       dragging: true,
+      dragPrepared: false,
     });
   }
   event.preventDefault();
@@ -322,6 +348,49 @@ export const zoom = (
   }
 };
 
+const getAccumulatedOffset = (imageElement) => {
+  const offset = {
+    top: imageElement.offsetTop,
+    left: imageElement.offsetLeft,
+  };
+
+  let ancestor = imageElement.offsetParent;
+
+  while (ancestor) {
+    offset.top += ancestor.offsetTop;
+    offset.left += ancestor.offsetLeft;
+    ancestor = ancestor.offsetParent;
+  }
+
+  return offset;
+};
+
+/** Calculates the mouse click position in percentage and returns the
+ * result in a callback */
+export const onAddHotspotPosition = ({
+  event,
+  image,
+  setCursor,
+  isEditable,
+  callback,
+}) => {
+  setCursor((cursor) => {
+    return { ...cursor, dragPrepared: false };
+  });
+  if (isEditable) {
+    const accumelatedOffset = getAccumulatedOffset(event.currentTarget);
+    const relativePosition = {
+      x: event.pageX - accumelatedOffset.left,
+      y: event.pageY - accumelatedOffset.top,
+    };
+    const percentagePosition = {
+      x: (relativePosition.x / image.width) * 100,
+      y: (relativePosition.y / image.height) * 100,
+    };
+    callback(percentagePosition);
+  }
+};
+
 /** Parent smart component with local state that renders an image with its hotspots */
 const ImageHotspots = ({
   hideZoomControls: hideZoomControlsProp,
@@ -334,10 +403,14 @@ const ImageHotspots = ({
   height,
   width,
   alt,
+  isEditable,
   isHotspotDataLoading,
+  onAddHotspotPosition: onAddHotspotPositionCallback,
+  onSelectHotspot,
   zoomMax,
   renderIconByName,
   locale,
+  selectedHotspots,
 }) => {
   // Image needs to be stored in state because we're dragging it around when zoomed in, and we need to keep track of when it loads
   const [image, setImage] = useState({});
@@ -377,6 +450,7 @@ const ImageHotspots = ({
   }, [container, zoomMax, image, minimap, options]);
 
   const { dragging } = cursor;
+  const { dragPrepared } = cursor;
   const { hideZoomControls, hideHotspots, hideMinimap, draggable } = options;
   const imageLoaded = image.initialWidth && image.initialHeight;
 
@@ -390,6 +464,7 @@ const ImageHotspots = ({
   };
 
   const imageStyle = {
+    cursor: isEditable && !dragging ? 'crosshair' : 'auto',
     position: 'relative',
     left: image.offsetX,
     top: image.offsetY,
@@ -404,10 +479,26 @@ const ImageHotspots = ({
     pointerEvents: 'none',
   };
 
+  const onHotspotClicked = useCallback(
+    (evt, position) => {
+      // It is possible to receive two events here, one Mouse event and one Pointer event.
+      // When used in the ImageHotspots component the Pointer event can somehow be from a
+      // previously clicked hotspot. See issue #1803
+      const isPointerEventOfTypeMouse = evt?.pointerType === 'mouse';
+      if (!isPointerEventOfTypeMouse && isEditable) {
+        onSelectHotspot(position);
+      }
+    },
+    [onSelectHotspot, isEditable]
+  );
+
   // Performance improvement
   const cachedHotspots = useMemo(
     () =>
       hotspots.map((hotspot) => {
+        const hotspotIsSelected = !!selectedHotspots.find(
+          (pos) => hotspot.x === pos.x && hotspot.y === pos.y
+        );
         return (
           <Hotspot
             {...omit(hotspot, 'content')}
@@ -425,10 +516,19 @@ const ImageHotspots = ({
             key={`${hotspot.x}-${hotspot.y}`}
             style={hotspotsStyle}
             renderIconByName={renderIconByName}
+            isSelected={hotspotIsSelected}
+            onClick={onHotspotClicked}
           />
         );
       }),
-    [hotspots, hotspotsStyle, locale, renderIconByName]
+    [
+      hotspots,
+      hotspotsStyle,
+      locale,
+      renderIconByName,
+      selectedHotspots,
+      onHotspotClicked,
+    ]
   );
 
   if (imageLoaded) {
@@ -481,11 +581,13 @@ const ImageHotspots = ({
           style={imageStyle}
           onMouseDown={(evt) => {
             if (!hideZoomControls && draggable) {
-              startDrag(evt, 'image', cursor, setCursor);
+              prepareDrag(evt, 'image', cursor, setCursor);
             }
           }}
           onMouseMove={(evt) => {
-            if (!hideZoomControls && dragging) {
+            if (!hideZoomControls && draggable && dragPrepared) {
+              startDrag(evt, 'image', cursor, setCursor);
+            } else if (!hideZoomControls && dragging) {
               whileDrag(
                 evt,
                 cursor,
@@ -497,9 +599,17 @@ const ImageHotspots = ({
               );
             }
           }}
-          onMouseUp={() => {
+          onMouseUp={(event) => {
             if (dragging) {
               stopDrag(cursor, setCursor);
+            } else {
+              onAddHotspotPosition({
+                event,
+                image,
+                setCursor,
+                isEditable,
+                callback: onAddHotspotPositionCallback,
+              });
             }
           }}
         />

--- a/src/components/ImageCard/ImageHotspots.story.jsx
+++ b/src/components/ImageCard/ImageHotspots.story.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { action } from '@storybook/addon-actions';
 import { text, object, boolean } from '@storybook/addon-knobs';
 import { spacing03 } from '@carbon/layout';
 
@@ -153,4 +154,55 @@ export const ImageSmallerThanCardMinimapAndZoomcontrolsShouldBeHidden = () => {
 
 ImageSmallerThanCardMinimapAndZoomcontrolsShouldBeHidden.story = {
   name: 'image smaller than card, minimap and zoomcontrols should be hidden',
+};
+
+export const Editable = () => {
+  const WithState = () => {
+    const [myHotspots, setMyHotspots] = useState(hotspots);
+    const [selectedHotspotPositions, setSelectedHotspotPositions] = useState(
+      []
+    );
+
+    const onAddHotspotPosition = (position) => {
+      const newHotspot = {
+        ...position,
+        content: (
+          <span
+            style={{
+              padding: spacing03,
+            }}>{`Hotspot ${position.x} - ${position.y}`}</span>
+        ),
+      };
+      setMyHotspots([...myHotspots, newHotspot]);
+      action('onAddHotspotPosition')(position);
+    };
+
+    const onSelectHotspot = (position) => {
+      // This example use single select, but we can allow multiple selected hotspots
+      // by modifying how onSelectHotspot alters the selectedHotspotPositions state.
+      setSelectedHotspotPositions([position]);
+      action('onSelectHotspot')(position);
+    };
+
+    return (
+      <div style={{ width: '450px', height: '300px' }}>
+        <ImageHotspots
+          isEditable
+          onAddHotspotPosition={onAddHotspotPosition}
+          onSelectHotspot={onSelectHotspot}
+          src={text('Image', landscape)}
+          alt={text('Alternate text', 'Sample image')}
+          height={300}
+          width={450}
+          hideZoomControls={boolean('Hide zoom controls', false)}
+          hotspots={myHotspots}
+          hideHotspots={boolean('Hide hotspots', false)}
+          hideMinimap={boolean('Hide Minimap', false)}
+          selectedHotspots={selectedHotspotPositions}
+        />
+      </div>
+    );
+  };
+
+  return <WithState />;
 };

--- a/src/components/ImageCard/ImageHotspots.test.jsx
+++ b/src/components/ImageCard/ImageHotspots.test.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { act, isDOMComponent } from 'react-dom/test-utils';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import userEvent from '@testing-library/user-event';
 
+import landscape from './landscape.jpg';
 import ImageHotspots, {
   calculateImageHeight,
   calculateImageWidth,
@@ -11,8 +13,39 @@ import ImageHotspots, {
   whileDrag,
   onImageLoad,
   zoom,
+  onAddHotspotPosition,
 } from './ImageHotspots';
 
+const getHotspots = () => {
+  return [
+    {
+      x: 10,
+      y: 20,
+      content: <span>Hotspot1</span>,
+      icon: 'warning',
+      color: 'white',
+      width: 20,
+      height: 20,
+    },
+    {
+      x: 50,
+      y: 10,
+      content: <span>Hotspot2</span>,
+      icon: 'warning',
+    },
+    {
+      x: 30,
+      y: 40,
+      content: <span>Hotspot3</span>,
+    },
+    {
+      x: 50,
+      y: 60,
+      content: <span>Hotspot4</span>,
+      color: 'green',
+    },
+  ];
+};
 describe('ImageHotspots', () => {
   let container;
 
@@ -37,6 +70,7 @@ describe('ImageHotspots', () => {
     expect(mockSetCursor).toHaveBeenCalledWith({
       cursorX: 200,
       cursorY: 300,
+      dragPrepared: false,
       dragging: true,
     });
   });
@@ -255,5 +289,114 @@ describe('ImageHotspots', () => {
     expect(screen.getByTitle(i18nTest.zoomOut)).toBeInTheDocument();
     expect(screen.queryByTitle(i18nDefault.zoomIn)).not.toBeInTheDocument();
     expect(screen.queryByTitle(i18nDefault.zoomOut)).not.toBeInTheDocument();
+  });
+  describe('isEditable', () => {
+    it('triggers onSelectHotspot callback when hotspot is clicked', () => {
+      const onSelectHotspot = jest.fn();
+
+      const { rerender } = render(
+        <ImageHotspots
+          onAddHotspotPosition={() => {}}
+          onSelectHotspot={onSelectHotspot}
+          src={landscape}
+          height={300}
+          width={450}
+          hotspots={getHotspots()}
+          selectedHotspots={[]}
+        />
+      );
+      const aHotspot = screen.getByTestId('hotspot-10-20');
+      expect(aHotspot).toBeVisible();
+      userEvent.click(within(aHotspot).getByRole('button'));
+      expect(onSelectHotspot).not.toHaveBeenCalled();
+
+      rerender(
+        <ImageHotspots
+          isEditable
+          onAddHotspotPosition={() => {}}
+          onSelectHotspot={onSelectHotspot}
+          src={landscape}
+          height={300}
+          width={450}
+          hotspots={getHotspots()}
+          selectedHotspots={[]}
+        />
+      );
+      const sameHotspot = screen.getByTestId('hotspot-10-20');
+      expect(sameHotspot).toBeVisible();
+      userEvent.click(within(sameHotspot).getByRole('button'));
+      expect(onSelectHotspot).toHaveBeenCalledWith({ x: 10, y: 20 });
+    });
+    it('triggers callback when the image is clicked', () => {
+      const onAddHotspotPosition = jest.fn();
+      const testImageText = 'test-image';
+
+      const { rerender } = render(
+        <ImageHotspots
+          alt={testImageText}
+          onAddHotspotPosition={onAddHotspotPosition}
+          onSelectHotspot={() => {}}
+          src={landscape}
+          height={300}
+          width={450}
+          hotspots={getHotspots()}
+          selectedHotspots={[]}
+        />
+      );
+
+      userEvent.click(screen.getByAltText(testImageText));
+      expect(onAddHotspotPosition).not.toHaveBeenCalled();
+
+      rerender(
+        <ImageHotspots
+          alt={testImageText}
+          isEditable
+          onAddHotspotPosition={onAddHotspotPosition}
+          onSelectHotspot={() => {}}
+          src={landscape}
+          height={300}
+          width={450}
+          hotspots={getHotspots()}
+          selectedHotspots={[]}
+        />
+      );
+
+      userEvent.click(screen.getByAltText(testImageText));
+      // We aren't more specific about the callback param here due to
+      // difficulties setting the event.pageX & event.pageY in the test,
+      // which are needed for getting the position of the click correct.
+      expect(onAddHotspotPosition).toHaveBeenCalled();
+    });
+    it('calculates the proper percentage coordinates for image click', () => {
+      const onAddHotspotPositionCallback = jest.fn();
+      const event = {
+        pageX: 100,
+        pageY: 100,
+        currentTarget: {
+          offsetTop: 5,
+          offsetLeft: 5,
+          offsetParent: { offsetTop: 5, offsetLeft: 5 },
+        },
+      };
+      const image = { width: 300, height: 450 };
+      let updatedCursor;
+      const setCursor = jest.fn().mockImplementation((func) => {
+        updatedCursor = func({});
+      });
+
+      onAddHotspotPosition({
+        event,
+        image,
+        setCursor,
+        isEditable: true,
+        callback: onAddHotspotPositionCallback,
+      });
+
+      expect(onAddHotspotPositionCallback).toHaveBeenCalledWith({
+        x: 30,
+        y: 20,
+      });
+      expect(updatedCursor).toEqual({ dragPrepared: false });
+    });
   });
 });

--- a/src/components/ImageCard/ImageHotspotsRender.test.jsx
+++ b/src/components/ImageCard/ImageHotspotsRender.test.jsx
@@ -61,6 +61,7 @@ describe('render tests for the image hotspots component', () => {
     const zoomInBtn = screen.getByTitle('Zoom in');
     fireEvent.click(zoomInBtn);
     fireEvent.mouseDown(img);
+    fireEvent.mouseMove(img);
     // Minimap should appear once drag starts
     expect(screen.queryByAltText('Minimap')).toBeTruthy();
     fireEvent.mouseUp(img);

--- a/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
+++ b/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
@@ -112,6 +112,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                 src="landscape.jpg"
                 style={
                   Object {
+                    "cursor": "auto",
                     "left": undefined,
                     "position": "relative",
                     "top": undefined,
@@ -131,7 +132,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                 }
               >
                 <div
-                  className="Hotspot__StyledHotspot-nlpwmi-0 fxwZek"
+                  className="iot--hotspot-container iot--hotspot-container--has-icon"
+                  data-testid="hotspot-35-65"
+                  icon="arrowDown"
+                  style={
+                    Object {
+                      "--height": 25,
+                      "--width": 25,
+                      "--x-pos": 35,
+                      "--y-pos": 65,
+                    }
+                  }
                 >
                   <div
                     aria-describedby={null}
@@ -354,6 +365,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                 src="landscape.jpg"
                 style={
                   Object {
+                    "cursor": "auto",
                     "left": undefined,
                     "position": "relative",
                     "top": undefined,
@@ -373,7 +385,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                 }
               >
                 <div
-                  className="Hotspot__StyledHotspot-nlpwmi-0 fxwZek"
+                  className="iot--hotspot-container iot--hotspot-container--has-icon"
+                  data-testid="hotspot-35-65"
+                  icon="arrowDown"
+                  style={
+                    Object {
+                      "--height": 25,
+                      "--width": 25,
+                      "--x-pos": 35,
+                      "--y-pos": 65,
+                    }
+                  }
                 >
                   <div
                     aria-describedby={null}
@@ -410,7 +432,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                   </div>
                 </div>
                 <div
-                  className="Hotspot__StyledHotspot-nlpwmi-0 kwumIH"
+                  className="iot--hotspot-container"
+                  data-testid="hotspot-45-25"
+                  icon={null}
+                  style={
+                    Object {
+                      "--height": 25,
+                      "--width": 25,
+                      "--x-pos": 45,
+                      "--y-pos": 25,
+                    }
+                  }
                 >
                   <div
                     aria-describedby={null}
@@ -451,7 +483,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                   </div>
                 </div>
                 <div
-                  className="Hotspot__StyledHotspot-nlpwmi-0 eqtfro"
+                  className="iot--hotspot-container"
+                  data-testid="hotspot-45-50"
+                  icon={null}
+                  style={
+                    Object {
+                      "--height": 25,
+                      "--width": 25,
+                      "--x-pos": 45,
+                      "--y-pos": 50,
+                    }
+                  }
                 >
                   <div
                     aria-describedby={null}
@@ -492,7 +534,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                   </div>
                 </div>
                 <div
-                  className="Hotspot__StyledHotspot-nlpwmi-0 jjFGEa"
+                  className="iot--hotspot-container iot--hotspot-container--has-icon"
+                  data-testid="hotspot-45-75"
+                  icon="arrowUp"
+                  style={
+                    Object {
+                      "--height": 25,
+                      "--width": 25,
+                      "--x-pos": 45,
+                      "--y-pos": 75,
+                    }
+                  }
                 >
                   <div
                     aria-describedby={null}
@@ -969,6 +1021,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                 src="landscape.jpg"
                 style={
                   Object {
+                    "cursor": "auto",
                     "left": undefined,
                     "position": "relative",
                     "top": undefined,

--- a/src/components/ImageCard/__snapshots__/ImageHotspots.story.storyshot
+++ b/src/components/ImageCard/__snapshots__/ImageHotspots.story.storyshot
@@ -1,5 +1,343 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/ImageHotspots Editable 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "height": "300px",
+          "width": "450px",
+        }
+      }
+    >
+      <div
+        onBlur={[Function]}
+        onMouseOut={[Function]}
+        style={
+          Object {
+            "background": "#eee",
+            "height": "100%",
+            "overflow": "hidden",
+            "position": "relative",
+            "textAlign": "center",
+            "width": "100%",
+          }
+        }
+      >
+        <img
+          alt="Sample image"
+          onLoad={[Function]}
+          onMouseDown={[Function]}
+          onMouseMove={[Function]}
+          onMouseUp={[Function]}
+          src="landscape.jpg"
+          style={
+            Object {
+              "cursor": "crosshair",
+              "left": undefined,
+              "position": "relative",
+              "top": undefined,
+            }
+          }
+        />
+        <div
+          style={
+            Object {
+              "left": undefined,
+              "margin": "auto",
+              "pointerEvents": "none",
+              "position": "absolute",
+              "right": "auto",
+              "top": undefined,
+            }
+          }
+        >
+          <div
+            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            data-testid="hotspot-10-20"
+            icon="warning"
+            style={
+              Object {
+                "--height": 20,
+                "--width": 20,
+                "--x-pos": 10,
+                "--y-pos": 20,
+              }
+            }
+          >
+            <div
+              aria-describedby={null}
+              aria-labelledby="hotspot-10-20"
+              className="bx--tooltip__label"
+              id="hotspot-10-20"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-hidden={true}
+                aria-label=""
+                fill="white"
+                focusable="false"
+                height={20}
+                preserveAspectRatio="xMidYMid meet"
+                title=""
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                />
+                <path
+                  d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                  data-icon-path="inner-path"
+                  fill="none"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            data-testid="hotspot-50-10"
+            icon="warning"
+            style={
+              Object {
+                "--height": 25,
+                "--width": 25,
+                "--x-pos": 50,
+                "--y-pos": 10,
+              }
+            }
+          >
+            <div
+              aria-describedby={null}
+              aria-labelledby="hotspot-50-10"
+              className="bx--tooltip__label"
+              id="hotspot-50-10"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-hidden={true}
+                aria-label=""
+                fill="blue"
+                focusable="false"
+                height={25}
+                preserveAspectRatio="xMidYMid meet"
+                title=""
+                viewBox="0 0 32 32"
+                width={25}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                />
+                <path
+                  d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                  data-icon-path="inner-path"
+                  fill="none"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="iot--hotspot-container"
+            data-testid="hotspot-30-40"
+            icon={null}
+            style={
+              Object {
+                "--height": 25,
+                "--width": 25,
+                "--x-pos": 30,
+                "--y-pos": 40,
+              }
+            }
+          >
+            <div
+              aria-describedby={null}
+              aria-labelledby="hotspot-30-40"
+              className="bx--tooltip__label"
+              id="hotspot-30-40"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                height={25}
+                width={25}
+              >
+                <circle
+                  cx={12.5}
+                  cy={12.5}
+                  fill="none"
+                  opacity="1"
+                  r={11.5}
+                  stroke="white"
+                  strokeWidth="2"
+                />
+                <circle
+                  cx={12.5}
+                  cy={12.5}
+                  fill="blue"
+                  opacity="0.7"
+                  r={11.5}
+                  stroke="none"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="iot--hotspot-container"
+            data-testid="hotspot-50-60"
+            icon={null}
+            style={
+              Object {
+                "--height": 25,
+                "--width": 25,
+                "--x-pos": 50,
+                "--y-pos": 60,
+              }
+            }
+          >
+            <div
+              aria-describedby={null}
+              aria-labelledby="hotspot-50-60"
+              className="bx--tooltip__label"
+              id="hotspot-50-60"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                height={25}
+                width={25}
+              >
+                <circle
+                  cx={12.5}
+                  cy={12.5}
+                  fill="none"
+                  opacity="1"
+                  r={11.5}
+                  stroke="white"
+                  strokeWidth="2"
+                />
+                <circle
+                  cx={12.5}
+                  cy={12.5}
+                  fill="green"
+                  opacity="0.7"
+                  r={11.5}
+                  stroke="none"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "bottom": 10,
+              "pointerEvents": "auto",
+              "position": "absolute",
+              "right": 10,
+            }
+          }
+        >
+          <button
+            onClick={[Function]}
+            style={
+              Object {
+                "background": "#fff",
+                "border": "none",
+                "boxShadow": "0px 0px 2px 0px rgba(0,0,0,0.5)",
+                "height": "25px",
+                "width": "25px",
+              }
+            }
+            title="Zoom in"
+            type="button"
+          >
+            +
+          </button>
+          <br />
+          <button
+            onClick={[Function]}
+            style={
+              Object {
+                "background": "#fff",
+                "border": "none",
+                "boxShadow": "0px 0px 2px 0px rgba(0,0,0,0.5)",
+                "height": "25px",
+                "width": "25px",
+              }
+            }
+            title="Zoom out"
+            type="button"
+          >
+            -
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/ImageHotspots image smaller than card, minimap and zoomcontrols should be hidden 1`] = `
 <div
   className="storybook-container"
@@ -43,6 +381,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
           src="MunichBuilding.png"
           style={
             Object {
+              "cursor": "auto",
               "left": undefined,
               "position": "relative",
               "top": undefined,
@@ -62,7 +401,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
           }
         >
           <div
-            className="Hotspot__StyledHotspot-nlpwmi-0 bnYUXp"
+            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            data-testid="hotspot-10-20"
+            icon="warning"
+            style={
+              Object {
+                "--height": 20,
+                "--width": 20,
+                "--x-pos": 10,
+                "--y-pos": 20,
+              }
+            }
           >
             <div
               aria-describedby={null}
@@ -102,7 +451,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="Hotspot__StyledHotspot-nlpwmi-0 kDDGXo"
+            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            data-testid="hotspot-50-10"
+            icon="warning"
+            style={
+              Object {
+                "--height": 25,
+                "--width": 25,
+                "--x-pos": 50,
+                "--y-pos": 10,
+              }
+            }
           >
             <div
               aria-describedby={null}
@@ -142,7 +501,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="Hotspot__StyledHotspot-nlpwmi-0 gFMCuA"
+            className="iot--hotspot-container"
+            data-testid="hotspot-30-40"
+            icon={null}
+            style={
+              Object {
+                "--height": 25,
+                "--width": 25,
+                "--x-pos": 30,
+                "--y-pos": 40,
+              }
+            }
           >
             <div
               aria-describedby={null}
@@ -183,7 +552,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="Hotspot__StyledHotspot-nlpwmi-0 hsZfSY"
+            className="iot--hotspot-container"
+            data-testid="hotspot-50-60"
+            icon={null}
+            style={
+              Object {
+                "--height": 25,
+                "--width": 25,
+                "--x-pos": 50,
+                "--y-pos": 60,
+              }
+            }
           >
             <div
               aria-describedby={null}
@@ -340,6 +719,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
           src="landscape.jpg"
           style={
             Object {
+              "cursor": "auto",
               "left": undefined,
               "position": "relative",
               "top": undefined,
@@ -359,7 +739,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
           }
         >
           <div
-            className="Hotspot__StyledHotspot-nlpwmi-0 bnYUXp"
+            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            data-testid="hotspot-10-20"
+            icon="warning"
+            style={
+              Object {
+                "--height": 20,
+                "--width": 20,
+                "--x-pos": 10,
+                "--y-pos": 20,
+              }
+            }
           >
             <div
               aria-describedby={null}
@@ -399,7 +789,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="Hotspot__StyledHotspot-nlpwmi-0 kDDGXo"
+            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            data-testid="hotspot-50-10"
+            icon="warning"
+            style={
+              Object {
+                "--height": 25,
+                "--width": 25,
+                "--x-pos": 50,
+                "--y-pos": 10,
+              }
+            }
           >
             <div
               aria-describedby={null}
@@ -439,7 +839,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="Hotspot__StyledHotspot-nlpwmi-0 gFMCuA"
+            className="iot--hotspot-container"
+            data-testid="hotspot-30-40"
+            icon={null}
+            style={
+              Object {
+                "--height": 25,
+                "--width": 25,
+                "--x-pos": 30,
+                "--y-pos": 40,
+              }
+            }
           >
             <div
               aria-describedby={null}
@@ -480,7 +890,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="Hotspot__StyledHotspot-nlpwmi-0 hsZfSY"
+            className="iot--hotspot-container"
+            data-testid="hotspot-50-60"
+            icon={null}
+            style={
+              Object {
+                "--height": 25,
+                "--width": 25,
+                "--x-pos": 50,
+                "--y-pos": 60,
+              }
+            }
           >
             <div
               aria-describedby={null}
@@ -637,6 +1057,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
           src="landscape.jpg"
           style={
             Object {
+              "cursor": "auto",
               "left": undefined,
               "position": "relative",
               "top": undefined,
@@ -656,7 +1077,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
           }
         >
           <div
-            className="Hotspot__StyledHotspot-nlpwmi-0 bnYUXp"
+            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            data-testid="hotspot-10-20"
+            icon="warning"
+            style={
+              Object {
+                "--height": 20,
+                "--width": 20,
+                "--x-pos": 10,
+                "--y-pos": 20,
+              }
+            }
           >
             <div
               aria-describedby={null}
@@ -696,7 +1127,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="Hotspot__StyledHotspot-nlpwmi-0 kDDGXo"
+            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            data-testid="hotspot-50-10"
+            icon="warning"
+            style={
+              Object {
+                "--height": 25,
+                "--width": 25,
+                "--x-pos": 50,
+                "--y-pos": 10,
+              }
+            }
           >
             <div
               aria-describedby={null}
@@ -736,7 +1177,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="Hotspot__StyledHotspot-nlpwmi-0 gFMCuA"
+            className="iot--hotspot-container"
+            data-testid="hotspot-30-40"
+            icon={null}
+            style={
+              Object {
+                "--height": 25,
+                "--width": 25,
+                "--x-pos": 30,
+                "--y-pos": 40,
+              }
+            }
           >
             <div
               aria-describedby={null}
@@ -777,7 +1228,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="Hotspot__StyledHotspot-nlpwmi-0 hsZfSY"
+            className="iot--hotspot-container"
+            data-testid="hotspot-50-60"
+            icon={null}
+            style={
+              Object {
+                "--height": 25,
+                "--width": 25,
+                "--x-pos": 50,
+                "--y-pos": 60,
+              }
+            }
           >
             <div
               aria-describedby={null}
@@ -934,6 +1395,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
           src="portrait.jpg"
           style={
             Object {
+              "cursor": "auto",
               "left": undefined,
               "position": "relative",
               "top": undefined,
@@ -953,7 +1415,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
           }
         >
           <div
-            className="Hotspot__StyledHotspot-nlpwmi-0 bnYUXp"
+            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            data-testid="hotspot-10-20"
+            icon="warning"
+            style={
+              Object {
+                "--height": 20,
+                "--width": 20,
+                "--x-pos": 10,
+                "--y-pos": 20,
+              }
+            }
           >
             <div
               aria-describedby={null}
@@ -993,7 +1465,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="Hotspot__StyledHotspot-nlpwmi-0 kDDGXo"
+            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            data-testid="hotspot-50-10"
+            icon="warning"
+            style={
+              Object {
+                "--height": 25,
+                "--width": 25,
+                "--x-pos": 50,
+                "--y-pos": 10,
+              }
+            }
           >
             <div
               aria-describedby={null}
@@ -1033,7 +1515,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="Hotspot__StyledHotspot-nlpwmi-0 gFMCuA"
+            className="iot--hotspot-container"
+            data-testid="hotspot-30-40"
+            icon={null}
+            style={
+              Object {
+                "--height": 25,
+                "--width": 25,
+                "--x-pos": 30,
+                "--y-pos": 40,
+              }
+            }
           >
             <div
               aria-describedby={null}
@@ -1074,7 +1566,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="Hotspot__StyledHotspot-nlpwmi-0 hsZfSY"
+            className="iot--hotspot-container"
+            data-testid="hotspot-50-60"
+            icon={null}
+            style={
+              Object {
+                "--height": 25,
+                "--width": 25,
+                "--x-pos": 50,
+                "--y-pos": 60,
+              }
+            }
           >
             <div
               aria-describedby={null}
@@ -1231,6 +1733,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
           src="portrait.jpg"
           style={
             Object {
+              "cursor": "auto",
               "left": undefined,
               "position": "relative",
               "top": undefined,
@@ -1250,7 +1753,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
           }
         >
           <div
-            className="Hotspot__StyledHotspot-nlpwmi-0 bnYUXp"
+            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            data-testid="hotspot-10-20"
+            icon="warning"
+            style={
+              Object {
+                "--height": 20,
+                "--width": 20,
+                "--x-pos": 10,
+                "--y-pos": 20,
+              }
+            }
           >
             <div
               aria-describedby={null}
@@ -1290,7 +1803,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="Hotspot__StyledHotspot-nlpwmi-0 kDDGXo"
+            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            data-testid="hotspot-50-10"
+            icon="warning"
+            style={
+              Object {
+                "--height": 25,
+                "--width": 25,
+                "--x-pos": 50,
+                "--y-pos": 10,
+              }
+            }
           >
             <div
               aria-describedby={null}
@@ -1330,7 +1853,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="Hotspot__StyledHotspot-nlpwmi-0 gFMCuA"
+            className="iot--hotspot-container"
+            data-testid="hotspot-30-40"
+            icon={null}
+            style={
+              Object {
+                "--height": 25,
+                "--width": 25,
+                "--x-pos": 30,
+                "--y-pos": 40,
+              }
+            }
           >
             <div
               aria-describedby={null}
@@ -1371,7 +1904,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="Hotspot__StyledHotspot-nlpwmi-0 hsZfSY"
+            className="iot--hotspot-container"
+            data-testid="hotspot-50-60"
+            icon={null}
+            style={
+              Object {
+                "--height": 25,
+                "--width": 25,
+                "--x-pos": 50,
+                "--y-pos": 60,
+              }
+            }
           >
             <div
               aria-describedby={null}

--- a/src/components/ImageCard/_hotspot.scss
+++ b/src/components/ImageCard/_hotspot.scss
@@ -1,0 +1,51 @@
+// Part of the css and the colors used come from old StyledComponents code
+// and should be replaced with actual carbon colors and design. See issue 1806
+
+@import '../../globals/vars';
+
+// The custom properties --x-pos, --y-pos, --width, --height are set
+// on the container by the react js code
+.#{$iot-prefix}--hotspot-container {
+  position: absolute;
+  font-family: Sans-Serif;
+  pointer-events: auto;
+  top: calc((var(--y-pos) * 1%) - ((var(--height) / 2) * 1px));
+  left: calc((var(--x-pos) * 1%) - ((var(--width) / 2) * 1px));
+
+  .bx--tooltip__label {
+    display: flex;
+    cursor: pointer;
+    box-shadow: 0 0 4px #999;
+    border-radius: 13px;
+    background: none;
+  }
+}
+
+.#{$iot-prefix}--hotspot-container--selected {
+  $padding: #{$spacing-02};
+  $border-width: #{$spacing-01};
+
+  top: calc(
+    (var(--y-pos) * 1%) -
+      (((var(--height) * 1px) / 2) + #{$padding} + #{$border-width})
+  );
+  left: calc(
+    (var(--x-pos) * 1%) -
+      (((var(--width) * 1px) / 2) + #{$padding} + #{$border-width})
+  );
+  box-sizing: border-box;
+  border: solid #{$border-width} $interactive-04;
+  padding: #{$padding};
+}
+
+.#{$iot-prefix}--hotspot-container--has-icon {
+  .bx--tooltip__label {
+    border: solid 1px #aaa;
+    cursor: pointer;
+    padding: $spacing-02;
+    background: white;
+    opacity: 0.9;
+    border-radius: 4px;
+    box-shadow: 0 0 8px #777;
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -145,6 +145,7 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 @import 'components/Slider/slider';
 @import 'components/Tile/tile';
 @import 'components/ImageCard/hotspot-content';
+@import 'components/ImageCard/hotspot';
 @import 'components/Skeleton/skeleton';
 @import 'components/InlineLoading/inline-loading';
 @import 'components/PaginationNav/pagination-nav';


### PR DESCRIPTION
Closes #1770

**Summary**
The ImageHotspots is enhanced to support selecting hotspots for editing and adding new ones by clicking on the image. It is **still possible to drag the image** when in isEditable mode which makes sense for precision positioning of new hotspots. 

**Change List (commits, features, bugs, etc)**
- Added isEditable prop to ImageHotspots.jsx inorder to enable selection and adding hotshpots
- Added callback for when a hotspot is clicked (selected) in the ImageHotspots.jsx
- Added callback for clicking the image to create a new hotspot ImageHotspots.jsx
- Changed the drag code to start drag on mouse move instead of mouse down in ImageHotspots.jsx
- Added isSelected to Hotspot.jsx
- Refactored the StyledComponents into external css for Hotspot.jsx
- Added a story
- Added unit tests

**Acceptance Test (how to verify the PR)**
1. Go to https://deploy-preview-1813--carbon-addons-iot-react.netlify.app?path=/story/watson-iot-imagehotspots--editable
2. Try selecting exiting hotspots. Make sure they don't move.
3. Try adding new hotspots by clicking on the map.
5. Zoom and make sure you can stil drag

**Note!** 
Clicking on hotspots doesn't always show the tooltip. This is an existing bug for which I filed a issue #1808
Apparently the same issue also prevents the selection from happening sometimes here. It works in dev mode so I assume it is a timing issue. I will look into that.