### PR TITLE
fix(ValueCard): don't abbreviate if precision is set

### DIFF
--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -20962,7 +20962,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 houHFr"
                               size="SMALLWIDE"
                               title="1709384.1 people"
                               value={1709384.1}
@@ -21419,7 +21419,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 houHFr"
                               size="SMALLWIDE"
                               title="1709384.1 people"
                               value={1709384.1}
@@ -21876,7 +21876,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 houHFr"
                               size="SMALLWIDE"
                               title="1709384.1 people"
                               value={1709384.1}
@@ -22333,7 +22333,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 houHFr"
                               size="SMALLWIDE"
                               title="1709384.1 people"
                               value={1709384.1}

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -920,7 +920,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             title="13572 "
                             value={13572}
                           >
-                            14K
+                            13,572
                           </span>
                         </div>
                         <span
@@ -3339,7 +3339,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             title="13572 "
                             value={13572}
                           >
-                            14K
+                            13,572
                           </span>
                         </div>
                         <span
@@ -5786,7 +5786,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             title="13572 "
                             value={13572}
                           >
-                            14K
+                            13,572
                           </span>
                         </div>
                         <span
@@ -10810,7 +10810,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             title="13572 "
                             value={13572}
                           >
-                            14K
+                            13,572
                           </span>
                         </div>
                         <span
@@ -12682,7 +12682,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="1352 steps"
                               value={1352}
                             >
-                              1K
+                              1,352
                             </span>
                           </div>
                           <span
@@ -12854,7 +12854,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="107324.3 kJ"
                               value={107324.3}
                             >
-                              107.3K
+                              107,324.3
                             </span>
                           </div>
                           <span
@@ -12935,12 +12935,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 drpvOh"
                               size="SMALL"
                               title="1709384.1 people"
                               value={1709384.1}
                             >
-                              1.7M
+                              1,709,384.1
                             </span>
                           </div>
                           <span
@@ -13369,7 +13369,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="1352 steps"
                               value={1352}
                             >
-                              1K
+                              1,352
                             </span>
                           </div>
                           <span
@@ -13541,7 +13541,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="107324.3 kJ"
                               value={107324.3}
                             >
-                              107.3K
+                              107,324.3
                             </span>
                           </div>
                           <span
@@ -13622,12 +13622,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 drpvOh"
                               size="SMALL"
                               title="1709384.1 people"
                               value={1709384.1}
                             >
-                              1.7M
+                              1,709,384.1
                             </span>
                           </div>
                           <span
@@ -16938,7 +16938,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="1352 steps"
                               value={1352}
                             >
-                              1K
+                              1,352
                             </span>
                           </div>
                           <span
@@ -17110,7 +17110,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="107324.3 kJ"
                               value={107324.3}
                             >
-                              107.3K
+                              107,324.3
                             </span>
                           </div>
                           <span
@@ -17191,12 +17191,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 drpvOh"
                               size="SMALLWIDE"
                               title="1709384.1 people"
                               value={1709384.1}
                             >
-                              1.7M
+                              1,709,384.1
                             </span>
                           </div>
                           <span
@@ -18845,7 +18845,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="1352 steps"
                               value={1352}
                             >
-                              1K
+                              1,352
                             </span>
                           </div>
                           <span
@@ -19017,7 +19017,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="107324.3 kJ"
                               value={107324.3}
                             >
-                              107.3K
+                              107,324.3
                             </span>
                           </div>
                           <span
@@ -19098,12 +19098,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 drpvOh"
                               size="SMALLWIDE"
                               title="1709384.1 people"
                               value={1709384.1}
                             >
-                              1.7M
+                              1,709,384.1
                             </span>
                           </div>
                           <span
@@ -20967,7 +20967,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="1709384.1 people"
                               value={1709384.1}
                             >
-                              1.7M
+                              1,709,384.1
                             </span>
                           </div>
                           <span
@@ -21424,7 +21424,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="1709384.1 people"
                               value={1709384.1}
                             >
-                              1.7M
+                              1,709,384.1
                             </span>
                           </div>
                           <span
@@ -21881,7 +21881,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="1709384.1 people"
                               value={1709384.1}
                             >
-                              1.7M
+                              1,709,384.1
                             </span>
                           </div>
                           <span
@@ -22338,7 +22338,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="1709384.1 people"
                               value={1709384.1}
                             >
-                              1.7M
+                              1,709,384.1
                             </span>
                           </div>
                           <span
