### PR TITLE
fix(cardEditForm): not using passed timeRange prop in the form

### DIFF
--- a/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
@@ -46,7 +46,6 @@ const propTypes = {
         zoomMax: PropTypes.number,
       }),
     ]),
-    interval: PropTypes.string,
     showLegend: PropTypes.bool,
   }),
   /** Callback function when form data changes */
@@ -172,16 +171,24 @@ const CardEditFormContent = ({
   getValidDataItems,
   getValidTimeRanges,
 }) => {
-  const { title, description, size, type, id } = cardConfig;
+  const { title, description, size, type, id, timeRange } = cardConfig;
   const mergedI18n = { ...defaultProps.i18n, ...i18n };
   const [selectedDataItems, setSelectedDataItems] = useState([]);
-  const [selectedTimeRange, setSelectedTimeRange] = useState('');
+  const [selectedTimeRange, setSelectedTimeRange] = useState(timeRange || '');
 
   const baseClassName = `${iotPrefix}--card-edit-form`;
 
   const validTimeRanges = getValidTimeRanges
     ? getValidTimeRanges(cardConfig, selectedDataItems)
     : defaultTimeRangeOptions;
+
+  const validTimeRangeOptions = validTimeRanges
+    ? validTimeRanges.map((range) => ({
+        id: range,
+        text: mergedI18n[`${range}Label`] || range,
+      }))
+    : [];
+
   return (
     <>
       <div className={`${baseClassName}--input`}>
@@ -236,21 +243,19 @@ const CardEditFormContent = ({
               label={mergedI18n.selectATimeRange}
               direction="bottom"
               itemToString={(item) => item.text}
-              items={
-                validTimeRanges
-                  ? validTimeRanges.map((range) => ({
-                      id: range,
-                      text: mergedI18n[range] || range,
-                    }))
-                  : []
-              }
+              items={validTimeRangeOptions}
+              selectedItem={validTimeRangeOptions.find(
+                // This is a hacky workaround for a carbon issue
+                (validTimeRangeOption) =>
+                  validTimeRangeOption.id === selectedTimeRange
+              )}
               light
               onChange={({ selectedItem }) => {
-                const { range, interval } = timeRangeToJSON[selectedItem.id];
+                const { range } = timeRangeToJSON[selectedItem.id];
                 setSelectedTimeRange(selectedItem.id);
                 onChange({
                   ...cardConfig,
-                  interval,
+                  timeRange: selectedItem.id,
                   dataSource: { ...cardConfig.dataSource, range },
                 });
               }}

--- a/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
@@ -250,8 +250,8 @@ const CardEditFormContent = ({
                   validTimeRangeOption.id === selectedTimeRange
               )}
               light
-              onChange={({ selectedItem, interval }) => {
-                const { range } = timeRangeToJSON[selectedItem.id];
+              onChange={({ selectedItem }) => {
+                const { range, interval } = timeRangeToJSON[selectedItem.id];
                 setSelectedTimeRange(selectedItem.id);
                 onChange({
                   ...cardConfig,

--- a/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
@@ -250,11 +250,12 @@ const CardEditFormContent = ({
                   validTimeRangeOption.id === selectedTimeRange
               )}
               light
-              onChange={({ selectedItem }) => {
+              onChange={({ selectedItem, interval }) => {
                 const { range } = timeRangeToJSON[selectedItem.id];
                 setSelectedTimeRange(selectedItem.id);
                 onChange({
                   ...cardConfig,
+                  interval,
                   timeRange: selectedItem.id,
                   dataSource: { ...cardConfig.dataSource, range },
                 });

--- a/src/components/CardEditor/CardEditForm/CardEditFormContent.test.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormContent.test.jsx
@@ -33,7 +33,7 @@ const cardConfig = {
 };
 
 const mockOnChange = jest.fn();
-const mockGetValidTimeRanges = jest.fn();
+const mockGetValidTimeRanges = jest.fn(() => ['last2Hours']);
 
 afterEach(() => {
   jest.clearAllMocks();
@@ -54,6 +54,24 @@ describe('CardEditFormContent', () => {
       );
       expect(mockOnChange).toHaveBeenCalled();
       expect(mockGetValidTimeRanges).toHaveBeenCalled();
+      // Time range selector should start unselected
+      const timeRangeSelector = screen.getAllByLabelText('Time range');
+      expect(timeRangeSelector[0].innerHTML).not.toEqual(
+        expect.stringContaining('last2Hours')
+      );
+    });
+    it('Should select timeRange if passed', () => {
+      render(
+        <CardEditFormContent
+          cardConfig={{ ...cardConfig, timeRange: 'last2Hours' }}
+          onChange={mockOnChange}
+          getValidTimeRanges={mockGetValidTimeRanges}
+        />
+      );
+      const timeRangeSelector = screen.getAllByLabelText('Time range');
+      expect(timeRangeSelector[0].innerHTML).toEqual(
+        expect.stringContaining('last2Hours')
+      );
     });
   });
 });

--- a/src/components/CardEditor/CardEditForm/CardEditFormSettings.test.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormSettings.test.jsx
@@ -29,7 +29,6 @@ const cardConfig = {
     timeDataSourceId: 'timestamp',
     addSpaceOnEdges: 1,
   },
-  interval: 'day',
 };
 
 const mockOnChange = jest.fn();

--- a/src/components/DashboardEditor/editorUtils.jsx
+++ b/src/components/DashboardEditor/editorUtils.jsx
@@ -144,6 +144,30 @@ export const getDefaultCard = (type, i18n) => {
  * maps a selected time range to what is expected in the dashboardJSON
  */
 export const timeRangeToJSON = {
+  lastHour: {
+    range: {
+      interval: 'hour',
+      count: -1,
+      type: 'rolling',
+    },
+    interval: 'hour',
+  },
+  last2Hours: {
+    range: {
+      interval: 'hour',
+      count: -2,
+      type: 'rolling',
+    },
+    interval: 'hour',
+  },
+  last4Hours: {
+    range: { interval: 'hour', count: -4, type: 'rolling' },
+    interval: 'hour',
+  },
+  last8Hours: {
+    range: { interval: 'hour', count: -8, type: 'rolling' },
+    interval: 'hour',
+  },
   last24Hours: {
     range: { interval: 'day', count: -1, type: 'rolling' },
     interval: 'hour',


### PR DESCRIPTION
Closes #https://github.ibm.com/wiotp/monitoring-dashboard/issues/1677

**Summary**

- Fixes an issue where the CardEditFormContent wasn't selecting the correct item by default

**Change List (commits, features, bugs, etc)**

- fix(CardEditFormContent): use the passed card.timeRange as default and correctly populate the dropdown and handle the updates
- fix(editorUtils): add the custom raw ranges to the timeRangesToJSON

**Acceptance Test (how to verify the PR)**

- verify CardEditFormContent testcases and the CardEditForm stories
