### PR TITLE
fix(dashboardeditor): add padding around skeletontext in loading

### DIFF
--- a/src/components/DashboardEditor/DashboardEditor.jsx
+++ b/src/components/DashboardEditor/DashboardEditor.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { InlineNotification } from 'carbon-components-react';
+import { InlineNotification, SkeletonText } from 'carbon-components-react';
 import isNil from 'lodash/isNil';
 import classnames from 'classnames';
 import update from 'immutability-helper';
@@ -11,12 +11,7 @@ import {
   CARD_ACTIONS,
   CARD_TYPES,
 } from '../../constants/LayoutConstants';
-import {
-  DashboardGrid,
-  CardEditor,
-  ErrorBoundary,
-  SkeletonText,
-} from '../../index';
+import { DashboardGrid, CardEditor, ErrorBoundary } from '../../index';
 import ImageGalleryModal, {
   ImagePropTypes,
 } from '../ImageGalleryModal/ImageGalleryModal';
@@ -394,7 +389,9 @@ const DashboardEditor = ({
   });
 
   return isLoading ? (
-    <SkeletonText width="30%" />
+    <div className={baseClassName}>
+      <SkeletonText width="30%" />
+    </div>
   ) : (
     <div className={baseClassName}>
       <div

--- a/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -4326,14 +4326,18 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         }
       }
     >
-      <p
-        className="bx--skeleton__text"
-        style={
-          Object {
-            "width": "30%",
+      <div
+        className="iot--dashboard-editor"
+      >
+        <p
+          className="bx--skeleton__text"
+          style={
+            Object {
+              "width": "30%",
+            }
           }
-        }
-      />
+        />
+      </div>
     </div>
   </div>
   <button

--- a/src/components/DashboardEditor/_dashboard-editor.scss
+++ b/src/components/DashboardEditor/_dashboard-editor.scss
@@ -1,6 +1,10 @@
 .#{$iot-prefix}--dashboard-editor {
   display: flex;
   height: 100%;
+  > .#{$prefix}--skeleton__text {
+    margin-top: 1rem;
+    margin-left: 1rem;
+  }
 
   &__overflow {
     overflow-x: auto; // allows a larger width

--- a/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
+++ b/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
@@ -1298,7 +1298,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                 <h2
                   className="iot--image-uploader-drop-label-text"
                 >
-                  Drag file here or click to upload file
+                  Drag and drop file here or click to select file
                 </h2>
                 <p
                   className="iot--image-uploader-drop-description-text"
@@ -1306,13 +1306,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                   Max file size is 1MB. Supported file types are: APNG, AVIF, GIF, JPEG, PNG, WebP
                 </p>
                 <button
-                  className="iot--btn bx--btn bx--btn--tertiary"
+                  className="iot--btn bx--btn bx--btn--primary"
                   disabled={false}
                   onClick={null}
                   tabIndex={0}
                   type="button"
                 >
-                  Add from gallery
+                  Browse images
                 </button>
                 <button
                   className="iot--btn bx--btn bx--btn--tertiary"

--- a/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
+++ b/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
@@ -1298,7 +1298,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                 <h2
                   className="iot--image-uploader-drop-label-text"
                 >
-                  Drag and drop file here or click to select file
+                  Drag file here or click to upload file
                 </h2>
                 <p
                   className="iot--image-uploader-drop-description-text"
@@ -1306,13 +1306,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                   Max file size is 1MB. Supported file types are: APNG, AVIF, GIF, JPEG, PNG, WebP
                 </p>
                 <button
-                  className="iot--btn bx--btn bx--btn--primary"
+                  className="iot--btn bx--btn bx--btn--tertiary"
                   disabled={false}
                   onClick={null}
                   tabIndex={0}
                   type="button"
                 >
-                  Browse images
+                  Add from gallery
                 </button>
                 <button
                   className="iot--btn bx--btn bx--btn--tertiary"


### PR DESCRIPTION
Closes #

**Summary**

- Very small fix to add the normal class around the skeleton text and add margin around it

**Change List (commits, features, bugs, etc)**

- fix(dashboardEditor): add div and padding

**Acceptance Test (how to verify the PR)**

- Verify the isLoading story for DashboardEditor has padding
