### PR TITLE
fix(TableCard): encode variables for linkTemplate

### DIFF
--- a/src/components/TableCard/TableCard.story.jsx
+++ b/src/components/TableCard/TableCard.story.jsx
@@ -71,6 +71,7 @@ export const WithLinks = () => {
   );
   const cardVariables = object('Dynamic link variable', {
     assetId: '11112',
+    company: 'ibm',
   });
   const tableLinkColumns = [
     {
@@ -81,7 +82,7 @@ export const WithLinks = () => {
       dataSourceId: 'deviceId',
       label: 'Link',
       linkTemplate: {
-        href: text('href', 'https://ibm.com/{assetId}'),
+        href: text('href', 'https://{company}.com/{assetId}'),
         target: select('target', ['_blank', null], '_blank'),
       },
     },
@@ -150,7 +151,7 @@ export const WithRowSpecificLinkVariables = () => {
       dataSourceId: 'Link',
       label: 'Link',
       linkTemplate: {
-        href: text('href', 'https://ibm.com/{deviceId}'),
+        href: text('href', 'https://ibm.com/{deviceId}?time={hour}'),
         target: select('target', ['_blank', null], '_blank'),
       },
     },

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -4648,7 +4648,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           >
                             <a
                               className="bx--link"
-                              href="https://ibm.com/73003"
+                              href="https://ibm.com/73003?time=10%2F28%2F2018%2007%3A34"
                               target="_blank"
                             >
                               Link
@@ -4840,7 +4840,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           >
                             <a
                               className="bx--link"
-                              href="https://ibm.com/73005"
+                              href="https://ibm.com/73005?time=10%2F28%2F2018%2007%3A34"
                               target="_blank"
                             >
                               Link
@@ -4987,7 +4987,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           >
                             <a
                               className="bx--link"
-                              href="https://ibm.com/73000"
+                              href="https://ibm.com/73000?time=10%2F28%2F2018%2007%3A34"
                               target="_blank"
                             >
                               Link
@@ -5179,7 +5179,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           >
                             <a
                               className="bx--link"
-                              href="https://ibm.com/73000"
+                              href="https://ibm.com/73000?time=10%2F28%2F2018%2007%3A34"
                               target="_blank"
                             >
                               Link
@@ -5371,7 +5371,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           >
                             <a
                               className="bx--link"
-                              href="https://ibm.com/73004"
+                              href="https://ibm.com/73004?time=10%2F28%2F2018%2007%3A34"
                               target="_blank"
                             >
                               Link
@@ -5563,7 +5563,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           >
                             <a
                               className="bx--link"
-                              href="https://ibm.com/73001"
+                              href="https://ibm.com/73001?time=10%2F28%2F2018%2007%3A34"
                               target="_blank"
                             >
                               Link
@@ -5710,7 +5710,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           >
                             <a
                               className="bx--link"
-                              href="https://ibm.com/73000"
+                              href="https://ibm.com/73000?time=10%2F28%2F2018%2007%3A34"
                               target="_blank"
                             >
                               Link
@@ -5857,7 +5857,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           >
                             <a
                               className="bx--link"
-                              href="https://ibm.com/73003"
+                              href="https://ibm.com/73003?time=10%2F28%2F2018%2007%3A34"
                               target="_blank"
                             >
                               Link
@@ -6004,7 +6004,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           >
                             <a
                               className="bx--link"
-                              href="https://ibm.com/73005"
+                              href="https://ibm.com/73005?time=10%2F28%2F2018%2007%3A34"
                               target="_blank"
                             >
                               Link
@@ -6196,7 +6196,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           >
                             <a
                               className="bx--link"
-                              href="https://ibm.com/73002"
+                              href="https://ibm.com/73002?time=10%2F28%2F2018%2007%3A34"
                               target="_blank"
                             >
                               Link

--- a/src/components/TableCard/tableCardUtils.jsx
+++ b/src/components/TableCard/tableCardUtils.jsx
@@ -45,9 +45,12 @@ export const createColumnsWithFormattedLinks = (columns, cardVariables) => {
             variableLink = linkTemplate.href;
             variables.forEach((variable) => {
               const variableValue = row[variable];
+              // encode value so the URL can be valid
+              const encodedValue = encodeURIComponent(variableValue);
+
               variableLink = variableLink.replace(
                 `{${variable}}`,
-                variableValue
+                encodedValue
               );
             });
           }
@@ -90,7 +93,9 @@ export const handleExpandedItemLinks = (row, expandedRow, cardVariables) => {
       variableLink = linkTemplate.href;
       variables.forEach((variable) => {
         const variableValue = row[variable];
-        variableLink = variableLink.replace(`{${variable}}`, variableValue);
+        // encode value so the URL can be valid
+        const encodedValue = encodeURIComponent(variableValue);
+        variableLink = variableLink.replace(`{${variable}}`, encodedValue);
       });
     }
     if (linkTemplate) {


### PR DESCRIPTION
Closes #1853

**Summary**

- Theres little control over row-specific variables as they're added in the renderDataFunction and can only use the current rows formatting. For example, if a timestamp is already being formatted in another column, the variable will also be formatted, which could cause problems in the URL. For example 7/20/2020 02:00 is not valid in URLs, but it still needs to be formatted in the other column
- This PR solves this issue by first encoding the variable, then passing it to the URL

**Acceptance Test (how to verify the PR)**

- Go to /?path=/story/watson-iot-tablecard--with-row-specific-link-variables and see that the `Link` values are being formatted with URL encoding
