### PR TITLE
feat(imagegallery): add delete option to modal

### DIFF
--- a/src/components/DashboardEditor/DashboardEditor.jsx
+++ b/src/components/DashboardEditor/DashboardEditor.jsx
@@ -126,6 +126,8 @@ const propTypes = {
    * @returns Array<string> error strings. return empty array if there is no errors
    */
   onValidateCardJson: PropTypes.func,
+  /** callback if an image is deleted from the gallery */
+  onImageDelete: PropTypes.func,
   /** optional loading prop to render the PageTitleBar loading state */
   isLoading: PropTypes.bool,
   /** internationalization strings */
@@ -150,6 +152,9 @@ const propTypes = {
     layoutInfoLg: PropTypes.string,
     layoutInfoMd: PropTypes.string,
     searchPlaceholderText: PropTypes.string,
+    imageGalleryDeleteLabelText: PropTypes.string,
+    imageGalleryDeleteModalLabelText: PropTypes.string,
+    imageGalleryDeleteModalTitleText: PropTypes.func,
     imageGalleryGridButtonText: PropTypes.string,
     imageGalleryInstructionText: PropTypes.string,
     imageGalleryListButtonText: PropTypes.string,
@@ -181,6 +186,7 @@ const defaultProps = {
   dataItems: [],
   availableDimensions: {},
   onCardChange: null,
+  onImageDelete: null,
   onLayoutChange: null,
   onDelete: null,
   onImport: null,
@@ -235,6 +241,7 @@ const DashboardEditor = ({
   dataItems,
   availableImages,
   headerBreadcrumbs,
+  onImageDelete,
   notification,
   onCardChange,
   onLayoutChange,
@@ -464,6 +471,7 @@ const DashboardEditor = ({
                   content={availableImages}
                   onClose={() => setIsImageGalleryModalOpen(false)}
                   onSubmit={handleImageSelection}
+                  onDelete={onImageDelete}
                   gridButtonText={i18n.imageGalleryGridButtonText}
                   instructionText={i18n.imageGalleryInstructionText}
                   listButtonText={i18n.imageGalleryListButtonText}
@@ -479,6 +487,9 @@ const DashboardEditor = ({
                     i18n.imageGalleryModalCloseIconDescriptionText
                   }
                   searchPlaceHolderText={i18n.imageGallerySearchPlaceHolderText}
+                  deleteLabelText={i18n.imageGalleryDeleteLabelText}
+                  deleteModalLabelText={i18n.imageGalleryDeleteModalLabelText}
+                  deleteModalTitleText={i18n.imageGalleryDeleteModalTitleText}
                 />
                 <DashboardGrid
                   isEditable

--- a/src/components/DashboardEditor/DashboardEditor.story.jsx
+++ b/src/components/DashboardEditor/DashboardEditor.story.jsx
@@ -75,6 +75,7 @@ export const Default = () => (
       onDelete={action('onDelete')}
       onCancel={action('onCancel')}
       onSubmit={action('onSubmit')}
+      onImageDelete={action('onImageDelete')}
       onLayoutChange={action('onLayoutChange')}
       isSubmitDisabled={boolean('isSubmitDisabled', false)}
       isSubmitLoading={boolean('isSubmitLoading', false)}

--- a/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -498,8 +498,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                         Cancel
                       </button>
                       <button
-                        className="iot--btn bx--btn bx--btn--primary"
-                        disabled={false}
+                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                        disabled={true}
                         onClick={[Function]}
                         tabIndex={0}
                         type="button"
@@ -1819,8 +1819,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                         Cancel
                       </button>
                       <button
-                        className="iot--btn bx--btn bx--btn--primary"
-                        disabled={false}
+                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                        disabled={true}
                         onClick={[Function]}
                         tabIndex={0}
                         type="button"
@@ -3856,8 +3856,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                         Cancel
                       </button>
                       <button
-                        className="iot--btn bx--btn bx--btn--primary"
-                        disabled={false}
+                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                        disabled={true}
                         onClick={[Function]}
                         tabIndex={0}
                         type="button"
@@ -5299,8 +5299,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                         Cancel
                       </button>
                       <button
-                        className="iot--btn bx--btn bx--btn--primary"
-                        disabled={false}
+                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                        disabled={true}
                         onClick={[Function]}
                         tabIndex={0}
                         type="button"
@@ -6486,8 +6486,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                         Cancel
                       </button>
                       <button
-                        className="iot--btn bx--btn bx--btn--primary"
-                        disabled={false}
+                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                        disabled={true}
                         onClick={[Function]}
                         tabIndex={0}
                         type="button"
@@ -7779,8 +7779,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                         Cancel
                       </button>
                       <button
-                        className="iot--btn bx--btn bx--btn--primary"
-                        disabled={false}
+                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                        disabled={true}
                         onClick={[Function]}
                         tabIndex={0}
                         type="button"
@@ -10637,8 +10637,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                         Cancel
                       </button>
                       <button
-                        className="iot--btn bx--btn bx--btn--primary"
-                        disabled={false}
+                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                        disabled={true}
                         onClick={[Function]}
                         tabIndex={0}
                         type="button"

--- a/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -3044,6 +3044,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
       eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim 
       ad minim veniam.
                                 </span>
+                              </div>
+                              <div
+                                className="iot--image-tile__image-container"
+                              >
+                                <img
+                                  alt="assemblyline"
+                                  src="assemblyline.jpg"
+                                />
                                 <button
                                   className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                                   disabled={false}
@@ -3077,14 +3085,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                     />
                                   </svg>
                                 </button>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="assemblyline"
-                                  src="assemblyline.jpg"
-                                />
                               </div>
                             </span>
                           </label>
@@ -3138,6 +3138,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                 <span>
                                   floow_plan
                                 </span>
+                              </div>
+                              <div
+                                className="iot--image-tile__image-container"
+                              >
+                                <img
+                                  alt="floow plan"
+                                  src="floow_plan.png"
+                                />
                                 <button
                                   className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                                   disabled={false}
@@ -3171,14 +3179,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                     />
                                   </svg>
                                 </button>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="floow plan"
-                                  src="floow_plan.png"
-                                />
                               </div>
                             </span>
                           </label>
@@ -3232,6 +3232,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                 <span>
                                   Manufacturing_plant
                                 </span>
+                              </div>
+                              <div
+                                className="iot--image-tile__image-container"
+                              >
+                                <img
+                                  alt="manufacturing plant"
+                                  src="Manufacturing_plant.png"
+                                />
                                 <button
                                   className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                                   disabled={false}
@@ -3265,14 +3273,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                     />
                                   </svg>
                                 </button>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="manufacturing plant"
-                                  src="Manufacturing_plant.png"
-                                />
                               </div>
                             </span>
                           </label>
@@ -3326,6 +3326,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                 <span>
                                   robot_arm
                                 </span>
+                              </div>
+                              <div
+                                className="iot--image-tile__image-container"
+                              >
+                                <img
+                                  alt="robot arm"
+                                  src="robot_arm.png"
+                                />
                                 <button
                                   className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                                   disabled={false}
@@ -3359,14 +3367,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                     />
                                   </svg>
                                 </button>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="robot arm"
-                                  src="robot_arm.png"
-                                />
                               </div>
                             </span>
                           </label>
@@ -3420,6 +3420,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                 <span>
                                   tankmodal
                                 </span>
+                              </div>
+                              <div
+                                className="iot--image-tile__image-container"
+                              >
+                                <img
+                                  alt="tankmodal"
+                                  src="tankmodal.png"
+                                />
                                 <button
                                   className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                                   disabled={false}
@@ -3453,14 +3461,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                     />
                                   </svg>
                                 </button>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="tankmodal"
-                                  src="tankmodal.png"
-                                />
                               </div>
                             </span>
                           </label>
@@ -3514,6 +3514,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                 <span>
                                   turbines
                                 </span>
+                              </div>
+                              <div
+                                className="iot--image-tile__image-container"
+                              >
+                                <img
+                                  alt="turbines"
+                                  src="turbines.png"
+                                />
                                 <button
                                   className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                                   disabled={false}
@@ -3547,14 +3555,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                     />
                                   </svg>
                                 </button>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="turbines"
-                                  src="turbines.png"
-                                />
                               </div>
                             </span>
                           </label>
@@ -3608,6 +3608,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                 <span>
                                   extra-wide-image
                                 </span>
+                              </div>
+                              <div
+                                className="iot--image-tile__image-container"
+                              >
+                                <img
+                                  alt="extra wide image"
+                                  src="extra-wide-image.png"
+                                />
                                 <button
                                   className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                                   disabled={false}
@@ -3641,14 +3649,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                     />
                                   </svg>
                                 </button>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="extra wide image"
-                                  src="extra-wide-image.png"
-                                />
                               </div>
                             </span>
                           </label>
@@ -3702,6 +3702,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                 <span>
                                   large
                                 </span>
+                              </div>
+                              <div
+                                className="iot--image-tile__image-container"
+                              >
+                                <img
+                                  alt="large image"
+                                  src="large.png"
+                                />
                                 <button
                                   className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                                   disabled={false}
@@ -3735,14 +3743,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                     />
                                   </svg>
                                 </button>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="large image"
-                                  src="large.png"
-                                />
                               </div>
                             </span>
                           </label>
@@ -3796,6 +3796,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                 <span>
                                   large_portrait
                                 </span>
+                              </div>
+                              <div
+                                className="iot--image-tile__image-container"
+                              >
+                                <img
+                                  alt="large image portrait"
+                                  src="large_portrait.png"
+                                />
                                 <button
                                   className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                                   disabled={false}
@@ -3829,14 +3837,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                     />
                                   </svg>
                                 </button>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="large image portrait"
-                                  src="large_portrait.png"
-                                />
                               </div>
                             </span>
                           </label>

--- a/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -498,8 +498,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                         Cancel
                       </button>
                       <button
-                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                        disabled={true}
+                        className="iot--btn bx--btn bx--btn--primary"
+                        disabled={false}
                         onClick={[Function]}
                         tabIndex={0}
                         type="button"
@@ -1819,8 +1819,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                         Cancel
                       </button>
                       <button
-                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                        disabled={true}
+                        className="iot--btn bx--btn bx--btn--primary"
+                        disabled={false}
                         onClick={[Function]}
                         tabIndex={0}
                         type="button"
@@ -3044,6 +3044,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
       eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim 
       ad minim veniam.
                                 </span>
+                                <button
+                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  tabIndex={0}
+                                  type="button"
+                                >
+                                  <span
+                                    className="bx--assistive-text"
+                                  >
+                                    Delete
+                                  </span>
+                                  <svg
+                                    aria-hidden="true"
+                                    aria-label="Delete"
+                                    className="bx--btn__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={16}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    role="img"
+                                    viewBox="0 0 32 32"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M12 12H14V24H12zM18 12H20V24H18z"
+                                    />
+                                    <path
+                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                    />
+                                  </svg>
+                                </button>
                               </div>
                               <div
                                 className="iot--image-tile__image-container"
@@ -3105,6 +3138,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                 <span>
                                   floow_plan
                                 </span>
+                                <button
+                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  tabIndex={0}
+                                  type="button"
+                                >
+                                  <span
+                                    className="bx--assistive-text"
+                                  >
+                                    Delete
+                                  </span>
+                                  <svg
+                                    aria-hidden="true"
+                                    aria-label="Delete"
+                                    className="bx--btn__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={16}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    role="img"
+                                    viewBox="0 0 32 32"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M12 12H14V24H12zM18 12H20V24H18z"
+                                    />
+                                    <path
+                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                    />
+                                  </svg>
+                                </button>
                               </div>
                               <div
                                 className="iot--image-tile__image-container"
@@ -3166,6 +3232,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                 <span>
                                   Manufacturing_plant
                                 </span>
+                                <button
+                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  tabIndex={0}
+                                  type="button"
+                                >
+                                  <span
+                                    className="bx--assistive-text"
+                                  >
+                                    Delete
+                                  </span>
+                                  <svg
+                                    aria-hidden="true"
+                                    aria-label="Delete"
+                                    className="bx--btn__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={16}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    role="img"
+                                    viewBox="0 0 32 32"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M12 12H14V24H12zM18 12H20V24H18z"
+                                    />
+                                    <path
+                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                    />
+                                  </svg>
+                                </button>
                               </div>
                               <div
                                 className="iot--image-tile__image-container"
@@ -3227,6 +3326,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                 <span>
                                   robot_arm
                                 </span>
+                                <button
+                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  tabIndex={0}
+                                  type="button"
+                                >
+                                  <span
+                                    className="bx--assistive-text"
+                                  >
+                                    Delete
+                                  </span>
+                                  <svg
+                                    aria-hidden="true"
+                                    aria-label="Delete"
+                                    className="bx--btn__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={16}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    role="img"
+                                    viewBox="0 0 32 32"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M12 12H14V24H12zM18 12H20V24H18z"
+                                    />
+                                    <path
+                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                    />
+                                  </svg>
+                                </button>
                               </div>
                               <div
                                 className="iot--image-tile__image-container"
@@ -3288,6 +3420,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                 <span>
                                   tankmodal
                                 </span>
+                                <button
+                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  tabIndex={0}
+                                  type="button"
+                                >
+                                  <span
+                                    className="bx--assistive-text"
+                                  >
+                                    Delete
+                                  </span>
+                                  <svg
+                                    aria-hidden="true"
+                                    aria-label="Delete"
+                                    className="bx--btn__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={16}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    role="img"
+                                    viewBox="0 0 32 32"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M12 12H14V24H12zM18 12H20V24H18z"
+                                    />
+                                    <path
+                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                    />
+                                  </svg>
+                                </button>
                               </div>
                               <div
                                 className="iot--image-tile__image-container"
@@ -3349,6 +3514,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                 <span>
                                   turbines
                                 </span>
+                                <button
+                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  tabIndex={0}
+                                  type="button"
+                                >
+                                  <span
+                                    className="bx--assistive-text"
+                                  >
+                                    Delete
+                                  </span>
+                                  <svg
+                                    aria-hidden="true"
+                                    aria-label="Delete"
+                                    className="bx--btn__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={16}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    role="img"
+                                    viewBox="0 0 32 32"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M12 12H14V24H12zM18 12H20V24H18z"
+                                    />
+                                    <path
+                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                    />
+                                  </svg>
+                                </button>
                               </div>
                               <div
                                 className="iot--image-tile__image-container"
@@ -3410,6 +3608,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                 <span>
                                   extra-wide-image
                                 </span>
+                                <button
+                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  tabIndex={0}
+                                  type="button"
+                                >
+                                  <span
+                                    className="bx--assistive-text"
+                                  >
+                                    Delete
+                                  </span>
+                                  <svg
+                                    aria-hidden="true"
+                                    aria-label="Delete"
+                                    className="bx--btn__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={16}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    role="img"
+                                    viewBox="0 0 32 32"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M12 12H14V24H12zM18 12H20V24H18z"
+                                    />
+                                    <path
+                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                    />
+                                  </svg>
+                                </button>
                               </div>
                               <div
                                 className="iot--image-tile__image-container"
@@ -3471,6 +3702,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                 <span>
                                   large
                                 </span>
+                                <button
+                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  tabIndex={0}
+                                  type="button"
+                                >
+                                  <span
+                                    className="bx--assistive-text"
+                                  >
+                                    Delete
+                                  </span>
+                                  <svg
+                                    aria-hidden="true"
+                                    aria-label="Delete"
+                                    className="bx--btn__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={16}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    role="img"
+                                    viewBox="0 0 32 32"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M12 12H14V24H12zM18 12H20V24H18z"
+                                    />
+                                    <path
+                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                    />
+                                  </svg>
+                                </button>
                               </div>
                               <div
                                 className="iot--image-tile__image-container"
@@ -3532,6 +3796,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                 <span>
                                   large_portrait
                                 </span>
+                                <button
+                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  tabIndex={0}
+                                  type="button"
+                                >
+                                  <span
+                                    className="bx--assistive-text"
+                                  >
+                                    Delete
+                                  </span>
+                                  <svg
+                                    aria-hidden="true"
+                                    aria-label="Delete"
+                                    className="bx--btn__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={16}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    role="img"
+                                    viewBox="0 0 32 32"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M12 12H14V24H12zM18 12H20V24H18z"
+                                    />
+                                    <path
+                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                    />
+                                  </svg>
+                                </button>
                               </div>
                               <div
                                 className="iot--image-tile__image-container"
@@ -3559,8 +3856,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                         Cancel
                       </button>
                       <button
-                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                        disabled={true}
+                        className="iot--btn bx--btn bx--btn--primary"
+                        disabled={false}
                         onClick={[Function]}
                         tabIndex={0}
                         type="button"
@@ -4998,8 +5295,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                         Cancel
                       </button>
                       <button
-                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                        disabled={true}
+                        className="iot--btn bx--btn bx--btn--primary"
+                        disabled={false}
                         onClick={[Function]}
                         tabIndex={0}
                         type="button"
@@ -6185,8 +6482,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                         Cancel
                       </button>
                       <button
-                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                        disabled={true}
+                        className="iot--btn bx--btn bx--btn--primary"
+                        disabled={false}
                         onClick={[Function]}
                         tabIndex={0}
                         type="button"
@@ -7478,8 +7775,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                         Cancel
                       </button>
                       <button
-                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                        disabled={true}
+                        className="iot--btn bx--btn bx--btn--primary"
+                        disabled={false}
                         onClick={[Function]}
                         tabIndex={0}
                         type="button"
@@ -10336,8 +10633,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                         Cancel
                       </button>
                       <button
-                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                        disabled={true}
+                        className="iot--btn bx--btn bx--btn--primary"
+                        disabled={false}
                         onClick={[Function]}
                         tabIndex={0}
                         type="button"

--- a/src/components/ImageGalleryModal/ImageGalleryModal.jsx
+++ b/src/components/ImageGalleryModal/ImageGalleryModal.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import { Grid20, List20 } from '@carbon/icons-react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import omit from 'lodash/omit';
+import { Modal } from 'carbon-components-react';
 
 import { settings } from '../../constants/Settings';
 import ComposedModal from '../ComposedModal';
@@ -47,6 +48,9 @@ const propTypes = {
   /** The image property to be included in the search */
   searchProperty: PropTypes.string,
 
+  /** optional method to allow deletion of the images in the gallery */
+  onDelete: PropTypes.func,
+
   /** The text of the grid button in the grid list toggle */
   gridButtonText: PropTypes.string,
   /** The text with instructions showing above the search */
@@ -60,6 +64,10 @@ const propTypes = {
   modalTitleText: PropTypes.string,
   /** The primary button (select) text of the modal */
   modalPrimaryButtonLabelText: PropTypes.string,
+  deleteLabelText: PropTypes.string,
+  deleteModalLabelText: PropTypes.string,
+  /** callback function that passes the image name and returns the title text for the delete */
+  deleteModalTitleText: PropTypes.func,
   /** The secondary button (cancel) text of the modal */
   modalSecondaryButtonLabelText: PropTypes.string,
   /** The text for the search input placeHolder */
@@ -72,6 +80,7 @@ const defaultProps = {
   defaultView: GRID,
   footer: {},
   searchProperty: 'id',
+  onDelete: null,
 
   gridButtonText: 'Grid',
   instructionText: 'Select the image that you want to display on this card.',
@@ -79,6 +88,10 @@ const defaultProps = {
   modalLabelText: 'New image card',
   modalTitleText: 'Image gallery',
   modalPrimaryButtonLabelText: 'Select',
+  deleteLabelText: 'Delete',
+  deleteModalLabelText: 'Delete image',
+  deleteModalTitleText: (image) =>
+    `Are you sure you want to delete the image: ${image}?`,
   modalSecondaryButtonLabelText: 'Cancel',
   modalCloseIconDescriptionText: 'Close',
   searchPlaceHolderText: 'Search image by file name',
@@ -94,17 +107,24 @@ const ImageGalleryModal = ({
   modalCloseIconDescriptionText,
   modalLabelText,
   modalTitleText,
+  deleteLabelText,
+  deleteModalLabelText,
+  deleteModalTitleText,
   modalPrimaryButtonLabelText,
   modalSecondaryButtonLabelText,
   onSubmit,
   onClose,
   searchPlaceHolderText,
   searchProperty,
+  onDelete,
   footer,
   ...composedModalProps
 }) => {
   const [activeView, setActiveView] = useState(defaultView);
   const [selectedImage, setSelectedImage] = useState();
+  const [isDeleteWarningModalOpen, setIsDeleteWarningModalOpen] = useState(
+    false
+  );
   const [filteredContent, setFilteredContent] = useState(content);
 
   // Need to support lazy loaded content
@@ -126,82 +146,109 @@ const ImageGalleryModal = ({
     setSelectedImage(undefined);
   };
 
+  const handleDelete = () => {
+    onDelete(selectedImage.id);
+    setIsDeleteWarningModalOpen(false);
+  };
+
   const baseClass = `${iotPrefix}--image-gallery-modal`;
   return (
-    <ComposedModal
-      type="normal"
-      className={classnames(className, baseClass)}
-      footer={{
-        isPrimaryButtonDisabled: !selectedImage,
-        primaryButtonLabel: modalPrimaryButtonLabelText,
-        secondaryButtonLabel: modalSecondaryButtonLabelText,
-        ...footer,
-      }}
-      header={{
-        label: modalLabelText,
-        title: modalTitleText,
-      }}
-      isLarge
-      iconDescription={modalCloseIconDescriptionText}
-      onClose={onClose}
-      onSubmit={() => {
-        // title only makes sense in the modal selector, not in the image card
-        onSubmit(omit(selectedImage, 'title'));
-      }}
-      {...composedModalProps}>
-      <div className={`${baseClass}__top-section`}>
-        <p className={`${baseClass}__instruction-text`} alt={instructionText}>
-          {instructionText}
-        </p>
-        <div className={`${baseClass}__search-list-view-container`}>
-          <Search
-            id={`${baseClass}--search`}
-            onChange={filterContent}
-            labelText=""
-            light
-            placeHolderText={searchPlaceHolderText}
-          />
-          <ContentSwitcher
-            className={`${baseClass}__content-switcher`}
-            onChange={(selected) => {
-              setActiveView(selected.name);
-            }}
-            selectedIndex={activeView === GRID ? 0 : 1}>
-            <IconSwitch
-              name={GRID}
-              size="large"
-              text={gridButtonText}
-              renderIcon={Grid20}
-              index={0}
+    <>
+      {isDeleteWarningModalOpen ? ( // warning modal to show first
+        <Modal
+          className={`${baseClass}--warning-modal`}
+          open={isDeleteWarningModalOpen}
+          danger
+          primaryButtonText={deleteLabelText}
+          secondaryButtonText={modalSecondaryButtonLabelText}
+          modalHeading={deleteModalTitleText(selectedImage?.id)}
+          size="xs"
+          iconDescription={modalCloseIconDescriptionText}
+          onRequestClose={() => setIsDeleteWarningModalOpen(false)}
+          onRequestSubmit={handleDelete}
+        />
+      ) : null}
+      <ComposedModal
+        type="normal"
+        className={classnames(className, baseClass)}
+        footer={{
+          primaryButtonLabel: modalPrimaryButtonLabelText,
+          secondaryButtonLabel: modalSecondaryButtonLabelText,
+          ...footer,
+        }}
+        header={{
+          label: modalLabelText,
+          title: modalTitleText,
+        }}
+        isLarge
+        iconDescription={modalCloseIconDescriptionText}
+        onClose={onClose}
+        onSubmit={() => {
+          // title only makes sense in the modal selector, not in the image card
+          onSubmit(omit(selectedImage, 'title'));
+        }}
+        {...composedModalProps}>
+        <div className={`${baseClass}__top-section`}>
+          <p className={`${baseClass}__instruction-text`} alt={instructionText}>
+            {instructionText}
+          </p>
+          <div className={`${baseClass}__search-list-view-container`}>
+            <Search
+              id={`${baseClass}--search`}
+              onChange={filterContent}
+              labelText=""
+              light
+              placeHolderText={searchPlaceHolderText}
             />
-            <IconSwitch
-              name={LIST}
-              size="large"
-              text={listButtonText}
-              renderIcon={List20}
-              index={1}
-            />
-          </ContentSwitcher>
+            <ContentSwitcher
+              className={`${baseClass}__content-switcher`}
+              onChange={(selected) => {
+                setActiveView(selected.name);
+              }}
+              selectedIndex={activeView === GRID ? 0 : 1}>
+              <IconSwitch
+                name={GRID}
+                size="large"
+                text={gridButtonText}
+                renderIcon={Grid20}
+                index={0}
+              />
+              <IconSwitch
+                name={LIST}
+                size="large"
+                text={listButtonText}
+                renderIcon={List20}
+                index={1}
+              />
+            </ContentSwitcher>
+          </div>
         </div>
-      </div>
-      <div className={`${baseClass}__flex-wrapper`}>
-        <div
-          className={classnames(`${baseClass}__scroll-panel`, {
-            [`${baseClass}__scroll-panel--grid`]: activeView === GRID,
-            [`${baseClass}__scroll-panel--list`]: activeView === LIST,
-          })}>
-          {filteredContent.map((imageProps) => (
-            <ImageTile
-              isWide={activeView === LIST}
-              key={imageProps.id}
-              {...imageProps}
-              toggleImageSelection={() => toggleImageSelection(imageProps)}
-              isSelected={selectedImage?.id === imageProps.id}
-            />
-          ))}
+        <div className={`${baseClass}__flex-wrapper`}>
+          <div
+            className={classnames(`${baseClass}__scroll-panel`, {
+              [`${baseClass}__scroll-panel--grid`]: activeView === GRID,
+              [`${baseClass}__scroll-panel--list`]: activeView === LIST,
+            })}>
+            {filteredContent.map((imageProps) => (
+              <ImageTile
+                isWide={activeView === LIST}
+                key={imageProps.id}
+                onDelete={(id) => {
+                  // set the current selected image and popup the warning modal
+                  if (selectedImage?.id !== id) {
+                    setSelectedImage(imageProps);
+                  }
+                  setIsDeleteWarningModalOpen(true);
+                }}
+                {...imageProps}
+                toggleImageSelection={() => toggleImageSelection(imageProps)}
+                isSelected={selectedImage?.id === imageProps.id}
+              />
+            ))}
+          </div>
         </div>
-      </div>
-    </ComposedModal>
+      </ComposedModal>
+    </>
   );
 };
 

--- a/src/components/ImageGalleryModal/ImageGalleryModal.jsx
+++ b/src/components/ImageGalleryModal/ImageGalleryModal.jsx
@@ -172,6 +172,7 @@ const ImageGalleryModal = ({
         type="normal"
         className={classnames(className, baseClass)}
         footer={{
+          isPrimaryButtonDisabled: !selectedImage,
           primaryButtonLabel: modalPrimaryButtonLabelText,
           secondaryButtonLabel: modalSecondaryButtonLabelText,
           ...footer,

--- a/src/components/ImageGalleryModal/ImageGalleryModal.story.jsx
+++ b/src/components/ImageGalleryModal/ImageGalleryModal.story.jsx
@@ -56,6 +56,7 @@ export const Basic = () => {
         key={regenerationKey} // Only used for story knob demo purpose
         onSubmit={action('onSubmit')}
         onClose={action('onClose')}
+        onDelete={action('onDelete')}
         content={editableContent}
         searchProperty={select(
           'searchProperty',

--- a/src/components/ImageGalleryModal/ImageGalleryModal.test.jsx
+++ b/src/components/ImageGalleryModal/ImageGalleryModal.test.jsx
@@ -170,4 +170,23 @@ describe('ImageGalleryModal', () => {
     userEvent.click(screen.getByRole('button', { name: 'Select' }));
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
+  it('clicking delete button triggers delete', () => {
+    const content = getTestContent();
+    const onSubmit = jest.fn();
+    const onDelete = jest.fn();
+    render(
+      <ImageGalleryModal
+        content={content}
+        onSubmit={onSubmit}
+        onDelete={onDelete}
+        onClose={() => {}}
+      />
+    );
+
+    userEvent.click(screen.getAllByRole('button', { name: 'Delete' })[0]);
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Are you sure you want/)).toBeInTheDocument();
+    userEvent.click(screen.getAllByRole('button', { name: 'Delete' })[0]);
+    expect(onDelete).toHaveBeenCalled();
+  });
 });

--- a/src/components/ImageGalleryModal/ImageTile.jsx
+++ b/src/components/ImageGalleryModal/ImageTile.jsx
@@ -1,4 +1,5 @@
-import { SelectableTile } from 'carbon-components-react';
+import { SelectableTile, Button } from 'carbon-components-react';
+import { TrashCan16 } from '@carbon/icons-react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -15,6 +16,11 @@ const propTypes = {
   toggleImageSelection: PropTypes.func.isRequired,
   src: PropTypes.string.isRequired,
   title: PropTypes.string,
+  i18n: PropTypes.shape({
+    deleteButtonLabel: PropTypes.string,
+  }),
+  /** function called with the image id if they click the delete button */
+  onDelete: PropTypes.func,
 };
 
 const defaultProps = {
@@ -22,6 +28,10 @@ const defaultProps = {
   isSelected: false,
   isWide: false,
   title: undefined,
+  i18n: {
+    deleteButtonLabel: 'Delete',
+  },
+  onDelete: null,
 };
 
 const matchFilename = /^(.+\/)*(.+)\.(.+)$/;
@@ -38,6 +48,8 @@ const ImageTile = ({
   isWide,
   toggleImageSelection,
   src,
+  onDelete,
+  i18n: { deleteButtonLabel },
   title,
 }) => {
   return (
@@ -51,6 +63,19 @@ const ImageTile = ({
       light>
       <div className={`${iotPrefix}--image-tile__title`}>
         <span>{title ?? extractFileName(src) ?? src}</span>
+        {onDelete ? (
+          <Button
+            className={`${iotPrefix}--image-tile__title__delete`}
+            renderIcon={TrashCan16}
+            hasIconOnly
+            iconDescription={deleteButtonLabel}
+            kind="ghost"
+            onClick={(event) => {
+              event.stopPropagation();
+              onDelete(id);
+            }}
+          />
+        ) : null}
       </div>
       <div className={`${iotPrefix}--image-tile__image-container`}>
         <img src={src} alt={alt} />

--- a/src/components/ImageGalleryModal/ImageTile.jsx
+++ b/src/components/ImageGalleryModal/ImageTile.jsx
@@ -63,6 +63,9 @@ const ImageTile = ({
       light>
       <div className={`${iotPrefix}--image-tile__title`}>
         <span>{title ?? extractFileName(src) ?? src}</span>
+      </div>
+      <div className={`${iotPrefix}--image-tile__image-container`}>
+        <img src={src} alt={alt} />
         {onDelete ? (
           <Button
             className={`${iotPrefix}--image-tile__title__delete`}
@@ -76,9 +79,6 @@ const ImageTile = ({
             }}
           />
         ) : null}
-      </div>
-      <div className={`${iotPrefix}--image-tile__image-container`}>
-        <img src={src} alt={alt} />
       </div>
     </SelectableTile>
   );

--- a/src/components/ImageGalleryModal/ImageTile.test.jsx
+++ b/src/components/ImageGalleryModal/ImageTile.test.jsx
@@ -9,11 +9,13 @@ describe('ImageTile', () => {
     expect(screen.queryByText('Delete')).toBeNull();
 
     const mockDelete = jest.fn();
+    const mockToggle = jest.fn();
     render(
       <ImageTile
         id="my image"
         src=" src: 'path/to/image-a.jpg'"
         onDelete={mockDelete}
+        toggleImageSelection={mockToggle}
       />
     );
     expect(screen.queryByText('Delete')).toBeDefined();

--- a/src/components/ImageGalleryModal/ImageTile.test.jsx
+++ b/src/components/ImageGalleryModal/ImageTile.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import ImageTile from './ImageTile';
+
+describe('ImageTile', () => {
+  it('delete button', () => {
+    render(<ImageTile id="my image" src=" src: 'path/to/image-a.jpg'" />);
+    expect(screen.queryByText('Delete')).toBeNull();
+
+    const mockDelete = jest.fn();
+    render(
+      <ImageTile
+        id="my image"
+        src=" src: 'path/to/image-a.jpg'"
+        onDelete={mockDelete}
+      />
+    );
+    expect(screen.queryByText('Delete')).toBeDefined();
+    expect(mockDelete).not.toHaveBeenCalled();
+    fireEvent.click(screen.queryByText('Delete'));
+    expect(mockDelete).toHaveBeenCalled();
+  });
+});

--- a/src/components/ImageGalleryModal/__snapshots__/ImageGalleryModal.story.storyshot
+++ b/src/components/ImageGalleryModal/__snapshots__/ImageGalleryModal.story.storyshot
@@ -274,6 +274,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
       eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim 
       ad minim veniam.
                       </span>
+                      <button
+                        className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Delete
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Delete"
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 12H14V24H12zM18 12H20V24H18z"
+                          />
+                          <path
+                            d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                          />
+                        </svg>
+                      </button>
                     </div>
                     <div
                       className="iot--image-tile__image-container"
@@ -335,6 +368,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         floow_plan
                       </span>
+                      <button
+                        className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Delete
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Delete"
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 12H14V24H12zM18 12H20V24H18z"
+                          />
+                          <path
+                            d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                          />
+                        </svg>
+                      </button>
                     </div>
                     <div
                       className="iot--image-tile__image-container"
@@ -396,6 +462,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         Manufacturing_plant
                       </span>
+                      <button
+                        className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Delete
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Delete"
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 12H14V24H12zM18 12H20V24H18z"
+                          />
+                          <path
+                            d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                          />
+                        </svg>
+                      </button>
                     </div>
                     <div
                       className="iot--image-tile__image-container"
@@ -457,6 +556,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         robot_arm
                       </span>
+                      <button
+                        className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Delete
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Delete"
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 12H14V24H12zM18 12H20V24H18z"
+                          />
+                          <path
+                            d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                          />
+                        </svg>
+                      </button>
                     </div>
                     <div
                       className="iot--image-tile__image-container"
@@ -518,6 +650,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         tankmodal
                       </span>
+                      <button
+                        className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Delete
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Delete"
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 12H14V24H12zM18 12H20V24H18z"
+                          />
+                          <path
+                            d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                          />
+                        </svg>
+                      </button>
                     </div>
                     <div
                       className="iot--image-tile__image-container"
@@ -579,6 +744,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         turbines
                       </span>
+                      <button
+                        className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Delete
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Delete"
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 12H14V24H12zM18 12H20V24H18z"
+                          />
+                          <path
+                            d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                          />
+                        </svg>
+                      </button>
                     </div>
                     <div
                       className="iot--image-tile__image-container"
@@ -640,6 +838,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         extra-wide-image
                       </span>
+                      <button
+                        className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Delete
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Delete"
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 12H14V24H12zM18 12H20V24H18z"
+                          />
+                          <path
+                            d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                          />
+                        </svg>
+                      </button>
                     </div>
                     <div
                       className="iot--image-tile__image-container"
@@ -701,6 +932,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         large
                       </span>
+                      <button
+                        className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Delete
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Delete"
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 12H14V24H12zM18 12H20V24H18z"
+                          />
+                          <path
+                            d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                          />
+                        </svg>
+                      </button>
                     </div>
                     <div
                       className="iot--image-tile__image-container"
@@ -762,6 +1026,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         large_portrait
                       </span>
+                      <button
+                        className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Delete
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Delete"
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 12H14V24H12zM18 12H20V24H18z"
+                          />
+                          <path
+                            d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                          />
+                        </svg>
+                      </button>
                     </div>
                     <div
                       className="iot--image-tile__image-container"
@@ -789,8 +1086,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
               Cancel
             </button>
             <button
-              className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-              disabled={true}
+              className="iot--btn bx--btn bx--btn--primary"
+              disabled={false}
               onClick={[Function]}
               tabIndex={0}
               type="button"
@@ -1109,6 +1406,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
       eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim 
       ad minim veniam.
                       </span>
+                      <button
+                        className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Delete
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Delete"
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 12H14V24H12zM18 12H20V24H18z"
+                          />
+                          <path
+                            d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                          />
+                        </svg>
+                      </button>
                     </div>
                     <div
                       className="iot--image-tile__image-container"
@@ -1170,6 +1500,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         floow_plan
                       </span>
+                      <button
+                        className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Delete
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Delete"
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 12H14V24H12zM18 12H20V24H18z"
+                          />
+                          <path
+                            d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                          />
+                        </svg>
+                      </button>
                     </div>
                     <div
                       className="iot--image-tile__image-container"
@@ -1231,6 +1594,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         Manufacturing_plant
                       </span>
+                      <button
+                        className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Delete
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Delete"
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 12H14V24H12zM18 12H20V24H18z"
+                          />
+                          <path
+                            d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                          />
+                        </svg>
+                      </button>
                     </div>
                     <div
                       className="iot--image-tile__image-container"
@@ -1292,6 +1688,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         robot_arm
                       </span>
+                      <button
+                        className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Delete
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Delete"
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 12H14V24H12zM18 12H20V24H18z"
+                          />
+                          <path
+                            d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                          />
+                        </svg>
+                      </button>
                     </div>
                     <div
                       className="iot--image-tile__image-container"
@@ -1353,6 +1782,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         tankmodal
                       </span>
+                      <button
+                        className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Delete
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Delete"
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 12H14V24H12zM18 12H20V24H18z"
+                          />
+                          <path
+                            d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                          />
+                        </svg>
+                      </button>
                     </div>
                     <div
                       className="iot--image-tile__image-container"
@@ -1414,6 +1876,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         turbines
                       </span>
+                      <button
+                        className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Delete
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Delete"
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 12H14V24H12zM18 12H20V24H18z"
+                          />
+                          <path
+                            d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                          />
+                        </svg>
+                      </button>
                     </div>
                     <div
                       className="iot--image-tile__image-container"
@@ -1475,6 +1970,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         extra-wide-image
                       </span>
+                      <button
+                        className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Delete
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Delete"
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 12H14V24H12zM18 12H20V24H18z"
+                          />
+                          <path
+                            d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                          />
+                        </svg>
+                      </button>
                     </div>
                     <div
                       className="iot--image-tile__image-container"
@@ -1536,6 +2064,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         large
                       </span>
+                      <button
+                        className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Delete
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Delete"
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 12H14V24H12zM18 12H20V24H18z"
+                          />
+                          <path
+                            d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                          />
+                        </svg>
+                      </button>
                     </div>
                     <div
                       className="iot--image-tile__image-container"
@@ -1597,6 +2158,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         large_portrait
                       </span>
+                      <button
+                        className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        <span
+                          className="bx--assistive-text"
+                        >
+                          Delete
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Delete"
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 12H14V24H12zM18 12H20V24H18z"
+                          />
+                          <path
+                            d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                          />
+                        </svg>
+                      </button>
                     </div>
                     <div
                       className="iot--image-tile__image-container"
@@ -1624,8 +2218,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
               Cancel
             </button>
             <button
-              className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-              disabled={true}
+              className="iot--btn bx--btn bx--btn--primary"
+              disabled={false}
               onClick={[Function]}
               tabIndex={0}
               type="button"

--- a/src/components/ImageGalleryModal/__snapshots__/ImageGalleryModal.story.storyshot
+++ b/src/components/ImageGalleryModal/__snapshots__/ImageGalleryModal.story.storyshot
@@ -274,6 +274,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
       eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim 
       ad minim veniam.
                       </span>
+                    </div>
+                    <div
+                      className="iot--image-tile__image-container"
+                    >
+                      <img
+                        alt="assemblyline"
+                        src="assemblyline.jpg"
+                      />
                       <button
                         className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                         disabled={false}
@@ -307,14 +315,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                           />
                         </svg>
                       </button>
-                    </div>
-                    <div
-                      className="iot--image-tile__image-container"
-                    >
-                      <img
-                        alt="assemblyline"
-                        src="assemblyline.jpg"
-                      />
                     </div>
                   </span>
                 </label>
@@ -368,6 +368,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         floow_plan
                       </span>
+                    </div>
+                    <div
+                      className="iot--image-tile__image-container"
+                    >
+                      <img
+                        alt="floow plan"
+                        src="floow_plan.png"
+                      />
                       <button
                         className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                         disabled={false}
@@ -401,14 +409,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                           />
                         </svg>
                       </button>
-                    </div>
-                    <div
-                      className="iot--image-tile__image-container"
-                    >
-                      <img
-                        alt="floow plan"
-                        src="floow_plan.png"
-                      />
                     </div>
                   </span>
                 </label>
@@ -462,6 +462,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         Manufacturing_plant
                       </span>
+                    </div>
+                    <div
+                      className="iot--image-tile__image-container"
+                    >
+                      <img
+                        alt="manufacturing plant"
+                        src="Manufacturing_plant.png"
+                      />
                       <button
                         className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                         disabled={false}
@@ -495,14 +503,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                           />
                         </svg>
                       </button>
-                    </div>
-                    <div
-                      className="iot--image-tile__image-container"
-                    >
-                      <img
-                        alt="manufacturing plant"
-                        src="Manufacturing_plant.png"
-                      />
                     </div>
                   </span>
                 </label>
@@ -556,6 +556,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         robot_arm
                       </span>
+                    </div>
+                    <div
+                      className="iot--image-tile__image-container"
+                    >
+                      <img
+                        alt="robot arm"
+                        src="robot_arm.png"
+                      />
                       <button
                         className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                         disabled={false}
@@ -589,14 +597,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                           />
                         </svg>
                       </button>
-                    </div>
-                    <div
-                      className="iot--image-tile__image-container"
-                    >
-                      <img
-                        alt="robot arm"
-                        src="robot_arm.png"
-                      />
                     </div>
                   </span>
                 </label>
@@ -650,6 +650,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         tankmodal
                       </span>
+                    </div>
+                    <div
+                      className="iot--image-tile__image-container"
+                    >
+                      <img
+                        alt="tankmodal"
+                        src="tankmodal.png"
+                      />
                       <button
                         className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                         disabled={false}
@@ -683,14 +691,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                           />
                         </svg>
                       </button>
-                    </div>
-                    <div
-                      className="iot--image-tile__image-container"
-                    >
-                      <img
-                        alt="tankmodal"
-                        src="tankmodal.png"
-                      />
                     </div>
                   </span>
                 </label>
@@ -744,6 +744,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         turbines
                       </span>
+                    </div>
+                    <div
+                      className="iot--image-tile__image-container"
+                    >
+                      <img
+                        alt="turbines"
+                        src="turbines.png"
+                      />
                       <button
                         className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                         disabled={false}
@@ -777,14 +785,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                           />
                         </svg>
                       </button>
-                    </div>
-                    <div
-                      className="iot--image-tile__image-container"
-                    >
-                      <img
-                        alt="turbines"
-                        src="turbines.png"
-                      />
                     </div>
                   </span>
                 </label>
@@ -838,6 +838,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         extra-wide-image
                       </span>
+                    </div>
+                    <div
+                      className="iot--image-tile__image-container"
+                    >
+                      <img
+                        alt="extra wide image"
+                        src="extra-wide-image.png"
+                      />
                       <button
                         className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                         disabled={false}
@@ -871,14 +879,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                           />
                         </svg>
                       </button>
-                    </div>
-                    <div
-                      className="iot--image-tile__image-container"
-                    >
-                      <img
-                        alt="extra wide image"
-                        src="extra-wide-image.png"
-                      />
                     </div>
                   </span>
                 </label>
@@ -932,6 +932,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         large
                       </span>
+                    </div>
+                    <div
+                      className="iot--image-tile__image-container"
+                    >
+                      <img
+                        alt="large image"
+                        src="large.png"
+                      />
                       <button
                         className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                         disabled={false}
@@ -965,14 +973,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                           />
                         </svg>
                       </button>
-                    </div>
-                    <div
-                      className="iot--image-tile__image-container"
-                    >
-                      <img
-                        alt="large image"
-                        src="large.png"
-                      />
                     </div>
                   </span>
                 </label>
@@ -1026,6 +1026,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         large_portrait
                       </span>
+                    </div>
+                    <div
+                      className="iot--image-tile__image-container"
+                    >
+                      <img
+                        alt="large image portrait"
+                        src="large_portrait.png"
+                      />
                       <button
                         className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                         disabled={false}
@@ -1059,14 +1067,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                           />
                         </svg>
                       </button>
-                    </div>
-                    <div
-                      className="iot--image-tile__image-container"
-                    >
-                      <img
-                        alt="large image portrait"
-                        src="large_portrait.png"
-                      />
                     </div>
                   </span>
                 </label>
@@ -1406,6 +1406,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
       eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim 
       ad minim veniam.
                       </span>
+                    </div>
+                    <div
+                      className="iot--image-tile__image-container"
+                    >
+                      <img
+                        alt="assemblyline"
+                        src="assemblyline.jpg"
+                      />
                       <button
                         className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                         disabled={false}
@@ -1439,14 +1447,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                           />
                         </svg>
                       </button>
-                    </div>
-                    <div
-                      className="iot--image-tile__image-container"
-                    >
-                      <img
-                        alt="assemblyline"
-                        src="assemblyline.jpg"
-                      />
                     </div>
                   </span>
                 </label>
@@ -1500,6 +1500,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         floow_plan
                       </span>
+                    </div>
+                    <div
+                      className="iot--image-tile__image-container"
+                    >
+                      <img
+                        alt="floow plan"
+                        src="floow_plan.png"
+                      />
                       <button
                         className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                         disabled={false}
@@ -1533,14 +1541,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                           />
                         </svg>
                       </button>
-                    </div>
-                    <div
-                      className="iot--image-tile__image-container"
-                    >
-                      <img
-                        alt="floow plan"
-                        src="floow_plan.png"
-                      />
                     </div>
                   </span>
                 </label>
@@ -1594,6 +1594,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         Manufacturing_plant
                       </span>
+                    </div>
+                    <div
+                      className="iot--image-tile__image-container"
+                    >
+                      <img
+                        alt="manufacturing plant"
+                        src="Manufacturing_plant.png"
+                      />
                       <button
                         className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                         disabled={false}
@@ -1627,14 +1635,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                           />
                         </svg>
                       </button>
-                    </div>
-                    <div
-                      className="iot--image-tile__image-container"
-                    >
-                      <img
-                        alt="manufacturing plant"
-                        src="Manufacturing_plant.png"
-                      />
                     </div>
                   </span>
                 </label>
@@ -1688,6 +1688,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         robot_arm
                       </span>
+                    </div>
+                    <div
+                      className="iot--image-tile__image-container"
+                    >
+                      <img
+                        alt="robot arm"
+                        src="robot_arm.png"
+                      />
                       <button
                         className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                         disabled={false}
@@ -1721,14 +1729,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                           />
                         </svg>
                       </button>
-                    </div>
-                    <div
-                      className="iot--image-tile__image-container"
-                    >
-                      <img
-                        alt="robot arm"
-                        src="robot_arm.png"
-                      />
                     </div>
                   </span>
                 </label>
@@ -1782,6 +1782,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         tankmodal
                       </span>
+                    </div>
+                    <div
+                      className="iot--image-tile__image-container"
+                    >
+                      <img
+                        alt="tankmodal"
+                        src="tankmodal.png"
+                      />
                       <button
                         className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                         disabled={false}
@@ -1815,14 +1823,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                           />
                         </svg>
                       </button>
-                    </div>
-                    <div
-                      className="iot--image-tile__image-container"
-                    >
-                      <img
-                        alt="tankmodal"
-                        src="tankmodal.png"
-                      />
                     </div>
                   </span>
                 </label>
@@ -1876,6 +1876,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         turbines
                       </span>
+                    </div>
+                    <div
+                      className="iot--image-tile__image-container"
+                    >
+                      <img
+                        alt="turbines"
+                        src="turbines.png"
+                      />
                       <button
                         className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                         disabled={false}
@@ -1909,14 +1917,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                           />
                         </svg>
                       </button>
-                    </div>
-                    <div
-                      className="iot--image-tile__image-container"
-                    >
-                      <img
-                        alt="turbines"
-                        src="turbines.png"
-                      />
                     </div>
                   </span>
                 </label>
@@ -1970,6 +1970,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         extra-wide-image
                       </span>
+                    </div>
+                    <div
+                      className="iot--image-tile__image-container"
+                    >
+                      <img
+                        alt="extra wide image"
+                        src="extra-wide-image.png"
+                      />
                       <button
                         className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                         disabled={false}
@@ -2003,14 +2011,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                           />
                         </svg>
                       </button>
-                    </div>
-                    <div
-                      className="iot--image-tile__image-container"
-                    >
-                      <img
-                        alt="extra wide image"
-                        src="extra-wide-image.png"
-                      />
                     </div>
                   </span>
                 </label>
@@ -2064,6 +2064,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         large
                       </span>
+                    </div>
+                    <div
+                      className="iot--image-tile__image-container"
+                    >
+                      <img
+                        alt="large image"
+                        src="large.png"
+                      />
                       <button
                         className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                         disabled={false}
@@ -2097,14 +2105,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                           />
                         </svg>
                       </button>
-                    </div>
-                    <div
-                      className="iot--image-tile__image-container"
-                    >
-                      <img
-                        alt="large image"
-                        src="large.png"
-                      />
                     </div>
                   </span>
                 </label>
@@ -2158,6 +2158,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                       <span>
                         large_portrait
                       </span>
+                    </div>
+                    <div
+                      className="iot--image-tile__image-container"
+                    >
+                      <img
+                        alt="large image portrait"
+                        src="large_portrait.png"
+                      />
                       <button
                         className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                         disabled={false}
@@ -2191,14 +2199,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
                           />
                         </svg>
                       </button>
-                    </div>
-                    <div
-                      className="iot--image-tile__image-container"
-                    >
-                      <img
-                        alt="large image portrait"
-                        src="large_portrait.png"
-                      />
                     </div>
                   </span>
                 </label>

--- a/src/components/ImageGalleryModal/__snapshots__/ImageGalleryModal.story.storyshot
+++ b/src/components/ImageGalleryModal/__snapshots__/ImageGalleryModal.story.storyshot
@@ -1086,8 +1086,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
               Cancel
             </button>
             <button
-              className="iot--btn bx--btn bx--btn--primary"
-              disabled={false}
+              className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+              disabled={true}
               onClick={[Function]}
               tabIndex={0}
               type="button"
@@ -2218,8 +2218,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Image
               Cancel
             </button>
             <button
-              className="iot--btn bx--btn bx--btn--primary"
-              disabled={false}
+              className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+              disabled={true}
               onClick={[Function]}
               tabIndex={0}
               type="button"

--- a/src/components/ImageGalleryModal/_image-gallery-modal.scss
+++ b/src/components/ImageGalleryModal/_image-gallery-modal.scss
@@ -4,6 +4,9 @@ $top-section-height: 6.25rem;
 $border-radius: 0.25rem;
 
 .#{$iot-prefix}--image-gallery-modal {
+  &--warning-modal {
+    z-index: 30000;
+  }
   &.#{$iot-prefix}--composed-modal.#{$iot-prefix}--composed-modal--large {
     .#{$prefix}--modal-container {
       background-color: $ui-02;

--- a/src/components/ImageGalleryModal/_image-tile.scss
+++ b/src/components/ImageGalleryModal/_image-tile.scss
@@ -72,7 +72,6 @@ $title-height: 3rem;
   background-color: $ui-01;
   padding-left: $spacing-05;
   padding-right: $spacing-07; // Make room for check mark when selected
-  position: relative;
   span {
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -83,7 +82,8 @@ $title-height: 3rem;
 // position the button on the far right
 .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$iot-prefix}--image-tile__title__delete {
   position: absolute;
-  right: 0px;
+  right: 0rem;
+  bottom: 0rem;
 }
 
 html[dir='rtl'] {

--- a/src/components/ImageGalleryModal/_image-tile.scss
+++ b/src/components/ImageGalleryModal/_image-tile.scss
@@ -72,12 +72,18 @@ $title-height: 3rem;
   background-color: $ui-01;
   padding-left: $spacing-05;
   padding-right: $spacing-07; // Make room for check mark when selected
-
+  position: relative;
   span {
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
   }
+}
+
+// position the button on the far right
+.#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$iot-prefix}--image-tile__title__delete {
+  position: absolute;
+  right: 0px;
 }
 
 html[dir='rtl'] {

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -6257,6 +6257,9 @@ Map {
       "className": "",
       "content": Array [],
       "defaultView": "grid",
+      "deleteLabelText": "Delete",
+      "deleteModalLabelText": "Delete image",
+      "deleteModalTitleText": [Function],
       "footer": Object {},
       "gridButtonText": "Grid",
       "instructionText": "Select the image that you want to display on this card.",
@@ -6266,6 +6269,7 @@ Map {
       "modalPrimaryButtonLabelText": "Select",
       "modalSecondaryButtonLabelText": "Cancel",
       "modalTitleText": "Image gallery",
+      "onDelete": null,
       "searchPlaceHolderText": "Search image by file name",
       "searchProperty": "id",
     },
@@ -6310,6 +6314,15 @@ Map {
           ],
         ],
         "type": "oneOf",
+      },
+      "deleteLabelText": Object {
+        "type": "string",
+      },
+      "deleteModalLabelText": Object {
+        "type": "string",
+      },
+      "deleteModalTitleText": Object {
+        "type": "func",
       },
       "error": Object {
         "type": "string",
@@ -6401,6 +6414,9 @@ Map {
       },
       "onClose": Object {
         "isRequired": true,
+        "type": "func",
+      },
+      "onDelete": Object {
         "type": "func",
       },
       "onSubmit": Object {
@@ -8481,6 +8497,7 @@ Map {
       "onDelete": null,
       "onEditTitle": null,
       "onExport": null,
+      "onImageDelete": null,
       "onImport": null,
       "onLayoutChange": null,
       "onSubmit": null,
@@ -8618,6 +8635,15 @@ Map {
             "headerXlargeButton": Object {
               "type": "string",
             },
+            "imageGalleryDeleteLabelText": Object {
+              "type": "string",
+            },
+            "imageGalleryDeleteModalLabelText": Object {
+              "type": "string",
+            },
+            "imageGalleryDeleteModalTitleText": Object {
+              "type": "func",
+            },
             "imageGalleryGridButtonText": Object {
               "type": "string",
             },
@@ -8708,6 +8734,9 @@ Map {
         "type": "func",
       },
       "onExport": Object {
+        "type": "func",
+      },
+      "onImageDelete": Object {
         "type": "func",
       },
       "onImport": Object {


### PR DESCRIPTION
Closes #

**Summary**

- feat(imagegallerymodal): allow the deletion in the imagegallery inside the dashboard editor

**Change List (commits, features, bugs, etc)**

- feat(DashboardEditor): add onImageDelete callback and new i18n labels imageGalleryDeleteLabelText: PropTypes.string,
    imageGalleryDeleteModalLabelText: PropTypes.string,
    imageGalleryDeleteModalTitleText: PropTypes.func,
- feat(ImageGalleryModal): support deletion if onDelete is set

**Acceptance Test (how to verify the PR)**

- Verify deletion is possible inside the dashboard editor
