### PR TITLE
fix(listitem): fix row actions issue

### DIFF
--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItem.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItem.jsx
@@ -262,7 +262,7 @@ const DataSeriesFormItem = ({
                 }}
               />
             ),
-            rowActions: [
+            rowActions: () => [
               <Button
                 key={`data-item-${series.dataSourceId}`}
                 renderIcon={Edit16}

--- a/src/components/List/ListItem/ListItem.jsx
+++ b/src/components/List/ListItem/ListItem.jsx
@@ -3,7 +3,6 @@ import { DragSource } from 'react-dnd';
 import classnames from 'classnames';
 import { Draggable16, ChevronUp16, ChevronDown16 } from '@carbon/icons-react';
 import PropTypes from 'prop-types';
-import isEmpty from 'lodash/isEmpty';
 import warning from 'warning';
 
 import { EditingStyle } from '../../../utils/DragAndDropUtils';
@@ -168,7 +167,7 @@ const ListItem = ({
     ) : null;
 
   const hasRowActions =
-    rowActions && (typeof rowActions === 'function' || !isEmpty(rowActions));
+    rowActions && (typeof rowActions === 'function' || rowActions?.length);
 
   const renderRowActions = () =>
     hasRowActions ? (

--- a/src/components/List/ListItem/ListItem.jsx
+++ b/src/components/List/ListItem/ListItem.jsx
@@ -167,9 +167,11 @@ const ListItem = ({
       </div>
     ) : null;
 
+  const hasRowActions =
+    rowActions && (typeof rowActions === 'function' || !isEmpty(rowActions));
+
   const renderRowActions = () =>
-    rowActions &&
-    (typeof rowActions === 'function' || rowActions.length > 0) ? (
+    hasRowActions ? (
       <div className={`${iotPrefix}--list-item--content--row-actions`}>
         {typeof rowActions === 'function' ? rowActions() : rowActions}
       </div>
@@ -244,9 +246,7 @@ const ListItem = ({
                     {
                       [`${iotPrefix}--list-item--category`]: isCategory,
                       [`${iotPrefix}--list-item--content--values__disabled`]: disabled,
-                      [`${iotPrefix}--list-item--content--values--value__with-actions`]: !isEmpty(
-                        rowActions
-                      ),
+                      [`${iotPrefix}--list-item--content--values--value__with-actions`]: hasRowActions,
                     }
                   )}
                   title={value}>
@@ -262,9 +262,7 @@ const ListItem = ({
                     `${iotPrefix}--list-item--content--values--value`,
                     `${iotPrefix}--list-item--content--values--value__large`,
                     {
-                      [`${iotPrefix}--list-item--content--values--value__with-actions`]: !isEmpty(
-                        rowActions
-                      ),
+                      [`${iotPrefix}--list-item--content--values--value__with-actions`]: hasRowActions,
                       [`${iotPrefix}--list-item--content--values__disabled`]: disabled,
                     }
                   )}>
@@ -281,9 +279,7 @@ const ListItem = ({
                     {
                       [`${iotPrefix}--list-item--category`]: isCategory,
                       [`${iotPrefix}--list-item--content--values__disabled`]: disabled,
-                      [`${iotPrefix}--list-item--content--values--value__with-actions`]: !isEmpty(
-                        rowActions
-                      ),
+                      [`${iotPrefix}--list-item--content--values--value__with-actions`]: hasRowActions,
                     }
                   )}
                   title={value}>
@@ -295,9 +291,7 @@ const ListItem = ({
                     className={classnames(
                       `${iotPrefix}--list-item--content--values--value`,
                       {
-                        [`${iotPrefix}--list-item--content--values--value__with-actions`]: !isEmpty(
-                          rowActions
-                        ),
+                        [`${iotPrefix}--list-item--content--values--value__with-actions`]: hasRowActions,
                         [`${iotPrefix}--list-item--content--values__disabled`]: disabled,
                       }
                     )}>

--- a/src/components/List/ListItem/ListItem.story.jsx
+++ b/src/components/List/ListItem/ListItem.story.jsx
@@ -330,7 +330,10 @@ export const WithOverflowMenuRowActions = () => (
     <ListItem
       {...dndProps}
       id="list-item"
-      value={text('value', 'List Item')}
+      value={text(
+        'value',
+        'List Item with really long values does it ellipse when I get really long text'
+      )}
       isExpandable={boolean('isExpandable', true)}
       onExpand={action('onExpand')}
       rowActions={[

--- a/src/components/List/ListItem/__snapshots__/ListItem.story.storyshot
+++ b/src/components/List/ListItem/__snapshots__/ListItem.story.storyshot
@@ -276,9 +276,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <div
                 className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                title="List Item"
+                title="List Item with really long values does it ellipse when I get really long text"
               >
-                List Item
+                List Item with really long values does it ellipse when I get really long text
               </div>
               <div
                 className="iot--list-item--content--row-actions"

--- a/src/components/List/ListItem/_list-item.scss
+++ b/src/components/List/ListItem/_list-item.scss
@@ -175,7 +175,7 @@
         text-overflow: ellipsis;
         padding-right: $spacing-09;
         &__with-actions {
-          padding-right: 0;
+          padding-right: $spacing-06; // save room for the action button
           width: $spacing-05;
         }
         &__large {

--- a/src/components/List/ListItem/_list-item.scss
+++ b/src/components/List/ListItem/_list-item.scss
@@ -175,7 +175,7 @@
         text-overflow: ellipsis;
         padding-right: $spacing-09;
         &__with-actions {
-          padding-right: $spacing-06; // save room for the action button
+          padding-right: $spacing-07; // save room for the action button
           width: $spacing-05;
         }
         &__large {


### PR DESCRIPTION
Closes #

**Summary**

- Fixes two issues,:
one the row actions cause the list values to overlap and the padding wasn't giving enough space
two fixes the warning thrown by the DataSeriesFormItem

**Acceptance Test (how to verify the PR)**

- Check the updated story to see the longer list item and notice the proptypes error goes away on the new data series form
