### PR TITLE
feat(imagegallery): link the image gallery to the dashboardeditor

### DIFF
--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/ImageCardFormItems/ImageCardFormContent.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/ImageCardFormItems/ImageCardFormContent.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Scale32 } from '@carbon/icons-react';
+// import { Scale32 } from '@carbon/icons-react';
 
-import Button from '../../../../Button';
+// import Button from '../../../../Button';
 import { settings } from '../../../../../constants/Settings';
 
 const { iotPrefix, prefix } = settings;
@@ -57,12 +57,12 @@ const ImageCardFormItems = ({ cardConfig, i18n }) => {
             value={cardConfig.content?.id || ''}
           />
         </label>
-        <Button
+        {/* TODO enable once hotspot editing is live <Button
           className={`${baseClassName}--form-section-image-btn`}
           size="small"
           renderIcon={Scale32}>
           {mergedI18n.editImage}
-        </Button>
+        </Button> */}
       </div>
     </>
   );

--- a/src/components/DashboardEditor/DashboardEditor.jsx
+++ b/src/components/DashboardEditor/DashboardEditor.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { InlineNotification } from 'carbon-components-react';
+import isNil from 'lodash/isNil';
 import classnames from 'classnames';
 import update from 'immutability-helper';
 
@@ -8,6 +9,7 @@ import { settings } from '../../constants/Settings';
 import {
   DASHBOARD_EDITOR_CARD_TYPES,
   CARD_ACTIONS,
+  CARD_TYPES,
 } from '../../constants/LayoutConstants';
 import {
   DashboardGrid,
@@ -15,6 +17,9 @@ import {
   ErrorBoundary,
   SkeletonText,
 } from '../../index';
+import ImageGalleryModal, {
+  ImagePropTypes,
+} from '../ImageGalleryModal/ImageGalleryModal';
 
 import DashboardEditorHeader from './DashboardEditorHeader/DashboardEditorHeader';
 import {
@@ -82,6 +87,7 @@ const propTypes = {
   /** an array of dataItems to be included on each card
    * this prop will be ignored if getValidDataItems is defined
    */
+  availableImages: ImagePropTypes,
   dataItems: DataItemsPropTypes,
   /** an object where the keys are available dimensions and the values are the values available for those dimensions
    *  ex: { manufacturer: ['Rentech', 'GHI Industries'], deviceid: ['73000', '73001', '73002'] }
@@ -142,6 +148,15 @@ const propTypes = {
     layoutInfoLg: PropTypes.string,
     layoutInfoMd: PropTypes.string,
     searchPlaceholderText: PropTypes.string,
+    imageGalleryGridButtonText: PropTypes.string,
+    imageGalleryInstructionText: PropTypes.string,
+    imageGalleryListButtonText: PropTypes.string,
+    imageGalleryModalLabelText: PropTypes.string,
+    imageGalleryModalTitleText: PropTypes.string,
+    imageGalleryModalPrimaryButtonLabelText: PropTypes.string,
+    imageGalleryModalSecondaryButtonLabelText: PropTypes.string,
+    imageGalleryModalCloseIconDescriptionText: PropTypes.string,
+    imageGallerySearchPlaceHolderText: PropTypes.string,
   }),
 };
 
@@ -160,6 +175,7 @@ const defaultProps = {
   onEditTitle: null,
   getValidDataItems: null,
   getValidTimeRanges: null,
+  availableImages: [],
   dataItems: [],
   availableDimensions: {},
   onCardChange: null,
@@ -214,6 +230,7 @@ const DashboardEditor = ({
   getValidDataItems,
   getValidTimeRanges,
   dataItems,
+  availableImages,
   headerBreadcrumbs,
   notification,
   onCardChange,
@@ -231,8 +248,10 @@ const DashboardEditor = ({
   i18n,
 }) => {
   const mergedI18n = { ...defaultProps.i18n, ...i18n };
+  // Need to keep track of whether the image gallery is open or not
+  const [isImageGalleryModalOpen, setIsImageGalleryModalOpen] = useState(false);
 
-  // show the gallery if no card is being edited
+  // show the card gallery if no card is being edited
   const [dashboardJson, setDashboardJson] = useState(initialValue);
   const [selectedCardId, setSelectedCardId] = useState();
   const [selectedBreakpointIndex, setSelectedBreakpointIndex] = useState(
@@ -303,8 +322,24 @@ const DashboardEditor = ({
             ? onCardChange(cardConfig, dashboardJson)
             : cardConfig
           : card
-      ),
+      ), // TODO: need to handle switching the image id and dynamically switching the src to the correct blob
     });
+
+  // Show the image gallery
+  const handleShowImageGallery = () => setIsImageGalleryModalOpen(true);
+
+  // Update the src section of a card when a new image is selected
+  const handleImageSelection = (selectedImage) => {
+    setDashboardJson((json) => ({
+      ...json,
+      cards: json.cards.map((card) =>
+        card.id === selectedCardId
+          ? { ...card, content: { ...card.content, ...selectedImage } }
+          : card
+      ),
+    }));
+    setIsImageGalleryModalOpen(false);
+  };
 
   const commonCardProps = (cardConfig, isSelected) => ({
     key: cardConfig.id,
@@ -324,6 +359,11 @@ const DashboardEditor = ({
     onClick: () => handleOnClick(onSelectCard, cardConfig.id),
     className: `${baseClassName}--preview__card`,
     isSelected,
+    // Add the show gallery to image card
+    onBrowseClick:
+      cardConfig.type === CARD_TYPES.IMAGE && isNil(cardConfig.content?.src)
+        ? handleShowImageGallery
+        : undefined,
   });
 
   return isLoading ? (
@@ -391,6 +431,27 @@ const DashboardEditor = ({
                     lowContrast
                   />
                 }>
+                <ImageGalleryModal
+                  open={isImageGalleryModalOpen}
+                  content={availableImages}
+                  onClose={() => setIsImageGalleryModalOpen(false)}
+                  onSubmit={handleImageSelection}
+                  gridButtonText={i18n.imageGalleryGridButtonText}
+                  instructionText={i18n.imageGalleryInstructionText}
+                  listButtonText={i18n.imageGalleryListButtonText}
+                  modalLabelText={i18n.imageGalleryModalLabelText}
+                  modalTitleText={i18n.imageGalleryModalTitleText}
+                  modalPrimaryButtonLabelText={
+                    i18n.imageGalleryModalPrimaryButtonLabelText
+                  }
+                  modalSecondaryButtonLabelText={
+                    i18n.imageGalleryModalSecondaryButtonLabelText
+                  }
+                  modalCloseIconDescriptionText={
+                    i18n.imageGalleryModalCloseIconDescriptionText
+                  }
+                  searchPlaceHolderText={i18n.imageGallerySearchPlaceHolderText}
+                />
                 <DashboardGrid
                   isEditable
                   breakpoint={currentBreakpoint}
@@ -419,7 +480,8 @@ const DashboardEditor = ({
                         onSelectCard,
                         onDuplicateCard,
                         onRemoveCard,
-                        isSelected
+                        isSelected,
+                        handleShowImageGallery
                       ) ?? getCardPreview(cardConfig, cardProps)
                     );
                   })}

--- a/src/components/DashboardEditor/DashboardEditor.story.jsx
+++ b/src/components/DashboardEditor/DashboardEditor.story.jsx
@@ -9,8 +9,41 @@ import {
 } from '@storybook/addon-knobs';
 
 import { Card, Link, InlineNotification } from '../../index';
+import assemblyline from '../ImageGalleryModal/images/assemblyline.jpg';
+import floow_plan from '../ImageGalleryModal/images/floow_plan.png'; // eslint-disable-line camelcase
+import manufacturing_plant from '../ImageGalleryModal/images/Manufacturing_plant.png'; // eslint-disable-line camelcase
+import extra_wide_image from '../ImageGalleryModal/images/extra-wide-image.png'; // eslint-disable-line camelcase
+import robot_arm from '../ImageGalleryModal/images/robot_arm.png'; // eslint-disable-line camelcase
+import tankmodal from '../ImageGalleryModal/images/tankmodal.png';
+import turbines from '../ImageGalleryModal/images/turbines.png';
+import large from '../ImageGalleryModal/images/large.png';
+import large_portrait from '../ImageGalleryModal/images/large_portrait.png'; // eslint-disable-line camelcase
 
 import DashboardEditor from './DashboardEditor';
+
+const images = [
+  {
+    id: 'assemblyline',
+    src: assemblyline,
+    alt: 'assemblyline',
+    title: `custom title assemblyline that is very long a and must be managed. 
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do 
+      eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim 
+      ad minim veniam.`,
+  },
+  { id: 'floow_plan', src: floow_plan, alt: 'floow plan' },
+  {
+    id: 'manufacturing_plant',
+    src: manufacturing_plant,
+    alt: 'manufacturing plant',
+  },
+  { id: 'robot_arm', src: robot_arm, alt: 'robot arm' },
+  { id: 'tankmodal', src: tankmodal, alt: 'tankmodal' },
+  { id: 'turbines', src: turbines, alt: 'turbines' },
+  { id: 'extra-wide-image', src: extra_wide_image, alt: 'extra wide image' },
+  { id: 'large', src: large, alt: 'large image' },
+  { id: 'large_portrait', src: large_portrait, alt: 'large image portrait' },
+];
 
 const mockDataItems = [
   { dataSourceId: 'torque_max', label: 'Torque Max' },
@@ -34,6 +67,7 @@ export const Default = () => (
     <DashboardEditor
       title={text('title', 'My dashboard')}
       dataItems={mockDataItems}
+      availableImages={images}
       onAddImage={action('onAddImage')}
       onEditTitle={action('onEditTitle')}
       onImport={action('onImport')}

--- a/src/components/DashboardEditor/DashboardEditor.test.jsx
+++ b/src/components/DashboardEditor/DashboardEditor.test.jsx
@@ -251,7 +251,7 @@ describe('DashboardEditor', () => {
   it('selecting cancel should fire onCancel', () => {
     render(<DashboardEditor {...commonProps} />);
     // find and click submit button
-    const cancelBtn = screen.getByText('Cancel');
+    const cancelBtn = screen.getAllByText('Cancel')[0];
     expect(cancelBtn).toBeInTheDocument();
     fireEvent.click(cancelBtn);
     expect(mockOnCancel).toBeCalled();

--- a/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -277,6 +277,246 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--dashboard-editor--preview__grid-container"
               >
                 <div
+                  className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
+                  data-floating-menu-container={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onClose={[Function]}
+                  onKeyDown={[Function]}
+                  open={false}
+                  role="presentation"
+                >
+                  <span
+                    className="bx--visually-hidden"
+                    role="link"
+                    tabIndex="0"
+                  >
+                    Focus sentinel
+                  </span>
+                  <div
+                    className="bx--modal-container"
+                    role="dialog"
+                  >
+                    <div
+                      className="bx--modal-header"
+                    >
+                      <p
+                        className="bx--modal-header__label bx--type-delta"
+                      >
+                        New image card
+                      </p>
+                      <p
+                        className="bx--modal-header__heading bx--type-beta"
+                      >
+                        Image gallery
+                      </p>
+                      <button
+                        aria-label="Close"
+                        className="bx--modal-close"
+                        onClick={[Function]}
+                        title="Close"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="bx--modal-close__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    <div
+                      className="bx--modal-content"
+                    >
+                      <div
+                        className="iot--image-gallery-modal__top-section"
+                      >
+                        <p
+                          alt="Select the image that you want to display on this card."
+                          className="iot--image-gallery-modal__instruction-text"
+                        >
+                          Select the image that you want to display on this card.
+                        </p>
+                        <div
+                          className="iot--image-gallery-modal__search-list-view-container"
+                        >
+                          <div
+                            aria-labelledby="iot--image-gallery-modal--search-search"
+                            className="bx--search bx--search--xl bx--search--light"
+                            role="search"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="bx--search-magnifier"
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                              />
+                            </svg>
+                            <label
+                              className="bx--label"
+                              htmlFor="iot--image-gallery-modal--search"
+                              id="iot--image-gallery-modal--search-search"
+                            >
+                              
+                            </label>
+                            <input
+                              autoComplete="off"
+                              className="bx--search-input"
+                              id="iot--image-gallery-modal--search"
+                              onChange={[Function]}
+                              placeholder="Search image by file name"
+                              role="searchbox"
+                              type="text"
+                            />
+                            <button
+                              aria-label="Clear search input"
+                              className="bx--search-close bx--search-close--hidden"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="currentColor"
+                                focusable="false"
+                                height={16}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 32 32"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <div
+                            className="bx--content-switcher iot--image-gallery-modal__content-switcher"
+                            onChange={[Function]}
+                            role="tablist"
+                          >
+                            <button
+                              className="iot--icon-switch iot--icon-switch--large bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                              disabled={false}
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              tabIndex={0}
+                              type="button"
+                            >
+                              <span
+                                className="bx--assistive-text"
+                              >
+                                Grid
+                              </span>
+                              <svg
+                                aria-hidden="true"
+                                aria-label="Grid"
+                                className="bx--btn__icon"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12 4H6A2 2 0 004 6v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0012 4zm0 8H6V6h6zM26 4H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0026 4zm0 8H20V6h6zM12 18H6a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0012 18zm0 8H6V20h6zM26 18H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0026 18zm0 8H20V20h6z"
+                                />
+                              </svg>
+                            </button>
+                            <button
+                              className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                              disabled={false}
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              tabIndex={0}
+                              type="button"
+                            >
+                              <span
+                                className="bx--assistive-text"
+                              >
+                                List
+                              </span>
+                              <svg
+                                aria-hidden="true"
+                                aria-label="List"
+                                className="bx--btn__icon"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M10 6H28V8H10zM10 24H28V26H10zM10 15H28V17H10zM4 15H6V17H4zM4 6H6V8H4zM4 24H6V26H4z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--image-gallery-modal__flex-wrapper"
+                      >
+                        <div
+                          className="iot--image-gallery-modal__scroll-panel iot--image-gallery-modal__scroll-panel--grid"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      className="bx--modal-footer iot--composed-modal-footer"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--secondary"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                        disabled={true}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Select
+                      </button>
+                    </div>
+                  </div>
+                  <span
+                    className="bx--visually-hidden"
+                    role="link"
+                    tabIndex="0"
+                  >
+                    Focus sentinel
+                  </span>
+                </div>
+                <div
                   style={
                     Object {
                       "flex": 1,
@@ -1358,6 +1598,246 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--dashboard-editor--preview__grid-container"
               >
                 <div
+                  className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
+                  data-floating-menu-container={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onClose={[Function]}
+                  onKeyDown={[Function]}
+                  open={false}
+                  role="presentation"
+                >
+                  <span
+                    className="bx--visually-hidden"
+                    role="link"
+                    tabIndex="0"
+                  >
+                    Focus sentinel
+                  </span>
+                  <div
+                    className="bx--modal-container"
+                    role="dialog"
+                  >
+                    <div
+                      className="bx--modal-header"
+                    >
+                      <p
+                        className="bx--modal-header__label bx--type-delta"
+                      >
+                        New image card
+                      </p>
+                      <p
+                        className="bx--modal-header__heading bx--type-beta"
+                      >
+                        Image gallery
+                      </p>
+                      <button
+                        aria-label="Close"
+                        className="bx--modal-close"
+                        onClick={[Function]}
+                        title="Close"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="bx--modal-close__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    <div
+                      className="bx--modal-content"
+                    >
+                      <div
+                        className="iot--image-gallery-modal__top-section"
+                      >
+                        <p
+                          alt="Select the image that you want to display on this card."
+                          className="iot--image-gallery-modal__instruction-text"
+                        >
+                          Select the image that you want to display on this card.
+                        </p>
+                        <div
+                          className="iot--image-gallery-modal__search-list-view-container"
+                        >
+                          <div
+                            aria-labelledby="iot--image-gallery-modal--search-search"
+                            className="bx--search bx--search--xl bx--search--light"
+                            role="search"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="bx--search-magnifier"
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                              />
+                            </svg>
+                            <label
+                              className="bx--label"
+                              htmlFor="iot--image-gallery-modal--search"
+                              id="iot--image-gallery-modal--search-search"
+                            >
+                              
+                            </label>
+                            <input
+                              autoComplete="off"
+                              className="bx--search-input"
+                              id="iot--image-gallery-modal--search"
+                              onChange={[Function]}
+                              placeholder="Search image by file name"
+                              role="searchbox"
+                              type="text"
+                            />
+                            <button
+                              aria-label="Clear search input"
+                              className="bx--search-close bx--search-close--hidden"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="currentColor"
+                                focusable="false"
+                                height={16}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 32 32"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <div
+                            className="bx--content-switcher iot--image-gallery-modal__content-switcher"
+                            onChange={[Function]}
+                            role="tablist"
+                          >
+                            <button
+                              className="iot--icon-switch iot--icon-switch--large bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                              disabled={false}
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              tabIndex={0}
+                              type="button"
+                            >
+                              <span
+                                className="bx--assistive-text"
+                              >
+                                Grid
+                              </span>
+                              <svg
+                                aria-hidden="true"
+                                aria-label="Grid"
+                                className="bx--btn__icon"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12 4H6A2 2 0 004 6v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0012 4zm0 8H6V6h6zM26 4H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0026 4zm0 8H20V6h6zM12 18H6a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0012 18zm0 8H6V20h6zM26 18H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0026 18zm0 8H20V20h6z"
+                                />
+                              </svg>
+                            </button>
+                            <button
+                              className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                              disabled={false}
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              tabIndex={0}
+                              type="button"
+                            >
+                              <span
+                                className="bx--assistive-text"
+                              >
+                                List
+                              </span>
+                              <svg
+                                aria-hidden="true"
+                                aria-label="List"
+                                className="bx--btn__icon"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M10 6H28V8H10zM10 24H28V26H10zM10 15H28V17H10zM4 15H6V17H4zM4 6H6V8H4zM4 24H6V26H4z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--image-gallery-modal__flex-wrapper"
+                      >
+                        <div
+                          className="iot--image-gallery-modal__scroll-panel iot--image-gallery-modal__scroll-panel--grid"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      className="bx--modal-footer iot--composed-modal-footer"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--secondary"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                        disabled={true}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Select
+                      </button>
+                    </div>
+                  </div>
+                  <span
+                    className="bx--visually-hidden"
+                    role="link"
+                    tabIndex="0"
+                  >
+                    Focus sentinel
+                  </span>
+                </div>
+                <div
                   style={
                     Object {
                       "flex": 1,
@@ -2304,6 +2784,799 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               <div
                 className="iot--dashboard-editor--preview__grid-container"
               >
+                <div
+                  className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
+                  data-floating-menu-container={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onClose={[Function]}
+                  onKeyDown={[Function]}
+                  open={false}
+                  role="presentation"
+                >
+                  <span
+                    className="bx--visually-hidden"
+                    role="link"
+                    tabIndex="0"
+                  >
+                    Focus sentinel
+                  </span>
+                  <div
+                    className="bx--modal-container"
+                    role="dialog"
+                  >
+                    <div
+                      className="bx--modal-header"
+                    >
+                      <p
+                        className="bx--modal-header__label bx--type-delta"
+                      >
+                        New image card
+                      </p>
+                      <p
+                        className="bx--modal-header__heading bx--type-beta"
+                      >
+                        Image gallery
+                      </p>
+                      <button
+                        aria-label="Close"
+                        className="bx--modal-close"
+                        onClick={[Function]}
+                        title="Close"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="bx--modal-close__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    <div
+                      className="bx--modal-content"
+                    >
+                      <div
+                        className="iot--image-gallery-modal__top-section"
+                      >
+                        <p
+                          alt="Select the image that you want to display on this card."
+                          className="iot--image-gallery-modal__instruction-text"
+                        >
+                          Select the image that you want to display on this card.
+                        </p>
+                        <div
+                          className="iot--image-gallery-modal__search-list-view-container"
+                        >
+                          <div
+                            aria-labelledby="iot--image-gallery-modal--search-search"
+                            className="bx--search bx--search--xl bx--search--light"
+                            role="search"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="bx--search-magnifier"
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                              />
+                            </svg>
+                            <label
+                              className="bx--label"
+                              htmlFor="iot--image-gallery-modal--search"
+                              id="iot--image-gallery-modal--search-search"
+                            >
+                              
+                            </label>
+                            <input
+                              autoComplete="off"
+                              className="bx--search-input"
+                              id="iot--image-gallery-modal--search"
+                              onChange={[Function]}
+                              placeholder="Search image by file name"
+                              role="searchbox"
+                              type="text"
+                            />
+                            <button
+                              aria-label="Clear search input"
+                              className="bx--search-close bx--search-close--hidden"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="currentColor"
+                                focusable="false"
+                                height={16}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 32 32"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <div
+                            className="bx--content-switcher iot--image-gallery-modal__content-switcher"
+                            onChange={[Function]}
+                            role="tablist"
+                          >
+                            <button
+                              className="iot--icon-switch iot--icon-switch--large bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                              disabled={false}
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              tabIndex={0}
+                              type="button"
+                            >
+                              <span
+                                className="bx--assistive-text"
+                              >
+                                Grid
+                              </span>
+                              <svg
+                                aria-hidden="true"
+                                aria-label="Grid"
+                                className="bx--btn__icon"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12 4H6A2 2 0 004 6v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0012 4zm0 8H6V6h6zM26 4H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0026 4zm0 8H20V6h6zM12 18H6a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0012 18zm0 8H6V20h6zM26 18H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0026 18zm0 8H20V20h6z"
+                                />
+                              </svg>
+                            </button>
+                            <button
+                              className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                              disabled={false}
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              tabIndex={0}
+                              type="button"
+                            >
+                              <span
+                                className="bx--assistive-text"
+                              >
+                                List
+                              </span>
+                              <svg
+                                aria-hidden="true"
+                                aria-label="List"
+                                className="bx--btn__icon"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M10 6H28V8H10zM10 24H28V26H10zM10 15H28V17H10zM4 15H6V17H4zM4 6H6V8H4zM4 24H6V26H4z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--image-gallery-modal__flex-wrapper"
+                      >
+                        <div
+                          className="iot--image-gallery-modal__scroll-panel iot--image-gallery-modal__scroll-panel--grid"
+                        >
+                          <input
+                            checked={false}
+                            className="bx--tile-input"
+                            id="assemblyline"
+                            onChange={[Function]}
+                            tabIndex={-1}
+                            title="title"
+                            type="checkbox"
+                            value="value"
+                          />
+                          <label
+                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                            htmlFor="assemblyline"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            selected={false}
+                            tabIndex={0}
+                          >
+                            <span
+                              className="bx--tile__checkmark"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="currentColor"
+                                focusable="false"
+                                height={16}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                />
+                                <path
+                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                  data-icon-path="inner-path"
+                                  opacity="0"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              className="bx--tile-content"
+                            >
+                              <div
+                                className="iot--image-tile__title"
+                              >
+                                <span>
+                                  custom title assemblyline that is very long a and must be managed. 
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do 
+      eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim 
+      ad minim veniam.
+                                </span>
+                              </div>
+                              <div
+                                className="iot--image-tile__image-container"
+                              >
+                                <img
+                                  alt="assemblyline"
+                                  src="assemblyline.jpg"
+                                />
+                              </div>
+                            </span>
+                          </label>
+                          <input
+                            checked={false}
+                            className="bx--tile-input"
+                            id="floow_plan"
+                            onChange={[Function]}
+                            tabIndex={-1}
+                            title="title"
+                            type="checkbox"
+                            value="value"
+                          />
+                          <label
+                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                            htmlFor="floow_plan"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            selected={false}
+                            tabIndex={0}
+                          >
+                            <span
+                              className="bx--tile__checkmark"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="currentColor"
+                                focusable="false"
+                                height={16}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                />
+                                <path
+                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                  data-icon-path="inner-path"
+                                  opacity="0"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              className="bx--tile-content"
+                            >
+                              <div
+                                className="iot--image-tile__title"
+                              >
+                                <span>
+                                  floow_plan
+                                </span>
+                              </div>
+                              <div
+                                className="iot--image-tile__image-container"
+                              >
+                                <img
+                                  alt="floow plan"
+                                  src="floow_plan.png"
+                                />
+                              </div>
+                            </span>
+                          </label>
+                          <input
+                            checked={false}
+                            className="bx--tile-input"
+                            id="manufacturing_plant"
+                            onChange={[Function]}
+                            tabIndex={-1}
+                            title="title"
+                            type="checkbox"
+                            value="value"
+                          />
+                          <label
+                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                            htmlFor="manufacturing_plant"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            selected={false}
+                            tabIndex={0}
+                          >
+                            <span
+                              className="bx--tile__checkmark"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="currentColor"
+                                focusable="false"
+                                height={16}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                />
+                                <path
+                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                  data-icon-path="inner-path"
+                                  opacity="0"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              className="bx--tile-content"
+                            >
+                              <div
+                                className="iot--image-tile__title"
+                              >
+                                <span>
+                                  Manufacturing_plant
+                                </span>
+                              </div>
+                              <div
+                                className="iot--image-tile__image-container"
+                              >
+                                <img
+                                  alt="manufacturing plant"
+                                  src="Manufacturing_plant.png"
+                                />
+                              </div>
+                            </span>
+                          </label>
+                          <input
+                            checked={false}
+                            className="bx--tile-input"
+                            id="robot_arm"
+                            onChange={[Function]}
+                            tabIndex={-1}
+                            title="title"
+                            type="checkbox"
+                            value="value"
+                          />
+                          <label
+                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                            htmlFor="robot_arm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            selected={false}
+                            tabIndex={0}
+                          >
+                            <span
+                              className="bx--tile__checkmark"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="currentColor"
+                                focusable="false"
+                                height={16}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                />
+                                <path
+                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                  data-icon-path="inner-path"
+                                  opacity="0"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              className="bx--tile-content"
+                            >
+                              <div
+                                className="iot--image-tile__title"
+                              >
+                                <span>
+                                  robot_arm
+                                </span>
+                              </div>
+                              <div
+                                className="iot--image-tile__image-container"
+                              >
+                                <img
+                                  alt="robot arm"
+                                  src="robot_arm.png"
+                                />
+                              </div>
+                            </span>
+                          </label>
+                          <input
+                            checked={false}
+                            className="bx--tile-input"
+                            id="tankmodal"
+                            onChange={[Function]}
+                            tabIndex={-1}
+                            title="title"
+                            type="checkbox"
+                            value="value"
+                          />
+                          <label
+                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                            htmlFor="tankmodal"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            selected={false}
+                            tabIndex={0}
+                          >
+                            <span
+                              className="bx--tile__checkmark"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="currentColor"
+                                focusable="false"
+                                height={16}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                />
+                                <path
+                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                  data-icon-path="inner-path"
+                                  opacity="0"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              className="bx--tile-content"
+                            >
+                              <div
+                                className="iot--image-tile__title"
+                              >
+                                <span>
+                                  tankmodal
+                                </span>
+                              </div>
+                              <div
+                                className="iot--image-tile__image-container"
+                              >
+                                <img
+                                  alt="tankmodal"
+                                  src="tankmodal.png"
+                                />
+                              </div>
+                            </span>
+                          </label>
+                          <input
+                            checked={false}
+                            className="bx--tile-input"
+                            id="turbines"
+                            onChange={[Function]}
+                            tabIndex={-1}
+                            title="title"
+                            type="checkbox"
+                            value="value"
+                          />
+                          <label
+                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                            htmlFor="turbines"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            selected={false}
+                            tabIndex={0}
+                          >
+                            <span
+                              className="bx--tile__checkmark"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="currentColor"
+                                focusable="false"
+                                height={16}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                />
+                                <path
+                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                  data-icon-path="inner-path"
+                                  opacity="0"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              className="bx--tile-content"
+                            >
+                              <div
+                                className="iot--image-tile__title"
+                              >
+                                <span>
+                                  turbines
+                                </span>
+                              </div>
+                              <div
+                                className="iot--image-tile__image-container"
+                              >
+                                <img
+                                  alt="turbines"
+                                  src="turbines.png"
+                                />
+                              </div>
+                            </span>
+                          </label>
+                          <input
+                            checked={false}
+                            className="bx--tile-input"
+                            id="extra-wide-image"
+                            onChange={[Function]}
+                            tabIndex={-1}
+                            title="title"
+                            type="checkbox"
+                            value="value"
+                          />
+                          <label
+                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                            htmlFor="extra-wide-image"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            selected={false}
+                            tabIndex={0}
+                          >
+                            <span
+                              className="bx--tile__checkmark"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="currentColor"
+                                focusable="false"
+                                height={16}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                />
+                                <path
+                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                  data-icon-path="inner-path"
+                                  opacity="0"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              className="bx--tile-content"
+                            >
+                              <div
+                                className="iot--image-tile__title"
+                              >
+                                <span>
+                                  extra-wide-image
+                                </span>
+                              </div>
+                              <div
+                                className="iot--image-tile__image-container"
+                              >
+                                <img
+                                  alt="extra wide image"
+                                  src="extra-wide-image.png"
+                                />
+                              </div>
+                            </span>
+                          </label>
+                          <input
+                            checked={false}
+                            className="bx--tile-input"
+                            id="large"
+                            onChange={[Function]}
+                            tabIndex={-1}
+                            title="title"
+                            type="checkbox"
+                            value="value"
+                          />
+                          <label
+                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                            htmlFor="large"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            selected={false}
+                            tabIndex={0}
+                          >
+                            <span
+                              className="bx--tile__checkmark"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="currentColor"
+                                focusable="false"
+                                height={16}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                />
+                                <path
+                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                  data-icon-path="inner-path"
+                                  opacity="0"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              className="bx--tile-content"
+                            >
+                              <div
+                                className="iot--image-tile__title"
+                              >
+                                <span>
+                                  large
+                                </span>
+                              </div>
+                              <div
+                                className="iot--image-tile__image-container"
+                              >
+                                <img
+                                  alt="large image"
+                                  src="large.png"
+                                />
+                              </div>
+                            </span>
+                          </label>
+                          <input
+                            checked={false}
+                            className="bx--tile-input"
+                            id="large_portrait"
+                            onChange={[Function]}
+                            tabIndex={-1}
+                            title="title"
+                            type="checkbox"
+                            value="value"
+                          />
+                          <label
+                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                            htmlFor="large_portrait"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            selected={false}
+                            tabIndex={0}
+                          >
+                            <span
+                              className="bx--tile__checkmark"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="currentColor"
+                                focusable="false"
+                                height={16}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                />
+                                <path
+                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                  data-icon-path="inner-path"
+                                  opacity="0"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              className="bx--tile-content"
+                            >
+                              <div
+                                className="iot--image-tile__title"
+                              >
+                                <span>
+                                  large_portrait
+                                </span>
+                              </div>
+                              <div
+                                className="iot--image-tile__image-container"
+                              >
+                                <img
+                                  alt="large image portrait"
+                                  src="large_portrait.png"
+                                />
+                              </div>
+                            </span>
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="bx--modal-footer iot--composed-modal-footer"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--secondary"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                        disabled={true}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Select
+                      </button>
+                    </div>
+                  </div>
+                  <span
+                    className="bx--visually-hidden"
+                    role="link"
+                    tabIndex="0"
+                  >
+                    Focus sentinel
+                  </span>
+                </div>
                 <div
                   style={
                     Object {
@@ -3504,6 +4777,246 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 className="iot--dashboard-editor--preview__grid-container"
               >
                 <div
+                  className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
+                  data-floating-menu-container={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onClose={[Function]}
+                  onKeyDown={[Function]}
+                  open={false}
+                  role="presentation"
+                >
+                  <span
+                    className="bx--visually-hidden"
+                    role="link"
+                    tabIndex="0"
+                  >
+                    Focus sentinel
+                  </span>
+                  <div
+                    className="bx--modal-container"
+                    role="dialog"
+                  >
+                    <div
+                      className="bx--modal-header"
+                    >
+                      <p
+                        className="bx--modal-header__label bx--type-delta"
+                      >
+                        New image card
+                      </p>
+                      <p
+                        className="bx--modal-header__heading bx--type-beta"
+                      >
+                        Image gallery
+                      </p>
+                      <button
+                        aria-label="Close"
+                        className="bx--modal-close"
+                        onClick={[Function]}
+                        title="Close"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="bx--modal-close__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    <div
+                      className="bx--modal-content"
+                    >
+                      <div
+                        className="iot--image-gallery-modal__top-section"
+                      >
+                        <p
+                          alt="Select the image that you want to display on this card."
+                          className="iot--image-gallery-modal__instruction-text"
+                        >
+                          Select the image that you want to display on this card.
+                        </p>
+                        <div
+                          className="iot--image-gallery-modal__search-list-view-container"
+                        >
+                          <div
+                            aria-labelledby="iot--image-gallery-modal--search-search"
+                            className="bx--search bx--search--xl bx--search--light"
+                            role="search"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="bx--search-magnifier"
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                              />
+                            </svg>
+                            <label
+                              className="bx--label"
+                              htmlFor="iot--image-gallery-modal--search"
+                              id="iot--image-gallery-modal--search-search"
+                            >
+                              
+                            </label>
+                            <input
+                              autoComplete="off"
+                              className="bx--search-input"
+                              id="iot--image-gallery-modal--search"
+                              onChange={[Function]}
+                              placeholder="Search image by file name"
+                              role="searchbox"
+                              type="text"
+                            />
+                            <button
+                              aria-label="Clear search input"
+                              className="bx--search-close bx--search-close--hidden"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="currentColor"
+                                focusable="false"
+                                height={16}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 32 32"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <div
+                            className="bx--content-switcher iot--image-gallery-modal__content-switcher"
+                            onChange={[Function]}
+                            role="tablist"
+                          >
+                            <button
+                              className="iot--icon-switch iot--icon-switch--large bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                              disabled={false}
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              tabIndex={0}
+                              type="button"
+                            >
+                              <span
+                                className="bx--assistive-text"
+                              >
+                                Grid
+                              </span>
+                              <svg
+                                aria-hidden="true"
+                                aria-label="Grid"
+                                className="bx--btn__icon"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12 4H6A2 2 0 004 6v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0012 4zm0 8H6V6h6zM26 4H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0026 4zm0 8H20V6h6zM12 18H6a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0012 18zm0 8H6V20h6zM26 18H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0026 18zm0 8H20V20h6z"
+                                />
+                              </svg>
+                            </button>
+                            <button
+                              className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                              disabled={false}
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              tabIndex={0}
+                              type="button"
+                            >
+                              <span
+                                className="bx--assistive-text"
+                              >
+                                List
+                              </span>
+                              <svg
+                                aria-hidden="true"
+                                aria-label="List"
+                                className="bx--btn__icon"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M10 6H28V8H10zM10 24H28V26H10zM10 15H28V17H10zM4 15H6V17H4zM4 6H6V8H4zM4 24H6V26H4z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--image-gallery-modal__flex-wrapper"
+                      >
+                        <div
+                          className="iot--image-gallery-modal__scroll-panel iot--image-gallery-modal__scroll-panel--grid"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      className="bx--modal-footer iot--composed-modal-footer"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--secondary"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                        disabled={true}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Select
+                      </button>
+                    </div>
+                  </div>
+                  <span
+                    className="bx--visually-hidden"
+                    role="link"
+                    tabIndex="0"
+                  >
+                    Focus sentinel
+                  </span>
+                </div>
+                <div
                   style={
                     Object {
                       "flex": 1,
@@ -4450,6 +5963,246 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               <div
                 className="iot--dashboard-editor--preview__grid-container"
               >
+                <div
+                  className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
+                  data-floating-menu-container={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onClose={[Function]}
+                  onKeyDown={[Function]}
+                  open={false}
+                  role="presentation"
+                >
+                  <span
+                    className="bx--visually-hidden"
+                    role="link"
+                    tabIndex="0"
+                  >
+                    Focus sentinel
+                  </span>
+                  <div
+                    className="bx--modal-container"
+                    role="dialog"
+                  >
+                    <div
+                      className="bx--modal-header"
+                    >
+                      <p
+                        className="bx--modal-header__label bx--type-delta"
+                      >
+                        New image card
+                      </p>
+                      <p
+                        className="bx--modal-header__heading bx--type-beta"
+                      >
+                        Image gallery
+                      </p>
+                      <button
+                        aria-label="Close"
+                        className="bx--modal-close"
+                        onClick={[Function]}
+                        title="Close"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="bx--modal-close__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    <div
+                      className="bx--modal-content"
+                    >
+                      <div
+                        className="iot--image-gallery-modal__top-section"
+                      >
+                        <p
+                          alt="Select the image that you want to display on this card."
+                          className="iot--image-gallery-modal__instruction-text"
+                        >
+                          Select the image that you want to display on this card.
+                        </p>
+                        <div
+                          className="iot--image-gallery-modal__search-list-view-container"
+                        >
+                          <div
+                            aria-labelledby="iot--image-gallery-modal--search-search"
+                            className="bx--search bx--search--xl bx--search--light"
+                            role="search"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="bx--search-magnifier"
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                              />
+                            </svg>
+                            <label
+                              className="bx--label"
+                              htmlFor="iot--image-gallery-modal--search"
+                              id="iot--image-gallery-modal--search-search"
+                            >
+                              
+                            </label>
+                            <input
+                              autoComplete="off"
+                              className="bx--search-input"
+                              id="iot--image-gallery-modal--search"
+                              onChange={[Function]}
+                              placeholder="Search image by file name"
+                              role="searchbox"
+                              type="text"
+                            />
+                            <button
+                              aria-label="Clear search input"
+                              className="bx--search-close bx--search-close--hidden"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="currentColor"
+                                focusable="false"
+                                height={16}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 32 32"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <div
+                            className="bx--content-switcher iot--image-gallery-modal__content-switcher"
+                            onChange={[Function]}
+                            role="tablist"
+                          >
+                            <button
+                              className="iot--icon-switch iot--icon-switch--large bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                              disabled={false}
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              tabIndex={0}
+                              type="button"
+                            >
+                              <span
+                                className="bx--assistive-text"
+                              >
+                                Grid
+                              </span>
+                              <svg
+                                aria-hidden="true"
+                                aria-label="Grid"
+                                className="bx--btn__icon"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12 4H6A2 2 0 004 6v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0012 4zm0 8H6V6h6zM26 4H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0026 4zm0 8H20V6h6zM12 18H6a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0012 18zm0 8H6V20h6zM26 18H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0026 18zm0 8H20V20h6z"
+                                />
+                              </svg>
+                            </button>
+                            <button
+                              className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                              disabled={false}
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              tabIndex={0}
+                              type="button"
+                            >
+                              <span
+                                className="bx--assistive-text"
+                              >
+                                List
+                              </span>
+                              <svg
+                                aria-hidden="true"
+                                aria-label="List"
+                                className="bx--btn__icon"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M10 6H28V8H10zM10 24H28V26H10zM10 15H28V17H10zM4 15H6V17H4zM4 6H6V8H4zM4 24H6V26H4z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--image-gallery-modal__flex-wrapper"
+                      >
+                        <div
+                          className="iot--image-gallery-modal__scroll-panel iot--image-gallery-modal__scroll-panel--grid"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      className="bx--modal-footer iot--composed-modal-footer"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--secondary"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                        disabled={true}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Select
+                      </button>
+                    </div>
+                  </div>
+                  <span
+                    className="bx--visually-hidden"
+                    role="link"
+                    tabIndex="0"
+                  >
+                    Focus sentinel
+                  </span>
+                </div>
                 <div
                   style={
                     Object {
@@ -5503,6 +7256,246 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               <div
                 className="iot--dashboard-editor--preview__grid-container"
               >
+                <div
+                  className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
+                  data-floating-menu-container={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onClose={[Function]}
+                  onKeyDown={[Function]}
+                  open={false}
+                  role="presentation"
+                >
+                  <span
+                    className="bx--visually-hidden"
+                    role="link"
+                    tabIndex="0"
+                  >
+                    Focus sentinel
+                  </span>
+                  <div
+                    className="bx--modal-container"
+                    role="dialog"
+                  >
+                    <div
+                      className="bx--modal-header"
+                    >
+                      <p
+                        className="bx--modal-header__label bx--type-delta"
+                      >
+                        New image card
+                      </p>
+                      <p
+                        className="bx--modal-header__heading bx--type-beta"
+                      >
+                        Image gallery
+                      </p>
+                      <button
+                        aria-label="Close"
+                        className="bx--modal-close"
+                        onClick={[Function]}
+                        title="Close"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="bx--modal-close__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    <div
+                      className="bx--modal-content"
+                    >
+                      <div
+                        className="iot--image-gallery-modal__top-section"
+                      >
+                        <p
+                          alt="Select the image that you want to display on this card."
+                          className="iot--image-gallery-modal__instruction-text"
+                        >
+                          Select the image that you want to display on this card.
+                        </p>
+                        <div
+                          className="iot--image-gallery-modal__search-list-view-container"
+                        >
+                          <div
+                            aria-labelledby="iot--image-gallery-modal--search-search"
+                            className="bx--search bx--search--xl bx--search--light"
+                            role="search"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="bx--search-magnifier"
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                              />
+                            </svg>
+                            <label
+                              className="bx--label"
+                              htmlFor="iot--image-gallery-modal--search"
+                              id="iot--image-gallery-modal--search-search"
+                            >
+                              
+                            </label>
+                            <input
+                              autoComplete="off"
+                              className="bx--search-input"
+                              id="iot--image-gallery-modal--search"
+                              onChange={[Function]}
+                              placeholder="Search image by file name"
+                              role="searchbox"
+                              type="text"
+                            />
+                            <button
+                              aria-label="Clear search input"
+                              className="bx--search-close bx--search-close--hidden"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="currentColor"
+                                focusable="false"
+                                height={16}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 32 32"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <div
+                            className="bx--content-switcher iot--image-gallery-modal__content-switcher"
+                            onChange={[Function]}
+                            role="tablist"
+                          >
+                            <button
+                              className="iot--icon-switch iot--icon-switch--large bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                              disabled={false}
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              tabIndex={0}
+                              type="button"
+                            >
+                              <span
+                                className="bx--assistive-text"
+                              >
+                                Grid
+                              </span>
+                              <svg
+                                aria-hidden="true"
+                                aria-label="Grid"
+                                className="bx--btn__icon"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12 4H6A2 2 0 004 6v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0012 4zm0 8H6V6h6zM26 4H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0026 4zm0 8H20V6h6zM12 18H6a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0012 18zm0 8H6V20h6zM26 18H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0026 18zm0 8H20V20h6z"
+                                />
+                              </svg>
+                            </button>
+                            <button
+                              className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                              disabled={false}
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              tabIndex={0}
+                              type="button"
+                            >
+                              <span
+                                className="bx--assistive-text"
+                              >
+                                List
+                              </span>
+                              <svg
+                                aria-hidden="true"
+                                aria-label="List"
+                                className="bx--btn__icon"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M10 6H28V8H10zM10 24H28V26H10zM10 15H28V17H10zM4 15H6V17H4zM4 6H6V8H4zM4 24H6V26H4z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--image-gallery-modal__flex-wrapper"
+                      >
+                        <div
+                          className="iot--image-gallery-modal__scroll-panel iot--image-gallery-modal__scroll-panel--grid"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      className="bx--modal-footer iot--composed-modal-footer"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--secondary"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                        disabled={true}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Select
+                      </button>
+                    </div>
+                  </div>
+                  <span
+                    className="bx--visually-hidden"
+                    role="link"
+                    tabIndex="0"
+                  >
+                    Focus sentinel
+                  </span>
+                </div>
                 <div
                   style={
                     Object {
@@ -8109,6 +10102,246 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               <div
                 className="iot--dashboard-editor--preview__grid-container"
               >
+                <div
+                  className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
+                  data-floating-menu-container={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onClose={[Function]}
+                  onKeyDown={[Function]}
+                  open={false}
+                  role="presentation"
+                >
+                  <span
+                    className="bx--visually-hidden"
+                    role="link"
+                    tabIndex="0"
+                  >
+                    Focus sentinel
+                  </span>
+                  <div
+                    className="bx--modal-container"
+                    role="dialog"
+                  >
+                    <div
+                      className="bx--modal-header"
+                    >
+                      <p
+                        className="bx--modal-header__label bx--type-delta"
+                      >
+                        New image card
+                      </p>
+                      <p
+                        className="bx--modal-header__heading bx--type-beta"
+                      >
+                        Image gallery
+                      </p>
+                      <button
+                        aria-label="Close"
+                        className="bx--modal-close"
+                        onClick={[Function]}
+                        title="Close"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="bx--modal-close__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    <div
+                      className="bx--modal-content"
+                    >
+                      <div
+                        className="iot--image-gallery-modal__top-section"
+                      >
+                        <p
+                          alt="Select the image that you want to display on this card."
+                          className="iot--image-gallery-modal__instruction-text"
+                        >
+                          Select the image that you want to display on this card.
+                        </p>
+                        <div
+                          className="iot--image-gallery-modal__search-list-view-container"
+                        >
+                          <div
+                            aria-labelledby="iot--image-gallery-modal--search-search"
+                            className="bx--search bx--search--xl bx--search--light"
+                            role="search"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="bx--search-magnifier"
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                              />
+                            </svg>
+                            <label
+                              className="bx--label"
+                              htmlFor="iot--image-gallery-modal--search"
+                              id="iot--image-gallery-modal--search-search"
+                            >
+                              
+                            </label>
+                            <input
+                              autoComplete="off"
+                              className="bx--search-input"
+                              id="iot--image-gallery-modal--search"
+                              onChange={[Function]}
+                              placeholder="Search image by file name"
+                              role="searchbox"
+                              type="text"
+                            />
+                            <button
+                              aria-label="Clear search input"
+                              className="bx--search-close bx--search-close--hidden"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="currentColor"
+                                focusable="false"
+                                height={16}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 32 32"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <div
+                            className="bx--content-switcher iot--image-gallery-modal__content-switcher"
+                            onChange={[Function]}
+                            role="tablist"
+                          >
+                            <button
+                              className="iot--icon-switch iot--icon-switch--large bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                              disabled={false}
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              tabIndex={0}
+                              type="button"
+                            >
+                              <span
+                                className="bx--assistive-text"
+                              >
+                                Grid
+                              </span>
+                              <svg
+                                aria-hidden="true"
+                                aria-label="Grid"
+                                className="bx--btn__icon"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12 4H6A2 2 0 004 6v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0012 4zm0 8H6V6h6zM26 4H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0026 4zm0 8H20V6h6zM12 18H6a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0012 18zm0 8H6V20h6zM26 18H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0026 18zm0 8H20V20h6z"
+                                />
+                              </svg>
+                            </button>
+                            <button
+                              className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                              disabled={false}
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              tabIndex={0}
+                              type="button"
+                            >
+                              <span
+                                className="bx--assistive-text"
+                              >
+                                List
+                              </span>
+                              <svg
+                                aria-hidden="true"
+                                aria-label="List"
+                                className="bx--btn__icon"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M10 6H28V8H10zM10 24H28V26H10zM10 15H28V17H10zM4 15H6V17H4zM4 6H6V8H4zM4 24H6V26H4z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--image-gallery-modal__flex-wrapper"
+                      >
+                        <div
+                          className="iot--image-gallery-modal__scroll-panel iot--image-gallery-modal__scroll-panel--grid"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      className="bx--modal-footer iot--composed-modal-footer"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--secondary"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                        disabled={true}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Select
+                      </button>
+                    </div>
+                  </div>
+                  <span
+                    className="bx--visually-hidden"
+                    role="link"
+                    tabIndex="0"
+                  >
+                    Focus sentinel
+                  </span>
+                </div>
                 <div
                   style={
                     Object {

--- a/src/components/ImageGalleryModal/ImageGalleryModal.jsx
+++ b/src/components/ImageGalleryModal/ImageGalleryModal.jsx
@@ -17,25 +17,34 @@ const LIST = 'list';
 
 const { iotPrefix } = settings;
 
+export const ImagePropTypes = PropTypes.arrayOf(
+  PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    src: PropTypes.string.isRequired,
+    /** The alt attribute of the image element */
+    alt: PropTypes.string,
+    /** Title to be shown above image. Defaults to file name from src. */
+    title: PropTypes.string,
+  })
+);
+
 const propTypes = {
   ...ComposedModalPropTypes, // eslint-disable-line react/forbid-foreign-prop-types
   /** Classname to be added to the root node */
   className: PropTypes.string,
   /** Array of the images that should be shown */
-  content: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.string.isRequired,
-      src: PropTypes.string.isRequired,
-      /** The alt attribute of the image element */
-      alt: PropTypes.string,
-      /** Title to be shown above image. Defaults to file name from src. */
-      title: PropTypes.string,
-    })
-  ),
+  content: ImagePropTypes,
   /** The name of the view to be selected by default */
   defaultView: PropTypes.oneOf([GRID, LIST]),
   /** The footer prop of the ComposedModalPropTypes */
   footer: ComposedModalPropTypes.footer,