@@ -23374,7 +23374,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="13634.56 MWh"
                               value={13634.56}
                             >
-                              13.6K
+                              13,634.6
                             </span>
                           </div>
                           <span
@@ -23423,7 +23423,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="1047.2 MWh"
                               value={1047.2}
                             >
-                              1.0K
+                              1,047.2
                             </span>
                           </div>
                           <span
@@ -24077,7 +24077,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="13634.56 MWh"
                               value={13634.56}
                             >
-                              13.6K
+                              13,634.6
                             </span>
                           </div>
                           <span
@@ -24126,7 +24126,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="1047.2 MWh"
                               value={1047.2}
                             >
-                              1.0K
+                              1,047.2
                             </span>
                           </div>
                           <span
@@ -25632,7 +25632,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             title="13572 "
                             value={13572}
                           >
-                            14K
+                            13,572
                           </span>
                         </div>
                         <span

--- a/src/components/ValueCard/ValueCard.story.jsx
+++ b/src/components/ValueCard/ValueCard.story.jsx
@@ -644,23 +644,23 @@ export const MediumVerticalMultiple = () => {
             {
               label: 'Comfort Level',
               dataSourceId: 'comfortLevel',
-              unit: '%',
+              precision: 4,
             },
             {
               label: 'Average Temperature',
               dataSourceId: 'averageTemp',
               unit: '˚F',
-              precision: 1,
+              precision: 6,
             },
-            { label: 'Utilization', dataSourceId: 'utilization', unit: '%' },
+            { label: 'Utilization', dataSourceId: 'utilization', precision: 2 },
           ]),
         }}
         breakpoint="lg"
         size={size}
         values={{
-          comfortLevel: number('comfortLevel', 89),
-          averageTemp: number('averageTemp', 76.7),
-          utilization: number('utilization', 76),
+          comfortLevel: number('comfortLevel', 100012312312.5023934),
+          averageTemp: number('averageTemp', 20302.5023934),
+          utilization: number('utilization', 404015614.5023934),
         }}
       />
     </div>
@@ -668,7 +668,7 @@ export const MediumVerticalMultiple = () => {
 };
 
 MediumVerticalMultiple.story = {
-  name: 'medium / vertical / multiple',
+  name: 'medium / vertical / multiple / long values',
 };
 
 export const MediumVertical2 = () => {

--- a/src/components/ValueCard/ValueCard.test.jsx
+++ b/src/components/ValueCard/ValueCard.test.jsx
@@ -113,7 +113,7 @@ describe('ValueCard', () => {
     );
 
     expect(originalValue).toBe(10000);
-    expect(defaultFormattedValue).toBe('10K');
+    expect(defaultFormattedValue).toBe('10,000');
     expect(screen.queryByText(testValue)).toBeTruthy();
   });
 });

--- a/src/components/ValueCard/ValueRenderer.jsx
+++ b/src/components/ValueCard/ValueRenderer.jsx
@@ -56,7 +56,15 @@ const Attribute = styled.div`
   ${(props) => props.isMini && 'align-items: center;'}
 `;
 
-/** Returns font size in rem */
+/**
+ * @param {Object} params
+ * @param {string || Number} params.value
+ * @param {string} params.size
+ * @param {Boolean} params.isSmall
+ * @param {Boolean} params.isMini
+ * @param {string} params.layout
+ * @returns {Number} font size in rem
+ */
 const determineFontSize = ({ value, size, isSmall, isMini, layout }) => {
   if (typeof value === 'string') {
     switch (size) {
@@ -68,12 +76,11 @@ const determineFontSize = ({ value, size, isSmall, isMini, layout }) => {
     }
   }
   const valueLength = value?.toString().length;
+  // mini is the smallest
   if (isMini) {
     return 1;
   }
-  if (isSmall) {
-    return 2;
-  }
+  // swap to a smaller font size if there is a long value
   if (valueLength > 15) {
     return 1.25;
   }
@@ -83,6 +90,11 @@ const determineFontSize = ({ value, size, isSmall, isMini, layout }) => {
   if (valueLength > 8) {
     return 1.75;
   }
+  // if its not a long value, use the small value size
+  if (isSmall) {
+    return 2;
+  }
+  // otherwise use the default font size
   return 2.5;
 };
 

--- a/src/components/ValueCard/ValueRenderer.jsx
+++ b/src/components/ValueCard/ValueRenderer.jsx
@@ -67,7 +67,23 @@ const determineFontSize = ({ value, size, isSmall, isMini, layout }) => {
       default:
     }
   }
-  return isMini ? 1 : isSmall ? 2 : 2.5;
+  const valueLength = value?.toString().length;
+  if (isMini) {
+    return 1;
+  }
+  if (isSmall) {
+    return 2;
+  }
+  if (valueLength > 15) {
+    return 1.25;
+  }
+  if (valueLength > 12) {
+    return 1.5;
+  }
+  if (valueLength > 8) {
+    return 1.75;
+  }
+  return 2.5;
 };
 
 /** Renders the actual attribute value */

