### PR TITLE
adding data-testid for specific components

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,13 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "type": "pwa-chrome",
+      "request": "launch",
+      "name": "Debug Story Book",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}/lib/index.js"
+    },
+    {
       "type": "node",
       "runtimeVersion": "12.17.0",
       "request": "launch",

--- a/src/components/CardEditor/CardEditForm/CardEditForm.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditForm.jsx
@@ -67,6 +67,7 @@ const propTypes = {
    */
   onValidateCardJson: PropTypes.func,
   currentBreakpoint: PropTypes.string,
+  testID: PropTypes.string,
 };
 
 const defaultProps = {
@@ -98,6 +99,7 @@ const defaultProps = {
   availableDimensions: {},
   onValidateCardJson: null,
   currentBreakpoint: 'xl',
+  testID: 'card-edit-form',
 };
 
 /**
@@ -176,6 +178,7 @@ const CardEditForm = ({
   getValidTimeRanges,
   currentBreakpoint,
   availableDimensions,
+  testID,
 }) => {
   const mergedI18n = { ...defaultProps.i18n, ...i18n };
   const [showEditor, setShowEditor] = useState(false);
@@ -239,6 +242,7 @@ const CardEditForm = ({
         </Tabs>
         <div className={`${baseClassName}--footer`}>
           <Button
+            data-testid={`${testID}-open-editor-button`}
             kind="tertiary"
             size="small"
             renderIcon={Code16}

--- a/src/components/CardEditor/CardEditor.jsx
+++ b/src/components/CardEditor/CardEditor.jsx
@@ -78,6 +78,8 @@ const propTypes = {
     searchPlaceholderText: PropTypes.string,
   }),
   currentBreakpoint: PropTypes.string,
+  /** Id that can be used for testing */
+  testID: PropTypes.string,
 };
 
 const defaultProps = {
@@ -97,6 +99,7 @@ const defaultProps = {
   supportedCardTypes: Object.keys(DASHBOARD_EDITOR_CARD_TYPES),
   onValidateCardJson: null,
   currentBreakpoint: 'xl',
+  testID: 'card-editor',
 };
 
 const baseClassName = `${iotPrefix}--card-editor`;
@@ -114,6 +117,7 @@ const CardEditor = ({
   availableDimensions,
   i18n,
   currentBreakpoint,
+  testID,
 }) => {
   const mergedI18n = { ...defaultProps.i18n, ...i18n };
 
@@ -121,7 +125,7 @@ const CardEditor = ({
   const showGallery = isNil(cardConfig);
 
   return (
-    <div className={baseClassName}>
+    <div className={baseClassName} data-testid={testID}>
       {!showGallery ? (
         <div className={`${baseClassName}--header`}>
           <Button
@@ -146,6 +150,7 @@ const CardEditor = ({
             onAddCard={onAddCard}
             supportedCardTypes={supportedCardTypes}
             i18n={mergedI18n}
+            data-testid={`${testID}-card-gallery-list`}
           />
         ) : (
           <CardEditForm

--- a/src/components/CardEditor/__snapshots__/CardEditor.story.storyshot
+++ b/src/components/CardEditor/__snapshots__/CardEditor.story.storyshot
@@ -23,6 +23,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
     >
       <div
         className="iot--card-editor"
+        data-testid="card-editor"
       >
         <div
           className="iot--card-editor--header"
@@ -769,6 +770,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <button
                 className="iot--btn bx--btn bx--btn--sm bx--btn--tertiary"
+                data-testid="card-edit-form-open-editor-button"
                 disabled={false}
                 onClick={[Function]}
                 tabIndex={0}
@@ -850,6 +852,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
     >
       <div
         className="iot--card-editor"
+        data-testid="card-editor"
       >
         <div
           className="iot--card-editor--header"
@@ -1535,6 +1538,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <button
                 className="iot--btn bx--btn bx--btn--sm bx--btn--tertiary"
+                data-testid="card-edit-form-open-editor-button"
                 disabled={false}
                 onClick={[Function]}
                 tabIndex={0}
@@ -1616,6 +1620,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
     >
       <div
         className="iot--card-editor"
+        data-testid="card-editor"
       >
         <div
           className="iot--card-editor--header"
@@ -2382,6 +2387,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             >
               <button
                 className="iot--btn bx--btn bx--btn--sm bx--btn--tertiary"
+                data-testid="card-edit-form-open-editor-button"
                 disabled={false}
                 onClick={[Function]}
                 tabIndex={0}
@@ -2480,6 +2486,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
       >
         <div
           className="iot--card-editor"
+          data-testid="card-editor"
         >
           <div
             className="iot--card-editor--header"
@@ -3080,6 +3087,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               >
                 <button
                   className="iot--btn bx--btn bx--btn--sm bx--btn--tertiary"
+                  data-testid="card-edit-form-open-editor-button"
                   disabled={false}
                   onClick={[Function]}
                   tabIndex={0}
@@ -3162,6 +3170,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
     >
       <div
         className="iot--card-editor"
+        data-testid="card-editor"
       >
         <div
           className="iot--card-editor--header"

--- a/src/components/DashboardEditor/DashboardEditor.story.jsx
+++ b/src/components/DashboardEditor/DashboardEditor.story.jsx
@@ -69,6 +69,9 @@ export const Default = () => (
       getValidDataItems={() => mockDataItems}
       dataItems={mockDataItems}
       availableImages={images}
+      i18n={{
+        headerEditTitleButton: 'Edit title updated',
+      }}
       onAddImage={action('onAddImage')}
       onEditTitle={action('onEditTitle')}
       onImport={action('onImport')}

--- a/src/components/DashboardEditor/DashboardEditorHeader/DashboardEditorHeader.jsx
+++ b/src/components/DashboardEditor/DashboardEditorHeader/DashboardEditorHeader.jsx
@@ -121,7 +121,7 @@ const DashboardEditorHeader = ({
   setSelectedBreakpointIndex,
   breakpointSwitcher,
 }) => {
-  const mergedI18n = { ...defaultProps.i18n, i18n };
+  const mergedI18n = { ...defaultProps.i18n, ...i18n };
   const baseClassName = `${iotPrefix}--dashboard-editor-header`;
   const extraContent = (
     <div className={`${baseClassName}--right`}>

--- a/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -2589,11 +2589,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                       <span
                         className="bx--assistive-text"
                       >
-                        Edit title
+                        Edit title updated
                       </span>
                       <svg
                         aria-hidden="true"
-                        aria-label="Edit title"
+                        aria-label="Edit title updated"
                         className="bx--btn__icon"
                         fill="currentColor"
                         focusable="false"

--- a/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -859,6 +859,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         >
           <div
             className="iot--card-editor"
+            data-testid="card-editor"
           >
             <div
               className="iot--card-editor--header"
@@ -1863,6 +1864,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         >
           <div
             className="iot--card-editor"
+            data-testid="card-editor"
           >
             <div
               className="iot--card-editor--header"
@@ -3897,6 +3899,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         >
           <div
             className="iot--card-editor"
+            data-testid="card-editor"
           >
             <div
               className="iot--card-editor--header"
@@ -5337,6 +5340,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         >
           <div
             className="iot--card-editor"
+            data-testid="card-editor"
           >
             <div
               className="iot--card-editor--header"
@@ -6627,6 +6631,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         >
           <div
             className="iot--card-editor"
+            data-testid="card-editor"
           >
             <div
               className="iot--card-editor--header"
@@ -9348,6 +9353,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         >
           <div
             className="iot--card-editor"
+            data-testid="card-editor"
           >
             <div
               className="iot--card-editor--header"
@@ -10746,6 +10752,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         >
           <div
             className="iot--card-editor"
+            data-testid="card-editor"
           >
             <div
               className="iot--card-editor--header"

--- a/src/components/Header/HeaderAction/HeaderAction.jsx
+++ b/src/components/Header/HeaderAction/HeaderAction.jsx
@@ -12,7 +12,7 @@ import HeaderActionPanel from './HeaderActionPanel';
 
 const { prefix: carbonPrefix } = settings;
 
-export const propTypes = {
+export const HeaderActionPropTypes = {
   /** details of the item to render in the action */
   item: PropTypes.shape(HeaderActionItemPropTypes).isRequired,
   /** unique index for the menu item */
@@ -131,7 +131,7 @@ const HeaderAction = ({ item, index, testID }) => {
   );
 };
 
-HeaderAction.propTypes = propTypes;
+HeaderAction.propTypes = HeaderActionPropTypes;
 HeaderAction.defaultProps = defaultProps;
 
 export default HeaderAction;

--- a/src/components/Header/HeaderAction/HeaderAction.jsx
+++ b/src/components/Header/HeaderAction/HeaderAction.jsx
@@ -12,11 +12,17 @@ import HeaderActionPanel from './HeaderActionPanel';
 
 const { prefix: carbonPrefix } = settings;
 
-export const HeaderActionPropTypes = {
+export const propTypes = {
   /** details of the item to render in the action */
   item: PropTypes.shape(HeaderActionItemPropTypes).isRequired,
   /** unique index for the menu item */
   index: PropTypes.number.isRequired,
+  /** Id that can be used for testing */
+  testID: PropTypes.string,
+};
+
+const defaultProps = {
+  testID: 'header-action',
 };
 
 /**
@@ -28,7 +34,7 @@ export const HeaderActionPropTypes = {
  * Consists of nav buttons that can be clicked to perform actions, open header panels (side panels),
  * or dropdown menus
  */
-const HeaderAction = ({ item, index }) => {
+const HeaderAction = ({ item, index, testID }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const parentContainerRef = useRef(null);
   const menuButtonRef = useRef(null);
@@ -100,8 +106,8 @@ const HeaderAction = ({ item, index }) => {
             ref={menuButtonRef}
             onToggleExpansion={toggleExpandedState}
             label={item.label}
-            data-testid="header-menu"
-            title="header-menu"
+            data-testid={testID}
+            title={item.label}
             childContent={item.childContent}
           />
         )}
@@ -117,6 +123,7 @@ const HeaderAction = ({ item, index }) => {
         item.className
       )}
       key={`menu-item-${item.label}-global-${index}`}
+      data-testid={`menu-item-${item.label}-global`}
       aria-label={item.label}
       onClick={item.onClick || (() => {})}>
       {item.btnContent}
@@ -124,6 +131,7 @@ const HeaderAction = ({ item, index }) => {
   );
 };
 
-HeaderAction.propTypes = HeaderActionPropTypes;
+HeaderAction.propTypes = propTypes;
+HeaderAction.defaultProps = defaultProps;
 
 export default HeaderAction;

--- a/src/components/Header/HeaderActionGroup.jsx
+++ b/src/components/Header/HeaderActionGroup.jsx
@@ -25,6 +25,7 @@ const HeaderActionGroup = ({ actionItems }) => {
             item={item}
             index={i}
             key={`header-action-item-${item.label}-${i}`}
+            testID={`header-action-item-${item.label}`}
           />
         ))}
       </HeaderGlobalBar>

--- a/src/components/Header/__snapshots__/Header.story.storyshot
+++ b/src/components/Header/__snapshots__/Header.story.storyshot
@@ -71,6 +71,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Heade
           <button
             aria-label="alerts"
             className="bx--header-action-btn bx--header__action"
+            data-testid="menu-item-alerts-global"
             onClick={[Function]}
             type="button"
           >
@@ -437,6 +438,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Heade
         <button
           aria-label="user"
           className="bx--header-action-btn bx--header__action"
+          data-testid="menu-item-user-global"
           onClick={[Function]}
           type="button"
         >

--- a/src/components/SideNav/__snapshots__/SideNav.story.storyshot
+++ b/src/components/SideNav/__snapshots__/SideNav.story.storyshot
@@ -75,6 +75,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/SideN
           <button
             aria-label="user"
             className="bx--header-action-btn bx--header__action"
+            data-testid="menu-item-user-global"
             onClick={[Function]}
             type="button"
           >

--- a/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
+++ b/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
@@ -148,6 +148,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
         <button
           aria-label="alerts"
           className="bx--header-action-btn bx--header__action"
+          data-testid="menu-item-alerts-global"
           onClick={[Function]}
           type="button"
         >
@@ -351,6 +352,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
         <button
           aria-label="Administration"
           className="bx--header-action-btn admin-icon bx--header__action"
+          data-testid="menu-item-Administration-global"
           onClick={[Function]}
           type="button"
         >
@@ -939,6 +941,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
         <button
           aria-label="Administration"
           className="bx--header-action-btn admin-icon bx--header__action"
+          data-testid="menu-item-Administration-global"
           onClick={[Function]}
           type="button"
         >
@@ -1882,6 +1885,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
         <button
           aria-label="Administration"
           className="bx--header-action-btn admin-icon bx--header__action"
+          data-testid="menu-item-Administration-global"
           onClick={[Function]}
           type="button"
         >
@@ -2452,6 +2456,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
         <button
           aria-label="Administration"
           className="bx--header-action-btn admin-icon bx--header__action"
+          data-testid="menu-item-Administration-global"
           onClick={[Function]}
           type="button"
         >

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -8800,6 +8800,7 @@ Map {
         "GROUPED_BAR",
         "STACKED_BAR",
       ],
+      "testID": "card-editor",
     },
     "propTypes": Object {
       "availableDimensions": Object {
@@ -8944,6 +8945,9 @@ Map {
           },
         ],
         "type": "arrayOf",
+      },
+      "testID": Object {
+        "type": "string",
       },
     },
   },


### PR DESCRIPTION
Closes https://github.ibm.com/wiotp/monitoring-dashboard/issues/1699
Closes https://github.ibm.com/wiotp/monitoring-dashboard/issues/1680

**Summary**

- Adding `data-testid` for a few of the component to use it for walkme and also for automated testing. 
- Passing the string literal to the child component.

**Acceptance Test (how to verify the PR)**

- Tested the component for which extra properties are added. 
