### PR TITLE
fix(imagecard): improve ux of uploading image

### DIFF
--- a/src/components/BarChartCard/barChartUtils.test.js
+++ b/src/components/BarChartCard/barChartUtils.test.js
@@ -158,7 +158,7 @@ describe('barChartUtils', () => {
     // check horizontal layout
     expect(
       formatChartData(series, null, 'city', null, BAR_CHART_TYPES.GROUPED)
-    ).toEqual([]);
+    ).toEqual(null);
   });
 
   it('formatChartData returns formatted data for group-based chart', () => {

--- a/src/components/DashboardEditor/editorUtils.jsx
+++ b/src/components/DashboardEditor/editorUtils.jsx
@@ -115,8 +115,6 @@ export const getDefaultCard = (type, i18n) => {
         content: {
           series: [],
           xLabel: 'Time',
-          yLabel: 'Temperature',
-          unit: '˚F',
           includeZeroOnXaxis: true,
           includeZeroOnYaxis: true,
           timeDataSourceId: 'timestamp',

--- a/src/components/ImageCard/ImageCard.jsx
+++ b/src/components/ImageCard/ImageCard.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import isNil from 'lodash/isNil';
+import pick from 'lodash/pick';
 import { Image32 } from '@carbon/icons-react';
 import { spacing05 } from '@carbon/layout';
 
@@ -42,7 +43,7 @@ const defaultProps = {
       'Max file size is 1MB. Supported file types are: JPEG, PNG, GIF, WEBP, TIFF, JPEG2000',
     uploadByURLCancel: 'Cancel',
     uploadByURLButton: 'OK',
-    browseImages: 'Browse images',
+    browseImages: 'Add from gallery',
     insertUrl: 'Insert from URL',
     urlInput: 'Type or insert URL',
     errorTitle: 'Error: ',
@@ -76,6 +77,8 @@ const ImageCard = ({
 }) => {
   const [imgContent, setImgContent] = useState(content);
   const hotspots = values ? values.hotspots || [] : [];
+
+  const { hasInsertFromUrl } = content || {};
 
   useEffect(() => {
     setImgContent(content);
@@ -140,6 +143,17 @@ const ImageCard = ({
                     width={width}
                     height={height}
                     onUpload={handleOnUpload}
+                    i18n={pick(
+                      otherLabels,
+                      'dropContainerLabelText',
+                      'dropContainerDescText',
+                      'uploadByURLCancel',
+                      'uploadByURLButton',
+                      'browseImages',
+                      'insertUrl',
+                      'urlInput'
+                    )}
+                    hasInsertFromUrl={hasInsertFromUrl}
                   />
                 ) : imgContent.src ? (
                   <ImageHotspots

--- a/src/components/ImageCard/ImageCard.jsx
+++ b/src/components/ImageCard/ImageCard.jsx
@@ -38,7 +38,7 @@ const propTypes = { ...CardPropTypes, ...ImageCardPropTypes };
 const defaultProps = {
   i18n: {
     loadingDataLabel: 'Loading hotspot data',
-    dropContainerLabelText: 'Drag and drop file here or click to select file',
+    dropContainerLabelText: 'Drag file here or click to upload file',
     dropContainerDescText:
       'Max file size is 1MB. Supported file types are: APNG, AVIF, GIF, JPEG, PNG, WebP',
     uploadByURLCancel: 'Cancel',

--- a/src/components/ImageCard/ImageCard.jsx
+++ b/src/components/ImageCard/ImageCard.jsx
@@ -40,7 +40,7 @@ const defaultProps = {
     loadingDataLabel: 'Loading hotspot data',
     dropContainerLabelText: 'Drag and drop file here or click to select file',
     dropContainerDescText:
-      'Max file size is 1MB. Supported file types are: JPEG, PNG, GIF, WEBP, TIFF, JPEG2000',
+      'Max file size is 1MB. Supported file types are: APNG, AVIF, GIF, JPEG, PNG, WebP',
     uploadByURLCancel: 'Cancel',
     uploadByURLButton: 'OK',
     browseImages: 'Add from gallery',

--- a/src/components/ImageCard/ImageCard.story.jsx
+++ b/src/components/ImageCard/ImageCard.story.jsx
@@ -15,6 +15,7 @@ const content = {
   src: imageFile,
   alt: 'Sample image',
   zoomMax: 10,
+  hasInsertFromUrl: true,
 };
 
 const values = {

--- a/src/components/ImageCard/ImageUploader.jsx
+++ b/src/components/ImageCard/ImageUploader.jsx
@@ -20,7 +20,8 @@ const i18nDefaults = {
     'Max file size is 1MB. Supported file types are: APNG, AVIF, GIF, JPEG, PNG, WebP',
   uploadByURLCancel: 'Cancel',
   uploadByURLButton: 'OK',
-  browseImages: 'Browse images',
+  browseImages: 'Add from gallery',
+  uploadFile: 'Click to upload file',
   insertUrl: 'Insert from URL',
   urlInput: 'Type or insert URL',
   errorTitle: 'Error: ',
@@ -32,6 +33,7 @@ const propTypes = {
   accept: PropTypes.arrayOf(PropTypes.string),
   onBrowseClick: PropTypes.func,
   onUpload: PropTypes.func,
+  hasInsertFromUrl: PropTypes.bool,
   i18n: PropTypes.shape({
     dropContainerLabelText: PropTypes.string,
     dropContainerDescText: PropTypes.string,
@@ -47,10 +49,18 @@ const defaultProps = {
   accept: ['APNG', 'AVIF', 'GIF', 'JPEG', 'JPG', 'PNG', 'WebP'],
   onBrowseClick: () => {},
   onUpload: () => {},
+  hasInsertFromUrl: false,
   i18n: i18nDefaults,
 };
 
-const ImageUploader = ({ onBrowseClick, i18n, onUpload, accept, ...other }) => {
+const ImageUploader = ({
+  hasInsertFromUrl,
+  onBrowseClick,
+  i18n,
+  onUpload,
+  accept,
+  ...other
+}) => {
   const [fromURL, setFromURL] = useState(false);
   const [error, setError] = useState(null);
   const [buttonSize, setButtonSize] = useState('default');
@@ -166,15 +176,17 @@ const ImageUploader = ({ onBrowseClick, i18n, onUpload, accept, ...other }) => {
             <p className={`${iotPrefix}--image-uploader-drop-description-text`}>
               {i18n.dropContainerDescText}
             </p>
-            <Button size={buttonSize} onClick={onBrowseClick} kind="primary">
+            <Button size={buttonSize} onClick={onBrowseClick} kind="tertiary">
               {i18n.browseImages}
             </Button>
-            <Button
-              size={buttonSize}
-              onClick={handleFromURLClick}
-              kind="tertiary">
-              {i18n.insertUrl}
-            </Button>
+            {hasInsertFromUrl ? (
+              <Button
+                size={buttonSize}
+                onClick={handleFromURLClick}
+                kind="tertiary">
+                {i18n.insertUrl}
+              </Button>
+            ) : null}
           </div>
         </>
       )}

--- a/src/components/ImageCard/ImageUploader.jsx
+++ b/src/components/ImageCard/ImageUploader.jsx
@@ -15,7 +15,7 @@ import { fetchDataURL } from '../../utils/cardUtilityFunctions';
 const { iotPrefix } = settings;
 
 const i18nDefaults = {
-  dropContainerLabelText: 'Drag and drop file here or click to select file',
+  dropContainerLabelText: 'Drag file here or click to upload file',
   dropContainerDescText:
     'Max file size is 1MB. Supported file types are: APNG, AVIF, GIF, JPEG, PNG, WebP',
   uploadByURLCancel: 'Cancel',

--- a/src/components/ImageCard/ImageUploader.jsx
+++ b/src/components/ImageCard/ImageUploader.jsx
@@ -21,7 +21,6 @@ const i18nDefaults = {
   uploadByURLCancel: 'Cancel',
   uploadByURLButton: 'OK',
   browseImages: 'Add from gallery',
-  uploadFile: 'Click to upload file',
   insertUrl: 'Insert from URL',
   urlInput: 'Type or insert URL',
   errorTitle: 'Error: ',

--- a/src/components/ImageCard/ImageUploader.test.jsx
+++ b/src/components/ImageCard/ImageUploader.test.jsx
@@ -25,7 +25,7 @@ describe('ImageUploader', () => {
   //   const { container } = render(<ImageUploader />);
 
   //   userEvent.click(
-  //     screen.getByText(/Drag and drop file here or click to select file/)
+  //     screen.getByText(/Drag file here or click to upload file/)
   //   );
   //   // await waitFor(() => expect(screen.getAllByText(/OK/)).toHaveLength(1));
   //   fireEvent.change(container.querySelector('input'), {

--- a/src/components/ImageCard/ImageUploader.test.jsx
+++ b/src/components/ImageCard/ImageUploader.test.jsx
@@ -10,7 +10,7 @@ import ImageUploader from './ImageUploader';
 
 describe('ImageUploader', () => {
   it('will switch to URL upload screen', () => {
-    render(<ImageUploader />);
+    render(<ImageUploader hasInsertFromUrl />);
 
     const insertFromURLBtn = screen.getByText(/Insert from URL/);
     userEvent.click(insertFromURLBtn);
@@ -19,6 +19,7 @@ describe('ImageUploader', () => {
     expect(screen.getAllByText(/Insert from URL/)).toHaveLength(1);
   });
 
+  // eslint-disable-next-line jest/no-commented-out-tests
   // it('will upload and use an image from URL', async () => {
   //   const file = new File(['(⌐□_□)'], 'chucknorris.png', { type: 'image/png' });
   //   const { container } = render(<ImageUploader />);

--- a/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
+++ b/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
@@ -1298,7 +1298,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                 <h2
                   className="iot--image-uploader-drop-label-text"
                 >
-                  Drag and drop file here or click to select file
+                  Drag file here or click to upload file
                 </h2>
                 <p
                   className="iot--image-uploader-drop-description-text"

--- a/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
+++ b/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
@@ -1303,7 +1303,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                 <p
                   className="iot--image-uploader-drop-description-text"
                 >
-                  Max file size is 1MB. Supported file types are: JPEG, PNG, GIF, WEBP, TIFF, JPEG2000
+                  Max file size is 1MB. Supported file types are: APNG, AVIF, GIF, JPEG, PNG, WebP
                 </p>
                 <button
                   className="iot--btn bx--btn bx--btn--tertiary"

--- a/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
+++ b/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
@@ -1303,16 +1303,16 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                 <p
                   className="iot--image-uploader-drop-description-text"
                 >
-                  Max file size is 1MB. Supported file types are: APNG, AVIF, GIF, JPEG, PNG, WebP
+                  Max file size is 1MB. Supported file types are: JPEG, PNG, GIF, WEBP, TIFF, JPEG2000
                 </p>
                 <button
-                  className="iot--btn bx--btn bx--btn--primary"
+                  className="iot--btn bx--btn bx--btn--tertiary"
                   disabled={false}
                   onClick={null}
                   tabIndex={0}
                   type="button"
                 >
-                  Browse images
+                  Add from gallery
                 </button>
                 <button
                   className="iot--btn bx--btn bx--btn--tertiary"

--- a/src/components/ImageCard/_image-uploader.scss
+++ b/src/components/ImageCard/_image-uploader.scss
@@ -16,11 +16,7 @@
 
   &-drop-label-text {
     color: $interactive-01;
-    display: flex;
-    align-items: center;
-    button {
-      margin-left: 1rem;
-    }
+    display: block;
     @include carbon--type-style('productive-heading-02');
     margin-bottom: $spacing-03;
   }

--- a/src/components/ImageCard/_image-uploader.scss
+++ b/src/components/ImageCard/_image-uploader.scss
@@ -16,7 +16,11 @@
 
   &-drop-label-text {
     color: $interactive-01;
-    display: block;
+    display: flex;
+    align-items: center;
+    button {
+      margin-left: 1rem;
+    }
     @include carbon--type-style('productive-heading-02');
     margin-bottom: $spacing-03;
   }

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -12742,7 +12742,7 @@ Map {
       "accept": null,
       "content": Object {},
       "i18n": Object {
-        "browseImages": "Browse images",
+        "browseImages": "Add from gallery",
         "dropContainerDescText": "Max file size is 1MB. Supported file types are: JPEG, PNG, GIF, WEBP, TIFF, JPEG2000",
         "dropContainerLabelText": "Drag and drop file here or click to select file",
         "errorTitle": "Error: ",

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -12743,7 +12743,7 @@ Map {
       "content": Object {},
       "i18n": Object {
         "browseImages": "Add from gallery",
-        "dropContainerDescText": "Max file size is 1MB. Supported file types are: JPEG, PNG, GIF, WEBP, TIFF, JPEG2000",
+        "dropContainerDescText": "Max file size is 1MB. Supported file types are: APNG, AVIF, GIF, JPEG, PNG, WebP",
         "dropContainerLabelText": "Drag and drop file here or click to select file",
         "errorTitle": "Error: ",
         "insertUrl": "Insert from URL",

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -12744,7 +12744,7 @@ Map {
       "i18n": Object {
         "browseImages": "Add from gallery",
         "dropContainerDescText": "Max file size is 1MB. Supported file types are: APNG, AVIF, GIF, JPEG, PNG, WebP",
-        "dropContainerLabelText": "Drag and drop file here or click to select file",
+        "dropContainerLabelText": "Drag file here or click to upload file",
         "errorTitle": "Error: ",
         "insertUrl": "Insert from URL",
         "loadingDataLabel": "Loading hotspot data",


### PR DESCRIPTION
Closes #

**Summary**

- Improves the UX of the image upload and allows consumers to disable/enable the insertImageFromUrl capability

**Change List (commits, features, bugs, etc)**

- test(barChartUtils): fix failing testcase
- fix(editorUtils): shouldn't default any yLabel or units for time series cards
- feat(ImageCard): improve UX of the browse image from gallery and allow disabling the inserting from URL functionality
- fix(ImageCard): need to pass the i18n translated labels through to ImageUploader
- test(publicAPI): fix the out of sync messages between ImageCard and ImageUploader default i18n props

**Acceptance Test (how to verify the PR)**

- Check the isEditable ImageCard story
![image](https://user-images.githubusercontent.com/6663002/101827615-27db9580-3af6-11eb-80c3-6678d0384cb5.png)

