### PR TITLE
1861 hotspot add text style hotspots

### DIFF
--- a/src/components/ColorDropdown/ColorDropdown.test.jsx
+++ b/src/components/ColorDropdown/ColorDropdown.test.jsx
@@ -4,9 +4,9 @@ import userEvent from '@testing-library/user-event';
 import { red50, blue50, green50 } from '@carbon/colors';
 
 import { settings } from '../../constants/Settings';
+import { hexToRgb } from '../../utils/componentUtilityFunctions';
 
 import ColorDropdown from './ColorDropdown';
-import { hexToRgb } from '../../utils/componentUtilityFunctions';
 
 const { iotPrefix } = settings;
 

--- a/src/components/ColorDropdown/ColorDropdown.test.jsx
+++ b/src/components/ColorDropdown/ColorDropdown.test.jsx
@@ -6,6 +6,7 @@ import { red50, blue50, green50 } from '@carbon/colors';
 import { settings } from '../../constants/Settings';
 
 import ColorDropdown from './ColorDropdown';
+import { hexToRgb } from '../../utils/componentUtilityFunctions';
 
 const { iotPrefix } = settings;
 
@@ -20,13 +21,7 @@ describe('ColorDropdown', () => {
     getColors().find((obj) => obj.name === name).carbonColor;
 
   const hexToRgbStyle = (hexColor) => {
-    const regexResult = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(
-      hexColor
-    );
-    const radix = 16;
-    const r = parseInt(regexResult[1], radix);
-    const g = parseInt(regexResult[2], radix);
-    const b = parseInt(regexResult[3], radix);
+    const { r, g, b } = hexToRgb(hexColor);
     return `rgb(${r}, ${g}, ${b})`;
   };
 

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -2140,7 +2140,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         }
                       >
                         <div
-                          className="iot--hotspot-container iot--hotspot-container--has-icon"
+                          className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
                           data-testid="hotspot-35-65"
                           icon="arrowDown"
                           style={
@@ -2185,7 +2185,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="iot--hotspot-container"
+                          className="iot--hotspot-container iot--hotspot-container--is-fixed"
                           data-testid="hotspot-45-25"
                           icon={null}
                           style={
@@ -2236,7 +2236,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="iot--hotspot-container"
+                          className="iot--hotspot-container iot--hotspot-container--is-fixed"
                           data-testid="hotspot-45-50"
                           icon={null}
                           style={
@@ -2287,7 +2287,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="iot--hotspot-container iot--hotspot-container--has-icon"
+                          className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
                           data-testid="hotspot-45-75"
                           icon="arrowUp"
                           style={
@@ -4559,7 +4559,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         }
                       >
                         <div
-                          className="iot--hotspot-container iot--hotspot-container--has-icon"
+                          className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
                           data-testid="hotspot-35-65"
                           icon="arrowDown"
                           style={
@@ -4604,7 +4604,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="iot--hotspot-container"
+                          className="iot--hotspot-container iot--hotspot-container--is-fixed"
                           data-testid="hotspot-45-25"
                           icon={null}
                           style={
@@ -4655,7 +4655,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="iot--hotspot-container"
+                          className="iot--hotspot-container iot--hotspot-container--is-fixed"
                           data-testid="hotspot-45-50"
                           icon={null}
                           style={
@@ -4706,7 +4706,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="iot--hotspot-container iot--hotspot-container--has-icon"
+                          className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
                           data-testid="hotspot-45-75"
                           icon="arrowUp"
                           style={
@@ -7006,7 +7006,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         }
                       >
                         <div
-                          className="iot--hotspot-container iot--hotspot-container--has-icon"
+                          className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
                           data-testid="hotspot-35-65"
                           icon="arrowDown"
                           style={
@@ -7051,7 +7051,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="iot--hotspot-container"
+                          className="iot--hotspot-container iot--hotspot-container--is-fixed"
                           data-testid="hotspot-45-25"
                           icon={null}
                           style={
@@ -7102,7 +7102,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="iot--hotspot-container"
+                          className="iot--hotspot-container iot--hotspot-container--is-fixed"
                           data-testid="hotspot-45-50"
                           icon={null}
                           style={
@@ -7153,7 +7153,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="iot--hotspot-container iot--hotspot-container--has-icon"
+                          className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
                           data-testid="hotspot-45-75"
                           icon="arrowUp"
                           style={
@@ -12030,7 +12030,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         }
                       >
                         <div
-                          className="iot--hotspot-container iot--hotspot-container--has-icon"
+                          className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
                           data-testid="hotspot-35-65"
                           icon="arrowDown"
                           style={
@@ -12075,7 +12075,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="iot--hotspot-container"
+                          className="iot--hotspot-container iot--hotspot-container--is-fixed"
                           data-testid="hotspot-45-25"
                           icon={null}
                           style={
@@ -12126,7 +12126,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="iot--hotspot-container"
+                          className="iot--hotspot-container iot--hotspot-container--is-fixed"
                           data-testid="hotspot-45-50"
                           icon={null}
                           style={
@@ -12177,7 +12177,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="iot--hotspot-container iot--hotspot-container--has-icon"
+                          className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
                           data-testid="hotspot-45-75"
                           icon="arrowUp"
                           style={
@@ -26852,7 +26852,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         }
                       >
                         <div
-                          className="iot--hotspot-container iot--hotspot-container--has-icon"
+                          className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
                           data-testid="hotspot-35-65"
                           icon="arrowDown"
                           style={
@@ -26897,7 +26897,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="iot--hotspot-container"
+                          className="iot--hotspot-container iot--hotspot-container--is-fixed"
                           data-testid="hotspot-45-25"
                           icon={null}
                           style={
@@ -26948,7 +26948,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="iot--hotspot-container"
+                          className="iot--hotspot-container iot--hotspot-container--is-fixed"
                           data-testid="hotspot-45-50"
                           icon={null}
                           style={
@@ -26999,7 +26999,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </div>
                         </div>
                         <div
-                          className="iot--hotspot-container iot--hotspot-container--has-icon"
+                          className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
                           data-testid="hotspot-45-75"
                           icon="arrowUp"
                           style={

--- a/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
@@ -2521,7 +2521,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                     }
                   >
                     <div
-                      className="iot--hotspot-container iot--hotspot-container--has-icon"
+                      className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
                       data-testid="hotspot-35-65"
                       icon="arrowDown"
                       style={

--- a/src/components/ImageCard/Hotspot.jsx
+++ b/src/components/ImageCard/Hotspot.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Tooltip } from 'carbon-components-react';
 import { g10 } from '@carbon/themes';
-import { withSize } from 'react-sizeme';
+import withSize from 'react-sizeme';
 
 import { settings } from '../../constants/Settings';
 import { hexToRgb } from '../../utils/componentUtilityFunctions';

--- a/src/components/ImageCard/Hotspot.jsx
+++ b/src/components/ImageCard/Hotspot.jsx
@@ -1,14 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import classnames from 'classnames';
 import { Tooltip } from 'carbon-components-react';
+import { g10 } from '@carbon/themes';
 
 import { settings } from '../../constants/Settings';
+import { hexToRgb } from '../../utils/componentUtilityFunctions';
 
 import { HotspotContentPropTypes } from './HotspotContent';
 import CardIcon from './CardIcon';
 
 const { iotPrefix } = settings;
+const { ui01, text01, ui03 } = g10;
 
 export const propTypes = {
   /** percentage from the left of the image to show this hotspot */
@@ -39,6 +42,26 @@ export const propTypes = {
   onClick: PropTypes.func,
   /** shows a border with padding when set to true */
   isSelected: PropTypes.bool,
+  /** determines the type of hotspot to render. Defaults to 'fixed'. */
+  type: PropTypes.oneOf(['fixed', 'variable', 'text']),
+  /** For text hotspots, true if title should be bold */
+  bold: PropTypes.bool,
+  /** For text hotspots, true if title should be italic */
+  italic: PropTypes.bool,
+  /** For text hotspots, true if title should be underline */
+  underline: PropTypes.bool,
+  /** For text hotspots, the hexdec color of the title font, e.g. #ff0000  */
+  fontColor: PropTypes.string,
+  /** For text hotspots, the size in px of the font, e.g. 12  */
+  fontSize: PropTypes.number,
+  /** For text hotspots, the hexdec color of the background, e.g. #ff0000  */
+  backgroundColor: PropTypes.string,
+  /** For text hotspots, the opactity of the background in percentage, e.g. 100 */
+  backgroundOpacity: PropTypes.number,
+  /** For text hotspots, the hexdec color of the border, e.g. #ff0000  */
+  borderColor: PropTypes.string,
+  /** For text hotspots, the border width in px, e.g. 12  */
+  borderWidth: PropTypes.number,
 };
 
 const defaultProps = {
@@ -50,6 +73,16 @@ const defaultProps = {
   renderIconByName: null,
   onClick: null,
   isSelected: false,
+  type: 'fixed',
+  bold: false,
+  italic: false,
+  underline: false,
+  fontColor: text01,
+  fontSize: 14,
+  backgroundColor: ui01,
+  backgroundOpacity: 100,
+  borderColor: ui03,
+  borderWidth: 0,
 };
 
 /**
@@ -68,6 +101,16 @@ const Hotspot = ({
   onClick,
   isSelected,
   className,
+  type,
+  bold,
+  italic,
+  underline,
+  fontColor,
+  fontSize,
+  backgroundColor,
+  backgroundOpacity,
+  borderColor,
+  borderWidth,
   ...others
 }) => {
   const defaultIcon = (
@@ -106,34 +149,58 @@ const Hotspot = ({
   );
 
   const id = `hotspot-${x}-${y}`;
+  const { r, g, b } = hexToRgb(backgroundColor);
+  const opacity = backgroundOpacity / 100;
 
   return (
     <div
       data-testid={id}
-      className={classNames(`${iotPrefix}--hotspot-container`, {
-        [`${iotPrefix}--hotspot-container--selected`]: isSelected,
-        [`${iotPrefix}--hotspot-container--has-icon`]: icon,
-      })}
       style={{
         '--x-pos': x,
         '--y-pos': y,
         '--width': width,
         '--height': height,
       }}
+      className={classnames(`${iotPrefix}--hotspot-container`, {
+        [`${iotPrefix}--hotspot-container--selected`]: isSelected,
+        [`${iotPrefix}--hotspot-container--has-icon`]: icon,
+        [`${iotPrefix}--hotspot-container--is-text`]: type === 'text',
+        [`${iotPrefix}--hotspot-container--is-fixed`]: type === 'fixed',
+      })}
       icon={icon}>
-      <Tooltip
-        {...others}
-        triggerText={iconToRender}
-        showIcon={false}
-        triggerId={id}
-        tooltipId={id}
-        onChange={(evt) => {
-          if (evt.type === 'click' && onClick) {
-            onClick(evt, { x, y });
-          }
-        }}>
-        {content}
-      </Tooltip>
+      {type === 'fixed' ? (
+        <Tooltip
+          {...others}
+          triggerText={iconToRender}
+          showIcon={false}
+          triggerId={id}
+          tooltipId={id}
+          onChange={(evt) => {
+            if (evt.type === 'click' && onClick) {
+              onClick(evt, { x, y });
+            }
+          }}>
+          {content}
+        </Tooltip>
+      ) : type === 'text' ? (
+        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
+        <div
+          role="complementary"
+          style={{
+            '--background-color': `rgba( ${r}, ${g}, ${b}, ${opacity})`,
+            '--border-color': borderColor,
+            '--border-width': borderWidth,
+            '--title-font-weight': bold ? 'bold' : 'normal',
+            '--title-font-style': italic ? 'italic' : 'normal',
+            '--title-text-decoration-line': underline ? 'underline' : 'none',
+            '--title-font-color': fontColor,
+            '--title-font-size': fontSize,
+          }}
+          className={`${iotPrefix}--text-hotspot`}
+          onClick={(evt) => onClick(evt, { x, y })}>
+          {content}
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/src/components/ImageCard/Hotspot.jsx
+++ b/src/components/ImageCard/Hotspot.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Tooltip } from 'carbon-components-react';
 import { g10 } from '@carbon/themes';
+import { withSize } from 'react-sizeme';
 
 import { settings } from '../../constants/Settings';
 import { hexToRgb } from '../../utils/componentUtilityFunctions';
@@ -151,57 +152,68 @@ const Hotspot = ({
   const id = `hotspot-${x}-${y}`;
   const { r, g, b } = hexToRgb(backgroundColor);
   const opacity = backgroundOpacity / 100;
+  const isTextType = type === 'text';
 
   return (
-    <div
-      data-testid={id}
-      style={{
-        '--x-pos': x,
-        '--y-pos': y,
-        '--width': width,
-        '--height': height,
+    <withSize.SizeMe monitorHeight={isTextType}>
+      {({ size: measuredSize }) => {
+        const containerWidth = isTextType ? measuredSize.width : width;
+        const containerHeight = isTextType ? measuredSize.height : height;
+        return (
+          <div
+            data-testid={id}
+            style={{
+              '--x-pos': x,
+              '--y-pos': y,
+              '--width': containerWidth,
+              '--height': containerHeight,
+            }}
+            className={classnames(`${iotPrefix}--hotspot-container`, {
+              [`${iotPrefix}--hotspot-container--selected`]: isSelected,
+              [`${iotPrefix}--hotspot-container--has-icon`]: icon,
+              [`${iotPrefix}--hotspot-container--is-text`]: isTextType,
+              [`${iotPrefix}--hotspot-container--is-fixed`]: type === 'fixed',
+            })}
+            icon={icon}>
+            {type === 'fixed' ? (
+              <Tooltip
+                {...others}
+                triggerText={iconToRender}
+                showIcon={false}
+                triggerId={id}
+                tooltipId={id}
+                onChange={(evt) => {
+                  if (evt.type === 'click' && onClick) {
+                    onClick(evt, { x, y });
+                  }
+                }}>
+                {content}
+              </Tooltip>
+            ) : isTextType ? (
+              // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
+              <div
+                role="complementary"
+                style={{
+                  '--background-color': `rgba( ${r}, ${g}, ${b}, ${opacity})`,
+                  '--border-color': borderColor,
+                  '--border-width': borderWidth,
+                  '--title-font-weight': bold ? 'bold' : 'normal',
+                  '--title-font-style': italic ? 'italic' : 'normal',
+                  '--title-text-decoration-line': underline
+                    ? 'underline'
+                    : 'none',
+                  '--title-font-color': fontColor,
+                  '--title-font-size': fontSize,
+                }}
+                className={`${iotPrefix}--text-hotspot`}
+                onClick={(evt) => onClick(evt, { x, y })}>
+                {content}
+              </div>
+            ) : null}
+          </div>
+        );
       }}
-      className={classnames(`${iotPrefix}--hotspot-container`, {
-        [`${iotPrefix}--hotspot-container--selected`]: isSelected,
-        [`${iotPrefix}--hotspot-container--has-icon`]: icon,
-        [`${iotPrefix}--hotspot-container--is-text`]: type === 'text',
-        [`${iotPrefix}--hotspot-container--is-fixed`]: type === 'fixed',
-      })}
-      icon={icon}>
-      {type === 'fixed' ? (
-        <Tooltip
-          {...others}
-          triggerText={iconToRender}
-          showIcon={false}
-          triggerId={id}
-          tooltipId={id}
-          onChange={(evt) => {
-            if (evt.type === 'click' && onClick) {
-              onClick(evt, { x, y });
-            }
-          }}>
-          {content}
-        </Tooltip>
-      ) : type === 'text' ? (
-        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
-        <div
-          role="complementary"
-          style={{
-            '--background-color': `rgba( ${r}, ${g}, ${b}, ${opacity})`,
-            '--border-color': borderColor,
-            '--border-width': borderWidth,
-            '--title-font-weight': bold ? 'bold' : 'normal',
-            '--title-font-style': italic ? 'italic' : 'normal',
-            '--title-text-decoration-line': underline ? 'underline' : 'none',
-            '--title-font-color': fontColor,
-            '--title-font-size': fontSize,
-          }}
-          className={`${iotPrefix}--text-hotspot`}
-          onClick={(evt) => onClick(evt, { x, y })}>
-          {content}
-        </div>
-      ) : null}
-    </div>
+    </withSize.SizeMe>
   );
 };
 

--- a/src/components/ImageCard/Hotspot.test.jsx
+++ b/src/components/ImageCard/Hotspot.test.jsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { g10 } from '@carbon/themes';
+
+import Hotspot from './Hotspot';
+import HotspotContent from './HotspotContent';
+
+const { text01, ui03 } = g10;
+
+describe('Hotspot', () => {
+  it('uses size and position', () => {
+    render(
+      <Hotspot
+        content={<HotspotContent />}
+        x={10}
+        y={5}
+        height={50}
+        width={200}
+        type="text"
+      />
+    );
+
+    const hotspotContainer = screen.getByTestId(/hotspot-10-5/);
+    expect(hotspotContainer).toHaveAttribute(
+      'style',
+      expect.stringContaining('--x-pos: 10')
+    );
+    expect(hotspotContainer).toHaveAttribute(
+      'style',
+      expect.stringContaining('--y-pos: 5')
+    );
+    expect(hotspotContainer).toHaveAttribute(
+      'style',
+      expect.stringContaining('--width: 200')
+    );
+    expect(hotspotContainer).toHaveAttribute(
+      'style',
+      expect.stringContaining('--height: 50')
+    );
+  });
+  describe('text type', () => {
+    it('uses defult text styles', () => {
+      render(<Hotspot x={10} y={5} content={<HotspotContent />} type="text" />);
+
+      const textHotspot = screen.getByTestId(/hotspot-10-5/).firstChild;
+      expect(textHotspot).toHaveAttribute(
+        'style',
+        expect.stringContaining('--background-color: rgba( 255, 255, 255, 1)')
+      );
+      expect(textHotspot).toHaveAttribute(
+        'style',
+        expect.stringContaining(`--border-color: ${ui03}`)
+      );
+      expect(textHotspot).toHaveAttribute(
+        'style',
+        expect.stringContaining('--border-width: 0')
+      );
+      expect(textHotspot).toHaveAttribute(
+        'style',
+        expect.stringContaining('--title-font-weight: normal')
+      );
+      expect(textHotspot).toHaveAttribute(
+        'style',
+        expect.stringContaining('--title-text-decoration-line: none')
+      );
+      expect(textHotspot).toHaveAttribute(
+        'style',
+        expect.stringContaining(`--title-font-color: ${text01}`)
+      );
+      expect(textHotspot).toHaveAttribute(
+        'style',
+        expect.stringContaining('--title-font-size: 14')
+      );
+    });
+
+    it('uses custom text styles', () => {
+      render(
+        <Hotspot
+          x={10}
+          y={5}
+          content={<HotspotContent />}
+          type="text"
+          bold
+          italic
+          underline
+          fontColor="#006666"
+          fontSize={16}
+          backgroundColor="#00FF00"
+          backgroundOpacity={50}
+          borderColor="#006666"
+          borderWidth={1}
+        />
+      );
+
+      const textHotspot = screen.getByTestId(/hotspot-10-5/).firstChild;
+      expect(textHotspot).toHaveAttribute(
+        'style',
+        expect.stringContaining('--background-color: rgba( 0, 255, 0, 0.5)')
+      );
+      expect(textHotspot).toHaveAttribute(
+        'style',
+        expect.stringContaining('--border-color: #006666')
+      );
+      expect(textHotspot).toHaveAttribute(
+        'style',
+        expect.stringContaining('--border-width: 1')
+      );
+      expect(textHotspot).toHaveAttribute(
+        'style',
+        expect.stringContaining('--title-font-weight: bold')
+      );
+      expect(textHotspot).toHaveAttribute(
+        'style',
+        expect.stringContaining('--title-text-decoration-line: underline')
+      );
+      expect(textHotspot).toHaveAttribute(
+        'style',
+        expect.stringContaining('--title-font-color: #006666')
+      );
+      expect(textHotspot).toHaveAttribute(
+        'style',
+        expect.stringContaining('--title-font-size: 16')
+      );
+    });
+    it('handles onClick callback', () => {
+      const onClick = jest.fn();
+      render(
+        <Hotspot
+          x={10}
+          y={5}
+          content={<HotspotContent title="test-title" />}
+          type="text"
+          onClick={onClick}
+        />
+      );
+
+      fireEvent.click(screen.getByText('test-title'));
+      expect(onClick).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/ImageCard/Hotspot.test.jsx
+++ b/src/components/ImageCard/Hotspot.test.jsx
@@ -16,7 +16,7 @@ describe('Hotspot', () => {
         y={5}
         height={50}
         width={200}
-        type="text"
+        type="fixed"
       />
     );
 

--- a/src/components/ImageCard/HotspotContent.jsx
+++ b/src/components/ImageCard/HotspotContent.jsx
@@ -11,7 +11,7 @@ import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import isNil from 'lodash/isNil';
 import isEmpty from 'lodash/isEmpty';
-import Edit from '@carbon/icons-react/lib/edit/20';
+import { Edit20 } from '@carbon/icons-react';
 
 import {
   formatNumberWithPrecision,
@@ -120,7 +120,7 @@ const HotspotContent = ({
         {titleValue !== null && titleValue !== '' ? (
           titleValue
         ) : isTitleEditable ? (
-          <Edit />
+          <Edit20 />
         ) : null}
       </h4>
     );

--- a/src/components/ImageCard/HotspotContent.jsx
+++ b/src/components/ImageCard/HotspotContent.jsx
@@ -7,19 +7,20 @@
  * trade secrets, irrespective of what has been deposited with the U.S. Copyright
  * Office.
  */
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import isNil from 'lodash/isNil';
 import isEmpty from 'lodash/isEmpty';
+import Edit from '@carbon/icons-react/lib/edit/20';
 
 import {
   formatNumberWithPrecision,
   findMatchingThresholds,
 } from '../../utils/cardUtilityFunctions';
 import { settings } from '../../constants/Settings';
+import { TextInput } from '../TextInput';
 
 import CardIcon from './CardIcon';
-import { TextInput } from 'carbon-components-react';
 
 const { iotPrefix } = settings;
 
@@ -70,7 +71,7 @@ export const HotspotContentPropTypes = {
 const defaultProps = {
   title: null,
   titlePlaceholderText: 'Enter label',
-  titleEditableHintText: 'Click to edit title',
+  titleEditableHintText: 'Click to edit label',
   description: null,
   values: {},
   attributes: [],
@@ -100,51 +101,69 @@ const HotspotContent = ({
     isTitleEditable && !title
   );
   const titleInputFocusRef = useRef(null);
+  const [titleValue, setTitleValue] = useState(title);
 
-  useEffect(() => {
-    if (showTitleInput) {
-      titleInputFocusRef.current?.focus();
-    }
-  });
+  if (showTitleInput && titleInputFocusRef.current) {
+    titleInputFocusRef.current.focus();
+  }
 
   const renderTitle = () => {
-    const editableTitle = (
-      <div className={`${iotPrefix}--hotspot-content-title-wrapper--editable`}>
-        <TextInput
-          className={`${iotPrefix}--hotspot-content-title-input`}
-          defaultValue={title}
-          id={`${id}-title`}
-          test-id={`${id}-title-test`}
-          ref={titleInputFocusRef}
-          onBlur={(evt) => {
-            const latestValue = evt.currentTarget.value;
-            setShowTitleInput(false);
-            if (title !== latestValue) {
-              onChange({ title: latestValue });
-            }
-          }}
-          labelText={''}
-          placeholder={titlePlaceholderText}
-        />
-      </div>
-    );
-
-    const headingTitle = (
+    const titleTextVersion = (
+      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
       <h4
         onClick={() => {
           if (isTitleEditable) {
             setShowTitleInput(isTitleEditable);
           }
         }}
-        title={isTitleEditable ? titleEditableHintText : title}>
-        {title}
+        title={isTitleEditable ? titleEditableHintText : titleValue}>
+        {titleValue !== null && titleValue !== '' ? (
+          titleValue
+        ) : isTitleEditable ? (
+          <Edit />
+        ) : null}
       </h4>
     );
 
+    const titleInputVersion = (
+      <>
+        <div
+          className={`${iotPrefix}--hotspot-content-title-wrapper--editable`}>
+          <TextInput
+            className={`${iotPrefix}--hotspot-content-title-input`}
+            defaultValue={title}
+            id={`${id}-title`}
+            data-testid={`${id}-title-test`}
+            ref={titleInputFocusRef}
+            onChange={(evt) => {
+              setTitleValue(evt.currentTarget.value);
+            }}
+            onBlur={(evt) => {
+              const latestValue = evt.currentTarget.value;
+              setShowTitleInput(false);
+              if (title !== latestValue) {
+                onChange({ title: latestValue });
+              }
+            }}
+            labelText=""
+            placeholder={titlePlaceholderText}
+          />
+        </div>
+        {
+          // We still render the non editable title but as visually hidden so that the width will be
+          // correctly modified as we type in the TextInput.
+          <h4
+            className={`${iotPrefix}--hotspot-content-title__visually-hidden`}>
+            {titleValue}
+          </h4>
+        }
+      </>
+    );
+
     return typeof title === 'string' && showTitleInput
-      ? editableTitle
+      ? titleInputVersion
       : typeof title === 'string'
-      ? headingTitle
+      ? titleTextVersion
       : React.isValidElement(title)
       ? title
       : null;

--- a/src/components/ImageCard/HotspotContent.test.jsx
+++ b/src/components/ImageCard/HotspotContent.test.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { red60 } from '@carbon/colors';
 
 import HotspotContent from './HotspotContent';
+import userEvent from '@testing-library/user-event';
 
 describe('HotspotContent', () => {
   it('basic attributes', () => {
@@ -198,5 +199,30 @@ describe('HotspotContent', () => {
       'Warning',
       expect.anything()
     );
+  });
+  it('calls onChange callback when editable title is modified', () => {
+    const onChange = jest.fn();
+    render(
+      <HotspotContent
+        onChange={onChange}
+        id="content"
+        title=""
+        isTitleEditable
+      />
+    );
+    const titleInputElement = screen.getByTestId('content-title-test');
+    expect(titleInputElement).toBeInTheDocument();
+    userEvent.type(titleInputElement, 'abc');
+    fireEvent.blur(titleInputElement, {
+      currentTarget: { value: titleInputElement.value },
+    });
+    expect(onChange).toHaveBeenCalledWith({ title: 'abc' });
+  });
+  it('activates text input when editable title is clicked', () => {
+    render(<HotspotContent id="content" title="my title" isTitleEditable />);
+    fireEvent.click(screen.getByText('my title'));
+
+    const titleInputElement = screen.getByTestId('content-title-test');
+    expect(titleInputElement).toBeInTheDocument();
   });
 });

--- a/src/components/ImageCard/HotspotContent.test.jsx
+++ b/src/components/ImageCard/HotspotContent.test.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { red60 } from '@carbon/colors';
 
 import HotspotContent from './HotspotContent';
-import userEvent from '@testing-library/user-event';
 
 describe('HotspotContent', () => {
   it('basic attributes', () => {

--- a/src/components/ImageCard/ImageHotspots.jsx
+++ b/src/components/ImageCard/ImageHotspots.jsx
@@ -566,6 +566,8 @@ const ImageHotspots = ({
       renderIconByName,
       selectedHotspots,
       onHotspotClicked,
+      isEditable,
+      onHotspotContentChanged,
     ]
   );
 

--- a/src/components/ImageCard/ImageHotspots.jsx
+++ b/src/components/ImageCard/ImageHotspots.jsx
@@ -38,6 +38,11 @@ const propTypes = {
   onAddHotspotPosition: PropTypes.func,
   /** Callback when a hotspot is clicked in isEditable mode, emits position obj {x, y} */
   onSelectHotspot: PropTypes.func,
+  /**
+   * Callback when the hotspot content is changed, emits position obj {x, y}
+   * and content change obj, e.g. {title: 'new title value'}
+   * */
+  onHotspotContentChanged: PropTypes.func,
   /** Current width in pixels */
   width: PropTypes.number.isRequired,
   zoomMax: PropTypes.number,
@@ -64,6 +69,7 @@ const defaultProps = {
   isEditable: false,
   onAddHotspotPosition: () => {},
   onSelectHotspot: () => {},
+  onHotspotContentChanged: () => {},
   background: '#eee',
   zoomMax: undefined,
   renderIconByName: null,
@@ -72,7 +78,8 @@ const defaultProps = {
     zoomOut: 'Zoom out',
     zoomToFit: 'Zoom to fit',
   },
-  locale: null,
+  // undefined instead of null allows for functions to set default values
+  locale: undefined,
   selectedHotspots: [],
 };
 
@@ -418,6 +425,7 @@ const ImageHotspots = ({
   isHotspotDataLoading,
   onAddHotspotPosition: onAddHotspotPositionCallback,
   onSelectHotspot,
+  onHotspotContentChanged,
   zoomMax,
   renderIconByName,
   locale,
@@ -518,8 +526,9 @@ const ImageHotspots = ({
   const cachedHotspots = useMemo(
     () =>
       hotspots.map((hotspot) => {
+        const { x, y } = hotspot;
         const hotspotIsSelected = !!selectedHotspots.find(
-          (pos) => hotspot.x === pos.x && hotspot.y === pos.y
+          (pos) => x === pos.x && y === pos.y
         );
         return (
           <Hotspot
@@ -532,10 +541,17 @@ const ImageHotspots = ({
                   {...hotspot.content}
                   locale={locale}
                   renderIconByName={renderIconByName}
+                  id={`hotspot-content-${x}-${y}`}
+                  isTitleEditable={
+                    (isEditable, hotspotIsSelected && hotspot.type === 'text')
+                  }
+                  onChange={(change) => {
+                    onHotspotContentChanged({ x, y }, change);
+                  }}
                 />
               )
             }
-            key={`${hotspot.x}-${hotspot.y}`}
+            key={`${x}-${y}`}
             style={hotspotsStyle}
             renderIconByName={renderIconByName}
             isSelected={hotspotIsSelected}

--- a/src/components/ImageCard/ImageHotspots.story.jsx
+++ b/src/components/ImageCard/ImageHotspots.story.jsx
@@ -32,7 +32,18 @@ const hotspots = [
   {
     x: 50,
     y: 60,
-    content: <span style={{ padding: spacing03 }}>Hotspot4</span>,
+    content: {
+      title: 'Hotspot3',
+      values: {
+        temperature: 35.35,
+        humidity: 99,
+      },
+      attributes: [
+        { dataSourceId: 'temperature', label: 'Temperature' },
+        { dataSourceId: 'humidity', label: 'Humidity' },
+      ],
+      locale: 'en',
+    },
     color: 'green',
   },
 ];
@@ -156,12 +167,52 @@ ImageSmallerThanCardMinimapAndZoomcontrolsShouldBeHidden.story = {
   name: 'image smaller than card, minimap and zoomcontrols should be hidden',
 };
 
-export const Editable = () => {
+export const EditableWithTextHotspot = () => {
   const WithState = () => {
-    const [myHotspots, setMyHotspots] = useState(hotspots);
-    const [selectedHotspotPositions, setSelectedHotspotPositions] = useState(
-      []
-    );
+    const [myHotspots, setMyHotspots] = useState([
+      ...hotspots,
+      {
+        x: 26,
+        y: 68,
+        type: 'text',
+        content: {
+          title: 'Facility rooms',
+          values: {
+            temperature: 35.35,
+            humidity: 99,
+          },
+          attributes: [
+            { dataSourceId: 'temperature', label: 'Temperature' },
+            { dataSourceId: 'humidity', label: 'Humidity' },
+          ],
+          locale: 'en',
+        },
+        bold: true,
+        italic: false,
+        underline: false,
+        fontColor: '#006666',
+        fontSize: 16,
+        backgroundColor: '#00FF00',
+        backgroundOpacity: 50,
+        borderColor: '#006666',
+        borderWidth: 1,
+        height: 100,
+        width: 200,
+      },
+      {
+        x: 75,
+        y: 10,
+        type: 'text',
+        content: { title: '' },
+        height: 36,
+        width: 100,
+        backgroundColor: '#999999',
+        backgroundOpacity: 50,
+      },
+    ]);
+    const [selectedHotspotPositions, setSelectedHotspotPositions] = useState([
+      { x: 75, y: 10 },
+    ]);
 
     const onAddHotspotPosition = (position) => {
       const newHotspot = {
@@ -184,12 +235,23 @@ export const Editable = () => {
       action('onSelectHotspot')(position);
     };
 
+    const onHotspotContentChanged = (position, change) => {
+      const modifiedHotspots = myHotspots.map((hotspot) =>
+        hotspot.x === position.x && hotspot.y === position.y
+          ? { ...hotspot, content: { ...hotspot.content, ...change } }
+          : hotspot
+      );
+      setMyHotspots(modifiedHotspots);
+      action('onHotspotContentChanged')(position, change);
+    };
+
     return (
       <div style={{ width: '450px', height: '300px' }}>
         <ImageHotspots
           isEditable
           onAddHotspotPosition={onAddHotspotPosition}
           onSelectHotspot={onSelectHotspot}
+          onHotspotContentChanged={onHotspotContentChanged}
           src={text('Image', landscape)}
           alt={text('Alternate text', 'Sample image')}
           height={300}
@@ -205,4 +267,8 @@ export const Editable = () => {
   };
 
   return <WithState />;
+};
+
+EditableWithTextHotspot.story = {
+  name: 'Editable with text hotspot',
 };

--- a/src/components/ImageCard/ImageHotspots.story.jsx
+++ b/src/components/ImageCard/ImageHotspots.story.jsx
@@ -194,24 +194,31 @@ export const EditableWithTextHotspot = () => {
         fontSize: 16,
         backgroundColor: '#00FF00',
         backgroundOpacity: 50,
-        borderColor: '#006666',
-        borderWidth: 1,
-        height: 100,
-        width: 200,
+        borderColor: '#FFFF00',
+        borderWidth: 8,
       },
       {
         x: 75,
         y: 10,
         type: 'text',
-        content: { title: '' },
-        height: 36,
-        width: 100,
+        content: { title: 'Storage' },
+        fontSize: 24,
         backgroundColor: '#999999',
         backgroundOpacity: 50,
       },
+      {
+        x: 75,
+        y: 40,
+        type: 'text',
+        content: { title: '' },
+        backgroundColor: '#ffffff',
+        backgroundOpacity: 90,
+        borderWidth: 1,
+        borderColor: '#DDDDDD',
+      },
     ]);
     const [selectedHotspotPositions, setSelectedHotspotPositions] = useState([
-      { x: 75, y: 10 },
+      { x: 75, y: 40 },
     ]);
 
     const onAddHotspotPosition = (position) => {

--- a/src/components/ImageCard/__snapshots__/HotspotContent.story.storyshot
+++ b/src/components/ImageCard/__snapshots__/HotspotContent.story.storyshot
@@ -97,6 +97,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Hotsp
             className="iot--hotspot-content"
           >
             <h4
+              onClick={[Function]}
               title="Hotspot title"
             >
               Hotspot title
@@ -299,6 +300,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Hotsp
             className="iot--hotspot-content"
           >
             <h4
+              onClick={[Function]}
               title="Hotspot title"
             >
               Hotspot title
@@ -511,6 +513,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Hotsp
             className="iot--hotspot-content"
           >
             <h4
+              onClick={[Function]}
               title="Hotspot title"
             >
               Hotspot title
@@ -767,6 +770,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Hotsp
             className="iot--hotspot-content"
           >
             <h4
+              onClick={[Function]}
               title="Hotspot title"
             >
               Hotspot title

--- a/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
+++ b/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
@@ -138,7 +138,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                 }
               >
                 <div
-                  className="iot--hotspot-container iot--hotspot-container--has-icon"
+                  className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
                   data-testid="hotspot-35-65"
                   icon="arrowDown"
                   style={
@@ -397,7 +397,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                 }
               >
                 <div
-                  className="iot--hotspot-container iot--hotspot-container--has-icon"
+                  className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
                   data-testid="hotspot-35-65"
                   icon="arrowDown"
                   style={
@@ -444,7 +444,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                   </div>
                 </div>
                 <div
-                  className="iot--hotspot-container"
+                  className="iot--hotspot-container iot--hotspot-container--is-fixed"
                   data-testid="hotspot-45-25"
                   icon={null}
                   style={
@@ -495,7 +495,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                   </div>
                 </div>
                 <div
-                  className="iot--hotspot-container"
+                  className="iot--hotspot-container iot--hotspot-container--is-fixed"
                   data-testid="hotspot-45-50"
                   icon={null}
                   style={
@@ -546,7 +546,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                   </div>
                 </div>
                 <div
-                  className="iot--hotspot-container iot--hotspot-container--has-icon"
+                  className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
                   data-testid="hotspot-45-75"
                   icon="arrowUp"
                   style={

--- a/src/components/ImageCard/__snapshots__/ImageHotspots.story.storyshot
+++ b/src/components/ImageCard/__snapshots__/ImageHotspots.story.storyshot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/ImageHotspots Editable 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/ImageHotspots Editable with text hotspot 1`] = `
 <div
   className="storybook-container"
 >
@@ -68,7 +68,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
           }
         >
           <div
-            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
             data-testid="hotspot-10-20"
             icon="warning"
             style={
@@ -118,7 +118,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
             data-testid="hotspot-50-10"
             icon="warning"
             style={
@@ -168,7 +168,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="iot--hotspot-container"
+            className="iot--hotspot-container iot--hotspot-container--is-fixed"
             data-testid="hotspot-30-40"
             icon={null}
             style={
@@ -219,7 +219,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="iot--hotspot-container"
+            className="iot--hotspot-container iot--hotspot-container--is-fixed"
             data-testid="hotspot-50-60"
             icon={null}
             style={
@@ -267,6 +267,105 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                   stroke="none"
                 />
               </svg>
+            </div>
+          </div>
+          <div
+            className="iot--hotspot-container iot--hotspot-container--is-text"
+            data-testid="hotspot-26-68"
+            icon={null}
+            style={
+              Object {
+                "--height": 100,
+                "--width": 200,
+                "--x-pos": 26,
+                "--y-pos": 68,
+              }
+            }
+          >
+            <div
+              className="iot--text-hotspot"
+              onClick={[Function]}
+              role="complementary"
+              style={
+                Object {
+                  "--background-color": "rgba( 0, 255, 0, 0.5)",
+                  "--border-color": "#006666",
+                  "--border-width": 1,
+                  "--title-font-color": "#006666",
+                  "--title-font-size": 16,
+                  "--title-font-style": "normal",
+                  "--title-font-weight": "bold",
+                  "--title-text-decoration-line": "none",
+                }
+              }
+            >
+              <div
+                className="iot--hotspot-content"
+              >
+                <h4
+                  title="Facility rooms"
+                >
+                  Facility rooms
+                </h4>
+                <div
+                  className="iot--hotspot-content-attribute"
+                >
+                  <div
+                    className="iot--hotspot-content-label-section"
+                  >
+                    <span
+                      className="iot--hotspot-content-label"
+                    >
+                      Temperature
+                      :
+                    </span>
+                  </div>
+                  <div
+                    className="iot--hotspot-content-threshold-section"
+                  >
+                    <span
+                      className="iot--hotspot-content-threshold"
+                      style={
+                        Object {
+                          "--threshold-color": "inherit ",
+                          "--threshold-padding": "0rem",
+                        }
+                      }
+                    >
+                      35.4
+                    </span>
+                  </div>
+                </div>
+                <div
+                  className="iot--hotspot-content-attribute"
+                >
+                  <div
+                    className="iot--hotspot-content-label-section"
+                  >
+                    <span
+                      className="iot--hotspot-content-label"
+                    >
+                      Humidity
+                      :
+                    </span>
+                  </div>
+                  <div
+                    className="iot--hotspot-content-threshold-section"
+                  >
+                    <span
+                      className="iot--hotspot-content-threshold"
+                      style={
+                        Object {
+                          "--threshold-color": "inherit ",
+                          "--threshold-padding": "0rem",
+                        }
+                      }
+                    >
+                      99.0
+                    </span>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -411,7 +510,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
           }
         >
           <div
-            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
             data-testid="hotspot-10-20"
             icon="warning"
             style={
@@ -461,7 +560,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
             data-testid="hotspot-50-10"
             icon="warning"
             style={
@@ -511,7 +610,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="iot--hotspot-container"
+            className="iot--hotspot-container iot--hotspot-container--is-fixed"
             data-testid="hotspot-30-40"
             icon={null}
             style={
@@ -562,7 +661,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="iot--hotspot-container"
+            className="iot--hotspot-container iot--hotspot-container--is-fixed"
             data-testid="hotspot-50-60"
             icon={null}
             style={
@@ -754,7 +853,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
           }
         >
           <div
-            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
             data-testid="hotspot-10-20"
             icon="warning"
             style={
@@ -804,7 +903,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
             data-testid="hotspot-50-10"
             icon="warning"
             style={
@@ -854,7 +953,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="iot--hotspot-container"
+            className="iot--hotspot-container iot--hotspot-container--is-fixed"
             data-testid="hotspot-30-40"
             icon={null}
             style={
@@ -905,7 +1004,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="iot--hotspot-container"
+            className="iot--hotspot-container iot--hotspot-container--is-fixed"
             data-testid="hotspot-50-60"
             icon={null}
             style={
@@ -1097,7 +1196,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
           }
         >
           <div
-            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
             data-testid="hotspot-10-20"
             icon="warning"
             style={
@@ -1147,7 +1246,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
             data-testid="hotspot-50-10"
             icon="warning"
             style={
@@ -1197,7 +1296,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="iot--hotspot-container"
+            className="iot--hotspot-container iot--hotspot-container--is-fixed"
             data-testid="hotspot-30-40"
             icon={null}
             style={
@@ -1248,7 +1347,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="iot--hotspot-container"
+            className="iot--hotspot-container iot--hotspot-container--is-fixed"
             data-testid="hotspot-50-60"
             icon={null}
             style={
@@ -1440,7 +1539,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
           }
         >
           <div
-            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
             data-testid="hotspot-10-20"
             icon="warning"
             style={
@@ -1490,7 +1589,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
             data-testid="hotspot-50-10"
             icon="warning"
             style={
@@ -1540,7 +1639,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="iot--hotspot-container"
+            className="iot--hotspot-container iot--hotspot-container--is-fixed"
             data-testid="hotspot-30-40"
             icon={null}
             style={
@@ -1591,7 +1690,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="iot--hotspot-container"
+            className="iot--hotspot-container iot--hotspot-container--is-fixed"
             data-testid="hotspot-50-60"
             icon={null}
             style={
@@ -1783,7 +1882,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
           }
         >
           <div
-            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
             data-testid="hotspot-10-20"
             icon="warning"
             style={
@@ -1833,7 +1932,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="iot--hotspot-container iot--hotspot-container--has-icon"
+            className="iot--hotspot-container iot--hotspot-container--has-icon iot--hotspot-container--is-fixed"
             data-testid="hotspot-50-10"
             icon="warning"
             style={
@@ -1883,7 +1982,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="iot--hotspot-container"
+            className="iot--hotspot-container iot--hotspot-container--is-fixed"
             data-testid="hotspot-30-40"
             icon={null}
             style={
@@ -1934,7 +2033,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             </div>
           </div>
           <div
-            className="iot--hotspot-container"
+            className="iot--hotspot-container iot--hotspot-container--is-fixed"
             data-testid="hotspot-50-60"
             icon={null}
             style={

--- a/src/components/ImageCard/__snapshots__/ImageHotspots.story.storyshot
+++ b/src/components/ImageCard/__snapshots__/ImageHotspots.story.storyshot
@@ -275,8 +275,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
             icon={null}
             style={
               Object {
-                "--height": 100,
-                "--width": 200,
+                "--height": undefined,
+                "--width": undefined,
                 "--x-pos": 26,
                 "--y-pos": 68,
               }
@@ -289,8 +289,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
               style={
                 Object {
                   "--background-color": "rgba( 0, 255, 0, 0.5)",
-                  "--border-color": "#006666",
-                  "--border-width": 1,
+                  "--border-color": "#FFFF00",
+                  "--border-width": 8,
                   "--title-font-color": "#006666",
                   "--title-font-size": 16,
                   "--title-font-style": "normal",
@@ -303,6 +303,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                 className="iot--hotspot-content"
               >
                 <h4
+                  onClick={[Function]}
                   title="Facility rooms"
                 >
                   Facility rooms
@@ -365,6 +366,120 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                     </span>
                   </div>
                 </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--hotspot-container iot--hotspot-container--is-text"
+            data-testid="hotspot-75-10"
+            icon={null}
+            style={
+              Object {
+                "--height": undefined,
+                "--width": undefined,
+                "--x-pos": 75,
+                "--y-pos": 10,
+              }
+            }
+          >
+            <div
+              className="iot--text-hotspot"
+              onClick={[Function]}
+              role="complementary"
+              style={
+                Object {
+                  "--background-color": "rgba( 153, 153, 153, 0.5)",
+                  "--border-color": "#e0e0e0",
+                  "--border-width": 0,
+                  "--title-font-color": "#161616",
+                  "--title-font-size": 24,
+                  "--title-font-style": "normal",
+                  "--title-font-weight": "normal",
+                  "--title-text-decoration-line": "none",
+                }
+              }
+            >
+              <div
+                className="iot--hotspot-content"
+              >
+                <h4
+                  onClick={[Function]}
+                  title="Storage"
+                >
+                  Storage
+                </h4>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--hotspot-container iot--hotspot-container--selected iot--hotspot-container--is-text"
+            data-testid="hotspot-75-40"
+            icon={null}
+            style={
+              Object {
+                "--height": undefined,
+                "--width": undefined,
+                "--x-pos": 75,
+                "--y-pos": 40,
+              }
+            }
+          >
+            <div
+              className="iot--text-hotspot"
+              onClick={[Function]}
+              role="complementary"
+              style={
+                Object {
+                  "--background-color": "rgba( 255, 255, 255, 0.9)",
+                  "--border-color": "#DDDDDD",
+                  "--border-width": 1,
+                  "--title-font-color": "#161616",
+                  "--title-font-size": 14,
+                  "--title-font-style": "normal",
+                  "--title-font-weight": "normal",
+                  "--title-text-decoration-line": "none",
+                }
+              }
+            >
+              <div
+                className="iot--hotspot-content"
+              >
+                <div
+                  className="iot--hotspot-content-title-wrapper--editable"
+                >
+                  <div
+                    className="bx--form-item bx--text-input-wrapper"
+                  >
+                    <div
+                      className="bx--text-input__field-outer-wrapper"
+                    >
+                      <div
+                        className="bx--text-input__field-wrapper"
+                        data-invalid={null}
+                        data-warn={null}
+                      >
+                        <input
+                          className="bx--text-input iot--hotspot-content-title-input"
+                          data-testid="hotspot-content-75-40-title-test"
+                          defaultValue=""
+                          disabled={false}
+                          id="hotspot-content-75-40-title"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          placeholder="Enter label"
+                          title="Enter label"
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <h4
+                  className="iot--hotspot-content-title__visually-hidden"
+                >
+                  
+                </h4>
               </div>
             </div>
           </div>

--- a/src/components/ImageCard/_hotspot.scss
+++ b/src/components/ImageCard/_hotspot.scss
@@ -2,22 +2,10 @@
 // and should be replaced with actual carbon colors and design. See issue 1806
 
 @import '../../globals/vars';
+@import '../../globals/theme';
 
-$selected-border-width: #{$spacing-01};
-
-@mixin selected($padding, $border-width) {
-  top: calc(
-    (var(--y-pos) * 1%) -
-      (((var(--height) * 1px) / 2) + #{$padding} + #{$border-width})
-  );
-  left: calc(
-    (var(--x-pos) * 1%) -
-      (((var(--width) * 1px) / 2) + #{$padding} + #{$border-width})
-  );
-  box-sizing: border-box;
-  border: solid #{$border-width} $interactive-04;
-  padding: #{$padding};
-}
+$selected-border-width: $spacing-01;
+$selected-border: solid $selected-border-width $interactive-04;
 
 // The custom properties --x-pos, --y-pos, --width, --height are set
 // on the container by the react js code. They do not include units.
@@ -32,7 +20,19 @@ $selected-border-width: #{$spacing-01};
 // FIXED HOTSPOT
 .#{$iot-prefix}--hotspot-container--is-fixed {
   &.#{$iot-prefix}--hotspot-container--selected {
-    @include selected($spacing-02, $selected-border-width);
+    $padding: $spacing-02;
+
+    box-sizing: border-box;
+    border: $selected-border;
+    padding: #{$padding};
+    top: calc(
+      (var(--y-pos) * 1%) -
+        (((var(--height) * 1px) / 2) + #{$padding} + #{$selected-border-width})
+    );
+    left: calc(
+      (var(--x-pos) * 1%) -
+        (((var(--width) * 1px) / 2) + #{$padding} + #{$selected-border-width})
+    );
   }
   &.#{$iot-prefix}--hotspot-container--has-icon {
     .bx--tooltip__label {
@@ -60,31 +60,60 @@ $selected-border-width: #{$spacing-01};
 // on the container by the react js code
 .#{$iot-prefix}--hotspot-container--is-text {
   &.#{$iot-prefix}--hotspot-container--selected {
-    @include selected(0px, $selected-border-width);
+    box-sizing: border-box;
+    border: $selected-border;
+    top: calc((var(--y-pos) * 1%) - (((var(--height) * 1px) / 2)));
+    left: calc((var(--x-pos) * 1%) - (((var(--width) * 1px) / 2)));
   }
 }
 
 .#{$iot-prefix}--text-hotspot {
   $padding: $spacing-03;
+  $min-width: $layout-06;
+  $text-input-height: $spacing-08;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   padding: $padding;
   box-sizing: border-box;
-
-  width: calc(var(--width) * 1px);
-  height: calc(var(--height) * 1px);
+  min-width: $min-width;
+  min-height: calc(#{$text-input-height});
+  border-style: solid;
   background-color: var(--background-color);
   border-color: var(--border-color);
-  border-style: solid;
   border-width: calc(var(--border-width) * 1px);
 
-  .#{$iot-prefix}--hotspot-content h4 {
-    @include type-style('productive-heading-01');
-    text-align: left;
+  .#{$iot-prefix}--hotspot-content {
+    & > *:nth-child(2) {
+      &.#{$iot-prefix}--hotspot-content-attribute {
+        margin-top: $spacing-03;
+      }
+    }
 
-    font-weight: var(--title-font-weight);
-    font-style: var(--title-font-style);
-    text-decoration-line: var(--title-text-decoration-line);
-    color: var(--title-font-color);
-    font-size: calc(var(--title-font-size) * 1px);
+    h4 {
+      @include type-style('productive-heading-01');
+      text-align: left;
+      padding-bottom: 0;
+      line-height: calc(var(--title-font-size) * 1.4px);
+      font-weight: var(--title-font-weight);
+      font-style: var(--title-font-style);
+      text-decoration-line: var(--title-text-decoration-line);
+      color: var(--title-font-color);
+      // Linting expects size to be in rem, but user size is given in px.
+      // font-size: calc(
+      //   ((var(--title-font-size) * 1px) / 16px) * 1rem
+      // );
+
+      // stylelint-disable-next-line declaration-property-unit-blacklist
+      font-size: calc(var(--title-font-size) * 1px);
+
+      // Used to expand the hotspot while the user types into the TextInput
+      &.#{$iot-prefix}--hotspot-content-title__visually-hidden {
+        visibility: hidden;
+        height: 0px;
+      }
+    }
   }
 
   .#{$iot-prefix}--hotspot-content-label-section {
@@ -97,11 +126,24 @@ $selected-border-width: #{$spacing-01};
   }
 
   .#{$iot-prefix}--hotspot-content-title-wrapper--editable {
-    $negative-margin: calc(-1 * (#{$padding} + #{$selected-border-width}));
-    margin: $negative-margin $negative-margin 0 $negative-margin;
+    $negative-margin-to-overide-parent-padding: calc(-1 * (#{$padding}));
+    margin: $negative-margin-to-overide-parent-padding;
+    width: calc(
+      (var(--width) * 1px) - $selected-border-width -
+        (var(--border-width) * 1px)
+    );
 
     .#{$iot-prefix}--hotspot-content-title-input {
       padding: 0 calc(#{$padding} + #{$selected-border-width});
+      width: calc(
+        (var(--width) * 1px) - (#{$selected-border-width} * 2) -
+          (var(--border-width) * 1px * 2)
+      );
+      height: $text-input-height;
+      border-bottom: none;
+      &:focus {
+        outline: none;
+      }
     }
   }
 }

--- a/src/components/ImageCard/_hotspot.scss
+++ b/src/components/ImageCard/_hotspot.scss
@@ -3,28 +3,9 @@
 
 @import '../../globals/vars';
 
-// The custom properties --x-pos, --y-pos, --width, --height are set
-// on the container by the react js code
-.#{$iot-prefix}--hotspot-container {
-  position: absolute;
-  font-family: Sans-Serif;
-  pointer-events: auto;
-  top: calc((var(--y-pos) * 1%) - ((var(--height) / 2) * 1px));
-  left: calc((var(--x-pos) * 1%) - ((var(--width) / 2) * 1px));
+$selected-border-width: #{$spacing-01};
 
-  .bx--tooltip__label {
-    display: flex;
-    cursor: pointer;
-    box-shadow: 0 0 4px #999;
-    border-radius: 13px;
-    background: none;
-  }
-}
-
-.#{$iot-prefix}--hotspot-container--selected {
-  $padding: #{$spacing-02};
-  $border-width: #{$spacing-01};
-
+@mixin selected($padding, $border-width) {
   top: calc(
     (var(--y-pos) * 1%) -
       (((var(--height) * 1px) / 2) + #{$padding} + #{$border-width})
@@ -38,14 +19,89 @@
   padding: #{$padding};
 }
 
-.#{$iot-prefix}--hotspot-container--has-icon {
+// The custom properties --x-pos, --y-pos, --width, --height are set
+// on the container by the react js code. They do not include units.
+.#{$iot-prefix}--hotspot-container {
+  position: absolute;
+  font-family: Sans-Serif;
+  pointer-events: auto;
+  top: calc((var(--y-pos) * 1%) - ((var(--height) / 2) * 1px));
+  left: calc((var(--x-pos) * 1%) - ((var(--width) / 2) * 1px));
+}
+
+// FIXED HOTSPOT
+.#{$iot-prefix}--hotspot-container--is-fixed {
+  &.#{$iot-prefix}--hotspot-container--selected {
+    @include selected($spacing-02, $selected-border-width);
+  }
+  &.#{$iot-prefix}--hotspot-container--has-icon {
+    .bx--tooltip__label {
+      border: solid 1px #aaa;
+      cursor: pointer;
+      padding: $spacing-02;
+      background: white;
+      opacity: 0.9;
+      border-radius: 4px;
+      box-shadow: 0 0 8px #777;
+    }
+  }
+
   .bx--tooltip__label {
-    border: solid 1px #aaa;
+    display: flex;
     cursor: pointer;
-    padding: $spacing-02;
-    background: white;
-    opacity: 0.9;
-    border-radius: 4px;
-    box-shadow: 0 0 8px #777;
+    box-shadow: 0 0 4px #999;
+    border-radius: 13px;
+    background: none;
+  }
+}
+
+// TEXT HOTSPOT
+// The custom properties --bold, --italic, --background-color etc are set
+// on the container by the react js code
+.#{$iot-prefix}--hotspot-container--is-text {
+  &.#{$iot-prefix}--hotspot-container--selected {
+    @include selected(0px, $selected-border-width);
+  }
+}
+
+.#{$iot-prefix}--text-hotspot {
+  $padding: $spacing-03;
+  padding: $padding;
+  box-sizing: border-box;
+
+  width: calc(var(--width) * 1px);
+  height: calc(var(--height) * 1px);
+  background-color: var(--background-color);
+  border-color: var(--border-color);
+  border-style: solid;
+  border-width: calc(var(--border-width) * 1px);
+
+  .#{$iot-prefix}--hotspot-content h4 {
+    @include type-style('productive-heading-01');
+    text-align: left;
+
+    font-weight: var(--title-font-weight);
+    font-style: var(--title-font-style);
+    text-decoration-line: var(--title-text-decoration-line);
+    color: var(--title-font-color);
+    font-size: calc(var(--title-font-size) * 1px);
+  }
+
+  .#{$iot-prefix}--hotspot-content-label-section {
+    text-align: left;
+  }
+  .#{$iot-prefix}--hotspot-content-label,
+  .#{$iot-prefix}--hotspot-content-threshold {
+    @include type-style('helper-text-01');
+    font-weight: normal;
+  }
+
+  .#{$iot-prefix}--hotspot-content-title-wrapper--editable {
+    $negative-margin: calc(-1 * (#{$padding} + #{$selected-border-width}));
+    margin: $negative-margin $negative-margin 0 $negative-margin;
+
+    .#{$iot-prefix}--hotspot-content-title-input {
+      padding: 0 calc(#{$padding} + #{$selected-border-width});
+    }
   }
 }

--- a/src/utils/componentUtilityFunctions.js
+++ b/src/utils/componentUtilityFunctions.js
@@ -3,6 +3,7 @@ import moment from 'moment';
 import { sortStates } from 'carbon-components-react/es/components/DataTable/state/sorting';
 import fileDownload from 'js-file-download';
 import isNil from 'lodash/isNil';
+import warning from 'warning';
 
 import {
   GUTTER,
@@ -359,4 +360,31 @@ export const convertStringsToDOMElement = (strings = []) => {
   return strings.map((string) => {
     return domparser.parseFromString(string, mimetype).querySelector('body');
   });
+};
+
+/**
+ * Converts a color in hexadecimal to the RGB values.
+ * @param {string} hexColor
+ * @returns {object} object with values for r, g, b properties
+ */
+export const hexToRgb = (hexColor) => {
+  const regexResult = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(
+    hexColor
+  );
+  const radix = 16;
+  let rgbColors;
+  try {
+    const r = parseInt(regexResult[1], radix);
+    const g = parseInt(regexResult[2], radix);
+    const b = parseInt(regexResult[3], radix);
+    rgbColors = { r, g, b };
+  } catch {
+    if (__DEV__) {
+      warning(
+        false,
+        'Incorrect color value used, expected hexadecimal string. Defaulting to gray.'
+      );
+    }
+  }
+  return rgbColors ?? { r: 200, g: 200, b: 200 };
 };


### PR DESCRIPTION
Closes #1861

**Summary**
Added text based hotspots. The text hotspots will adjust in height and width depending on the content. The styling of the content can be modified using the hotspot config data.

**Change List (commits, features, bugs, etc)**
_Hotspot_
- Added `type` prop. Can be fixed, text or variable. Text type is represented by a new selectable div that shows all content directly.
- Added text formatting props with default values. The props are modified and pass to the stylesheets as CSS custom properties.
- Added size measurement for text type hotspots so that height and width can be dynamic 
- Updated stylesheets. Part of the HotspotContent styles are overridden here since we need access to properties of the hotspot (size, padding, border etc).
- added unit tests

_HotspotContent_
- added `isTitleEditable` and `onChange` prop
- added title input with autofocus and onBlur to trigger change. A visually hidden version of the text based title is still rendered in order to allow the hotspot to grow in width as the user types in the text field.
- added i18n labels
- added unit tests

_ImageHotspots_
- Added onHotspotContentChanged 
- Added logic to determine when the hotspot title is editable
- Modified the story to show working example

- Created a reusable hexToRgb function since it was used in multiple places now

**Acceptance Test (how to verify the PR)**
Since there isn't much of a spec I recommend playing around with the story by clicking and modifying the titles to make sure it feels okay and looks good.

https://deploy-preview-1874--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-imagehotspots--editable-with-text-hotspot
