### PR TITLE
fix(dashboard-editor): prioritize valid data for barchart previews

### DIFF
--- a/src/components/DashboardEditor/DashboardEditor.jsx
+++ b/src/components/DashboardEditor/DashboardEditor.jsx
@@ -497,6 +497,9 @@ const DashboardEditor = ({
                   {dashboardJson.cards.map((cardConfig) => {
                     const isSelected = cardConfig.id === selectedCardId;
                     const cardProps = commonCardProps(cardConfig, isSelected);
+                    const dataItemsForCard = getValidDataItems
+                      ? getValidDataItems(cardConfig)
+                      : dataItems;
                     // if renderCardPreview function not defined, or it returns null, render default preview
                     return (
                       renderCardPreview(
@@ -511,7 +514,7 @@ const DashboardEditor = ({
                       getCardPreview(
                         cardConfig,
                         cardProps,
-                        dataItems,
+                        dataItemsForCard,
                         availableDimensions
                       )
                     );

--- a/src/components/DashboardEditor/DashboardEditor.story.jsx
+++ b/src/components/DashboardEditor/DashboardEditor.story.jsx
@@ -66,6 +66,7 @@ export const Default = () => (
   <div style={{ height: 'calc(100vh - 6rem)' }}>
     <DashboardEditor
       title={text('title', 'My dashboard')}
+      getValidDataItems={() => mockDataItems}
       dataItems={mockDataItems}
       availableImages={images}
       onAddImage={action('onAddImage')}


### PR DESCRIPTION
**Summary**

Quick fix for the BarCharts to check for `getValidDataItems` for their data preview.

**Change List (commits, features, bugs, etc)**

Add a check for `getValidDataItems`

**Acceptance Test (how to verify the PR)**

Make sure that you can still see the data preview in the `DashboardEditor` stories
