### PR TITLE
fix(line-card-range): remove datasource range from editor render of linecard

### DIFF
--- a/src/components/DashboardEditor/DashboardEditor.story.jsx
+++ b/src/components/DashboardEditor/DashboardEditor.story.jsx
@@ -145,7 +145,14 @@ export const WithInitialValue = () => (
               timeDataSourceId: 'timestamp',
               addSpaceOnEdges: 1,
             },
-            interval: 'day',
+            timeRange: 'thisWeek',
+            dataSource: {
+              range: {
+                interval: 'week',
+                count: -1,
+                type: 'periodToDate',
+              },
+            },
           },
         ],
         layouts: {

--- a/src/components/DashboardEditor/editorUtils.jsx
+++ b/src/components/DashboardEditor/editorUtils.jsx
@@ -386,7 +386,6 @@ const renderTimeSeriesCard = (cardConfig, commonProps) => {
       isEditable
       values={[]}
       interval={timeRangeJSON?.interval || 'day'}
-      timeRange={cardConfig?.dataSource?.range}
       {...cardConfig}
       {...commonProps}
     />


### PR DESCRIPTION
**Summary**

The TimeSeries cards in the dashboard editor were incorrectly looking at the the `dataSource.range` prop for the `timeRange` on a TimeSeries card.

**Change List (commits, features, bugs, etc)**

Remove the timeRange prop definition from the `TimeSeriesCard` render in the dashboard editor

**Acceptance Test (how to verify the PR)**

Go to the `DashboardEditor` `With initial values` story and see that the TimeSeriesCard is properly set to `thisWeek` and the time range picker in the cardEditor is pre-populated.
