### PR TITLE
fix(hierarchylist): selection is lost when rerender occurs

### DIFF
--- a/src/components/List/HierarchyList/HierarchyList.jsx
+++ b/src/components/List/HierarchyList/HierarchyList.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import cloneDeep from 'lodash/cloneDeep';
 import debounce from 'lodash/debounce';
 import isNil from 'lodash/isNil';
+import isEqual from 'lodash/isEqual';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 
 import { caseInsensitiveSearch } from '../../../utils/componentUtilityFunctions';
@@ -260,8 +261,10 @@ const HierarchyList = ({
         });
         setExpandedIds(tempExpandedIds);
 
-        // If the defaultSelectedId prop is updated from the outside, we need to use it
-        handleSelect(defaultSelectedId);
+        if (!isEqual(selectedIds, [defaultSelectedId])) {
+          // If the defaultSelectedId prop is updated from the outside, we need to use it
+          handleSelect(defaultSelectedId);
+        }
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/List/ListItem/ListItem.jsx
+++ b/src/components/List/ListItem/ListItem.jsx
@@ -84,7 +84,7 @@ const ListItemDefaultProps = {
   selected: false,
   expanded: false,
   secondaryValue: null,
-  rowActions: [],
+  rowActions: null,
   icon: null,
   iconPosition: 'left',
   nestingLevel: 0,

--- a/src/components/List/ListItem/_list-item.scss
+++ b/src/components/List/ListItem/_list-item.scss
@@ -122,7 +122,7 @@
 
   &__selected {
     border-left: solid $spacing-02 $interactive-01;
-    padding-left: $spacing-04;
+    padding-left: $spacing-01;
     color: $text-01;
     background: $selected-ui;
   }


### PR DESCRIPTION
Closes #

**Summary**

- Fixes a bug where the handleSelect would trigger twice and unselect a item if the graph rerendered

**Change List (commits, features, bugs, etc)**

- fix(HierarchyList): only trigger handleSelect if the item isn't already selected
- fix(ListItem): default prop should not be array
- fix(listitem.scss): reduce the selected items padding

**Acceptance Test (how to verify the PR)**

- Verify all the list stories
