### PR TITLE
fix(dashboardeditor): add ability to validate uploaded image

### DIFF
--- a/src/components/CardEditor/CardEditForm/CardEditForm.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditForm.jsx
@@ -245,7 +245,13 @@ const CardEditForm = ({
             onClick={() => {
               setModalData(
                 JSON.stringify(
-                  omit(cardConfig, ['id', 'content.src', 'content.imgState']),
+                  omit(cardConfig, [
+                    'id',
+                    'content.src',
+                    'content.imgState',
+                    'i18n',
+                    'validateUploadedImage',
+                  ]),
                   null,
                   4
                 )

--- a/src/components/DashboardEditor/DashboardEditor.jsx
+++ b/src/components/DashboardEditor/DashboardEditor.jsx
@@ -121,6 +121,8 @@ const propTypes = {
    * @returns Array<string> error strings. return empty array if there is no errors
    */
   onValidateCardJson: PropTypes.func,
+  /** callback function to validate the uploaded image */
+  onValidateUploadedImage: PropTypes.func,
   /** callback if an image is deleted from the gallery */
   onImageDelete: PropTypes.func,
   /** optional loading prop to render the PageTitleBar loading state */
@@ -191,6 +193,7 @@ const defaultProps = {
   isSubmitDisabled: false,
   isSubmitLoading: false,
   onValidateCardJson: null,
+  onValidateUploadedImage: null,
   isLoading: false,
   i18n: {
     headerEditTitleButton: 'Edit title',
@@ -249,6 +252,7 @@ const DashboardEditor = ({
   isSubmitDisabled,
   isSubmitLoading,
   onValidateCardJson,
+  onValidateUploadedImage,
   availableDimensions,
   isLoading,
   i18n,
@@ -271,6 +275,11 @@ const DashboardEditor = ({
       ? LAYOUTS[breakpointSwitcher.initialValue].breakpoint
       : LAYOUTS.FIT_TO_SCREEN.breakpoint
   );
+
+  useEffect(() => {
+    // if the loaded template changes, we need to update the state
+    setDashboardJson(initialValue);
+  }, [initialValue]);
 
   // force a window resize so that react-grid-layout will trigger its reorder / resize
   useEffect(() => {
@@ -392,6 +401,10 @@ const DashboardEditor = ({
     onBrowseClick:
       cardConfig.type === CARD_TYPES.IMAGE && isNil(cardConfig.content?.src)
         ? handleShowImageGallery
+        : undefined,
+    validateUploadedImage:
+      cardConfig.type === CARD_TYPES.IMAGE
+        ? onValidateUploadedImage
         : undefined,
   });
 

--- a/src/components/ImageCard/ImageCard.jsx
+++ b/src/components/ImageCard/ImageCard.jsx
@@ -48,6 +48,8 @@ const defaultProps = {
     urlInput: 'Type or insert URL',
     errorTitle: 'Upload error: ',
     fileTooLarge: 'Image file is too large',
+    wrongFileType: (accept) =>
+      `This file is not one of the accepted file types, ${accept.join(', ')}`,
   },
   locale: 'en',
   content: {},
@@ -159,7 +161,8 @@ const ImageCard = ({
                       'insertUrl',
                       'urlInput',
                       'fileTooLarge',
-                      'errorTitle'
+                      'errorTitle',
+                      'wrongFileType'
                     )}
                     hasInsertFromUrl={hasInsertFromUrl}
                     validateUploadedImage={validateUploadedImage}

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -8502,6 +8502,7 @@ Map {
       "onLayoutChange": null,
       "onSubmit": null,
       "onValidateCardJson": null,
+      "onValidateUploadedImage": null,
       "renderCardPreview": [Function],
       "renderHeader": null,
       "supportedCardTypes": Array [
@@ -8749,6 +8750,9 @@ Map {
         "type": "func",
       },
       "onValidateCardJson": Object {
+        "type": "func",
+      },
+      "onValidateUploadedImage": Object {
         "type": "func",
       },
       "renderCardPreview": Object {
@@ -12781,6 +12785,7 @@ Map {
         "uploadByURLButton": "OK",
         "uploadByURLCancel": "Cancel",
         "urlInput": "Type or insert URL",
+        "wrongFileType": [Function],
       },
       "locale": "en",
       "maxFileSizeInBytes": 1048576,


### PR DESCRIPTION
Closes #

**Summary**

- fix(CardEditForm): hide the i18n and validateUploadedImage props in the modal
- feat(DashboardEditor): need to expose the onValidateUploadedImage to the DashboardEditor like the other callbacks
- fix(imageCard): need to pass along the wrongFileType function to the ImageUploader

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- tests here
