### PR TITLE
(feat): Consistent  header for CardEditor 

### DIFF
--- a/src/components/CardEditor/CardEditor.jsx
+++ b/src/components/CardEditor/CardEditor.jsx
@@ -133,7 +133,15 @@ const CardEditor = ({
             {mergedI18n.addCardButton}
           </Button>
         </div>
-      ) : null}
+      ) : (
+        <div className={`${baseClassName}--header`}>
+          <h2 className={`${baseClassName}--header--title`}>
+            {mergedI18n.galleryHeader}
+          </h2>
+        </div>
+      )
+
+      }
       <div className={`${baseClassName}--content`}>
         {showGallery ? (
           <CardGalleryList

--- a/src/components/CardEditor/CardEditor.jsx
+++ b/src/components/CardEditor/CardEditor.jsx
@@ -139,9 +139,7 @@ const CardEditor = ({
             {mergedI18n.galleryHeader}
           </h2>
         </div>
-      )
-
-      }
+      )}
       <div className={`${baseClassName}--content`}>
         {showGallery ? (
           <CardGalleryList

--- a/src/components/CardEditor/CardGalleryList/CardGalleryList.jsx
+++ b/src/components/CardEditor/CardGalleryList/CardGalleryList.jsx
@@ -71,6 +71,7 @@ const CardGalleryList = ({ supportedCardTypes, onAddCard, i18n }) => {
   const mergedI18n = { ...defaultProps.i18n, ...i18n };
   return (
     <SimpleList
+      title=""
       isFullHeight
       hasSearch
       hasPagination={false}

--- a/src/components/CardEditor/CardGalleryList/CardGalleryList.jsx
+++ b/src/components/CardEditor/CardGalleryList/CardGalleryList.jsx
@@ -71,7 +71,6 @@ const CardGalleryList = ({ supportedCardTypes, onAddCard, i18n }) => {
   const mergedI18n = { ...defaultProps.i18n, ...i18n };
   return (
     <SimpleList
-      title={mergedI18n.galleryHeader}
       isFullHeight
       hasSearch
       hasPagination={false}

--- a/src/components/CardEditor/__snapshots__/CardEditor.story.storyshot
+++ b/src/components/CardEditor/__snapshots__/CardEditor.story.storyshot
@@ -3065,6 +3065,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         className="iot--card-editor"
       >
         <div
+          className="iot--card-editor--header"
+        >
+          <h2
+            className="iot--card-editor--header--title"
+          >
+            Gallery
+          </h2>
+        </div>
+        <div
           className="iot--card-editor--content"
         >
           <div
@@ -3073,18 +3082,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             <div
               className="iot--list-header-container"
             >
-              <div
-                className="iot--list-header"
-              >
-                <div
-                  className="iot--list-header--title"
-                >
-                  Gallery
-                </div>
-                <div
-                  className="iot--list-header--btn-container"
-                />
-              </div>
               <div
                 className="iot--list-header--search"
               >

--- a/src/components/CardEditor/_card-editor.scss
+++ b/src/components/CardEditor/_card-editor.scss
@@ -6,7 +6,7 @@
   flex-direction: column;
   border-left: 1px solid $ui-03;
   &--header {
-    flex: 0 0 3rem;
+    flex: 0 0 3.5rem;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -17,6 +17,7 @@
     }
     button.gallery-button {
       /* make ghost button stretch full width */
+      height: calc(100% - 0.5rem);
       justify-content: space-between;
       width: 100%;
     }
@@ -29,5 +30,11 @@
     .#{$iot-prefix}--list-item {
       height: $spacing-09;
     }
+  }
+
+  &--header--title {
+    @include type-style('productive-heading-02');
+    padding-left: $spacing-03;
+    width: 100%;
   }
 }

--- a/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -861,6 +861,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             className="iot--card-editor"
           >
             <div
+              className="iot--card-editor--header"
+            >
+              <h2
+                className="iot--card-editor--header--title"
+              >
+                Gallery
+              </h2>
+            </div>
+            <div
               className="iot--card-editor--content"
             >
               <div
@@ -869,18 +878,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 <div
                   className="iot--list-header-container"
                 >
-                  <div
-                    className="iot--list-header"
-                  >
-                    <div
-                      className="iot--list-header--title"
-                    >
-                      Gallery
-                    </div>
-                    <div
-                      className="iot--list-header--btn-container"
-                    />
-                  </div>
                   <div
                     className="iot--list-header--search"
                   >
@@ -1868,6 +1865,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             className="iot--card-editor"
           >
             <div
+              className="iot--card-editor--header"
+            >
+              <h2
+                className="iot--card-editor--header--title"
+              >
+                Gallery
+              </h2>
+            </div>
+            <div
               className="iot--card-editor--content"
             >
               <div
@@ -1876,18 +1882,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 <div
                   className="iot--list-header-container"
                 >
-                  <div
-                    className="iot--list-header"
-                  >
-                    <div
-                      className="iot--list-header--title"
-                    >
-                      Gallery
-                    </div>
-                    <div
-                      className="iot--list-header--btn-container"
-                    />
-                  </div>
                   <div
                     className="iot--list-header--search"
                   >
@@ -3608,6 +3602,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             className="iot--card-editor"
           >
             <div
+              className="iot--card-editor--header"
+            >
+              <h2
+                className="iot--card-editor--header--title"
+              >
+                Gallery
+              </h2>
+            </div>
+            <div
               className="iot--card-editor--content"
             >
               <div
@@ -3616,18 +3619,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 <div
                   className="iot--list-header-container"
                 >
-                  <div
-                    className="iot--list-header"
-                  >
-                    <div
-                      className="iot--list-header--title"
-                    >
-                      Gallery
-                    </div>
-                    <div
-                      className="iot--list-header--btn-container"
-                    />
-                  </div>
                   <div
                     className="iot--list-header--search"
                   >
@@ -5047,6 +5038,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             className="iot--card-editor"
           >
             <div
+              className="iot--card-editor--header"
+            >
+              <h2
+                className="iot--card-editor--header--title"
+              >
+                Gallery
+              </h2>
+            </div>
+            <div
               className="iot--card-editor--content"
             >
               <div
@@ -5055,18 +5055,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 <div
                   className="iot--list-header-container"
                 >
-                  <div
-                    className="iot--list-header"
-                  >
-                    <div
-                      className="iot--list-header--title"
-                    >
-                      Gallery
-                    </div>
-                    <div
-                      className="iot--list-header--btn-container"
-                    />
-                  </div>
                   <div
                     className="iot--list-header--search"
                   >
@@ -6340,6 +6328,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             className="iot--card-editor"
           >
             <div
+              className="iot--card-editor--header"
+            >
+              <h2
+                className="iot--card-editor--header--title"
+              >
+                Gallery
+              </h2>
+            </div>
+            <div
               className="iot--card-editor--content"
             >
               <div
@@ -6348,18 +6345,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 <div
                   className="iot--list-header-container"
                 >
-                  <div
-                    className="iot--list-header"
-                  >
-                    <div
-                      className="iot--list-header--title"
-                    >
-                      Gallery
-                    </div>
-                    <div
-                      className="iot--list-header--btn-container"
-                    />
-                  </div>
                   <div
                     className="iot--list-header--search"
                   >
@@ -8984,6 +8969,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             className="iot--card-editor"
           >
             <div
+              className="iot--card-editor--header"
+            >
+              <h2
+                className="iot--card-editor--header--title"
+              >
+                Gallery
+              </h2>
+            </div>
+            <div
               className="iot--card-editor--content"
             >
               <div
@@ -8992,18 +8986,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 <div
                   className="iot--list-header-container"
                 >
-                  <div
-                    className="iot--list-header"
-                  >
-                    <div
-                      className="iot--list-header--title"
-                    >
-                      Gallery
-                    </div>
-                    <div
-                      className="iot--list-header--btn-container"
-                    />
-                  </div>
                   <div
                     className="iot--list-header--search"
                   >
@@ -10385,6 +10367,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             className="iot--card-editor"
           >
             <div
+              className="iot--card-editor--header"
+            >
+              <h2
+                className="iot--card-editor--header--title"
+              >
+                Gallery
+              </h2>
+            </div>
+            <div
               className="iot--card-editor--content"
             >
               <div
@@ -10393,18 +10384,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                 <div
                   className="iot--list-header-container"
                 >
-                  <div
-                    className="iot--list-header"
-                  >
-                    <div
-                      className="iot--list-header--title"
-                    >
-                      Gallery
-                    </div>
-                    <div
-                      className="iot--list-header--btn-container"
-                    />
-                  </div>
                   <div
                     className="iot--list-header--search"
                   >


### PR DESCRIPTION
Closes #1561

**Summary**

- This PR uses a consistently styled header that is part of the `CardEditor` component for both the "Gallery" section and the "Add a card" section. We no longer utilize `SimpleList` header

**Change List (commits, features, bugs, etc)**

- Added the "gallery" header section to `CardEditor.jsx`
- change `title` prop for `SimpleList` in `CardGalleryList.jsx`
- add styles to `_card-editor.scss`

**Acceptance Test (how to verify the PR)**

- Go to Dashboard editor [story](https://deploy-preview-1870--carbon-addons-iot-react.netlify.app/)
- Click on card type to add. 
- Click on "Add a card" header
- see that styles look the same as production with the change of making the "add to card" header have the same height as the "Gallery" header.