+  /** Callback called with selected image props when modal submit button is pressed. */
+  onSubmit: PropTypes.func.isRequired,
+  /** Callback called when modal close icon or cancel button is pressed */
+  onClose: PropTypes.func.isRequired,
+  /** The image property to be included in the search */
+  searchProperty: PropTypes.string,
+
   /** The text of the grid button in the grid list toggle */
   gridButtonText: PropTypes.string,
   /** The text with instructions showing above the search */
@@ -51,14 +60,8 @@ const propTypes = {
   modalPrimaryButtonLabelText: PropTypes.string,
   /** The secondary button (cancel) text of the modal */
   modalSecondaryButtonLabelText: PropTypes.string,
-  /** Callback called with selected image props when modal submit button is pressed. */
-  onSubmit: PropTypes.func.isRequired,
-  /** Callback called when modal close icon or cancel button is pressed */
-  onClose: PropTypes.func.isRequired,
   /** The text for the search input placeHolder */
   searchPlaceHolderText: PropTypes.string,
-  /** The image property to be included in the search */
-  searchProperty: PropTypes.string,
 };
 
 const defaultProps = {
@@ -66,6 +69,8 @@ const defaultProps = {
   content: [],
   defaultView: GRID,
   footer: {},
+  searchProperty: 'id',
+
   gridButtonText: 'Grid',
   instructionText: 'Select the image that you want to display on this card.',
   listButtonText: 'List',
@@ -75,7 +80,6 @@ const defaultProps = {
   modalSecondaryButtonLabelText: 'Cancel',
   modalCloseIconDescriptionText: 'Close',
   searchPlaceHolderText: 'Search image by file name',
-  searchProperty: 'src',
 };
 
 const ImageGalleryModal = ({

--- a/src/components/ImageGalleryModal/ImageGalleryModal.test.jsx
+++ b/src/components/ImageGalleryModal/ImageGalleryModal.test.jsx
@@ -70,7 +70,7 @@ describe('ImageGalleryModal', () => {
     expect(screen.getByAltText(content[1].alt)).toBeVisible();
     expect(screen.getByAltText(content[2].alt)).toBeVisible();
 
-    userEvent.type(screen.getByRole('searchbox'), 'imagE-b');
+    userEvent.type(screen.getByRole('searchbox'), 'b');
     expect(screen.queryAllByAltText(content[0].alt)).toHaveLength(0);
     expect(screen.getByAltText(content[1].alt)).toBeVisible();
     expect(screen.queryAllByAltText(content[2].alt)).toHaveLength(0);

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -6188,7 +6188,7 @@ Map {
       "modalSecondaryButtonLabelText": "Cancel",
       "modalTitleText": "Image gallery",
       "searchPlaceHolderText": "Search image by file name",
-      "searchProperty": "src",
+      "searchProperty": "id",
     },
     "propTypes": Object {
       "children": Object {
@@ -8355,6 +8355,7 @@ Map {
   "DashboardEditor" => Object {
     "defaultProps": Object {
       "availableDimensions": Object {},
+      "availableImages": Array [],
       "breakpointSwitcher": null,
       "dataItems": Array [],
       "getValidDataItems": null,
@@ -8417,6 +8418,32 @@ Map {
           Object {},
         ],
         "type": "shape",
+      },
+      "availableImages": Object {
+        "args": Array [
+          Object {
+            "args": Array [
+              Object {
+                "alt": Object {
+                  "type": "string",
+                },
+                "id": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+                "src": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+                "title": Object {
+                  "type": "string",
+                },
+              },
+            ],
+            "type": "shape",
+          },
+        ],
+        "type": "arrayOf",
       },
       "breakpointSwitcher": Object {
         "args": Array [
@@ -8503,6 +8530,33 @@ Map {
               "type": "string",
             },
             "headerXlargeButton": Object {
+              "type": "string",
+            },
+            "imageGalleryGridButtonText": Object {
+              "type": "string",
+            },
+            "imageGalleryInstructionText": Object {
+              "type": "string",
+            },
+            "imageGalleryListButtonText": Object {
+              "type": "string",
+            },
+            "imageGalleryModalCloseIconDescriptionText": Object {
+              "type": "string",
+            },
+            "imageGalleryModalLabelText": Object {
+              "type": "string",
+            },
+            "imageGalleryModalPrimaryButtonLabelText": Object {
+              "type": "string",
+            },
+            "imageGalleryModalSecondaryButtonLabelText": Object {
+              "type": "string",
+            },
+            "imageGalleryModalTitleText": Object {
+              "type": "string",
+            },
+            "imageGallerySearchPlaceHolderText": Object {
               "type": "string",
             },
             "layoutInfoLg": Object {


### PR DESCRIPTION
Partial/further work of #1786, #1741 

**Summary**

- feat(ImageGallery): links the imageGallery to be used in the DashboardEditor

**Change List (commits, features, bugs, etc)**

- fix(ImageCardFormContent): temporarily hide the Edit Image button as the hotspot editing isn't ready yet
- feat(DashboardEditor): show/hide and update the cards based on the ImageGalleryModal
- fix(ImageGalleryModal): should search on id by default since src usually is a base64 encoded string

**Acceptance Test (how to verify the PR)**

- Verify you can select images from the ImageGallery in the DashboardEditor