--- a/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -1913,7 +1913,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 jKAmol"
                     size="LARGETHIN"
                     title="Australia "
                     value="Australia"
@@ -2220,7 +2220,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                     title="20000000000000000 "
                     value={20000000000000000}
                   >
-                    20,000T
+                    20,000,000,000,000,000
                   </span>
                 </div>
                 <span
@@ -2343,12 +2343,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 jKAmol"
                     size="MEDIUM"
                     title="100000000 Wh"
                     value={100000000}
                   >
-                    100M
+                    100,000,000
                   </span>
                 </div>
                 <span
@@ -2392,12 +2392,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 eiVIVr"
                     size="MEDIUM"
                     title="40000000000000 Wh"
                     value={40000000000000}
                   >
-                    40T
+                    40,000,000,000,000
                   </span>
                 </div>
                 <span
@@ -3030,7 +3030,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/ValueCard medium / vertical / multiple 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/ValueCard medium / vertical / multiple / long values 1`] = `
 <div
   className="storybook-container"
 >
@@ -3096,16 +3096,16 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                 size="MEDIUM"
               >
                 <div
-                  className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                  className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 bBjGNb"
                     size="MEDIUM"
-                    title="89 %"
-                    value={89}
+                    title="100012312312.5024 "
+                    value={100012312312.5024}
                   >
-                    89
+                    100,012,312,312.5024
                   </span>
                 </div>
                 <span
@@ -3116,7 +3116,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                     }
                   }
                 >
-                  %
+                  
                 </span>
               </div>
               <div
@@ -3149,12 +3149,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 eiVIVr"
                     size="MEDIUM"
-                    title="76.7 ˚F"
-                    value={76.7}
+                    title="20302.5023934 ˚F"
+                    value={20302.5023934}
                   >
-                    76.7
+                    20,302.502393
                   </span>
                 </div>
                 <span
@@ -3194,16 +3194,16 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                 size="MEDIUM"
               >
                 <div
-                  className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                  className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 bBjGNb"
                     size="MEDIUM"
-                    title="76 %"
-                    value={76}
+                    title="404015614.5023934 "
+                    value={404015614.5023934}
                   >
-                    76
+                    404,015,614.50
                   </span>
                 </div>
                 <span
@@ -3214,7 +3214,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                     }
                   }
                 >
-                  %
+                  
                 </span>
               </div>
               <div
@@ -3685,7 +3685,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                     title="345678234234234240 %"
                     value={345678234234234240}
                   >
-                    345,678T
+                    345,678,234,234,234,240
                   </span>
                 </div>
                 <span
@@ -3764,7 +3764,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                     title="456778234234234240 ˚F"
                     value={456778234234234240}
                   >
-                    456,778T
+                    456,778,234,234,234,240
                   </span>
                 </div>
                 <span
@@ -3843,7 +3843,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                     title="88888678234234240000 ˚F"
                     value={88888678234234240000}
                   >
-                    88,888,678T
+                    88,888,678,234,234,240,000
                   </span>
                 </div>
                 <span
@@ -4684,7 +4684,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                     title="13572 "
                     value={13572}
                   >
-                    14K
+                    13,572
                   </span>
                 </div>
                 <span
@@ -4812,7 +4812,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                     title="13572 "
                     value={13572}
                   >
-                    14K
+                    13,572
                   </span>
                 </div>
                 <span

--- a/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -2215,7 +2215,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 kmAyHP"
                     size="SMALL"
                     title="20000000000000000 "
                     value={20000000000000000}
@@ -3680,7 +3680,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kolfZc"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 gQouVk"
                     size="MEDIUMTHIN"
                     title="345678234234234240 %"
                     value={345678234234234240}
