### PR TITLE
fix(dashboardeditor): need to refactor function to react component so it can be memoized

### DIFF
--- a/src/components/BarChartCard/BarChartCard.jsx
+++ b/src/components/BarChartCard/BarChartCard.jsx
@@ -87,28 +87,31 @@ const BarChartCard = ({
 
   const memoizedGenerateSampleValues = useMemo(
     () =>
-      generateSampleValues(
-        series,
-        timeDataSourceId,
-        interval,
-        timeRange,
-        categoryDataSourceId
-      ),
+      isEditable
+        ? generateSampleValues(
+            series,
+            timeDataSourceId,
+            interval,
+            timeRange,
+            categoryDataSourceId
+          )
+        : [],
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [series, interval, timeRange]
+    [series, interval, timeRange, isEditable]
   );
 
   const memoizedGenerateSampleValuesForEditor = useMemo(
     () =>
-      generateSampleValuesForEditor(
-        valuesProp,
-        categoryDataSourceId,
-        timeDataSourceId,
-        availableDimensions,
-        interval,
-        timeRange
-      ),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+      isDashboardPreview
+        ? generateSampleValuesForEditor(
+            valuesProp,
+            categoryDataSourceId,
+            timeDataSourceId,
+            availableDimensions,
+            interval,
+            timeRange
+          )
+        : [],
     [
       availableDimensions,
       categoryDataSourceId,
@@ -117,7 +120,6 @@ const BarChartCard = ({
       interval,
       timeRange,
       valuesProp,
-      series.length,
     ]
   );
 

--- a/src/components/DashboardEditor/DashboardEditor.jsx
+++ b/src/components/DashboardEditor/DashboardEditor.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { InlineNotification, SkeletonText } from 'carbon-components-react';
 import isNil from 'lodash/isNil';
@@ -17,10 +17,10 @@ import ImageGalleryModal, {
 } from '../ImageGalleryModal/ImageGalleryModal';
 
 import DashboardEditorHeader from './DashboardEditorHeader/DashboardEditorHeader';
+import DashboardEditorCardRenderer from './DashboardEditorCardRenderer';
 import {
   getDefaultCard,
   getDuplicateCard,
-  getCardPreview,
   renderBreakpointInfo,
   handleKeyDown,
   handleOnClick,
@@ -257,7 +257,7 @@ const DashboardEditor = ({
   isLoading,
   i18n,
 }) => {
-  const mergedI18n = { ...defaultProps.i18n, ...i18n };
+  const mergedI18n = useMemo(() => ({ ...defaultProps.i18n, ...i18n }), [i18n]);
   // Need to keep track of whether the image gallery is open or not
   const [isImageGalleryModalOpen, setIsImageGalleryModalOpen] = useState(false);
 
@@ -290,78 +290,88 @@ const DashboardEditor = ({
    * Adds a default, empty card to the preview
    * @param {string} type card type
    */
-  const addCard = (type) => {
-    const cardConfig = getDefaultCard(type, mergedI18n);
-    setDashboardJson({
-      ...dashboardJson,
-      cards: [...dashboardJson.cards, cardConfig],
-    });
-    setSelectedCardId(cardConfig.id);
-  };
+  const addCard = useCallback(
+    (type) => {
+      const cardConfig = getDefaultCard(type, mergedI18n);
+      // eslint-disable-next-line no-shadow
+      setDashboardJson((dashboardJson) => ({
+        ...dashboardJson,
+        cards: [...dashboardJson.cards, cardConfig],
+      }));
+      setSelectedCardId(cardConfig.id);
+    },
+    [mergedI18n]
+  );
 
   /**
    * Adds a cloned card with a new unique id to the preview
    * @param {string} id
    */
-  const duplicateCard = (id) => {
-    const cardConfig = getDuplicateCard(
-      dashboardJson.cards.find((i) => i.id === id)
-    );
-    setDashboardJson({
-      ...dashboardJson,
-      cards: [...dashboardJson.cards, cardConfig],
+  const duplicateCard = useCallback((id) => {
+    // eslint-disable-next-line no-shadow
+    setDashboardJson((dashboardJson) => {
+      const cardConfig = getDuplicateCard(
+        dashboardJson.cards.find((i) => i.id === id)
+      );
+      return {
+        ...dashboardJson,
+        cards: [...dashboardJson.cards, cardConfig],
+      };
     });
-    setSelectedCardId(cardConfig.id);
-  };
+    setSelectedCardId(id);
+  }, []);
 
   /**
    * Deletes a card from the preview
    * @param {string} id
    */
-  const removeCard = (id) =>
-    setDashboardJson({
-      ...dashboardJson,
-      cards: dashboardJson.cards.filter((i) => i.id !== id),
-    });
+  const removeCard = useCallback(
+    (id) =>
+      // eslint-disable-next-line no-shadow
+      setDashboardJson((dashboardJson) => ({
+        ...dashboardJson,
+        cards: dashboardJson.cards.filter((i) => i.id !== id),
+      })),
+    []
+  );
 
-  const onSelectCard = (id) => setSelectedCardId(id);
-  const onDuplicateCard = (id) => duplicateCard(id);
-  const onRemoveCard = (id) => removeCard(id);
-
-  const handleOnCardChange = (cardConfig) => {
-    // need to handle resetting the src of the image for image cards based on the id
-    if (
-      cardConfig.type === CARD_TYPES.IMAGE &&
-      cardConfig.content.imgState !== 'new'
-    ) {
-      // eslint-disable-next-line no-param-reassign
-      cardConfig.content.src = availableImages.find(
-        (image) => image.id === cardConfig.content.id
-      )?.src;
-    } else if (
-      cardConfig.content.imgState === 'new' &&
-      !imagesToUpload.some((image) => image.id === cardConfig.content.id)
-    ) {
-      if (cardConfig.content.id && cardConfig.content.src) {
-        setImagesToUpload((prevImagesToUpload) => [
-          ...prevImagesToUpload,
-          { id: cardConfig.content.id, src: cardConfig.content.src },
-        ]);
+  const handleOnCardChange = useCallback(
+    (cardConfig) => {
+      // need to handle resetting the src of the image for image cards based on the id
+      if (
+        cardConfig.type === CARD_TYPES.IMAGE &&
+        cardConfig.content.imgState !== 'new'
+      ) {
+        // eslint-disable-next-line no-param-reassign
+        cardConfig.content.src = availableImages.find(
+          (image) => image.id === cardConfig.content.id
+        )?.src;
+      } else if (
+        cardConfig.content.imgState === 'new' &&
+        !imagesToUpload.some((image) => image.id === cardConfig.content.id)
+      ) {
+        if (cardConfig.content.id && cardConfig.content.src) {
+          setImagesToUpload((prevImagesToUpload) => [
+            ...prevImagesToUpload,
+            { id: cardConfig.content.id, src: cardConfig.content.src },
+          ]);
+        }
       }
-    }
 
-    // TODO: this is really inefficient
-    setDashboardJson((oldJSON) => ({
-      ...oldJSON,
-      cards: oldJSON.cards.map((card) =>
-        card.id === cardConfig.id
-          ? onCardChange
-            ? onCardChange(cardConfig, oldJSON)
-            : cardConfig
-          : card
-      ),
-    }));
-  };
+      // TODO: this is really inefficient
+      setDashboardJson((oldJSON) => ({
+        ...oldJSON,
+        cards: oldJSON.cards.map((card) =>
+          card.id === cardConfig.id
+            ? onCardChange
+              ? onCardChange(cardConfig, oldJSON)
+              : cardConfig
+            : card
+        ),
+      }));
+    },
+    [availableImages, imagesToUpload, onCardChange]
+  );
 
   // Show the image gallery
   const handleShowImageGallery = () => setIsImageGalleryModalOpen(true);
@@ -379,34 +389,79 @@ const DashboardEditor = ({
     setIsImageGalleryModalOpen(false);
   };
 
-  const commonCardProps = (cardConfig, isSelected) => ({
-    key: cardConfig.id,
-    tooltip: cardConfig.description,
-    availableActions: { clone: true, delete: true },
-    onCardAction: (id, actionId, payload) => {
-      if (actionId === CARD_ACTIONS.CLONE_CARD) {
-        onDuplicateCard(id);
-      } else if (actionId === CARD_ACTIONS.DELETE_CARD) {
-        onRemoveCard(id);
-      } else if (actionId === CARD_ACTIONS.ON_CARD_CHANGE) {
-        handleOnCardChange(update(cardConfig, payload));
-      }
-    },
-    tabIndex: 0,
-    onKeyDown: (e) => handleKeyDown(e, onSelectCard, cardConfig.id),
-    onClick: () => handleOnClick(onSelectCard, cardConfig.id),
-    className: `${baseClassName}--preview__card`,
-    isSelected,
-    // Add the show gallery to image card
-    onBrowseClick:
-      cardConfig.type === CARD_TYPES.IMAGE && isNil(cardConfig.content?.src)
-        ? handleShowImageGallery
-        : undefined,
-    validateUploadedImage:
-      cardConfig.type === CARD_TYPES.IMAGE
-        ? onValidateUploadedImage
-        : undefined,
-  });
+  const commonCardProps = useCallback(
+    (cardConfig, isSelected) => ({
+      key: cardConfig.id,
+      tooltip: cardConfig.description,
+      availableActions: { clone: true, delete: true },
+      onCardAction: (id, actionId, payload) => {
+        if (actionId === CARD_ACTIONS.CLONE_CARD) {
+          duplicateCard(id);
+        } else if (actionId === CARD_ACTIONS.DELETE_CARD) {
+          removeCard(id);
+        } else if (actionId === CARD_ACTIONS.ON_CARD_CHANGE) {
+          handleOnCardChange(update(cardConfig, payload));
+        }
+      },
+      tabIndex: 0,
+      onKeyDown: (e) => handleKeyDown(e, setSelectedCardId, cardConfig.id),
+      onClick: () => handleOnClick(setSelectedCardId, cardConfig.id),
+      className: `${baseClassName}--preview__card`,
+      isSelected,
+      // Add the show gallery to image card
+      onBrowseClick:
+        cardConfig.type === CARD_TYPES.IMAGE && isNil(cardConfig.content?.src)
+          ? handleShowImageGallery
+          : undefined,
+      validateUploadedImage:
+        cardConfig.type === CARD_TYPES.IMAGE
+          ? onValidateUploadedImage
+          : undefined,
+    }),
+    [duplicateCard, handleOnCardChange, onValidateUploadedImage, removeCard]
+  );
+
+  const cards = useMemo(
+    () =>
+      dashboardJson?.cards?.map((cardConfig) => {
+        const isSelected = cardConfig.id === selectedCardId;
+        const cardProps = commonCardProps(cardConfig, isSelected);
+        const dataItemsForCard = getValidDataItems
+          ? getValidDataItems(cardConfig)
+          : dataItems;
+        // if renderCardPreview function not defined, or it returns null, render default preview
+        return (
+          renderCardPreview(
+            cardConfig,
+            cardProps,
+            setSelectedCardId,
+            duplicateCard,
+            removeCard,
+            isSelected,
+            handleShowImageGallery
+          ) ?? (
+            <DashboardEditorCardRenderer
+              key={cardConfig.id}
+              {...cardConfig}
+              {...cardProps}
+              dataItems={dataItemsForCard}
+              availableDimensions={availableDimensions}
+            />
+          )
+        );
+      }),
+    [
+      availableDimensions,
+      commonCardProps,
+      dashboardJson,
+      dataItems,
+      duplicateCard,
+      getValidDataItems,
+      removeCard,
+      renderCardPreview,
+      selectedCardId,
+    ]
+  );
 
   return isLoading ? (
     <div className={baseClassName}>
@@ -518,31 +573,7 @@ const DashboardEditor = ({
                     });
                   }}
                   supportedLayouts={['xl', 'lg', 'md']}>
-                  {dashboardJson.cards.map((cardConfig) => {
-                    const isSelected = cardConfig.id === selectedCardId;
-                    const cardProps = commonCardProps(cardConfig, isSelected);
-                    const dataItemsForCard = getValidDataItems
-                      ? getValidDataItems(cardConfig)
-                      : dataItems;
-                    // if renderCardPreview function not defined, or it returns null, render default preview
-                    return (
-                      renderCardPreview(
-                        cardConfig,
-                        cardProps,
-                        onSelectCard,
-                        onDuplicateCard,
-                        onRemoveCard,
-                        isSelected,
-                        handleShowImageGallery
-                      ) ??
-                      getCardPreview(
-                        cardConfig,
-                        cardProps,
-                        dataItemsForCard,
-                        availableDimensions
-                      )
-                    );
-                  })}
+                  {cards}
                 </DashboardGrid>
               </ErrorBoundary>
             </div>

--- a/src/components/DashboardEditor/DashboardEditorCardRenderer.jsx
+++ b/src/components/DashboardEditor/DashboardEditorCardRenderer.jsx
@@ -1,0 +1,195 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable react/destructuring-assignment */
+import React, { useMemo } from 'react';
+import omit from 'lodash/omit';
+import find from 'lodash/find';
+import isEqual from 'lodash/isEqual';
+import isEmpty from 'lodash/isEmpty';
+import isNil from 'lodash/isNil';
+import { Warning24 } from '@carbon/icons-react';
+
+import { CARD_TYPES } from '../../constants/LayoutConstants';
+import {
+  Card,
+  ValueCard,
+  TimeSeriesCard,
+  BarChartCard,
+  ImageCard,
+  TableCard,
+  ListCard,
+} from '../../index';
+
+import {
+  validThresholdIcons,
+  timeRangeToJSON,
+  isCardJsonValid,
+} from './editorUtils';
+
+/**
+ * Renders a card and lists the JSON within
+ * @param {Object} cardConfig
+ * @param {Object} commonProps
+ * @returns {Node}
+ */
+const renderDefaultCard = (props) => (
+  <Card isEditable {...props}>
+    <div style={{ padding: '1rem' }}>{JSON.stringify(props.id, null, 4)}</div>
+  </Card>
+);
+
+/**
+ * @param {Object} cardConfig
+ * @param {Object} commonProps
+ * @returns {Node}
+ */
+const renderValueCard = (props) => (
+  <ValueCard
+    // render the icon in the right color in the card preview
+    renderIconByName={(iconName, iconProps) => {
+      const iconToRender = validThresholdIcons.find(
+        (icon) => icon.name === iconName
+      )?.carbonIcon || <Warning24 />;
+      // eslint-disable-next-line react/prop-types
+      return <div style={{ color: iconProps.fill }}>{iconToRender}</div>;
+    }}
+    isEditable
+    {...props}
+  />
+);
+/**
+ * @param {Object} cardConfig
+ * @param {Object} commonProps
+ * @returns {Node}
+ */
+const renderTimeSeriesCard = (props) => {
+  // apply the timeRange for the card preview
+  const timeRangeJSON = find(timeRangeToJSON, ({ range }) =>
+    isEqual(range, props?.dataSource?.range)
+  );
+  return (
+    <TimeSeriesCard
+      isEditable
+      values={[]}
+      interval={timeRangeJSON?.interval || 'day'}
+      {...props}
+    />
+  );
+};
+
+/**
+ * @param {Object} cardConfig
+ * @param {Object} commonProps
+ * @returns {Node}
+ */
+const EditorBarChartCard = ({ dataItems, availableDimensions, ...props }) => {
+  // apply the timeRange for the card preview
+  const timeRangeJSON = find(timeRangeToJSON, ({ range }) =>
+    isEqual(range, props?.dataSource?.range)
+  );
+
+  // Need to memoize this to stop it from rerendering
+  const values = useMemo(() => {
+    return !props.dataSource?.groupBy && isEmpty(props.content.series)
+      ? []
+      : dataItems;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.dataSource, props.content.series, dataItems.length]); // this is a little bit of a hack because I don't want to do an object compare
+
+  return (
+    <BarChartCard
+      isEditable
+      isDashboardPreview
+      values={values}
+      availableDimensions={availableDimensions}
+      interval={timeRangeJSON?.interval || 'day'}
+      {...props}
+    />
+  );
+};
+
+/**
+ * @param {Object} cardConfig
+ * @param {Object} commonProps
+ * @returns {Node}
+ */
+const renderTableCard = (props) => <TableCard isEditable {...props} />;
+
+/**
+ * @param {Object} cardConfig
+ * @param {Object} commonProps
+ * @returns {Node}
+ */
+const renderImageCard = (props) => <ImageCard isEditable {...props} />;
+
+/**
+ * @param {Object} cardConfig
+ * @param {Object} commonProps
+ * @returns {Node}
+ */
+const renderListCard = (props) => <ListCard isEditable {...props} />;
+
+/**
+ * @param {Object} cardConfig
+ * @param {Object} commonProps
+ * @returns {Node}
+ */
+const renderCustomCard = (props) => {
+  return (
+    <Card
+      hideHeader={isNil(props.title)}
+      // need to omit the content because its getting passed content to be rendered, which should not
+      // get attached to the card wrapper
+      {...omit(props, 'content')}>
+      {
+        // If content is a function, this is a react component
+        typeof props.content === 'function' ? <props.content /> : props.content
+      }
+    </Card>
+  );
+};
+
+/**
+ * Returns a Card component for preview in the dashboard
+ * @param {Object} cardConfig, the JSON configuration of the card
+ * @param {Object} commonProps basic card config props
+ * @param {Array} dataItems list of dataItems available to the card
+ * @param {Object} availableDimensions collection of dimensions where the key is the
+ * dimension and the value is a list of values for that dimension
+ * @returns {Node}
+ */
+const DashboardEditorCardRenderer = ({
+  dataItems,
+  availableDimensions,
+  ...others
+}) => {
+  if (!isCardJsonValid(others)) {
+    return renderDefaultCard(others);
+  }
+
+  switch (others.type) {
+    case CARD_TYPES.VALUE:
+      return renderValueCard(others);
+    case CARD_TYPES.TIMESERIES:
+      return renderTimeSeriesCard(others);
+    case CARD_TYPES.BAR:
+      return (
+        <EditorBarChartCard
+          {...others}
+          dataItems={dataItems}
+          availableDimensions={availableDimensions}
+        />
+      );
+    case CARD_TYPES.TABLE:
+      return renderTableCard(others);
+    case CARD_TYPES.IMAGE:
+      return renderImageCard(others);
+    case CARD_TYPES.LIST:
+      return renderListCard(others);
+    case CARD_TYPES.CUSTOM:
+      return renderCustomCard(others);
+    default:
+      return renderDefaultCard(others);
+  }
+};
+
+export default DashboardEditorCardRenderer;

--- a/src/components/DashboardEditor/DashboardEditorCardRenderer.test.jsx
+++ b/src/components/DashboardEditor/DashboardEditorCardRenderer.test.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { CARD_SIZES, CARD_TYPES } from '../../constants/LayoutConstants';
+
+import DashboardEditorCardRenderer from './DashboardEditorCardRenderer';
+
+describe('DashboardEditorCardRenderer', () => {
+  it('default card just renders id', () => {
+    render(
+      <DashboardEditorCardRenderer type={CARD_TYPES.TIMESERIES} id="myid" />
+    );
+    expect(screen.getByText(/myid/)).toBeInTheDocument();
+  });
+  it('list card renders list', () => {
+    const listCardData = [
+      {
+        id: 'row-1',
+        value: 'Row content 1',
+        link: 'https://internetofthings.ibmcloud.com/',
+      },
+    ];
+    render(
+      <DashboardEditorCardRenderer
+        type={CARD_TYPES.LIST}
+        id="listCard"
+        isResizable
+        key="listCard"
+        title="ListCard render"
+        size={CARD_SIZES.SMALL}
+        data={listCardData}
+        hasMoreData={false}
+        loadData={() => {}}
+      />
+    );
+    expect(screen.getByText(/Row content 1/)).toBeInTheDocument();
+  });
+});

--- a/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -8948,20 +8948,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                             "--card-content-height": "256px",
                           }
                         }
-                      >
-                        <span
-                          className="react-resizable-handle react-resizable-handle-se"
-                          onMouseDown={[Function]}
-                          onMouseUp={[Function]}
-                          onTouchEnd={[Function]}
-                          onTouchStart={[Function]}
-                          style={
-                            Object {
-                              "touchAction": "none",
-                            }
-                          }
-                        />
-                      </div>
+                      />
                     </div>
                     <div
                       className="iot--card react-grid-item iot--dashboard-editor--preview__card react-draggable react-resizable-hide react-resizable iot--card--wrapper"

--- a/src/components/DashboardEditor/editorUtils.jsx
+++ b/src/components/DashboardEditor/editorUtils.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import uuid from 'uuid';
 import isNil from 'lodash/isNil';
 import isEmpty from 'lodash/isEmpty';
+import omit from 'lodash/omit';
 import {
   purple70,
   cyan50,

--- a/src/components/DashboardEditor/editorUtils.jsx
+++ b/src/components/DashboardEditor/editorUtils.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import uuid from 'uuid';
 import isNil from 'lodash/isNil';
-import omit from 'lodash/omit';
-import find from 'lodash/find';
 import isEmpty from 'lodash/isEmpty';
-import isEqual from 'lodash/isEqual';
 import {
   purple70,
   cyan50,
@@ -58,15 +55,6 @@ import {
   BAR_CHART_LAYOUTS,
   DASHBOARD_EDITOR_CARD_TYPES,
 } from '../../constants/LayoutConstants';
-import {
-  Card,
-  ValueCard,
-  TimeSeriesCard,
-  BarChartCard,
-  ImageCard,
-  TableCard,
-  ListCard,
-} from '../../index';
 
 /**
  * Returns a duplicate card configuration
@@ -340,143 +328,6 @@ export const isCardJsonValid = (cardConfig) => {
 };
 
 /**
- * Renders a card and lists the JSON within
- * @param {Object} cardConfig
- * @param {Object} commonProps
- * @returns {Node}
- */
-const renderDefaultCard = (cardConfig, commonProps) => (
-  <Card isEditable {...cardConfig} {...commonProps}>
-    <div style={{ padding: '1rem' }}>{JSON.stringify(cardConfig, null, 4)}</div>
-  </Card>
-);
-
-/**
- * @param {Object} cardConfig
- * @param {Object} commonProps
- * @returns {Node}
- */
-const renderValueCard = (cardConfig, commonProps) => (
-  <ValueCard
-    // render the icon in the right color in the card preview
-    renderIconByName={(iconName, props) => {
-      const iconToRender = validThresholdIcons.find(
-        (icon) => icon.name === iconName
-      )?.carbonIcon || <Warning24 />;
-      // eslint-disable-next-line react/prop-types
-      return <div style={{ color: props.fill }}>{iconToRender}</div>;
-    }}
-    isEditable
-    {...cardConfig}
-    {...commonProps}
-  />
-);
-/**
- * @param {Object} cardConfig
- * @param {Object} commonProps
- * @returns {Node}
- */
-const renderTimeSeriesCard = (cardConfig, commonProps) => {
-  // apply the timeRange for the card preview
-  const timeRangeJSON = find(timeRangeToJSON, ({ range }) =>
-    isEqual(range, cardConfig?.dataSource?.range)
-  );
-  return (
-    <TimeSeriesCard
-      isEditable
-      values={[]}
-      interval={timeRangeJSON?.interval || 'day'}
-      {...cardConfig}
-      {...commonProps}
-    />
-  );
-};
-
-/**
- * @param {Object} cardConfig
- * @param {Object} commonProps
- * @returns {Node}
- */
-const renderBarChartCard = (
-  cardConfig,
-  commonProps,
-  dataItems,
-  availableDimensions
-) => {
-  // apply the timeRange for the card preview
-  const timeRangeJSON = find(timeRangeToJSON, ({ range }) =>
-    isEqual(range, cardConfig?.dataSource?.range)
-  );
-  return (
-    <BarChartCard
-      isEditable
-      isDashboardPreview
-      values={
-        !cardConfig.dataSource?.groupBy && isEmpty(cardConfig.content.series)
-          ? []
-          : dataItems
-      }
-      availableDimensions={availableDimensions}
-      interval={timeRangeJSON?.interval || 'day'}
-      {...cardConfig}
-      {...commonProps}
-    />
-  );
-};
-
-/**
- * @param {Object} cardConfig
- * @param {Object} commonProps
- * @returns {Node}
- */
-const renderTableCard = (cardConfig, commonProps) => (
-  <TableCard isEditable {...cardConfig} {...commonProps} />
-);
-
-/**
- * @param {Object} cardConfig
- * @param {Object} commonProps
- * @returns {Node}
- */
-const renderImageCard = (cardConfig, commonProps) => (
-  <ImageCard isEditable {...cardConfig} {...commonProps} />
-);
-
-/**
- * @param {Object} cardConfig
- * @param {Object} commonProps
- * @returns {Node}
- */
-const renderListCard = (cardConfig, commonProps) => (
-  <ListCard isEditable {...cardConfig} {...commonProps} />
-);
-
-/**
- * @param {Object} cardConfig
- * @param {Object} commonProps
- * @returns {Node}
- */
-const renderCustomCard = (cardConfig, commonProps) => {
-  return (
-    <Card
-      hideHeader={isNil(cardConfig.title)}
-      // need to omit the content because its getting passed content to be rendered, which should not
-      // get attached to the card wrapper
-      {...omit(cardConfig, 'content')}
-      {...commonProps}>
-      {
-        // If content is a function, this is a react component
-        typeof cardConfig.content === 'function' ? (
-          <cardConfig.content />
-        ) : (
-          cardConfig.content
-        )
-      }
-    </Card>
-  );
-};
-
-/**
  * Selects the card if the key is 'enter' or 'space'
  * @param {Event} evt
  * @param {Function} onSelectCard
@@ -495,50 +346,6 @@ export const handleKeyDown = (evt, onSelectCard, id) => {
  */
 export const handleOnClick = (onSelectCard, id) => {
   onSelectCard(id);
-};
-
-/**
- * Returns a Card component for preview in the dashboard
- * @param {Object} cardConfig, the JSON configuration of the card
- * @param {Object} commonProps basic card config props
- * @param {Array} dataItems list of dataItems available to the card
- * @param {Object} availableDimensions collection of dimensions where the key is the
- * dimension and the value is a list of values for that dimension
- * @returns {Node}
- */
-export const getCardPreview = (
-  cardConfig,
-  commonProps,
-  dataItems,
-  availableDimensions
-) => {
-  if (!isCardJsonValid(cardConfig)) {
-    return renderDefaultCard(cardConfig, commonProps);
-  }
-
-  switch (cardConfig.type) {
-    case CARD_TYPES.VALUE:
-      return renderValueCard(cardConfig, commonProps);
-    case CARD_TYPES.TIMESERIES:
-      return renderTimeSeriesCard(cardConfig, commonProps);
-    case CARD_TYPES.BAR:
-      return renderBarChartCard(
-        cardConfig,
-        commonProps,
-        dataItems,
-        availableDimensions
-      );
-    case CARD_TYPES.TABLE:
-      return renderTableCard(cardConfig, commonProps);
-    case CARD_TYPES.IMAGE:
-      return renderImageCard(cardConfig, commonProps);
-    case CARD_TYPES.LIST:
-      return renderListCard(cardConfig, commonProps);
-    case CARD_TYPES.CUSTOM:
-      return renderCustomCard(cardConfig, commonProps);
-    default:
-      return renderDefaultCard(cardConfig, commonProps);
-  }
 };
 
 /**


### PR DESCRIPTION
Need to add lots of memoizing to React Editor components to improve performance

Closes #

**Summary**

- fix(BarChartCard): memoize the sample data creation
- fix(DashboardEditor): wrap all function definitions with useCallback and memoize where possible
- refactor(DashboardEditorCardRenderer): need to change the getCardPreview to a React component so I have more control over memoizing and rerender cycle
- refactor(editorUtils): move the render helper functions to DashboardEditorCardRenderer, ideally they will be all migrated to components rather than render functions


**Acceptance Test (how to verify the PR)**

- Verify the DashboardEditor story
