### PR TITLE
feat: tablecard editing support for dashboard editor

### DIFF
--- a/src/components/CardEditor/CardEditForm/CardEditForm.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditForm.jsx
@@ -226,6 +226,7 @@ const CardEditForm = ({
           </Tab>
           <Tab label={mergedI18n.settingsTabLabel}>
             <CardEditFormSettings
+              availableDimensions={availableDimensions}
               cardConfig={
                 cardConfig.type === CARD_TYPES.CUSTOM
                   ? { ...omit(cardConfig, 'content') }

--- a/src/components/CardEditor/CardEditForm/CardEditForm.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditForm.jsx
@@ -11,7 +11,7 @@ import {
 import { settings } from '../../../constants/Settings';
 import { Tabs, Tab, Button } from '../../../index';
 import CardCodeEditor from '../../CardCodeEditor/CardCodeEditor';
-import { DataItemsPropTypes } from '../../DashboardEditor/DashboardEditor';
+import { DataItemsPropTypes } from '../../DashboardEditor/editorUtils';
 
 import CardEditFormContent from './CardEditFormContent';
 import CardEditFormSettings from './CardEditFormSettings';

--- a/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
@@ -131,7 +131,6 @@ const CardEditFormContent = ({
           onChange={onChange}
           dataItems={dataItems}
           selectedDataItems={selectedDataItems}
-          selectedTimeRange={selectedTimeRange}
           setSelectedDataItems={setSelectedDataItems}
           getValidDataItems={getValidDataItems}
           availableDimensions={availableDimensions}

--- a/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
@@ -7,6 +7,7 @@ import { DataItemsPropTypes } from '../../DashboardEditor/DashboardEditor';
 import CommonCardEditFormFields from './CommonCardEditFormFields';
 import DataSeriesFormContent from './CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent';
 import ImageCardFormContent from './CardEditFormItems/ImageCardFormItems/ImageCardFormContent';
+import TableCardFormContent from './CardEditFormItems/TableCardFormItems/TableCardFormContent';
 
 const propTypes = {
   /** card data value */
@@ -121,7 +122,23 @@ const CardEditFormContent = ({
           i18n={mergedI18n}
           onChange={onChange}
         />
-      ) : (
+      ) : type === CARD_TYPES.TABLE ?
+      (
+
+        <TableCardFormContent
+          cardConfig={cardConfig}
+          i18n={mergedI18n}
+          onChange={onChange}
+          dataItems={dataItems}
+          selectedDataItems={selectedDataItems}
+          selectedTimeRange={selectedTimeRange}
+          setSelectedDataItems={setSelectedDataItems}
+          getValidDataItems={getValidDataItems}
+          availableDimensions={availableDimensions}
+        />
+      )
+
+      :(
         <DataSeriesFormContent
           cardConfig={cardConfig}
           onChange={onChange}

--- a/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { CARD_TYPES } from '../../../constants/LayoutConstants';
-import { DataItemsPropTypes } from '../../DashboardEditor/DashboardEditor';
+import { DataItemsPropTypes } from '../../DashboardEditor/editorUtils';
 
 import CommonCardEditFormFields from './CommonCardEditFormFields';
 import DataSeriesFormContent from './CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent';

--- a/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
@@ -122,9 +122,7 @@ const CardEditFormContent = ({
           i18n={mergedI18n}
           onChange={onChange}
         />
-      ) : type === CARD_TYPES.TABLE ?
-      (
-
+      ) : type === CARD_TYPES.TABLE ? (
         <TableCardFormContent
           cardConfig={cardConfig}
           i18n={mergedI18n}
@@ -135,9 +133,7 @@ const CardEditFormContent = ({
           getValidDataItems={getValidDataItems}
           availableDimensions={availableDimensions}
         />
-      )
-
-      :(
+      ) : (
         <DataSeriesFormContent
           cardConfig={cardConfig}
           onChange={onChange}

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
@@ -67,7 +67,7 @@ const propTypes = {
   availableDimensions: PropTypes.shape({}),
   /* callback when image input value changes (File object) */
   onChange: PropTypes.func.isRequired,
-  setEditDataSeries: PropTypes.func.isRequired,
+  setEditDataSeries: PropTypes.func,
   editDataSeries: PropTypes.arrayOf(
     PropTypes.shape({
       dataSourceId: PropTypes.string,
@@ -110,7 +110,7 @@ const defaultProps = {
     dataItemEditorDataItemAddThreshold: 'Add threshold',
     dataItemEditorBarColor: 'Bar color',
     dataItemEditorLineColor: 'Line color',
-    source: 'Source data item'
+    source: 'Source data item',
   },
   editDataSeries: [],
   showEditor: false,
@@ -118,6 +118,7 @@ const defaultProps = {
   availableDimensions: {},
   editDataItem: {},
   setEditDataItem: null,
+  setEditDataSeries: null,
 };
 
 const DATAITEM_COLORS_OPTIONS = [
@@ -348,7 +349,8 @@ const DataSeriesFormItemModal = ({
             }
             value={editDataItem.label}
           />
-          <p className={`${baseClassName}--input-group--span`}>{`${mergedI18n.source}: ${editDataItem.dataSourceId}`}</p>
+          <p
+            className={`${baseClassName}--input-group--span`}>{`${mergedI18n.source}: ${editDataItem.dataSourceId}`}</p>
         </div>
       </div>
       <ThresholdsFormItem

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
@@ -88,6 +88,7 @@ const propTypes = {
     dataItemEditorDataItemFilter: PropTypes.string,
     dataItemEditorDataItemThresholds: PropTypes.string,
     dataItemEditorDataItemAddThreshold: PropTypes.string,
+    source: PropTypes.string,
   }),
 };
 
@@ -109,6 +110,7 @@ const defaultProps = {
     dataItemEditorDataItemAddThreshold: 'Add threshold',
     dataItemEditorBarColor: 'Bar color',
     dataItemEditorLineColor: 'Line color',
+    source: 'Source data item'
   },
   editDataSeries: [],
   showEditor: false,
@@ -328,6 +330,40 @@ const DataSeriesFormItemModal = ({
     </>
   );
 
+  const TableCardDataEditor = (
+    <>
+      <div className={`${baseClassName}--input-group`}>
+        <div className={`${baseClassName}--input-group--item`}>
+          <TextInput
+            id={`${id}_attribute-label`}
+            labelText={mergedI18n.dataItemEditorDataItemCustomLabel}
+            light
+            onChange={(evt) =>
+              setEditDataItem({
+                ...editDataItem,
+                label: evt.target.value,
+              })
+            }
+            value={editDataItem.label}
+          />
+          <p className={`${baseClassName}--input-group--span`}>{`${mergedI18n.source}: ${editDataItem.dataSourceId}`}</p>
+        </div>
+      </div>
+      <ThresholdsFormItem
+        id={`${id}_thresholds`}
+        thresholds={editDataItem.thresholds}
+        selectedIcon={{ carbonIcon: <WarningAlt32 />, name: 'Warning alt' }}
+        selectedColor={{ carbonColor: red60, name: 'red60' }}
+        onChange={(thresholds) => {
+          setEditDataItem({
+            ...editDataItem,
+            thresholds,
+          });
+        }}
+      />
+    </>
+  );
+
   return (
     <>
       {showEditor ? (
@@ -356,6 +392,8 @@ const DataSeriesFormItemModal = ({
             }}>
             {type === CARD_TYPES.TIMESERIES || type === CARD_TYPES.BAR
               ? DataSeriesEditorTable
+              : type === CARD_TYPES.TABLE
+              ? TableCardDataEditor
               : ValueCardDataEditor}
           </ComposedModal>
         </div>

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
@@ -8,9 +8,9 @@ import { settings } from '../../../../../constants/Settings';
 import {
   DATAITEM_COLORS_OPTIONS,
   handleDataSeriesChange,
+  DataItemsPropTypes,
 } from '../../../../DashboardEditor/editorUtils';
 import { Button, List, MultiSelect, Dropdown } from '../../../../../index';
-import { DataItemsPropTypes } from '../../../../DashboardEditor/DashboardEditor';
 import DataSeriesFormItemModal from '../DataSeriesFormItemModal';
 import {
   CARD_TYPES,

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -115,6 +115,11 @@ const TableCardFormContent = ({
     [availableDimensions]
   );
 
+  const initialSelectedDimensions = useMemo(
+    () => dataSection.filter((col) => col.type === 'DIMENSION'),
+    [dataSection]
+  );
+
   return (
     <>
       <DataSeriesFormItemModal
@@ -164,8 +169,7 @@ const TableCardFormContent = ({
           label={mergedI18n.selectGroupByDimensions}
           direction="bottom"
           itemToString={(item) => item.id}
-          // TODO: need to populate selected dimensions in the edit case
-          // initialSelectedItems={initialSelectedItems}
+          initialSelectedItems={initialSelectedDimensions}
           items={validDimensions}
           light
           onChange={({ selectedItems }) => {

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -93,6 +93,7 @@ const TableCardFormContent = ({
   i18n,
 }) => {
   const mergedI18n = { ...defaultProps.i18n, ...i18n };
+  const { content: { columns }} = cardConfig;
 
   const [showEditor, setShowEditor] = useState(false);
   const [editDataItem, setEditDataItem] = useState({});
@@ -109,6 +110,8 @@ const TableCardFormContent = ({
   const initialSelectedItems = formatDataItemsForDropdown(dataSection);
 
   const validDimensions = useMemo(() => Object.keys(availableDimensions).map(i => ({ id: i, text: i})), [availableDimensions]);
+  const timeStampColumn = cardConfig.content?.columns?.filter(col => col.type === 'TIMESTAMP').map(i => ({id: i.dataSourceId, text: i.label, type: 'TIMESTAMP'}));
+  const dataItemColumns = cardConfig.content?.columns?.filter(col => !col?.hasOwnProperty('type'));
 
   return (
     <>
@@ -162,9 +165,14 @@ const TableCardFormContent = ({
           items={validDimensions}
           light
           onChange={({ selectedItems }) => {
-            console.log({selectedItems: selectedItems.map(i => ({...i, type: 'dimension'})), availableDimensions})
+            console.log({selectedItems: selectedItems.map(i => ({...i, type: 'DIMENSION'})), availableDimensions})
             const newCard = handleDataSeriesChange(
-              selectedItems.map(i => ({...i, type: 'dimension'})),
+              [
+                ...timeStampColumn.map(i => ({id: i.dataSourceId, text: i.label, type: 'TIMESTAMP'})) || [],
+                ...selectedItems.map(i => ({...i, type: 'DIMENSION'})),
+                ...dataItemColumns
+                  .map(i => ({id: i.dataSourceId, text: i.label})) || []
+              ],
               cardConfig,
             );
             // setSelectedDataItems(selectedItems.map(({ id }) => id));

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -162,9 +162,9 @@ const TableCardFormContent = ({
           items={validDimensions}
           light
           onChange={({ selectedItems }) => {
-            console.log({selectedItems, availableDimensions})
+            console.log({selectedItems: selectedItems.map(i => ({...i, type: 'dimension'})), availableDimensions})
             const newCard = handleDataSeriesChange(
-              selectedItems,
+              selectedItems.map(i => ({...i, type: 'dimension'})),
               cardConfig,
             );
             // setSelectedDataItems(selectedItems.map(({ id }) => id));

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -1,0 +1,287 @@
+import React, { useState, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { Edit16 } from '@carbon/icons-react';
+import omit from 'lodash/omit';
+
+
+import { settings } from '../../../../../constants/Settings';
+import {
+  DATAITEM_COLORS_OPTIONS,
+  handleDataSeriesChange,
+} from '../../../../DashboardEditor/editorUtils';
+import { Button, List, MultiSelect } from '../../../../../index';
+import { DataItemsPropTypes } from '../../../../DashboardEditor/DashboardEditor';
+import DataSeriesFormItemModal from '../DataSeriesFormItemModal';
+import {
+  CARD_TYPES
+} from '../../../../../constants/LayoutConstants';
+
+const { iotPrefix } = settings;
+
+
+const propTypes = {
+  /* card value */
+
+  cardConfig: PropTypes.shape({
+    id: PropTypes.string,
+    title: PropTypes.string,
+    size: PropTypes.string,
+    type: PropTypes.string,
+    content: PropTypes.shape({
+      series: PropTypes.arrayOf(
+        PropTypes.shape({
+          label: PropTypes.string,
+          dataSourceId: PropTypes.string,
+          color: PropTypes.string,
+        })
+      ),
+      xLabel: PropTypes.string,
+      yLabel: PropTypes.string,
+      unit: PropTypes.string,
+      includeZeroOnXaxis: PropTypes.bool,
+      includeZeroOnYaxis: PropTypes.bool,
+      timeDataSourceId: PropTypes.string,
+      showLegend: PropTypes.bool,
+    }),
+    interval: PropTypes.string,
+  }),
+  /* callback when image input value changes (File object) */
+  onChange: PropTypes.func.isRequired,
+  i18n: PropTypes.shape({}),
+  /** if provided, returns an array of strings which are the dataItems to be allowed
+   * on each card
+   * getValidDataItems(card, selectedTimeRange)
+   */
+  getValidDataItems: PropTypes.func,
+  /** an array of dataItems to be included on each card
+   * this prop will be ignored if getValidDataItems is defined
+   */
+  dataItems: DataItemsPropTypes,
+  /** an object where the keys are available dimensions and the values are the values available for those dimensions
+   *  ex: { manufacturer: ['Rentech', 'GHI Industries'], deviceid: ['73000', '73001', '73002'] }
+   */
+  availableDimensions: PropTypes.shape({}),
+  /** list of dataItem names that have been selected to display on the card */
+  selectedDataItems: PropTypes.arrayOf(PropTypes.string),
+  setSelectedDataItems: PropTypes.func.isRequired,
+  selectedTimeRange: PropTypes.string.isRequired,
+};
+
+const defaultProps = {
+  cardConfig: {},
+  i18n: {
+    dataItemEditorTitle: 'Edit data series',
+    dataItemEditorDataItemTitle: 'Data item',
+    dataItemEditorDimensionTitle: 'Group by',
+    dataItemEditorDataItemLabel: 'Label',
+    dataItemEditorLegendColor: 'Legend color',
+    dataSeriesTitle: 'Data',
+    selectDataItems: 'Select data item(s)',
+    selectGroupByDimensions: 'Select dimension(s)',
+    dataItem: 'Data item',
+    edit: 'Edit',
+    remove: 'Remove',
+    customize: 'Customize',
+  },
+  getValidDataItems: null,
+  dataItems: [],
+  selectedDataItems: [],
+  availableDimensions: {},
+};
+
+export const formatDataItemsForDropdown = (dataItems) =>
+  dataItems?.map(({ dataSourceId }) => ({
+    id: dataSourceId,
+    text: dataSourceId,
+  })) || [];
+
+
+
+const TableCardFormContent = ({
+  cardConfig,
+  dataItems,
+  getValidDataItems,
+  onChange,
+  selectedDataItems,
+  setSelectedDataItems,
+  selectedTimeRange,
+  availableDimensions,
+  i18n,
+}) => {
+  const mergedI18n = { ...defaultProps.i18n, ...i18n };
+
+  const [showEditor, setShowEditor] = useState(false);
+  const [editDataItem, setEditDataItem] = useState({});
+  const [editDataSeries, setEditDataSeries] = useState(
+    cardConfig.content?.series || []
+  );
+  const [removedDataItems, setRemovedDataItems] = useState([]);
+
+  const baseClassName = `${iotPrefix}--card-edit-form`;
+
+  const isComplexDataSeries =
+    cardConfig.type === CARD_TYPES.TIMESERIES ||
+    cardConfig.type === CARD_TYPES.BAR;
+
+
+  // determine which content section to look at
+  const dataSection =
+    cardConfig.type === CARD_TYPES.TIMESERIES ||
+    cardConfig.type === CARD_TYPES.BAR
+      ? cardConfig?.content?.series
+      : cardConfig.type === CARD_TYPES.TABLE
+      ? cardConfig?.content?.columns.filter(column => column.label !== '--')
+      : cardConfig?.content?.attributes;
+
+  const initialSelectedItems = formatDataItemsForDropdown(dataSection);
+
+  const validDataItems = getValidDataItems
+    ? getValidDataItems(cardConfig, selectedTimeRange)
+    : dataItems;
+  const validDimensions = useMemo(() => Object.keys(availableDimensions).map(i => ({ id: i, text: i})), [availableDimensions]);
+
+  return (
+    <>
+      <DataSeriesFormItemModal
+        cardConfig={cardConfig}
+        showEditor={showEditor}
+        setShowEditor={setShowEditor}
+        editDataSeries={editDataSeries}
+        setEditDataSeries={setEditDataSeries}
+        editDataItem={editDataItem}
+        setEditDataItem={setEditDataItem}
+        availableDimensions={availableDimensions}
+        onChange={onChange}
+        i18n={mergedI18n}
+      />
+      <div className={`${baseClassName}--form-section`}>
+        {mergedI18n.dataSeriesTitle}
+      </div>
+      <div className={`${baseClassName}--input`}>
+        <MultiSelect
+          // need to re-gen if selected card changes or if a dataItem is removed from the list
+          key={`data-item-select-${removedDataItems.length}-selected_card-id-${cardConfig.id}`}
+          id={`${cardConfig.id}_dataSourceIds`}
+          label={mergedI18n.selectDataItems}
+          direction="bottom"
+          itemToString={(item) => item.id}
+          initialSelectedItems={initialSelectedItems}
+          items={formatDataItemsForDropdown(validDataItems)}
+          light
+          onChange={({ selectedItems }) => {
+            console.log({selectedItems})
+            const newCard = handleDataSeriesChange(
+              selectedItems,
+              cardConfig,
+              setEditDataSeries
+            );
+            setSelectedDataItems(selectedItems.map(({ id }) => id));
+            onChange(newCard);
+          }}
+          titleText={mergedI18n.dataItem}
+        />
+      </div>
+      <div className={`${baseClassName}--input`}>
+        <MultiSelect
+          // need to re-gen if selected card changes or if a dataItem is removed from the list
+          key={`data-item-select-${removedDataItems.length}-selected_card-id-${cardConfig.id}`}
+          id={`${cardConfig.id}_dataSourceIds`}
+          label={mergedI18n.selectGroupByDimensions}
+          direction="bottom"
+          itemToString={(item) => item.id}
+          // initialSelectedItems={initialSelectedItems}
+          items={validDimensions}
+          light
+          onChange={({ selectedItems }) => {
+            console.log({selectedItems, availableDimensions})
+            const newCard = handleDataSeriesChange(
+              selectedItems,
+              cardConfig,
+              setEditDataSeries
+            );
+            setSelectedDataItems(selectedItems.map(({ id }) => id));
+            onChange(newCard);
+          }}
+          titleText={mergedI18n.dataItemEditorDimensionTitle}
+        />
+      </div>
+      <List
+        key={`data-item-list${selectedDataItems.length}`}
+        // need to force an empty "empty state"
+        emptyState={<div />}
+        title=""
+        items={dataSection?.map((dataItem, i) => ({
+          id: dataItem.dataSourceId,
+          content: {
+            value: dataItem.label,
+            icon: isComplexDataSeries ? (
+              <div
+                style={{
+                  width: '1rem',
+                  height: '1rem',
+                  backgroundColor:
+                    dataItem.color ||
+                    DATAITEM_COLORS_OPTIONS[i % DATAITEM_COLORS_OPTIONS.length],
+                }}
+              />
+            ) : null,
+            rowActions: () => [
+              <Button
+                key={`data-item-${dataItem.dataSourceId}`}
+                renderIcon={Edit16}
+                hasIconOnly
+                kind="ghost"
+                size="small"
+                onClick={() => {
+                  if (isComplexDataSeries) {
+                    const filteredItems = cardConfig.content?.series?.filter(
+                      (item) => item.dataSourceId !== dataItem.dataSourceId
+                    );
+                    setSelectedDataItems(
+                      filteredItems.map((item) => item.dataSourceId)
+                    );
+                    setRemovedDataItems([
+                      ...removedDataItems,
+                      cardConfig.content?.series?.find(
+                        (item) => item.dataSourceId === dataItem.dataSourceId
+                      ),
+                    ]);
+                    setEditDataSeries(filteredItems);
+                    onChange({
+                      ...cardConfig,
+                      content: {
+                        ...cardConfig.content,
+                        series: filteredItems,
+                      },
+                    });
+                  } else {
+                    setEditDataItem(dataItem);
+                    setShowEditor(true);
+                  }
+                }}
+                iconDescription={
+                  isComplexDataSeries ? mergedI18n.remove : mergedI18n.edit
+                }
+              />,
+            ],
+          },
+        }))}
+      />
+      {isComplexDataSeries && dataSection.length ? (
+        <Button
+          renderIcon={Edit16}
+          kind="ghost"
+          size="small"
+          onClick={() => {
+            setShowEditor(true);
+          }}
+          iconDescription={mergedI18n.customize}>
+          {mergedI18n.customize}
+        </Button>
+      ) : null}
+    </>
+  );
+};
+TableCardFormContent.defaultProps = defaultProps;
+TableCardFormContent.propTypes = propTypes;
+export default TableCardFormContent;

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -2,17 +2,17 @@ import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Edit16 } from '@carbon/icons-react';
 
-
 import { settings } from '../../../../../constants/Settings';
-import {
-  handleDataSeriesChange,
-} from '../../../../DashboardEditor/editorUtils';
+import { handleDataSeriesChange } from '../../../../DashboardEditor/editorUtils';
 import { Button, List, MultiSelect } from '../../../../../index';
 import { DataItemsPropTypes } from '../../../../DashboardEditor/DashboardEditor';
 import DataSeriesFormItemModal from '../DataSeriesFormItemModal';
+import {
+  CARD_SIZES,
+  CARD_TYPES,
+} from '../../../../../constants/LayoutConstants';
 
 const { iotPrefix } = settings;
-
 
 const propTypes = {
   /* card value */
@@ -20,27 +20,20 @@ const propTypes = {
   cardConfig: PropTypes.shape({
     id: PropTypes.string,
     title: PropTypes.string,
-    size: PropTypes.string,
-    type: PropTypes.string,
+    size: PropTypes.oneOf(Object.keys(CARD_SIZES)),
+    type: PropTypes.oneOf([CARD_TYPES.TABLE]),
     content: PropTypes.shape({
-      series: PropTypes.arrayOf(
+      columns: PropTypes.arrayOf(
         PropTypes.shape({
           label: PropTypes.string,
           dataSourceId: PropTypes.string,
-          color: PropTypes.string,
+          // most data item columns won't have types, only dimensions or timestamps
+          type: PropTypes.oneOf(['DIMENSION', 'TIMESTAMP']),
         })
       ),
-      xLabel: PropTypes.string,
-      yLabel: PropTypes.string,
-      unit: PropTypes.string,
-      includeZeroOnXaxis: PropTypes.bool,
-      includeZeroOnYaxis: PropTypes.bool,
-      timeDataSourceId: PropTypes.string,
-      showLegend: PropTypes.bool,
     }),
-    interval: PropTypes.string,
   }),
-  /* callback when image input value changes (File object) */
+  /* callback when any changes are made to the card config, the full updated card JSON is passed as the argument */
   onChange: PropTypes.func.isRequired,
   i18n: PropTypes.shape({}),
   /** an array of dataItems to be included on each card */
@@ -51,6 +44,7 @@ const propTypes = {
   availableDimensions: PropTypes.shape({}),
   /** list of dataItem names that have been selected to display on the card */
   selectedDataItems: PropTypes.arrayOf(PropTypes.string),
+  /** the callback is called with a list of the new data item names selected */
   setSelectedDataItems: PropTypes.func.isRequired,
 };
 
@@ -81,8 +75,6 @@ export const formatDataItemsForDropdown = (dataItems) =>
     text: dataSourceId,
   }));
 
-
-
 const TableCardFormContent = ({
   cardConfig,
   dataItems,
@@ -93,25 +85,35 @@ const TableCardFormContent = ({
   i18n,
 }) => {
   const mergedI18n = { ...defaultProps.i18n, ...i18n };
-  const { content: { columns }} = cardConfig;
+  const {
+    content: { columns },
+  } = cardConfig;
 
   const [showEditor, setShowEditor] = useState(false);
+  // Need to keep track of the data item that's currently being edited so the detailed modal knows which one to show
   const [editDataItem, setEditDataItem] = useState({});
-  const [editDataSeries, setEditDataSeries] = useState(
-    cardConfig.content?.series || []
+
+  const dataSection = useMemo(
+    () =>
+      Array.isArray(columns) // Filter out the fake columns from the selected data items view
+        ? columns.filter((col) => col.label !== '--')
+        : [],
+    [columns]
   );
 
   const baseClassName = `${iotPrefix}--card-edit-form`;
 
+  // This is used in the edit case where some of these data items have been selected before
+  const initialSelectedItems = useMemo(
+    () => formatDataItemsForDropdown(dataSection),
+    [dataSection]
+  );
 
-  // determine which content section to look at
-  const dataSection = columns.filter(col => col.label !== '--');
-
-  const initialSelectedItems = formatDataItemsForDropdown(dataSection);
-
-  const validDimensions = useMemo(() => Object.keys(availableDimensions).map(i => ({ id: i, text: i})), [availableDimensions]);
-
-  const dataItemColumns = useMemo(() => columns?.filter(col => !col?.hasOwnProperty('type')).map(i => ({id: i.dataSourceId, text: i.label})), [columns]);
+  // find valid dimension data item names
+  const validDimensions = useMemo(
+    () => Object.keys(availableDimensions).map((i) => ({ id: i, text: i })),
+    [availableDimensions]
+  );
 
   return (
     <>
@@ -119,8 +121,8 @@ const TableCardFormContent = ({
         cardConfig={cardConfig}
         showEditor={showEditor}
         setShowEditor={setShowEditor}
-        editDataSeries={editDataSeries}
-        setEditDataSeries={setEditDataSeries}
+        editDataSeries={dataSection}
+        // setEditDataSeries={setDataSection}
         editDataItem={editDataItem}
         setEditDataItem={setEditDataItem}
         availableDimensions={availableDimensions}
@@ -130,7 +132,9 @@ const TableCardFormContent = ({
       <div className={`${baseClassName}--form-section`}>
         {mergedI18n.dataSeriesTitle}
       </div>
-      <div className={`${baseClassName}--input`}>
+      <div
+        className={`${baseClassName}--input`} // data item selector
+      >
         <MultiSelect
           // need to re-gen if selected card changes or if a dataItem is removed from the list
           key={`data-item-select-selected_card-id-${cardConfig.id}`}
@@ -142,17 +146,17 @@ const TableCardFormContent = ({
           items={formatDataItemsForDropdown(dataItems)}
           light
           onChange={({ selectedItems }) => {
-            const newCard = handleDataSeriesChange(
-              selectedItems,
-              cardConfig,
-            );
+            const newCard = handleDataSeriesChange(selectedItems, cardConfig);
             setSelectedDataItems(selectedItems.map(({ id }) => id));
             onChange(newCard);
           }}
           titleText={mergedI18n.dataItem}
         />
       </div>
-      <div className={`${baseClassName}--input`}>
+
+      <div
+        className={`${baseClassName}--input`} // Dimensions selector
+      >
         <MultiSelect
           // need to re-gen if selected card changes or if a dataItem is removed from the list
           key={`data-item-select-selected_card-id-${cardConfig.id}`}
@@ -160,16 +164,15 @@ const TableCardFormContent = ({
           label={mergedI18n.selectGroupByDimensions}
           direction="bottom"
           itemToString={(item) => item.id}
+          // TODO: need to populate selected dimensions in the edit case
           // initialSelectedItems={initialSelectedItems}
           items={validDimensions}
           light
           onChange={({ selectedItems }) => {
+            // Add the new dimensions as dimension columns at the beginning of the table
             const newCard = handleDataSeriesChange(
-              [
-                ...selectedItems.map(i => ({...i, type: 'DIMENSION'})),
-                ...dataItemColumns
-              ],
-              cardConfig,
+              selectedItems.map((i) => ({ ...i, type: 'DIMENSION' })),
+              cardConfig
             );
             // setSelectedDataItems(selectedItems.map(({ id }) => id));
             onChange(newCard);
@@ -178,11 +181,12 @@ const TableCardFormContent = ({
         />
       </div>
       <List
+        // Lists the selected dataItem columns in the bottom section and allow additional configuration
         key={`data-item-list${selectedDataItems.length}`}
         // need to force an empty "empty state"
         emptyState={<div />}
         title=""
-        items={dataSection?.map((dataItem, i) => ({
+        items={dataSection?.map((dataItem) => ({
           id: dataItem.dataSourceId,
           content: {
             value: dataItem.label,
@@ -195,8 +199,8 @@ const TableCardFormContent = ({
                 kind="ghost"
                 size="small"
                 onClick={() => {
-                    setEditDataItem(dataItem);
-                    setShowEditor(true);
+                  setEditDataItem(dataItem);
+                  setShowEditor(true);
                 }}
                 iconDescription={mergedI18n.edit}
               />,

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -3,9 +3,11 @@ import PropTypes from 'prop-types';
 import { Edit16 } from '@carbon/icons-react';
 
 import { settings } from '../../../../../constants/Settings';
-import { handleDataSeriesChange } from '../../../../DashboardEditor/editorUtils';
+import {
+  handleDataSeriesChange,
+  DataItemsPropTypes,
+} from '../../../../DashboardEditor/editorUtils';
 import { Button, List, MultiSelect } from '../../../../../index';
-import { DataItemsPropTypes } from '../../../../DashboardEditor/DashboardEditor';
 import DataSeriesFormItemModal from '../DataSeriesFormItemModal';
 import {
   CARD_SIZES,

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -151,7 +151,13 @@ const TableCardFormContent = ({
           items={formatDataItemsForDropdown(dataItems)}
           light
           onChange={({ selectedItems }) => {
-            const newCard = handleDataSeriesChange(selectedItems, cardConfig);
+            const newCard = handleDataSeriesChange(
+              selectedItems,
+              cardConfig,
+              null,
+              null,
+              false
+            );
             setSelectedDataItems(selectedItems.map(({ id }) => id));
             onChange(newCard);
           }}
@@ -176,7 +182,10 @@ const TableCardFormContent = ({
             // Add the new dimensions as dimension columns at the beginning of the table
             const newCard = handleDataSeriesChange(
               selectedItems.map((i) => ({ ...i, type: 'DIMENSION' })),
-              cardConfig
+              cardConfig,
+              null,
+              null,
+              true
             );
             // setSelectedDataItems(selectedItems.map(({ id }) => id));
             onChange(newCard);

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -93,13 +93,9 @@ const TableCardFormContent = ({
   // Need to keep track of the data item that's currently being edited so the detailed modal knows which one to show
   const [editDataItem, setEditDataItem] = useState({});
 
-  const dataSection = useMemo(
-    () =>
-      Array.isArray(columns) // Filter out the fake columns from the selected data items view
-        ? columns.filter((col) => col.label !== '--')
-        : [],
-    [columns]
-  );
+  const dataSection = useMemo(() => (Array.isArray(columns) ? columns : []), [
+    columns,
+  ]);
 
   const baseClassName = `${iotPrefix}--card-edit-form`;
 

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -105,13 +105,13 @@ const TableCardFormContent = ({
 
 
   // determine which content section to look at
-  const dataSection = cardConfig?.content?.columns.filter(column => column.label !== '--');
+  const dataSection = columns.filter(col => col.label !== '--');
 
   const initialSelectedItems = formatDataItemsForDropdown(dataSection);
 
   const validDimensions = useMemo(() => Object.keys(availableDimensions).map(i => ({ id: i, text: i})), [availableDimensions]);
-  const timeStampColumn = cardConfig.content?.columns?.filter(col => col.type === 'TIMESTAMP').map(i => ({id: i.dataSourceId, text: i.label, type: 'TIMESTAMP'}));
-  const dataItemColumns = cardConfig.content?.columns?.filter(col => !col?.hasOwnProperty('type'));
+
+  const dataItemColumns = useMemo(() => columns?.filter(col => !col?.hasOwnProperty('type')).map(i => ({id: i.dataSourceId, text: i.label})), [columns]);
 
   return (
     <>
@@ -142,7 +142,6 @@ const TableCardFormContent = ({
           items={formatDataItemsForDropdown(dataItems)}
           light
           onChange={({ selectedItems }) => {
-            console.log({selectedItems})
             const newCard = handleDataSeriesChange(
               selectedItems,
               cardConfig,
@@ -165,13 +164,10 @@ const TableCardFormContent = ({
           items={validDimensions}
           light
           onChange={({ selectedItems }) => {
-            console.log({selectedItems: selectedItems.map(i => ({...i, type: 'DIMENSION'})), availableDimensions})
             const newCard = handleDataSeriesChange(
               [
-                ...timeStampColumn.map(i => ({id: i.dataSourceId, text: i.label, type: 'TIMESTAMP'})) || [],
                 ...selectedItems.map(i => ({...i, type: 'DIMENSION'})),
                 ...dataItemColumns
-                  .map(i => ({id: i.dataSourceId, text: i.label})) || []
               ],
               cardConfig,
             );

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
@@ -71,5 +71,7 @@ describe('TableCardFormContent', () => {
     expect(screen.queryByText('Temperature')).toBeDefined();
     expect(screen.queryByText('Timestamp')).toBeDefined();
     expect(screen.queryByText('Manufacturer')).toBeDefined();
+    // both the dimension and attribute show show selections
+    expect(screen.queryAllByTitle('Clear all selected items')).toHaveLength(2);
   });
 });

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
@@ -43,6 +43,53 @@ describe('TableCardFormContent', () => {
     expect(screen.queryByText('manufacturer')).toBeDefined();
     expect(screen.queryByText('deviceid')).toBeDefined();
   });
+  it('selecting data attributes shows clear button', () => {
+    const mockOnChange = jest.fn();
+    render(<TableCardFormContent {...commonProps} onChange={mockOnChange} />);
+    expect(mockOnChange).not.toHaveBeenCalled();
+    // check for the temperature and pressure to be shown under data items
+    fireEvent.click(screen.getByLabelText(/Select data/));
+    expect(screen.queryByText('temperature')).toBeDefined();
+    fireEvent.click(screen.queryByText('temperature'));
+    // the selection state of the box should be updated
+    expect(screen.queryAllByTitle('Clear all selected items')).toHaveLength(1);
+    // the callback for onChange should be called
+    expect(mockOnChange).toHaveBeenCalledWith({
+      ...commonCardConfig,
+      content: {
+        columns: [
+          { dataSourceId: 'timestamp', label: 'Timestamp', type: 'TIMESTAMP' },
+          { dataSourceId: 'temperature', label: 'temperature' },
+        ],
+      },
+    });
+  });
+  it('selecting dimensions shows clear button', () => {
+    const mockOnChange = jest.fn();
+    render(<TableCardFormContent {...commonProps} onChange={mockOnChange} />);
+    expect(mockOnChange).not.toHaveBeenCalled();
+    // check for the temperature and pressure to be shown under data items
+    fireEvent.click(screen.getByLabelText(/Select dim/));
+    expect(screen.queryByText('manufacturer')).toBeDefined();
+    fireEvent.click(screen.queryByText('manufacturer'));
+    // the selection state of the box should be updated
+    expect(screen.queryAllByTitle('Clear all selected items')).toHaveLength(1);
+    // the callback for onChange should be called
+    expect(mockOnChange).toHaveBeenCalledWith({
+      ...commonCardConfig,
+      ...commonCardConfig,
+      content: {
+        columns: [
+          { dataSourceId: 'timestamp', label: 'Timestamp', type: 'TIMESTAMP' },
+          {
+            dataSourceId: 'manufacturer',
+            label: 'manufacturer',
+            type: 'DIMENSION',
+          },
+        ],
+      },
+    });
+  });
   it('edit mode with dataitems and dimension columns show work correctly', () => {
     render(
       <TableCardFormContent

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
@@ -58,7 +58,12 @@ describe('TableCardFormContent', () => {
       ...commonCardConfig,
       content: {
         columns: [
-          { dataSourceId: 'timestamp', label: 'Timestamp', type: 'TIMESTAMP' },
+          {
+            dataSourceId: 'timestamp',
+            label: 'Timestamp',
+            type: 'TIMESTAMP',
+            sort: 'DESC',
+          },
           { dataSourceId: 'temperature', label: 'temperature' },
         ],
       },
@@ -80,7 +85,12 @@ describe('TableCardFormContent', () => {
       ...commonCardConfig,
       content: {
         columns: [
-          { dataSourceId: 'timestamp', label: 'Timestamp', type: 'TIMESTAMP' },
+          {
+            dataSourceId: 'timestamp',
+            label: 'Timestamp',
+            type: 'TIMESTAMP',
+            sort: 'DESC',
+          },
           {
             dataSourceId: 'manufacturer',
             label: 'manufacturer',

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import {
+  CARD_SIZES,
+  CARD_TYPES,
+} from '../../../../../constants/LayoutConstants';
+
+import TableCardFormContent from './TableCardFormContent';
+
+const commonCardConfig = {
+  id: 'id',
+  title: 'My Table Card',
+  size: CARD_SIZES.LARGE,
+  type: CARD_TYPES.TABLE,
+  content: {},
+};
+const commonProps = {
+  cardConfig: commonCardConfig,
+  dataItems: [
+    { dataSourceId: 'temperature', label: 'Temperature' },
+    { dataSourceId: 'pressure', label: 'Pressure' },
+  ],
+  availableDimensions: {
+    manufacturer: ['Rentech', 'GHI'],
+    deviceid: ['73000', '73001'],
+  },
+  onChange: jest.fn(),
+  setSelectedDataItems: jest.fn(),
+};
+
+describe('TableCardFormContent', () => {
+  it('should render dataitems and dimensions', () => {
+    render(<TableCardFormContent {...commonProps} />);
+    // check for the temperature and pressure to be shown under data items
+    fireEvent.click(screen.getByLabelText(/Select data/));
+    expect(screen.queryByText('temperature')).toBeDefined();
+    expect(screen.queryByText('pressure')).toBeDefined();
+    expect(screen.queryByText('manufacturer')).toBeNull();
+
+    // check for the dimensions to be shown
+    fireEvent.click(screen.getByLabelText(/Select dim/));
+    expect(screen.queryByText('manufacturer')).toBeDefined();
+    expect(screen.queryByText('deviceid')).toBeDefined();
+  });
+  it('edit mode with dataitems and dimension columns show work correctly', () => {
+    render(
+      <TableCardFormContent
+        {...commonProps}
+        cardConfig={{
+          ...commonCardConfig,
+          content: {
+            columns: [
+              {
+                label: 'Timestamp',
+                dataSourceId: 'timestamp',
+                type: 'TIMESTAMP',
+              },
+              {
+                label: 'Manufacturer',
+                dataSourceId: 'manufacturer',
+                type: 'DIMENSION',
+              },
+              { label: 'Temperature', dataSourceId: 'temperature' },
+            ],
+          },
+        }}
+      />
+    );
+    // All of the existing columns should be rendered in the data section
+    expect(screen.queryByText('Temperature')).toBeDefined();
+    expect(screen.queryByText('Timestamp')).toBeDefined();
+    expect(screen.queryByText('Manufacturer')).toBeDefined();
+  });
+});

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormSettings.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormSettings.jsx
@@ -146,25 +146,25 @@ const TableCardFormSettings = ({ cardConfig, onChange, i18n }) => {
           />
         </div>
       </div>
-      {/* <div className={`${baseClassName}--input`}>
+      <div className={`${baseClassName}--input`}>
         <div className={`${baseClassName}--input--toggle-field`}>
           <span>{mergedI18n.allowNavigation}</span>
           <ToggleSmall
-            data-testid={`${baseClassName}--input-toggle1`}
-            id={`${baseClassName}--input-toggle-1`}
+            data-testid={`${baseClassName}--input-toggle2`}
+            id={`${baseClassName}--input-toggle-2`}
             aria-label={mergedI18n.allowNavigation}
             labelA=""
             labelB=""
-            toggled={cardConfig.content?.showHeader ?? true}
+            toggled={cardConfig.content?.allowNavigation ?? true}
             onToggle={(bool) =>
               onChange({
                 ...cardConfig,
-                content: { ...cardConfig.content, showHeader: bool },
+                // content: { ...cardConfig.content, showHeader: bool },
               })
             }
           />
         </div>
-      </div> */}
+      </div>
     </>
   );
 };

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormSettings.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormSettings.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState, useMemo} from 'react';
 import PropTypes from 'prop-types';
 import omit from 'lodash/omit';
 
@@ -28,6 +28,7 @@ const propTypes = {
     ascending: PropTypes.string,
     descending: PropTypes.string,
     showHeader: PropTypes.string,
+    allowNavigation: PropTypes.string,
   }),
   /** an object where the keys are available dimensions and the values are the values available for those dimensions
    *  ex: { manufacturer: ['Rentech', 'GHI Industries'], deviceid: ['73000', '73001', '73002'] }
@@ -44,6 +45,7 @@ const defaultProps = {
     ascending: 'Ascending',
     descending: 'Descending',
     showHeader: 'Show table header',
+    allowNavigation: 'Allow navigation to assets',
   },
   availableDimensions: {},
 };
@@ -53,6 +55,8 @@ const TableCardFormSettings = ({ cardConfig, onChange, i18n }) => {
   const { content, id } = cardConfig;
 
   const baseClassName = `${iotPrefix}--card-edit-form`;
+  const dataItems = useMemo(() => content?.columns.map(column => column.label), [content]);
+  const [sortByValue, setSortByValue] = useState(dataItems[0]);
 
   return (
     <>
@@ -84,31 +88,15 @@ const TableCardFormSettings = ({ cardConfig, onChange, i18n }) => {
       </div> */}
       <div className={`${baseClassName}--input`}>
         <Dropdown
-          id={`${id}_value-card-decimal-place`}
+          id={`${id}_sort_by_dropdown`}
           titleText={mergedI18n.sortBy}
           direction="bottom"
           label=""
-          items={cardConfig.content?.columns.map(column => column.label)}
+          items={dataItems}
           light
-          selectedItem={content?.precision?.toString() || mergedI18n.sortByTitle}
+          selectedItem={sortByValue}
           onChange={({ selectedItem }) => {
-            const isSet = selectedItem !== 'Not set';
-            if (isSet) {
-              onChange({
-                ...cardConfig,
-                content: {
-                  ...content,
-                  precision: Number(selectedItem),
-                },
-              });
-            } else {
-              onChange({
-                ...cardConfig,
-                content: {
-                  ...omit(content, 'precision'),
-                },
-              });
-            }
+              setSortByValue(selectedItem);
           }}
         />
       </div>
@@ -118,7 +106,7 @@ const TableCardFormSettings = ({ cardConfig, onChange, i18n }) => {
             onChange={(evt) =>
               onChange({
                 ...cardConfig,
-                content: { ...cardConfig.content, sort: evt },
+                content: { ...cardConfig.content, sort: evt},
               })
             }
             orientation="vertical"
@@ -158,6 +146,25 @@ const TableCardFormSettings = ({ cardConfig, onChange, i18n }) => {
           />
         </div>
       </div>
+      {/* <div className={`${baseClassName}--input`}>
+        <div className={`${baseClassName}--input--toggle-field`}>
+          <span>{mergedI18n.allowNavigation}</span>
+          <ToggleSmall
+            data-testid={`${baseClassName}--input-toggle1`}
+            id={`${baseClassName}--input-toggle-1`}
+            aria-label={mergedI18n.allowNavigation}
+            labelA=""
+            labelB=""
+            toggled={cardConfig.content?.showHeader ?? true}
+            onToggle={(bool) =>
+              onChange({
+                ...cardConfig,
+                content: { ...cardConfig.content, showHeader: bool },
+              })
+            }
+          />
+        </div>
+      </div> */}
     </>
   );
 };

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormSettings.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormSettings.jsx
@@ -155,11 +155,11 @@ const TableCardFormSettings = ({ cardConfig, onChange, i18n }) => {
             aria-label={mergedI18n.allowNavigation}
             labelA=""
             labelB=""
-            toggled={cardConfig.content?.allowNavigation ?? true}
+            toggled={cardConfig.content?.allowNavigation ?? false}
             onToggle={(bool) =>
               onChange({
                 ...cardConfig,
-                // content: { ...cardConfig.content, showHeader: bool },
+                content: { ...cardConfig.content, allowNavigation: bool },
               })
             }
           />

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormSettings.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormSettings.jsx
@@ -1,12 +1,15 @@
-import React, {useState, useMemo} from 'react';
+import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import omit from 'lodash/omit';
+import isEmpty from 'lodash/isEmpty';
 
 import { settings } from '../../../../../constants/Settings';
-import { ToggleSmall, Dropdown, FormGroup, RadioButton, RadioButtonGroup } from '../../../../../index';
 import {
-  TableCardPropTypes,
-} from '../../../../../constants/CardPropTypes';
+  ToggleSmall,
+  Dropdown,
+  RadioButton,
+  RadioButtonGroup,
+} from '../../../../../index';
+import { TableCardPropTypes } from '../../../../../constants/CardPropTypes';
 
 const { iotPrefix } = settings;
 
@@ -55,8 +58,16 @@ const TableCardFormSettings = ({ cardConfig, onChange, i18n }) => {
   const { content, id } = cardConfig;
 
   const baseClassName = `${iotPrefix}--card-edit-form`;
-  const dataItems = useMemo(() => content?.columns.map(column => column.label), [content]);
-  const [sortByValue, setSortByValue] = useState(dataItems[0]);
+  const dataItems = useMemo(
+    () =>
+      Array.isArray(content?.columns)
+        ? content?.columns.map((column) => column.label)
+        : [],
+    [content]
+  );
+
+  // default to timestamp sort
+  const [sortByValue, setSortByValue] = useState('timestamp');
 
   return (
     <>
@@ -86,47 +97,52 @@ const TableCardFormSettings = ({ cardConfig, onChange, i18n }) => {
             }}
           />
       </div> */}
-      <div className={`${baseClassName}--input`}>
-        <Dropdown
-          id={`${id}_sort_by_dropdown`}
-          titleText={mergedI18n.sortBy}
-          direction="bottom"
-          label=""
-          items={dataItems}
-          light
-          selectedItem={sortByValue}
-          onChange={({ selectedItem }) => {
-              setSortByValue(selectedItem);
-          }}
-        />
-      </div>
-      <div className={`${baseClassName}--input`}>
-          <RadioButtonGroup
-            name={`${baseClassName}--input-radios`}
-            onChange={(evt) =>
-              onChange({
-                ...cardConfig,
-                content: { ...cardConfig.content, sort: evt},
-              })
-            }
-            orientation="vertical"
-            legend={`${mergedI18n.descending}`}
-            labelPosition="right"
-            valueSelected={cardConfig.content?.displayOption}>
-            <RadioButton
-              data-testid={`${baseClassName}--input-radio1`}
-              value="DESC"
-              id={`${baseClassName}--input-radio-1`}
-              labelText={mergedI18n.descending}
+      {!isEmpty(cardConfig?.content?.columns) ? (
+        <>
+          <div className={`${baseClassName}--input`}>
+            <Dropdown
+              id={`${id}_sort_by_dropdown`}
+              titleText={mergedI18n.sortBy}
+              direction="bottom"
+              hideLabel
+              label={mergedI18n.sortBy}
+              items={dataItems}
+              light
+              selectedItem={sortByValue}
+              onChange={({ selectedItem }) => {
+                setSortByValue(selectedItem);
+              }}
             />
-            <RadioButton
-              data-testid={`${baseClassName}--input-radio2`}
-              value="ASC"
-              id={`${baseClassName}--input-radio-2`}
-              labelText={mergedI18n.ascending}
-            />
-          </RadioButtonGroup>
-      </div>
+          </div>
+          <div className={`${baseClassName}--input`}>
+            <RadioButtonGroup
+              name={`${baseClassName}--input-radios`}
+              onChange={(evt) =>
+                onChange({
+                  ...cardConfig,
+                  content: { ...cardConfig.content, sort: evt },
+                })
+              }
+              orientation="vertical"
+              legend={`${mergedI18n.descending}`}
+              labelPosition="right"
+              valueSelected={cardConfig.content?.displayOption}>
+              <RadioButton
+                data-testid={`${baseClassName}--input-radio1`}
+                value="DESC"
+                id={`${baseClassName}--input-radio-1`}
+                labelText={mergedI18n.descending}
+              />
+              <RadioButton
+                data-testid={`${baseClassName}--input-radio2`}
+                value="ASC"
+                id={`${baseClassName}--input-radio-2`}
+                labelText={mergedI18n.ascending}
+              />
+            </RadioButtonGroup>
+          </div>
+        </>
+      ) : null}
       <div className={`${baseClassName}--input`}>
         <div className={`${baseClassName}--input--toggle-field`}>
           <span>{mergedI18n.showHeader}</span>

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormSettings.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormSettings.jsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import omit from 'lodash/omit';
+
+import { settings } from '../../../../../constants/Settings';
+import { ToggleSmall, Dropdown, FormGroup, RadioButton, RadioButtonGroup } from '../../../../../index';
+import {
+  TableCardPropTypes,
+} from '../../../../../constants/CardPropTypes';
+
+const { iotPrefix } = settings;
+
+const propTypes = {
+  /** card data value */
+  cardConfig: PropTypes.shape({
+    id: PropTypes.string,
+    title: PropTypes.string,
+    size: PropTypes.string,
+    type: PropTypes.string,
+    content: TableCardPropTypes.content,
+  }),
+  /** Callback function when form data changes */
+  onChange: PropTypes.func.isRequired,
+  i18n: PropTypes.shape({
+    rowsPerPage: PropTypes.string,
+    sortBy: PropTypes.string,
+    sortByDataItem: PropTypes.string,
+    ascending: PropTypes.string,
+    descending: PropTypes.string,
+    showHeader: PropTypes.string,
+  }),
+  /** an object where the keys are available dimensions and the values are the values available for those dimensions
+   *  ex: { manufacturer: ['Rentech', 'GHI Industries'], deviceid: ['73000', '73001', '73002'] }
+   */
+  availableDimensions: PropTypes.shape({}),
+};
+
+const defaultProps = {
+  cardConfig: {},
+  i18n: {
+    rowsPerPage: 'Rows per page',
+    sortBy: 'Sort by',
+    sortByTitle: 'Sort by data item',
+    ascending: 'Ascending',
+    descending: 'Descending',
+    showHeader: 'Show table header',
+  },
+  availableDimensions: {},
+};
+
+const TableCardFormSettings = ({ cardConfig, onChange, i18n }) => {
+  const mergedI18n = { ...defaultProps.i18n, ...i18n };
+  const { content, id } = cardConfig;
+
+  const baseClassName = `${iotPrefix}--card-edit-form`;
+
+  return (
+    <>
+      {/* This is handled by the card. Do we want to override this or will it mess with the grid layout?
+      <div className={`${baseClassName}--input`}>
+        <Dropdown
+            id={`${cardConfig.id}_rows_per_page`}
+            direction="bottom"
+            label={mergedI18n.rowsPerPage}
+            light
+            titleText={mergedI18n.rowsPerPage}
+            items={[]}
+            selectedItem={cardConfig.content?.categoryDataSourceId}
+            onChange={({ selectedItem }) => {
+              onChange({
+                ...cardConfig,
+                content: {
+                  ...cardConfig.content,
+                  timeDataSourceId: 'timestamp',
+                  categoryDataSourceId: selectedItem,
+                },
+                dataSource: {
+                  ...cardConfig.dataSource,
+                  groupBy: [selectedItem],
+                },
+              });
+            }}
+          />
+      </div> */}
+      <div className={`${baseClassName}--input`}>
+        <Dropdown
+          id={`${id}_value-card-decimal-place`}
+          titleText={mergedI18n.sortBy}
+          direction="bottom"
+          label=""
+          items={cardConfig.content?.columns.map(column => column.label)}
+          light
+          selectedItem={content?.precision?.toString() || mergedI18n.sortByTitle}
+          onChange={({ selectedItem }) => {
+            const isSet = selectedItem !== 'Not set';
+            if (isSet) {
+              onChange({
+                ...cardConfig,
+                content: {
+                  ...content,
+                  precision: Number(selectedItem),
+                },
+              });
+            } else {
+              onChange({
+                ...cardConfig,
+                content: {
+                  ...omit(content, 'precision'),
+                },
+              });
+            }
+          }}
+        />
+      </div>
+      <div className={`${baseClassName}--input`}>
+          <RadioButtonGroup
+            name={`${baseClassName}--input-radios`}
+            onChange={(evt) =>
+              onChange({
+                ...cardConfig,
+                content: { ...cardConfig.content, sort: evt },
+              })
+            }
+            orientation="vertical"
+            legend={`${mergedI18n.descending}`}
+            labelPosition="right"
+            valueSelected={cardConfig.content?.displayOption}>
+            <RadioButton
+              data-testid={`${baseClassName}--input-radio1`}
+              value="DESC"
+              id={`${baseClassName}--input-radio-1`}
+              labelText={mergedI18n.descending}
+            />
+            <RadioButton
+              data-testid={`${baseClassName}--input-radio2`}
+              value="ASC"
+              id={`${baseClassName}--input-radio-2`}
+              labelText={mergedI18n.ascending}
+            />
+          </RadioButtonGroup>
+      </div>
+      <div className={`${baseClassName}--input`}>
+        <div className={`${baseClassName}--input--toggle-field`}>
+          <span>{mergedI18n.showHeader}</span>
+          <ToggleSmall
+            data-testid={`${baseClassName}--input-toggle1`}
+            id={`${baseClassName}--input-toggle-1`}
+            aria-label={mergedI18n.showHeader}
+            labelA=""
+            labelB=""
+            toggled={cardConfig.content?.showHeader ?? true}
+            onToggle={(bool) =>
+              onChange({
+                ...cardConfig,
+                content: { ...cardConfig.content, showHeader: bool },
+              })
+            }
+          />
+        </div>
+      </div>
+    </>
+  );
+};
+
+TableCardFormSettings.propTypes = propTypes;
+TableCardFormSettings.defaultProps = defaultProps;
+
+export default TableCardFormSettings;

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormSettings.test.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormSettings.test.jsx
@@ -1,19 +1,21 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 import {
   CARD_SIZES,
   CARD_TYPES,
 } from '../../../../../constants/LayoutConstants';
 
-import TableCardFormSettings from './TableCardFormSettings';
+import TableCardFormSettings, {
+  updateColumnSort,
+} from './TableCardFormSettings';
 
 const commonCardConfig = {
   id: 'id',
   title: 'My Table Card',
   size: CARD_SIZES.LARGE,
   type: CARD_TYPES.TABLE,
-  content: {},
+  content: { columns: [] },
 };
 const commonProps = {
   cardConfig: commonCardConfig,
@@ -24,9 +26,35 @@ const commonProps = {
   },
 };
 describe('TableCardFormSettings', () => {
+  it('updateColumnSort where a column is already sorted', () => {
+    const mockColumns = [
+      { dataSourceId: 'timestamp', sort: 'DESC' },
+      { dataSourceId: 'manufacturer' },
+    ];
+    expect(updateColumnSort(mockColumns, 'manufacturer', 'ASC')).toEqual([
+      { dataSourceId: 'timestamp', sort: undefined },
+      { dataSourceId: 'manufacturer', sort: 'ASC' },
+    ]);
+    expect(updateColumnSort(mockColumns, 'timestamp', 'ASC')).toEqual([
+      { dataSourceId: 'timestamp', sort: 'ASC' },
+      { dataSourceId: 'manufacturer' },
+    ]);
+  });
+  it('updateColumnSort with no previous column sort', () => {
+    const mockColumns = [
+      { dataSourceId: 'timestamp' },
+      { dataSourceId: 'manufacturer' },
+    ];
+    expect(updateColumnSort(mockColumns, 'manufacturer', 'ASC')).toEqual([
+      { dataSourceId: 'timestamp' },
+      { dataSourceId: 'manufacturer', sort: 'ASC' },
+    ]);
+  });
   it('sort by drop down does not render with no columns', () => {
     render(<TableCardFormSettings {...commonProps} />);
     expect(screen.queryByLabelText('Sort by')).toBeNull();
+    expect(screen.queryByText('Ascending')).toBeNull();
+    expect(screen.queryByText('Descending')).toBeNull();
   });
   it('sort by drop down renders with columns', () => {
     render(
@@ -47,5 +75,103 @@ describe('TableCardFormSettings', () => {
       />
     );
     expect(screen.queryAllByLabelText('Sort by')).toBeDefined();
+    expect(screen.queryByText('Ascending')).toBeDefined();
+    expect(screen.queryByText('Descending')).toBeDefined();
+  });
+  it('sort by drop down populates correctly', () => {
+    render(
+      <TableCardFormSettings
+        {...commonProps}
+        cardConfig={{
+          ...commonCardConfig,
+          content: {
+            columns: [
+              {
+                dataSourceId: 'timestamp',
+                label: 'Timestamp',
+                type: 'TIMESTAMP',
+              },
+              {
+                dataSourceId: 'manufacturer',
+                label: 'Manufacturer',
+                sort: 'DESC',
+              },
+            ],
+          },
+        }}
+      />
+    );
+    expect(screen.queryAllByLabelText('Sort by')[0].innerHTML).toEqual(
+      expect.stringContaining('manufacturer')
+    );
+  });
+  it('changing sort calls onChange', () => {
+    const mockOnChange = jest.fn();
+    render(
+      <TableCardFormSettings
+        {...commonProps}
+        onChange={mockOnChange}
+        cardConfig={{
+          ...commonCardConfig,
+          content: {
+            columns: [
+              {
+                dataSourceId: 'timestamp',
+                label: 'Timestamp',
+                type: 'TIMESTAMP',
+              },
+              {
+                dataSourceId: 'manufacturer',
+                label: 'Manufacturer',
+                sort: 'DESC',
+              },
+            ],
+          },
+        }}
+      />
+    );
+    fireEvent.click(screen.getAllByLabelText('Sort by')[0]);
+    fireEvent.click(screen.getByText('timestamp'));
+    expect(mockOnChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.objectContaining({
+          columns: [
+            {
+              dataSourceId: 'timestamp',
+              label: 'Timestamp',
+              type: 'TIMESTAMP',
+              sort: 'DESC',
+            },
+            {
+              dataSourceId: 'manufacturer',
+              label: 'Manufacturer',
+              sort: undefined,
+            },
+          ],
+        }),
+      })
+    );
+  });
+  it('toggle showHeader should call onChange', () => {
+    const mockOnChange = jest.fn();
+    render(<TableCardFormSettings {...commonProps} onChange={mockOnChange} />);
+    expect(mockOnChange).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByLabelText('Show table header'));
+    expect(mockOnChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.objectContaining({ showHeader: false }),
+      })
+    );
+  });
+  it('toggle allowNavigation should call onChange', () => {
+    const mockOnChange = jest.fn();
+    render(<TableCardFormSettings {...commonProps} onChange={mockOnChange} />);
+    expect(mockOnChange).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByLabelText('Allow navigation to assets'));
+    expect(mockOnChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.objectContaining({ allowNavigation: true }),
+      })
+    );
   });
 });

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormSettings.test.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormSettings.test.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import {
+  CARD_SIZES,
+  CARD_TYPES,
+} from '../../../../../constants/LayoutConstants';
+
+import TableCardFormSettings from './TableCardFormSettings';
+
+const commonCardConfig = {
+  id: 'id',
+  title: 'My Table Card',
+  size: CARD_SIZES.LARGE,
+  type: CARD_TYPES.TABLE,
+  content: {},
+};
+const commonProps = {
+  cardConfig: commonCardConfig,
+  onChange: jest.fn(),
+  availableDimensions: {
+    manufacturer: ['Rentech', 'GHI'],
+    deviceid: ['73000', '73001'],
+  },
+};
+describe('TableCardFormSettings', () => {
+  it('sort by drop down does not render with no columns', () => {
+    render(<TableCardFormSettings {...commonProps} />);
+    expect(screen.queryByLabelText('Sort by')).toBeNull();
+  });
+  it('sort by drop down renders with columns', () => {
+    render(
+      <TableCardFormSettings
+        {...commonProps}
+        cardConfig={{
+          ...commonCardConfig,
+          content: {
+            columns: [
+              {
+                dataSourceId: 'timestamp',
+                label: 'Timestamp',
+                type: 'TIMESTAMP',
+              },
+            ],
+          },
+        }}
+      />
+    );
+    expect(screen.queryAllByLabelText('Sort by')).toBeDefined();
+  });
+});

--- a/src/components/CardEditor/CardEditForm/CardEditFormSettings.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormSettings.jsx
@@ -58,7 +58,12 @@ const defaultProps = {
   },
 };
 
-const CardEditFormSettings = ({ cardConfig, onChange, i18n, availableDimensions }) => {
+const CardEditFormSettings = ({
+  cardConfig,
+  onChange,
+  i18n,
+  availableDimensions,
+}) => {
   const mergedI18n = { ...defaultProps.i18n, ...i18n };
   const { type } = cardConfig;
 
@@ -103,7 +108,7 @@ const CardEditFormSettings = ({ cardConfig, onChange, i18n, availableDimensions 
           i18n={mergedI18n}
           onChange={onChange}
         />
-      )
+      );
     default:
       return null;
   }

--- a/src/components/CardEditor/CardEditForm/CardEditFormSettings.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormSettings.jsx
@@ -7,8 +7,13 @@ import DataSeriesFormSettings from './CardEditFormItems/DataSeriesFormItems/Data
 import ValueCardFormSettings from './CardEditFormItems/ValueCardFormItems/ValueCardFormSettings';
 import ImageCardFormSettings from './CardEditFormItems/ImageCardFormItems/ImageCardFormSettings';
 import BarChartCardFormSettings from './CardEditFormItems/BarChartCardFormItems/BarChartCardFormSettings';
+import TableCardFormSettings from './CardEditFormItems/TableCardFormItems/TableCardFormSettings';
 
 const propTypes = {
+  /** an object where the keys are available dimensions and the values are the values available for those dimensions
+   *  ex: { manufacturer: ['Rentech', 'GHI Industries'], deviceid: ['73000', '73001', '73002'] }
+   */
+  availableDimensions: PropTypes.shape({}),
   /** card data value */
   cardConfig: PropTypes.shape({
     id: PropTypes.string,
@@ -39,6 +44,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  availableDimensions: {},
   cardConfig: {},
   i18n: {
     xAxisLabel: 'X-axis label',
@@ -52,7 +58,7 @@ const defaultProps = {
   },
 };
 
-const CardEditFormSettings = ({ cardConfig, onChange, i18n }) => {
+const CardEditFormSettings = ({ cardConfig, onChange, i18n, availableDimensions }) => {
   const mergedI18n = { ...defaultProps.i18n, ...i18n };
   const { type } = cardConfig;
 
@@ -89,6 +95,15 @@ const CardEditFormSettings = ({ cardConfig, onChange, i18n }) => {
           onChange={onChange}
         />
       );
+    case CARD_TYPES.TABLE:
+      return (
+        <TableCardFormSettings
+          availableDimensions={availableDimensions}
+          cardConfig={cardConfig}
+          i18n={mergedI18n}
+          onChange={onChange}
+        />
+      )
     default:
       return null;
   }

--- a/src/components/CardEditor/CardEditForm/_card-edit-form.scss
+++ b/src/components/CardEditor/CardEditForm/_card-edit-form.scss
@@ -125,6 +125,10 @@
       margin-right: 1rem;
       max-width: 5rem;
     }
+
+    &--span {
+      font-size: 0.75rem;
+    }
   }
   &--threshold-input-group {
     display: flex;

--- a/src/components/DashboardEditor/DashboardEditor.jsx
+++ b/src/components/DashboardEditor/DashboardEditor.jsx
@@ -24,16 +24,10 @@ import {
   renderBreakpointInfo,
   handleKeyDown,
   handleOnClick,
+  DataItemsPropTypes,
 } from './editorUtils';
 
 const { iotPrefix } = settings;
-
-export const DataItemsPropTypes = PropTypes.arrayOf(
-  PropTypes.shape({
-    dataSourceId: PropTypes.string,
-    label: PropTypes.string,
-  })
-);
 
 const propTypes = {
   /** Dashboard title */

--- a/src/components/DashboardEditor/DashboardEditorCardRenderer.jsx
+++ b/src/components/DashboardEditor/DashboardEditorCardRenderer.jsx
@@ -112,7 +112,14 @@ const EditorBarChartCard = ({ dataItems, availableDimensions, ...props }) => {
  * @param {Object} commonProps
  * @returns {Node}
  */
-const renderTableCard = (props) => <TableCard isEditable {...props} />;
+const renderTableCard = (props) => (
+  <TableCard
+    // TODO: workaround need to regen TableCard if columns change
+    key={JSON.stringify(props?.content?.columns)}
+    isEditable
+    {...props}
+  />
+);
 
 /**
  * @param {Object} cardConfig

--- a/src/components/DashboardEditor/editorUtils.jsx
+++ b/src/components/DashboardEditor/editorUtils.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import uuid from 'uuid';
 import isNil from 'lodash/isNil';
 import isEmpty from 'lodash/isEmpty';
@@ -56,6 +57,13 @@ import {
   BAR_CHART_LAYOUTS,
   DASHBOARD_EDITOR_CARD_TYPES,
 } from '../../constants/LayoutConstants';
+
+export const DataItemsPropTypes = PropTypes.arrayOf(
+  PropTypes.shape({
+    dataSourceId: PropTypes.string,
+    label: PropTypes.string,
+  })
+);
 
 /**
  * Returns a duplicate card configuration

--- a/src/components/DashboardEditor/editorUtils.jsx
+++ b/src/components/DashboardEditor/editorUtils.jsx
@@ -431,7 +431,7 @@ export const handleDataSeriesChange = (
   setEditDataSeries,
   hotspotIndex
 ) => {
-  const { type } = cardConfig;
+  const { type, content } = cardConfig;
   let series;
   let attributes;
   let columns;
@@ -453,19 +453,14 @@ export const handleDataSeriesChange = (
         content: { ...cardConfig.content, series },
       };
     case CARD_TYPES.TABLE:
-      if (selectedItems[0].hasOwnProperty('type')) {
-        columns = [
-          ...(selectedItems.map(i => ({dataSourceId: i.id, label: i.text})) ?? []),
-          ...(cardConfig.content.columns.filter(column => column.dataSourceId !== 'timestamp') ?? [])
-        ]
-
-      }
-      else {
-        columns = selectedItems.map(i => ({dataSourceId: i.id, label: i.text})) ?? [];
-      }
+      dataSection = selectedItems.map(i => i.hasOwnProperty('type') ?
+        {dataSourceId: i.id, label: i.text, type: i.type} :
+        {dataSourceId: i.id, label: i.text}
+      )
+      columns = content.columns.filter(col => col.type === 'TIMESTAMP')
       return {
         ...cardConfig,
-        content: { ...cardConfig.content, columns: [{dataSourceId: 'timestamp', label: 'timestamp', type: 'timestamp'}, ...columns] },
+        content: { ...cardConfig.content, columns: [{dataSourceId: 'timestamp', label: 'Timestamp', type: 'TIMESTAMP'}, ...dataSection] },
     };
     case CARD_TYPES.IMAGE:
       dataSection = [...(cardConfig.content?.hotspots || [])];

--- a/src/components/DashboardEditor/editorUtils.jsx
+++ b/src/components/DashboardEditor/editorUtils.jsx
@@ -460,6 +460,7 @@ export const handleDataSeriesChange = (
               dataSourceId: 'timestamp',
               label: 'Timestamp',
               type: 'TIMESTAMP',
+              sort: 'DESC',
             };
       const existingDimensionColumns = Array.isArray(content?.columns)
         ? content.columns.filter((col) => col.type === 'DIMENSION')

--- a/src/components/DashboardEditor/editorUtils.jsx
+++ b/src/components/DashboardEditor/editorUtils.jsx
@@ -643,10 +643,19 @@ export const handleDataSeriesChange = (
         content: { ...cardConfig.content, series },
       };
     case CARD_TYPES.TABLE:
-      columns = selectedItems.length > 0 ? selectedItems.map(i => ({dataSourceId: i.id, label: i.text})) : cardConfig.content.columns;
+      if (selectedItems[0].hasOwnProperty('type')) {
+        columns = [
+          ...(selectedItems.map(i => ({dataSourceId: i.id, label: i.text})) ?? []),
+          ...(cardConfig.content.columns.filter(column => column.dataSourceId !== 'timestamp') ?? [])
+        ]
+
+      }
+      else {
+        columns = selectedItems.map(i => ({dataSourceId: i.id, label: i.text})) ?? [];
+      }
       return {
         ...cardConfig,
-        content: { ...cardConfig.content, columns },
+        content: { ...cardConfig.content, columns: [{dataSourceId: 'timestamp', label: 'timestamp', type: 'timestamp'}, ...columns] },
       };
     default:
       return cardConfig;

--- a/src/components/DashboardEditor/editorUtils.jsx
+++ b/src/components/DashboardEditor/editorUtils.jsx
@@ -625,6 +625,7 @@ export const handleDataSeriesChange = (
   const { type } = cardConfig;
   let series;
   let attributes;
+  let columns;
 
   switch (type) {
     case CARD_TYPES.VALUE:
@@ -640,6 +641,12 @@ export const handleDataSeriesChange = (
       return {
         ...cardConfig,
         content: { ...cardConfig.content, series },
+      };
+    case CARD_TYPES.TABLE:
+      columns = selectedItems.length > 0 ? selectedItems.map(i => ({dataSourceId: i.id, label: i.text})) : cardConfig.content.columns;
+      return {
+        ...cardConfig,
+        content: { ...cardConfig.content, columns },
       };
     default:
       return cardConfig;
@@ -681,6 +688,16 @@ export const handleDataItemEdit = (
       return {
         ...cardConfig,
         content: { ...content, series: dataSection },
+      };
+    case CARD_TYPES.TABLE:
+      dataSection = [...content.columns];
+      editDataItemIndex = dataSection.findIndex(
+        (dataItem) => dataItem.dataSourceId === editDataItem.dataSourceId
+      );
+      dataSection[editDataItemIndex] = editDataItem;
+      return {
+        ...cardConfig,
+        content: { ...cardConfig.content, columns: dataSection },
       };
     default:
       return cardConfig;

--- a/src/components/DashboardEditor/editorUtils.jsx
+++ b/src/components/DashboardEditor/editorUtils.jsx
@@ -429,7 +429,8 @@ export const handleDataSeriesChange = (
   selectedItems,
   cardConfig,
   setEditDataSeries,
-  hotspotIndex
+  hotspotIndex,
+  isDimensionUpdate
 ) => {
   const { type, content } = cardConfig;
   let series;
@@ -451,10 +452,6 @@ export const handleDataSeriesChange = (
         content: { ...cardConfig.content, series },
       };
     case CARD_TYPES.TABLE: {
-      const isDimensionUpdate = selectedItems.find(
-        (item) => item.type === 'DIMENSION'
-      );
-
       const existingAttributeColumns = Array.isArray(content?.columns)
         ? content.columns.filter((col) => !col.type)
         : [];

--- a/src/components/DashboardEditor/editorUtils.jsx
+++ b/src/components/DashboardEditor/editorUtils.jsx
@@ -457,10 +457,10 @@ export const handleDataSeriesChange = (
         {dataSourceId: i.id, label: i.text, type: i.type} :
         {dataSourceId: i.id, label: i.text}
       )
-      columns = content.columns.filter(col => col.type === 'TIMESTAMP')
+      columns = content.columns.filter(col => col.type === 'TIMESTAMP')[0] || {dataSourceId: 'timestamp', label: 'Timestamp', type: 'TIMESTAMP'}
       return {
         ...cardConfig,
-        content: { ...cardConfig.content, columns: [{dataSourceId: 'timestamp', label: 'Timestamp', type: 'TIMESTAMP'}, ...dataSection] },
+        content: { ...cardConfig.content, columns: [columns, ...dataSection] },
     };
     case CARD_TYPES.IMAGE:
       dataSection = [...(cardConfig.content?.hotspots || [])];

--- a/src/components/DashboardEditor/editorUtils.jsx
+++ b/src/components/DashboardEditor/editorUtils.jsx
@@ -143,16 +143,7 @@ export const getDefaultCard = (type, i18n) => {
       return {
         ...baseCardProps,
         content: {
-          columns: [
-            {
-              dataSourceId: 'undefined',
-              label: '--',
-            },
-            {
-              dataSourceId: 'undefined2',
-              label: '--',
-            },
-          ],
+          columns: [],
         },
       };
     case DASHBOARD_EDITOR_CARD_TYPES.IMAGE:

--- a/src/components/DashboardEditor/editorUtils.test.jsx
+++ b/src/components/DashboardEditor/editorUtils.test.jsx
@@ -301,6 +301,7 @@ describe('editorUtils', () => {
               dataSourceId: 'timestamp',
               label: 'Timestamp',
               type: 'TIMESTAMP',
+              sort: 'DESC',
             },
             {
               dataSourceId: 'key1',
@@ -329,6 +330,7 @@ describe('editorUtils', () => {
                 dataSourceId: 'timestamp',
                 label: 'Timestamp',
                 type: 'TIMESTAMP',
+                sort: 'DESC',
               },
               {
                 dataSourceId: 'manufacturer',
@@ -352,6 +354,7 @@ describe('editorUtils', () => {
               dataSourceId: 'timestamp',
               label: 'Timestamp',
               type: 'TIMESTAMP',
+              sort: 'DESC',
             },
             {
               dataSourceId: 'manufacturer',
@@ -389,6 +392,7 @@ describe('editorUtils', () => {
               dataSourceId: 'timestamp',
               label: 'Timestamp',
               type: 'TIMESTAMP',
+              sort: 'DESC',
             },
             {
               dataSourceId: 'manufacturer',

--- a/src/components/DashboardEditor/editorUtils.test.jsx
+++ b/src/components/DashboardEditor/editorUtils.test.jsx
@@ -275,7 +275,182 @@ describe('editorUtils', () => {
       );
       expect(newCard).toEqual(omit(mockTimeSeriesCard, 'type'));
     });
-
+    // base table card
+    const mockTableCard = {
+      id: 'Standard',
+      title: 'table card',
+      type: 'TABLE',
+      size: 'LARGE',
+      content: {},
+    };
+    it('handleDataSeriesChange should correctly format the columns for new table card attributes', () => {
+      const selectedItems = [
+        { id: 'key1', text: 'Key 1' },
+        { id: 'key2', text: 'Key 2' },
+      ];
+      const newCard = handleDataSeriesChange(
+        selectedItems,
+        mockTableCard,
+        () => {}
+      );
+      expect(newCard).toEqual({
+        ...mockTableCard,
+        content: {
+          columns: [
+            {
+              dataSourceId: 'timestamp',
+              label: 'Timestamp',
+              type: 'TIMESTAMP',
+            },
+            {
+              dataSourceId: 'key1',
+              label: 'Key 1',
+            },
+            {
+              dataSourceId: 'key2',
+              label: 'Key 2',
+            },
+          ],
+        },
+      });
+    });
+    it('handleDataSeriesChange existing card should correctly add the columns for new table card attributes', () => {
+      const selectedItems = [
+        { id: 'key1', text: 'Key 1' },
+        { id: 'key2', text: 'Key 2' },
+      ];
+      const newCard = handleDataSeriesChange(
+        selectedItems,
+        {
+          ...mockTableCard,
+          content: {
+            columns: [
+              {
+                dataSourceId: 'timestamp',
+                label: 'Timestamp',
+                type: 'TIMESTAMP',
+              },
+              {
+                dataSourceId: 'manufacturer',
+                label: 'Manufacturer',
+                type: 'DIMENSION',
+              },
+              {
+                dataSourceId: 'key1',
+                label: 'Key 1',
+              },
+            ],
+          },
+        },
+        () => {}
+      );
+      expect(newCard).toEqual({
+        ...mockTableCard,
+        content: {
+          columns: [
+            {
+              dataSourceId: 'timestamp',
+              label: 'Timestamp',
+              type: 'TIMESTAMP',
+            },
+            {
+              dataSourceId: 'manufacturer',
+              label: 'Manufacturer',
+              type: 'DIMENSION',
+            },
+            {
+              dataSourceId: 'key1',
+              label: 'Key 1',
+            },
+            {
+              dataSourceId: 'key2',
+              label: 'Key 2',
+            },
+          ],
+        },
+      });
+    });
+    it('handleDataSeriesChange should correctly format the columns for new table card dimensions', () => {
+      const selectedItems = [{ id: 'manufacturer', text: 'Manufacturer' }];
+      const newCard = handleDataSeriesChange(
+        selectedItems,
+        mockTableCard,
+        () => {}
+      );
+      expect(newCard).toEqual({
+        ...mockTableCard,
+        content: {
+          columns: [
+            {
+              dataSourceId: 'timestamp',
+              label: 'Timestamp',
+              type: 'TIMESTAMP',
+            },
+            {
+              dataSourceId: 'manufacturer',
+              label: 'Manufacturer',
+            },
+          ],
+        },
+      });
+    });
+    it('handleDataSeriesChange existing card should correctly add the columns for new table card dimensions', () => {
+      const selectedItems = [
+        { id: 'manufacturer', text: 'Manufacturer', type: 'DIMENSION' },
+        { id: 'deviceid', text: 'Device', type: 'DIMENSION' },
+      ];
+      const newCard = handleDataSeriesChange(
+        selectedItems,
+        {
+          ...mockTableCard,
+          content: {
+            columns: [
+              {
+                dataSourceId: 'timestamp',
+                label: 'Timestamp',
+                type: 'TIMESTAMP',
+              },
+              {
+                dataSourceId: 'manufacturer',
+                label: 'Manufacturer',
+                type: 'DIMENSION',
+              },
+              {
+                dataSourceId: 'key1',
+                label: 'Key 1',
+              },
+            ],
+          },
+        },
+        () => {}
+      );
+      expect(newCard).toEqual({
+        ...mockTableCard,
+        content: {
+          columns: [
+            {
+              dataSourceId: 'timestamp',
+              label: 'Timestamp',
+              type: 'TIMESTAMP',
+            },
+            {
+              dataSourceId: 'manufacturer',
+              label: 'Manufacturer',
+              type: 'DIMENSION',
+            },
+            {
+              dataSourceId: 'deviceid',
+              label: 'Device',
+              type: 'DIMENSION',
+            },
+            {
+              dataSourceId: 'key1',
+              label: 'Key 1',
+            },
+          ],
+        },
+      });
+    });
     it('should correctly format the data in Timeseries', () => {
       const selectedItems = [
         { id: 'key1', text: 'Key 1' },

--- a/src/components/DashboardEditor/editorUtils.test.jsx
+++ b/src/components/DashboardEditor/editorUtils.test.jsx
@@ -371,11 +371,15 @@ describe('editorUtils', () => {
       });
     });
     it('handleDataSeriesChange should correctly format the columns for new table card dimensions', () => {
-      const selectedItems = [{ id: 'manufacturer', text: 'Manufacturer' }];
+      const selectedItems = [
+        { id: 'manufacturer', text: 'Manufacturer', type: 'DIMENSION' },
+      ];
       const newCard = handleDataSeriesChange(
         selectedItems,
         mockTableCard,
-        () => {}
+        () => {},
+        null,
+        true
       );
       expect(newCard).toEqual({
         ...mockTableCard,
@@ -389,6 +393,7 @@ describe('editorUtils', () => {
             {
               dataSourceId: 'manufacturer',
               label: 'Manufacturer',
+              type: 'DIMENSION',
             },
           ],
         },
@@ -422,7 +427,9 @@ describe('editorUtils', () => {
             ],
           },
         },
-        () => {}
+        () => {},
+        null,
+        true
       );
       expect(newCard).toEqual({
         ...mockTableCard,

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -7032,9 +7032,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         >
                           <span
                             className=""
-                            title="hh:mm:ss"
+                            title="xx/xx/xxxx xx:xx"
                           >
-                            hh:mm:ss
+                            xx/xx/xxxx xx:xx
                           </span>
                         </span>
                       </td>
@@ -7097,9 +7097,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         >
                           <span
                             className=""
-                            title="hh:mm:ss"
+                            title="xx/xx/xxxx xx:xx"
                           >
-                            hh:mm:ss
+                            xx/xx/xxxx xx:xx
                           </span>
                         </span>
                       </td>
@@ -7162,9 +7162,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         >
                           <span
                             className=""
-                            title="hh:mm:ss"
+                            title="xx/xx/xxxx xx:xx"
                           >
-                            hh:mm:ss
+                            xx/xx/xxxx xx:xx
                           </span>
                         </span>
                       </td>
@@ -7227,9 +7227,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         >
                           <span
                             className=""
-                            title="hh:mm:ss"
+                            title="xx/xx/xxxx xx:xx"
                           >
-                            hh:mm:ss
+                            xx/xx/xxxx xx:xx
                           </span>
                         </span>
                       </td>
@@ -7292,9 +7292,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         >
                           <span
                             className=""
-                            title="hh:mm:ss"
+                            title="xx/xx/xxxx xx:xx"
                           >
-                            hh:mm:ss
+                            xx/xx/xxxx xx:xx
                           </span>
                         </span>
                       </td>
@@ -7357,9 +7357,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         >
                           <span
                             className=""
-                            title="hh:mm:ss"
+                            title="xx/xx/xxxx xx:xx"
                           >
-                            hh:mm:ss
+                            xx/xx/xxxx xx:xx
                           </span>
                         </span>
                       </td>
@@ -7422,9 +7422,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         >
                           <span
                             className=""
-                            title="hh:mm:ss"
+                            title="xx/xx/xxxx xx:xx"
                           >
-                            hh:mm:ss
+                            xx/xx/xxxx xx:xx
                           </span>
                         </span>
                       </td>
@@ -7487,9 +7487,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         >
                           <span
                             className=""
-                            title="hh:mm:ss"
+                            title="xx/xx/xxxx xx:xx"
                           >
-                            hh:mm:ss
+                            xx/xx/xxxx xx:xx
                           </span>
                         </span>
                       </td>
@@ -7552,9 +7552,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         >
                           <span
                             className=""
-                            title="hh:mm:ss"
+                            title="xx/xx/xxxx xx:xx"
                           >
-                            hh:mm:ss
+                            xx/xx/xxxx xx:xx
                           </span>
                         </span>
                       </td>
@@ -7617,9 +7617,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         >
                           <span
                             className=""
-                            title="hh:mm:ss"
+                            title="xx/xx/xxxx xx:xx"
                           >
-                            hh:mm:ss
+                            xx/xx/xxxx xx:xx
                           </span>
                         </span>
                       </td>
@@ -8500,9 +8500,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         >
                           <span
                             className=""
-                            title="hh:mm:ss"
+                            title="xx/xx/xxxx xx:xx"
                           >
-                            hh:mm:ss
+                            xx/xx/xxxx xx:xx
                           </span>
                         </span>
                       </td>
@@ -8598,9 +8598,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         >
                           <span
                             className=""
-                            title="hh:mm:ss"
+                            title="xx/xx/xxxx xx:xx"
                           >
-                            hh:mm:ss
+                            xx/xx/xxxx xx:xx
                           </span>
                         </span>
                       </td>
@@ -8696,9 +8696,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         >
                           <span
                             className=""
-                            title="hh:mm:ss"
+                            title="xx/xx/xxxx xx:xx"
                           >
-                            hh:mm:ss
+                            xx/xx/xxxx xx:xx
                           </span>
                         </span>
                       </td>
@@ -8794,9 +8794,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         >
                           <span
                             className=""
-                            title="hh:mm:ss"
+                            title="xx/xx/xxxx xx:xx"
                           >
-                            hh:mm:ss
+                            xx/xx/xxxx xx:xx
                           </span>
                         </span>
                       </td>
@@ -8892,9 +8892,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         >
                           <span
                             className=""
-                            title="hh:mm:ss"
+                            title="xx/xx/xxxx xx:xx"
                           >
-                            hh:mm:ss
+                            xx/xx/xxxx xx:xx
                           </span>
                         </span>
                       </td>
@@ -8990,9 +8990,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         >
                           <span
                             className=""
-                            title="hh:mm:ss"
+                            title="xx/xx/xxxx xx:xx"
                           >
-                            hh:mm:ss
+                            xx/xx/xxxx xx:xx
                           </span>
                         </span>
                       </td>
@@ -9088,9 +9088,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         >
                           <span
                             className=""
-                            title="hh:mm:ss"
+                            title="xx/xx/xxxx xx:xx"
                           >
-                            hh:mm:ss
+                            xx/xx/xxxx xx:xx
                           </span>
                         </span>
                       </td>
@@ -9186,9 +9186,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         >
                           <span
                             className=""
-                            title="hh:mm:ss"
+                            title="xx/xx/xxxx xx:xx"
                           >
-                            hh:mm:ss
+                            xx/xx/xxxx xx:xx
                           </span>
                         </span>
                       </td>
@@ -9284,9 +9284,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         >
                           <span
                             className=""
-                            title="hh:mm:ss"
+                            title="xx/xx/xxxx xx:xx"
                           >
-                            hh:mm:ss
+                            xx/xx/xxxx xx:xx
                           </span>
                         </span>
                       </td>
@@ -9382,9 +9382,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         >
                           <span
                             className=""
-                            title="hh:mm:ss"
+                            title="xx/xx/xxxx xx:xx"
                           >
-                            hh:mm:ss
+                            xx/xx/xxxx xx:xx
                           </span>
                         </span>
                       </td>

--- a/src/components/TableCard/_table-card.scss
+++ b/src/components/TableCard/_table-card.scss
@@ -1,5 +1,9 @@
 @import '../../globals/vars';
 
+.#{$iot-prefix}--card--content .#{$iot-prefix}--table-container {
+  overflow-x: hidden; // scrolling should be handled inside the table, not between the card and the table
+}
+
 .#{$iot-prefix}--table-card--overflow-menu {
   margin-left: $spacing-03;
   opacity: 1;

--- a/src/components/TimeSeriesCard/timeSeriesUtils.js
+++ b/src/components/TimeSeriesCard/timeSeriesUtils.js
@@ -88,7 +88,7 @@ export const generateTableSampleValues = (id, columns) => {
     id: `sample-values-${id}-${index}`,
     values: columns.reduce((obj, column) => {
       obj[column.dataSourceId] = // eslint-disable-line no-param-reassign
-        column.type === 'TIMESTAMP' ? 'hh:mm:ss' : '--';
+        column.type === 'TIMESTAMP' ? 'xx/xx/xxxx xx:xx' : '--';
       return obj;
     }, {}),
   }));


### PR DESCRIPTION
Closes #1739 

**Summary**

- Add support for table cards in the dashboard editor. 

**Change List (commits, features, bugs, etc)**

- Added `TableCardFormSettings.jsx`, `TableCardFormContent.jsx`
- updated 'CardEditForm.jsx`, `CardEditFormContent.jsx`, `CardEditFormSettings.jsx`, and `editorUtils.js` to support TableCard

**Acceptance Test (how to verify the PR)**

- Go to[ dasbhoard editor story](https://deploy-preview-1889--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-experimental-dashboardeditor--default) and choose a Table Card. 
- Play around with the form and see changes in the card
