### PR TITLE
fix(tablecardformcontent): dimensions were not populating in the edit…

### DIFF
--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -96,12 +96,14 @@ const TableCardFormContent = ({
   const baseClassName = `${iotPrefix}--card-edit-form`;
 
   // This is used in the edit case where some of these data items have been selected before
-  const initialSelectedItems = useMemo(
+  const initialSelectedAttributes = useMemo(
     () =>
-      dataSection?.map(({ dataSourceId }) => ({
-        id: dataSourceId,
-        text: dataSourceId,
-      })),
+      dataSection
+        .filter((col) => !col.type)
+        .map(({ dataSourceId }) => ({
+          id: dataSourceId,
+          text: dataSourceId,
+        })),
     [dataSection]
   );
 
@@ -112,7 +114,13 @@ const TableCardFormContent = ({
   );
 
   const initialSelectedDimensions = useMemo(
-    () => dataSection.filter((col) => col.type === 'DIMENSION'),
+    () =>
+      dataSection
+        .filter((col) => col.type === 'DIMENSION')
+        .map(({ dataSourceId }) => ({
+          id: dataSourceId,
+          text: dataSourceId,
+        })),
     [dataSection]
   );
 
@@ -151,7 +159,7 @@ const TableCardFormContent = ({
           label={mergedI18n.selectDataItems}
           direction="bottom"
           itemToString={(item) => item.id}
-          initialSelectedItems={initialSelectedItems}
+          initialSelectedItems={initialSelectedAttributes}
           items={validDataItems}
           light
           onChange={({ selectedItems }) => {

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { Edit16 } from '@carbon/icons-react';
 import isEmpty from 'lodash/isEmpty';
@@ -133,6 +133,32 @@ const TableCardFormContent = ({
     [dataItems]
   );
 
+  // need to handle thresholds from the DataSeriesFormItemModal and convert it to the right format
+  const handleDataItemModalChanges = useCallback(
+    (card) => {
+      const allThresholds = [];
+      // the table card is looking for the thresholds on the main content object
+      const updatedColumns = card?.content?.columns?.map(
+        // eslint-disable-next-line no-unused-vars
+        ({ thresholds, ...others }) => {
+          if (!isEmpty(thresholds)) {
+            allThresholds.push(...thresholds);
+          }
+          return others;
+        }
+      );
+      onChange({
+        ...card,
+        content: {
+          ...card.content,
+          columns: updatedColumns,
+          thresholds: allThresholds,
+        },
+      });
+    },
+    [onChange]
+  );
+
   return (
     <>
       <DataSeriesFormItemModal
@@ -143,7 +169,7 @@ const TableCardFormContent = ({
         editDataItem={editDataItem}
         setEditDataItem={setEditDataItem}
         availableDimensions={availableDimensions}
-        onChange={onChange}
+        onChange={handleDataItemModalChanges}
         i18n={mergedI18n}
       />
       <div className={`${baseClassName}--form-section`}>

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
@@ -131,4 +131,56 @@ describe('TableCardFormContent', () => {
     // both the dimension and attribute show show selections
     expect(screen.queryAllByTitle('Clear all selected items')).toHaveLength(2);
   });
+  it('edit mode with dataitems adds threshold correctly', () => {
+    const mockOnChange = jest.fn();
+    const mockCardConfig = {
+      ...commonCardConfig,
+      content: {
+        columns: [
+          {
+            label: 'Timestamp',
+            dataSourceId: 'timestamp',
+            type: 'TIMESTAMP',
+          },
+          {
+            label: 'Manufacturer',
+            dataSourceId: 'manufacturer',
+            type: 'DIMENSION',
+          },
+          { label: 'Temperature', dataSourceId: 'temperature' },
+        ],
+      },
+    };
+    render(
+      <TableCardFormContent
+        {...commonProps}
+        onChange={mockOnChange}
+        cardConfig={mockCardConfig}
+      />
+    );
+    // All of the existing columns should be rendered in the data section
+    expect(screen.queryByText('Temperature')).toBeDefined();
+    expect(screen.queryByText('Timestamp')).toBeDefined();
+    expect(screen.queryByText('Manufacturer')).toBeDefined();
+
+    // Popup the Data Item Editor
+    fireEvent.click(screen.queryAllByText('Edit')[1]);
+    expect(screen.queryByText('Customize data series')).toBeDefined();
+    fireEvent.click(screen.queryByText(/Add threshold/));
+    fireEvent.click(screen.queryByText('Save'));
+    expect(mockOnChange).toHaveBeenCalledWith({
+      ...mockCardConfig,
+      content: {
+        ...mockCardConfig.content,
+        thresholds: [
+          {
+            color: '#da1e28',
+            comparison: '>',
+            icon: 'Warning alt',
+            value: 0,
+          },
+        ],
+      },
+    });
+  });
 });

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
@@ -176,6 +176,7 @@ describe('TableCardFormContent', () => {
           {
             color: '#da1e28',
             comparison: '>',
+            dataSourceId: 'manufacturer',
             icon: 'Warning alt',
             value: 0,
           },

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormSettings.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormSettings.jsx
@@ -220,7 +220,7 @@ const TableCardFormSettings = ({ cardConfig, onChange, i18n }) => {
             aria-label={mergedI18n.showHeader}
             labelA=""
             labelB=""
-            toggled={cardConfig.content?.showHeader ?? true}
+            toggled={cardConfig.content?.showHeader}
             onToggle={(bool) =>
               onChange({
                 ...cardConfig,
@@ -239,7 +239,7 @@ const TableCardFormSettings = ({ cardConfig, onChange, i18n }) => {
             aria-label={mergedI18n.allowNavigation}
             labelA=""
             labelB=""
-            toggled={cardConfig.content?.allowNavigation ?? false}
+            toggled={cardConfig.content?.allowNavigation}
             onToggle={(bool) =>
               onChange({
                 ...cardConfig,

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormSettings.test.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormSettings.test.jsx
@@ -15,7 +15,7 @@ const commonCardConfig = {
   title: 'My Table Card',
   size: CARD_SIZES.LARGE,
   type: CARD_TYPES.TABLE,
-  content: { columns: [] },
+  content: { columns: [], showHeader: true, allowNavigation: true },
 };
 const commonProps = {
   cardConfig: commonCardConfig,
@@ -170,7 +170,7 @@ describe('TableCardFormSettings', () => {
     fireEvent.click(screen.getByLabelText('Allow navigation to assets'));
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({
-        content: expect.objectContaining({ allowNavigation: true }),
+        content: expect.objectContaining({ allowNavigation: false }),
       })
     );
   });

--- a/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormSettings.test.jsx
+++ b/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormSettings.test.jsx
@@ -40,6 +40,16 @@ describe('TableCardFormSettings', () => {
       { dataSourceId: 'manufacturer' },
     ]);
   });
+  it('updateColumnSort same sort', () => {
+    const mockColumns = [
+      { dataSourceId: 'timestamp', sort: 'DESC' },
+      { dataSourceId: 'manufacturer' },
+    ];
+    expect(updateColumnSort(mockColumns, 'timestamp', 'DESC')).toEqual([
+      { dataSourceId: 'timestamp', sort: 'DESC' },
+      { dataSourceId: 'manufacturer' },
+    ]);
+  });
   it('updateColumnSort with no previous column sort', () => {
     const mockColumns = [
       { dataSourceId: 'timestamp' },

--- a/src/components/DashboardEditor/editorUtils.jsx
+++ b/src/components/DashboardEditor/editorUtils.jsx
@@ -152,6 +152,8 @@ export const getDefaultCard = (type, i18n) => {
         ...baseCardProps,
         content: {
           columns: [],
+          allowNavigation: true,
+          showHeader: true,
         },
       };
     case DASHBOARD_EDITOR_CARD_TYPES.IMAGE:

--- a/src/components/DashboardEditor/editorUtils.test.jsx
+++ b/src/components/DashboardEditor/editorUtils.test.jsx
@@ -133,6 +133,8 @@ describe('editorUtils', () => {
       const defaultCard = getDefaultCard(CARD_TYPES.TABLE, i18n);
       expect(defaultCard.type).toEqual(CARD_TYPES.TABLE);
       expect(defaultCard.content).toBeDefined();
+      expect(defaultCard.content.showHeader).toEqual(true);
+      expect(defaultCard.content.allowNavigation).toEqual(true);
     });
     it('should return ImageCard', () => {
       const defaultCard = getDefaultCard(CARD_TYPES.IMAGE, i18n);


### PR DESCRIPTION
… case

Closes #

**Summary**

- Small bugs related to the TableCard Editor found during integration testing in Monitor

**Change List (commits, features, bugs, etc)**

- fix(TableCardFormContent): the existing dimension values were not being populated correctly in the edit case
- fix(TableCardFormSettings): don't set defaults for form widgets here, set them in the actual getDefaultCard helper method, this helps the UI align with the card JSON so downstream consumers can correctly know the values
- fix(editorUtils): set default values for the advanced Table Card settings here

**Acceptance Test (how to verify the PR)**

- Verify the DashboardEditor edit cases for TableCards
