### PR TITLE
fix(overflow): removed default background color for button

### DIFF
--- a/src/components/OverflowMenu/_overflow-menu.scss
+++ b/src/components/OverflowMenu/_overflow-menu.scss
@@ -1,1 +1,5 @@
 @import '~carbon-components/scss/components/overflow-menu/overflow-menu';
+
+button.#{$prefix}--overflow-menu {
+  background-color: none;
+}


### PR DESCRIPTION
Closes #1852

**Summary**

- Removed the background color from the overflow button

**Change List (commits, features, bugs, etc)**

- _overflow-menu.scss

**Acceptance Test (how to verify the PR)**

- head on over to https://deploy-preview-1858--carbon-addons-iot-react.netlify.app?path=/story/overflowmenu--basic and verify the background color was removed.
- Should look exactly like: https://carbon-addons-iot-react.com/?path=/story/overflowmenu--basic