@@ -3759,7 +3759,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kolfZc"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 gQouVk"
                     size="MEDIUMTHIN"
                     title="456778234234234240 ˚F"
                     value={456778234234234240}
@@ -3838,7 +3838,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kolfZc"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 gQouVk"
                     size="MEDIUMTHIN"
                     title="88888678234234240000 ˚F"
                     value={88888678234234240000}

--- a/src/utils/__tests__/cardUtilityFunctions.test.jsx
+++ b/src/utils/__tests__/cardUtilityFunctions.test.jsx
@@ -49,7 +49,7 @@ describe('cardUtilityFunctions', () => {
   it('formatNumberWithPrecision', () => {
     expect(formatNumberWithPrecision(3.45, 1, 'fr')).toEqual('3,5'); // decimal separator should be comma
     expect(formatNumberWithPrecision(3.45, 2, 'en')).toEqual('3.45'); // decimal separator should be period
-    expect(formatNumberWithPrecision(35000, 2, 'en')).toEqual('35.00K'); // K separator
+    expect(formatNumberWithPrecision(35000, 2, 'en')).toEqual('35,000.00'); // decimal separator should be period
     expect(formatNumberWithPrecision(35000, null, 'en')).toEqual('35K'); // K separator
   });
   it('formatChartNumberWithPrecision', () => {

--- a/src/utils/cardUtilityFunctions.js
+++ b/src/utils/cardUtilityFunctions.js
@@ -150,60 +150,27 @@ export const getUpdatedCardSize = (oldSize) => {
  * @param {number} precision, how many decimal values to display configured at the attribute level
  * @param {string} locale, the local browser locale because locales use different decimal separators
  */
-export const formatNumberWithPrecision = (
-  value,
-  precision = 0,
-  locale = 'en'
-) => {
-  return value > 1000000000000
-    ? `${(value / 1000000000000).toLocaleString(
-        locale,
-        !isNil(precision)
-          ? {
-              minimumFractionDigits: precision,
-              maximumFractionDigits: precision,
-            }
-          : undefined
-      )}T`
-    : value > 1000000000
-    ? `${(value / 1000000000).toLocaleString(
-        locale,
-        !isNil(precision)
-          ? {
-              minimumFractionDigits: precision,
-              maximumFractionDigits: precision,
-            }
-          : undefined
-      )}B`
-    : value > 1000000
-    ? `${(value / 1000000).toLocaleString(
-        locale,
-        !isNil(precision)
-          ? {
-              minimumFractionDigits: precision,
-              maximumFractionDigits: precision,
-            }
-          : undefined
-      )}M`
-    : value > 1000
-    ? `${(value / 1000).toLocaleString(
-        locale,
-        !isNil(precision)
-          ? {
-              minimumFractionDigits: precision,
-              maximumFractionDigits: precision,
-            }
-          : undefined
-      )}K`
-    : value.toLocaleString(
-        locale,
-        !isNil(precision)
-          ? {
-              minimumFractionDigits: precision,
-              maximumFractionDigits: precision,
-            }
-          : undefined
-      );
+export const formatNumberWithPrecision = (value, precision, locale = 'en') => {
+  // do not truncate if precision is set
+  if (!isNil(precision)) {
+    return value.toLocaleString(locale, {
+      minimumFractionDigits: precision,
+      maximumFractionDigits: precision,
+    });
+  } // truncate if precision is not set
+  if (value > 1000000000000) {
+    return `${(value / 1000000000000).toLocaleString(locale)}T`;
+  }
+  if (value > 1000000000) {
+    return `${(value / 1000000000).toLocaleString(locale)}B`;
+  }
+  if (value > 1000000) {
+    return `${(value / 1000000).toLocaleString(locale, !isNil(precision))}M`;
+  }
+  if (value > 1000) {
+    return `${(value / 1000).toLocaleString(locale)}K`;
+  }
+  return value.toLocaleString(locale);
 };
 
 /**


### PR DESCRIPTION
Closes #1892

**Summary**

- If precision is set, the value will not be truncated. Instead, the font-size will adjust according to the length of the value to attempt to keep the value on 1 line and stay readable

**Change List (commits, features, bugs, etc)**

- Update story to use long values for precision testing

**Acceptance Test (how to verify the PR)**

- Go to /?path=/story/watson-iot-valuecard--medium-vertical-multiple in the netlify and use the knobs to try different large values with varied precisions. Font sizes should adjust according to the value length
