### PR TITLE
fix(statefultilegallery): add missing onclick

### DIFF
--- a/src/components/TileGallery/StatefulTileGallery.jsx
+++ b/src/components/TileGallery/StatefulTileGallery.jsx
@@ -47,6 +47,7 @@ const propTypes = {
           title: PropTypes.string.isRequired,
           description: PropTypes.string,
           moreInfoLink: PropTypes.string,
+          onClick: PropTypes.func,
           icon: PropTypes.oneOfType([
             PropTypes.shape({
               width: PropTypes.string,
@@ -176,6 +177,7 @@ const StatefulTileGallery = ({
                       mode={thumbnails ? 'grid' : 'list'}
                       title={galleryItem.title}
                       description={galleryItem.description}
+                      onClick={galleryItem.onClick}
                       moreInfoLink={galleryItem.moreInfoLink}
                       icon={galleryItem.icon}
                       afterContent={galleryItem.afterContent}

--- a/src/components/TileGallery/TileGallery.test.jsx
+++ b/src/components/TileGallery/TileGallery.test.jsx
@@ -146,6 +146,14 @@ describe('TileGallery', () => {
   it('StatefulTileGallery', () => {
     const searchValue = 'description';
 
+    const onClick = jest.fn();
+
+    // replace storyboard action with jest.fn()
+    const modifiedGalleryData = galleryData.map((gd) => ({
+      ...gd,
+      galleryItems: gd.galleryItems.map((gi) => ({ ...gi, onClick })),
+    }));
+
     const wrapper = mount(
       <StatefulTileGallery
         title="Dashboard"
@@ -153,7 +161,7 @@ describe('TileGallery', () => {
         hasSwitcher
         hasButton
         buttonText="Create"
-        galleryData={galleryData}
+        galleryData={modifiedGalleryData}
       />
     );
 
@@ -172,6 +180,10 @@ describe('TileGallery', () => {
     expect(wrapper.find('TileGalleryItem').first().props().mode).toEqual(
       'grid'
     );
+
+    // test tile onClick
+    wrapper.find('.tile-gallery-item').first().simulate('click');
+    expect(onClick).toHaveBeenCalledTimes(1);
 
     // Change Tile Item mode
     wrapper.find('button.bx--content-switcher-btn').first().simulate('click');

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -16917,6 +16917,9 @@ Map {
                           "moreInfoLink": Object {
                             "type": "string",
                           },
+                          "onClick": Object {
+                            "type": "func",
+                          },
                           "thumbnail": Object {
                             "type": "node",
                           },


### PR DESCRIPTION
Closes #1887

**Summary**

- Adds missing `onClick` prop to `galleryItems` in `StatefulTileGallery`

**Change List (commits, features, bugs, etc)**

- Add `onClick` prop to `StatefulTileGallery`
- Add test to check `onClick`  action

**Acceptance Test (how to verify the PR)**

- Added test to check `onClick` in `StatefulTileGallery`