### PR TITLE
style(editor): update height to accomodate suite header

### DIFF
--- a/src/components/DashboardEditor/DashboardEditor.story.jsx
+++ b/src/components/DashboardEditor/DashboardEditor.story.jsx
@@ -64,47 +64,45 @@ export default {
 };
 
 export const Default = () => (
-  <div style={{ height: 'calc(100vh - 6rem)' }}>
-    <DashboardEditor
-      title={text('title', 'My dashboard')}
-      getValidDataItems={() => mockDataItems}
-      dataItems={mockDataItems}
-      availableImages={images}
-      i18n={{
-        headerEditTitleButton: 'Edit title updated',
-      }}
-      onAddImage={action('onAddImage')}
-      onEditTitle={action('onEditTitle')}
-      onImport={action('onImport')}
-      onExport={action('onExport')}
-      onDelete={action('onDelete')}
-      onCancel={action('onCancel')}
-      onSubmit={action('onSubmit')}
-      onImageDelete={action('onImageDelete')}
-      onLayoutChange={action('onLayoutChange')}
-      isSubmitDisabled={boolean('isSubmitDisabled', false)}
-      isSubmitLoading={boolean('isSubmitLoading', false)}
-      availableDimensions={{
-        deviceid: ['73000', '73001', '73002'],
-        manufacturer: ['rentech', 'GHI Industries'],
-      }}
-      supportedCardTypes={array('supportedCardTypes', [
-        'TIMESERIES',
-        'SIMPLE_BAR',
-        'GROUPED_BAR',
-        'STACKED_BAR',
-        'VALUE',
-        'IMAGE',
-        'TABLE',
-        'CUSTOM',
-      ])}
-      headerBreadcrumbs={[
-        <Link href="www.ibm.com">Dashboard library</Link>,
-        <Link href="www.ibm.com">Favorites</Link>,
-      ]}
-      isLoading={boolean('isLoading', false)}
-    />
-  </div>
+  <DashboardEditor
+    title={text('title', 'My dashboard')}
+    getValidDataItems={() => mockDataItems}
+    dataItems={mockDataItems}
+    availableImages={images}
+    i18n={{
+      headerEditTitleButton: 'Edit title updated',
+    }}
+    onAddImage={action('onAddImage')}
+    onEditTitle={action('onEditTitle')}
+    onImport={action('onImport')}
+    onExport={action('onExport')}
+    onDelete={action('onDelete')}
+    onCancel={action('onCancel')}
+    onSubmit={action('onSubmit')}
+    onImageDelete={action('onImageDelete')}
+    onLayoutChange={action('onLayoutChange')}
+    isSubmitDisabled={boolean('isSubmitDisabled', false)}
+    isSubmitLoading={boolean('isSubmitLoading', false)}
+    availableDimensions={{
+      deviceid: ['73000', '73001', '73002'],
+      manufacturer: ['rentech', 'GHI Industries'],
+    }}
+    supportedCardTypes={array('supportedCardTypes', [
+      'TIMESERIES',
+      'SIMPLE_BAR',
+      'GROUPED_BAR',
+      'STACKED_BAR',
+      'VALUE',
+      'IMAGE',
+      'TABLE',
+      'CUSTOM',
+    ])}
+    headerBreadcrumbs={[
+      <Link href="www.ibm.com">Dashboard library</Link>,
+      <Link href="www.ibm.com">Favorites</Link>,
+    ]}
+    isLoading={boolean('isLoading', false)}
+  />
 );
 
 Default.story = {
@@ -112,193 +110,191 @@ Default.story = {
 };
 
 export const WithInitialValue = () => (
-  <div style={{ height: 'calc(100vh - 6rem)' }}>
-    <DashboardEditor
-      title="Custom dashboard"
-      dataItems={mockDataItems}
-      initialValue={{
-        cards: [
-          {
-            id: 'Table',
-            title: 'Table card',
-            size: 'LARGE',
-            type: 'TABLE',
-            content: {
-              columns: [
-                {
-                  dataSourceId: 'undefined',
-                  label: '--',
-                },
-                {
-                  dataSourceId: 'undefined2',
-                  label: '--',
-                },
-              ],
-            },
-          },
-          {
-            id: 'Custom',
-            title: 'Custom rendered card',
-            type: 'CUSTOM',
-            size: 'MEDIUM',
-            value: 35,
-          },
-          {
-            id: 'Standard',
-            title: 'Default rendered card',
-            type: 'VALUE',
-            size: 'MEDIUM',
-            content: {
-              attributes: [
-                {
-                  dataSourceId: 'key1',
-                  unit: '%',
-                  label: 'Key 1',
-                },
-                {
-                  dataSourceId: 'key2',
-                  unit: 'lb',
-                  label: 'Key 2',
-                },
-              ],
-            },
-          },
-          {
-            id: 'Timeseries',
-            title: 'Timeseries',
-            size: 'MEDIUMWIDE',
-            type: 'TIMESERIES',
-            content: {
-              series: [
-                {
-                  label: 'Temperature',
-                  dataSourceId: 'temperature',
-                },
-                {
-                  label: 'Pressure',
-                  dataSourceId: 'pressure',
-                },
-              ],
-              xLabel: 'Time',
-              yLabel: 'Temperature (˚F)',
-              includeZeroOnXaxis: true,
-              includeZeroOnYaxis: true,
-              timeDataSourceId: 'timestamp',
-              addSpaceOnEdges: 1,
-            },
-            timeRange: 'thisWeek',
-            dataSource: {
-              range: {
-                interval: 'week',
-                count: -1,
-                type: 'periodToDate',
+  <DashboardEditor
+    title="Custom dashboard"
+    dataItems={mockDataItems}
+    initialValue={{
+      cards: [
+        {
+          id: 'Table',
+          title: 'Table card',
+          size: 'LARGE',
+          type: 'TABLE',
+          content: {
+            columns: [
+              {
+                dataSourceId: 'undefined',
+                label: '--',
               },
+              {
+                dataSourceId: 'undefined2',
+                label: '--',
+              },
+            ],
+          },
+        },
+        {
+          id: 'Custom',
+          title: 'Custom rendered card',
+          type: 'CUSTOM',
+          size: 'MEDIUM',
+          value: 35,
+        },
+        {
+          id: 'Standard',
+          title: 'Default rendered card',
+          type: 'VALUE',
+          size: 'MEDIUM',
+          content: {
+            attributes: [
+              {
+                dataSourceId: 'key1',
+                unit: '%',
+                label: 'Key 1',
+              },
+              {
+                dataSourceId: 'key2',
+                unit: 'lb',
+                label: 'Key 2',
+              },
+            ],
+          },
+        },
+        {
+          id: 'Timeseries',
+          title: 'Timeseries',
+          size: 'MEDIUMWIDE',
+          type: 'TIMESERIES',
+          content: {
+            series: [
+              {
+                label: 'Temperature',
+                dataSourceId: 'temperature',
+              },
+              {
+                label: 'Pressure',
+                dataSourceId: 'pressure',
+              },
+            ],
+            xLabel: 'Time',
+            yLabel: 'Temperature (˚F)',
+            includeZeroOnXaxis: true,
+            includeZeroOnYaxis: true,
+            timeDataSourceId: 'timestamp',
+            addSpaceOnEdges: 1,
+          },
+          timeRange: 'thisWeek',
+          dataSource: {
+            range: {
+              interval: 'week',
+              count: -1,
+              type: 'periodToDate',
             },
           },
+        },
+        {
+          id: 'Bar',
+          title: 'Bar',
+          size: 'MEDIUM',
+          type: 'BAR',
+          content: {
+            type: 'SIMPLE',
+            layout: 'VERTICAL',
+            series: [
+              {
+                dataSourceId: 'pressure',
+                label: 'pressure',
+                color: '#6929c4',
+              },
+            ],
+            timeDataSourceId: 'timestamp',
+          },
+        },
+      ],
+      layouts: {
+        lg: [
+          { h: 4, i: 'Table', w: 8, x: 0, y: 0 },
+          { h: 2, i: 'Custom', w: 4, x: 8, y: 0 },
           {
-            id: 'Bar',
-            title: 'Bar',
-            size: 'MEDIUM',
-            type: 'BAR',
-            content: {
-              type: 'SIMPLE',
-              layout: 'VERTICAL',
-              series: [
-                {
-                  dataSourceId: 'pressure',
-                  label: 'pressure',
-                  color: '#6929c4',
-                },
-              ],
-              timeDataSourceId: 'timestamp',
-            },
+            h: 2,
+            i: 'Standard',
+            w: 4,
+            x: 12,
+            y: 0,
+          },
+          {
+            h: 2,
+            i: 'Timeseries',
+            w: 8,
+            x: 1,
+            y: 4,
           },
         ],
-        layouts: {
-          lg: [
-            { h: 4, i: 'Table', w: 8, x: 0, y: 0 },
-            { h: 2, i: 'Custom', w: 4, x: 8, y: 0 },
-            {
-              h: 2,
-              i: 'Standard',
-              w: 4,
-              x: 12,
-              y: 0,
-            },
-            {
-              h: 2,
-              i: 'Timeseries',
-              w: 8,
-              x: 1,
-              y: 4,
-            },
-          ],
-          md: [
-            { h: 4, i: 'Table', w: 8, x: 0, y: 0 },
-            { h: 2, i: 'Custom', w: 4, x: 8, y: 0 },
-            {
-              h: 2,
-              i: 'Standard',
-              w: 4,
-              x: 12,
-              y: 0,
-            },
-            {
-              h: 2,
-              i: 'Timeseries',
-              w: 8,
-              x: 1,
-              y: 4,
-            },
-          ],
-          xl: [
-            { h: 4, i: 'Table', w: 8, x: 0, y: 0 },
-            { h: 2, i: 'Custom', w: 4, x: 8, y: 0 },
-            {
-              h: 2,
-              i: 'Standard',
-              w: 4,
-              x: 12,
-              y: 0,
-            },
-            {
-              h: 2,
-              i: 'Timeseries',
-              w: 8,
-              x: 1,
-              y: 4,
-            },
-          ],
-        },
-      }}
-      onEditTitle={action('onEditTitle')}
-      onImport={action('onImport')}
-      onExport={action('onExport')}
-      onDelete={action('onDelete')}
-      onCancel={action('onCancel')}
-      onSubmit={action('onSubmit')}
-      onLayoutChange={action('onLayoutChange')}
-      supportedCardTypes={[
-        'TIMESERIES',
-        'SIMPLE_BAR',
-        'GROUPED_BAR',
-        'STACKED_BAR',
-        'VALUE',
-        'IMAGE',
-        'TABLE',
-      ]}
-      i18n={{
-        CUSTOM: 'Custom',
-      }}
-      headerBreadcrumbs={[
-        <Link href="www.ibm.com">Dashboard library</Link>,
-        <Link href="www.ibm.com">Favorites</Link>,
-      ]}
-      isLoading={boolean('isLoading', false)}
-      isSubmitDisabled={boolean('isSubmitDisabled', false)}
-      isSubmitLoading={boolean('isSubmitLoading', false)}
-    />
-  </div>
+        md: [
+          { h: 4, i: 'Table', w: 8, x: 0, y: 0 },
+          { h: 2, i: 'Custom', w: 4, x: 8, y: 0 },
+          {
+            h: 2,
+            i: 'Standard',
+            w: 4,
+            x: 12,
+            y: 0,
+          },
+          {
+            h: 2,
+            i: 'Timeseries',
+            w: 8,
+            x: 1,
+            y: 4,
+          },
+        ],
+        xl: [
+          { h: 4, i: 'Table', w: 8, x: 0, y: 0 },
+          { h: 2, i: 'Custom', w: 4, x: 8, y: 0 },
+          {
+            h: 2,
+            i: 'Standard',
+            w: 4,
+            x: 12,
+            y: 0,
+          },
+          {
+            h: 2,
+            i: 'Timeseries',
+            w: 8,
+            x: 1,
+            y: 4,
+          },
+        ],
+      },
+    }}
+    onEditTitle={action('onEditTitle')}
+    onImport={action('onImport')}
+    onExport={action('onExport')}
+    onDelete={action('onDelete')}
+    onCancel={action('onCancel')}
+    onSubmit={action('onSubmit')}
+    onLayoutChange={action('onLayoutChange')}
+    supportedCardTypes={[
+      'TIMESERIES',
+      'SIMPLE_BAR',
+      'GROUPED_BAR',
+      'STACKED_BAR',
+      'VALUE',
+      'IMAGE',
+      'TABLE',
+    ]}
+    i18n={{
+      CUSTOM: 'Custom',
+    }}
+    headerBreadcrumbs={[
+      <Link href="www.ibm.com">Dashboard library</Link>,
+      <Link href="www.ibm.com">Favorites</Link>,
+    ]}
+    isLoading={boolean('isLoading', false)}
+    isSubmitDisabled={boolean('isSubmitDisabled', false)}
+    isSubmitLoading={boolean('isSubmitLoading', false)}
+  />
 );
 
 WithInitialValue.story = {
@@ -306,72 +302,70 @@ WithInitialValue.story = {
 };
 
 export const WithCustomOnCardChange = () => (
-  <div style={{ height: 'calc(100vh - 6rem)' }}>
-    <DashboardEditor
-      isSubmitDisabled={boolean('isSubmitDisabled', false)}
-      isSubmitLoading={boolean('isSubmitLoading', false)}
-      title="Custom dashboard"
-      dataItems={mockDataItems}
-      initialValue={{
-        cards: [
-          {
-            id: 'Timeseries',
-            title: 'Untitled',
-            size: 'MEDIUMWIDE',
-            type: 'TIMESERIES',
-            content: {
-              series: [
-                {
-                  label: 'Temperature',
-                  dataSourceId: 'temperature',
-                },
-                {
-                  label: 'Pressure',
-                  dataSourceId: 'pressure',
-                },
-              ],
-              xLabel: 'Time',
-              yLabel: 'Temperature (˚F)',
-              includeZeroOnXaxis: true,
-              includeZeroOnYaxis: true,
-              timeDataSourceId: 'timestamp',
-              addSpaceOnEdges: 1,
-            },
-            interval: 'day',
+  <DashboardEditor
+    isSubmitDisabled={boolean('isSubmitDisabled', false)}
+    isSubmitLoading={boolean('isSubmitLoading', false)}
+    title="Custom dashboard"
+    dataItems={mockDataItems}
+    initialValue={{
+      cards: [
+        {
+          id: 'Timeseries',
+          title: 'Untitled',
+          size: 'MEDIUMWIDE',
+          type: 'TIMESERIES',
+          content: {
+            series: [
+              {
+                label: 'Temperature',
+                dataSourceId: 'temperature',
+              },
+              {
+                label: 'Pressure',
+                dataSourceId: 'pressure',
+              },
+            ],
+            xLabel: 'Time',
+            yLabel: 'Temperature (˚F)',
+            includeZeroOnXaxis: true,
+            includeZeroOnYaxis: true,
+            timeDataSourceId: 'timestamp',
+            addSpaceOnEdges: 1,
           },
-        ],
-        layouts: {},
-      }}
-      onEditTitle={action('onEditTitle')}
-      onImport={action('onImport')}
-      onExport={action('onExport')}
-      onDelete={action('onDelete')}
-      onCancel={action('onCancel')}
-      onSubmit={action('onSubmit')}
-      onCardChange={(card) => {
-        action('onCardChange');
-        return card;
-      }}
-      onLayoutChange={action('onLayoutChange')}
-      supportedCardTypes={[
-        'TIMESERIES',
-        'SIMPLE_BAR',
-        'GROUPED_BAR',
-        'STACKED_BAR',
-        'VALUE',
-        'IMAGE',
-        'TABLE',
-      ]}
-      i18n={{
-        CUSTOM: 'Custom',
-      }}
-      headerBreadcrumbs={[
-        <Link href="www.ibm.com">Dashboard library</Link>,
-        <Link href="www.ibm.com">Favorites</Link>,
-      ]}
-      isLoading={boolean('isLoading', false)}
-    />
-  </div>
+          interval: 'day',
+        },
+      ],
+      layouts: {},
+    }}
+    onEditTitle={action('onEditTitle')}
+    onImport={action('onImport')}
+    onExport={action('onExport')}
+    onDelete={action('onDelete')}
+    onCancel={action('onCancel')}
+    onSubmit={action('onSubmit')}
+    onCardChange={(card) => {
+      action('onCardChange');
+      return card;
+    }}
+    onLayoutChange={action('onLayoutChange')}
+    supportedCardTypes={[
+      'TIMESERIES',
+      'SIMPLE_BAR',
+      'GROUPED_BAR',
+      'STACKED_BAR',
+      'VALUE',
+      'IMAGE',
+      'TABLE',
+    ]}
+    i18n={{
+      CUSTOM: 'Custom',
+    }}
+    headerBreadcrumbs={[
+      <Link href="www.ibm.com">Dashboard library</Link>,
+      <Link href="www.ibm.com">Favorites</Link>,
+    ]}
+    isLoading={boolean('isLoading', false)}
+  />
 );
 
 WithCustomOnCardChange.story = {
@@ -379,56 +373,54 @@ WithCustomOnCardChange.story = {
 };
 
 export const WithNotifications = () => (
-  <div style={{ height: 'calc(100vh - 6rem)' }}>
-    <DashboardEditor
-      isSubmitDisabled={boolean('isSubmitDisabled', false)}
-      isSubmitLoading={boolean('isSubmitLoading', false)}
-      title={text('title', 'My dashboard')}
-      onEditTitle={action('onEditTitle')}
-      onImport={action('onImport')}
-      onExport={action('onExport')}
-      onDelete={action('onDelete')}
-      onCancel={action('onCancel')}
-      onSubmit={action('onSubmit')}
-      supportedCardTypes={array('supportedCardTypes', [
-        'TIMESERIES',
-        'SIMPLE_BAR',
-        'GROUPED_BAR',
-        'STACKED_BAR',
-        'VALUE',
-        'IMAGE',
-        'TABLE',
-        'CUSTOM',
-      ])}
-      headerBreadcrumbs={[
-        <Link href="www.ibm.com">Dashboard library</Link>,
-        <Link href="www.ibm.com">Favorites</Link>,
-      ]}
-      notification={
-        <>
-          <InlineNotification
-            title="This is the dashboard editor"
-            subtitle="Use the side panel to create or edit cards"
-            kind="info"
-            lowContrast
-          />
-          <InlineNotification
-            title="Import successful"
-            subtitle="The JSON import was successful"
-            kind="success"
-            lowContrast
-          />
-          <InlineNotification
-            title="Data error"
-            subtitle="The image provided was not able to be fetched"
-            kind="error"
-            lowContrast
-          />
-        </>
-      }
-      isLoading={boolean('isLoading', false)}
-    />
-  </div>
+  <DashboardEditor
+    isSubmitDisabled={boolean('isSubmitDisabled', false)}
+    isSubmitLoading={boolean('isSubmitLoading', false)}
+    title={text('title', 'My dashboard')}
+    onEditTitle={action('onEditTitle')}
+    onImport={action('onImport')}
+    onExport={action('onExport')}
+    onDelete={action('onDelete')}
+    onCancel={action('onCancel')}
+    onSubmit={action('onSubmit')}
+    supportedCardTypes={array('supportedCardTypes', [
+      'TIMESERIES',
+      'SIMPLE_BAR',
+      'GROUPED_BAR',
+      'STACKED_BAR',
+      'VALUE',
+      'IMAGE',
+      'TABLE',
+      'CUSTOM',
+    ])}
+    headerBreadcrumbs={[
+      <Link href="www.ibm.com">Dashboard library</Link>,
+      <Link href="www.ibm.com">Favorites</Link>,
+    ]}
+    notification={
+      <>
+        <InlineNotification
+          title="This is the dashboard editor"
+          subtitle="Use the side panel to create or edit cards"
+          kind="info"
+          lowContrast
+        />
+        <InlineNotification
+          title="Import successful"
+          subtitle="The JSON import was successful"
+          kind="success"
+          lowContrast
+        />
+        <InlineNotification
+          title="Data error"
+          subtitle="The image provided was not able to be fetched"
+          kind="error"
+          lowContrast
+        />
+      </>
+    }
+    isLoading={boolean('isLoading', false)}
+  />
 );
 
 WithNotifications.story = {
@@ -473,95 +465,93 @@ WithBreakpointSwitcher.story = {
 };
 
 export const CustomCardPreviewRenderer = () => (
-  <div style={{ height: 'calc(100vh - 6rem)' }}>
-    <DashboardEditor
-      isSubmitDisabled={boolean('isSubmitDisabled', false)}
-      isSubmitLoading={boolean('isSubmitLoading', false)}
-      title="Custom dashboard"
-      initialValue={object('initialValue', {
-        cards: [
-          {
-            id: 'Custom',
-            title: 'Custom rendered card',
-            type: 'CUSTOM',
-            size: 'MEDIUM',
-            value: 35,
+  <DashboardEditor
+    isSubmitDisabled={boolean('isSubmitDisabled', false)}
+    isSubmitLoading={boolean('isSubmitLoading', false)}
+    title="Custom dashboard"
+    initialValue={object('initialValue', {
+      cards: [
+        {
+          id: 'Custom',
+          title: 'Custom rendered card',
+          type: 'CUSTOM',
+          size: 'MEDIUM',
+          value: 35,
+        },
+        {
+          id: 'Standard',
+          title: 'Default rendered card',
+          type: 'VALUE',
+          size: 'MEDIUM',
+          content: {
+            attributes: [
+              {
+                dataSourceId: 'key1',
+                unit: '%',
+                label: 'Key 1',
+              },
+              {
+                dataSourceId: 'key2',
+                unit: 'lb',
+                label: 'Key 2',
+              },
+            ],
           },
-          {
-            id: 'Standard',
-            title: 'Default rendered card',
-            type: 'VALUE',
-            size: 'MEDIUM',
-            content: {
-              attributes: [
-                {
-                  dataSourceId: 'key1',
-                  unit: '%',
-                  label: 'Key 1',
-                },
-                {
-                  dataSourceId: 'key2',
-                  unit: 'lb',
-                  label: 'Key 2',
-                },
-              ],
-            },
-          },
-        ],
-        layouts: {},
-      })}
-      onEditTitle={action('onEditTitle')}
-      onImport={action('onImport')}
-      onExport={action('onExport')}
-      onDelete={action('onDelete')}
-      onCancel={action('onCancel')}
-      onSubmit={action('onSubmit')}
-      onLayoutChange={action('onLayoutChange')}
-      supportedCardTypes={array('supportedCardTypes', [
-        'TIMESERIES',
-        'SIMPLE_BAR',
-        'GROUPED_BAR',
-        'STACKED_BAR',
-        'VALUE',
-        'IMAGE',
-        'TABLE',
-        'CUSTOM',
-      ])}
-      i18n={{
-        CUSTOM: 'Custom',
-      }}
-      headerBreadcrumbs={[
-        <Link href="www.ibm.com">Dashboard library</Link>,
-        <Link href="www.ibm.com">Favorites</Link>,
-      ]}
-      renderCardPreview={(
-        cardConfig,
-        cardProps,
-        // These props are not used, but they could be to create your own implementation
-        onSelectCard, // eslint-disable-line no-unused-vars
-        onDuplicateCard, // eslint-disable-line no-unused-vars
-        onRemoveCard, // eslint-disable-line no-unused-vars
-        isSelected // eslint-disable-line no-unused-vars
-      ) => {
-        return cardConfig.type === 'CUSTOM' ? (
-          <Card
-            key={cardConfig.id}
-            id={cardConfig.id}
-            size={cardConfig.size}
-            title={cardConfig.title}
-            isEditable
-            {...cardProps}>
-            <div style={{ padding: '1rem' }}>
-              This content is rendered by the renderCardPreview function. The
-              &quot;value&quot; property on the card will be rendered here:
-              <h3>{cardConfig.value}</h3>
-            </div>
-          </Card>
-        ) : undefined;
-      }}
-      isLoading={boolean('isLoading', false)}
-    />
-  </div>
+        },
+      ],
+      layouts: {},
+    })}
+    onEditTitle={action('onEditTitle')}
+    onImport={action('onImport')}
+    onExport={action('onExport')}
+    onDelete={action('onDelete')}
+    onCancel={action('onCancel')}
+    onSubmit={action('onSubmit')}
+    onLayoutChange={action('onLayoutChange')}
+    supportedCardTypes={array('supportedCardTypes', [
+      'TIMESERIES',
+      'SIMPLE_BAR',
+      'GROUPED_BAR',
+      'STACKED_BAR',
+      'VALUE',
+      'IMAGE',
+      'TABLE',
+      'CUSTOM',
+    ])}
+    i18n={{
+      CUSTOM: 'Custom',
+    }}
+    headerBreadcrumbs={[
+      <Link href="www.ibm.com">Dashboard library</Link>,
+      <Link href="www.ibm.com">Favorites</Link>,
+    ]}
+    renderCardPreview={(
+      cardConfig,
+      cardProps,
+      // These props are not used, but they could be to create your own implementation
+      onSelectCard, // eslint-disable-line no-unused-vars
+      onDuplicateCard, // eslint-disable-line no-unused-vars
+      onRemoveCard, // eslint-disable-line no-unused-vars
+      isSelected // eslint-disable-line no-unused-vars
+    ) => {
+      return cardConfig.type === 'CUSTOM' ? (
+        <Card
+          key={cardConfig.id}
+          id={cardConfig.id}
+          size={cardConfig.size}
+          title={cardConfig.title}
+          isEditable
+          {...cardProps}>
+          <div style={{ padding: '1rem' }}>
+            This content is rendered by the renderCardPreview function. The
+            &quot;value&quot; property on the card will be rendered here:
+            <h3>{cardConfig.value}</h3>
+          </div>
+        </Card>
+      ) : undefined;
+    }}
+    isLoading={boolean('isLoading', false)}
+  />
 );
 
 CustomCardPreviewRenderer.story = {
@@ -592,290 +582,284 @@ isLoading.story = {
 };
 
 export const I18N = () => (
-  <div style={{ height: 'calc(100vh - 6rem)' }}>
-    <DashboardEditor
-      title={text('title', 'My dashboard')}
-      getValidDataItems={() => mockDataItems}
-      dataItems={mockDataItems}
-      availableImages={images}
-      onAddImage={action('onAddImage')}
-      onEditTitle={action('onEditTitle')}
-      onImport={action('onImport')}
-      onExport={action('onExport')}
-      onDelete={action('onDelete')}
-      onCancel={action('onCancel')}
-      onSubmit={action('onSubmit')}
-      onImageDelete={action('onImageDelete')}
-      onLayoutChange={action('onLayoutChange')}
-      isSubmitDisabled={boolean('isSubmitDisabled', false)}
-      isSubmitLoading={boolean('isSubmitLoading', false)}
-      availableDimensions={{
-        deviceid: ['73000', '73001', '73002'],
-        manufacturer: ['rentech', 'GHI Industries'],
-      }}
-      supportedCardTypes={array('supportedCardTypes', [
-        'TIMESERIES',
-        'SIMPLE_BAR',
-        'GROUPED_BAR',
-        'STACKED_BAR',
-        'VALUE',
-        'IMAGE',
-        'TABLE',
-        'CUSTOM',
-      ])}
-      i18n={{
-        // dashboard header
-        headerEditTitleButton: 'headerEditTitleButton',
-        headerImportButton: 'headerImportButton',
-        headerExportButton: 'headerExportButton',
-        headerCancelButton: 'headerCancelButton',
-        headerSubmitButton: 'headerSubmitButton',
-        headerDeleteButton: 'headerDeleteButton',
-        headerFitToScreenButton: 'headerFitToScreenButton',
-        headerLargeButton: 'headerLargeButton',
-        headerMediumButton: 'headerMediumButton',
-        headerSmallButton: 'headerSmallButton',
-        layoutInfoLg: 'layoutInfoLg',
-        layoutInfoMd: 'layoutInfoMd',
-        layoutInfoSm: 'layoutInfoSm',
+  <DashboardEditor
+    title={text('title', 'My dashboard')}
+    getValidDataItems={() => mockDataItems}
+    dataItems={mockDataItems}
+    availableImages={images}
+    onAddImage={action('onAddImage')}
+    onEditTitle={action('onEditTitle')}
+    onImport={action('onImport')}
+    onExport={action('onExport')}
+    onDelete={action('onDelete')}
+    onCancel={action('onCancel')}
+    onSubmit={action('onSubmit')}
+    onImageDelete={action('onImageDelete')}
+    onLayoutChange={action('onLayoutChange')}
+    isSubmitDisabled={boolean('isSubmitDisabled', false)}
+    isSubmitLoading={boolean('isSubmitLoading', false)}
+    availableDimensions={{
+      deviceid: ['73000', '73001', '73002'],
+      manufacturer: ['rentech', 'GHI Industries'],
+    }}
+    supportedCardTypes={array('supportedCardTypes', [
+      'TIMESERIES',
+      'SIMPLE_BAR',
+      'GROUPED_BAR',
+      'STACKED_BAR',
+      'VALUE',
+      'IMAGE',
+      'TABLE',
+      'CUSTOM',
+    ])}
+    i18n={{
+      // dashboard header
+      headerEditTitleButton: 'headerEditTitleButton',
+      headerImportButton: 'headerImportButton',
+      headerExportButton: 'headerExportButton',
+      headerCancelButton: 'headerCancelButton',
+      headerSubmitButton: 'headerSubmitButton',
+      headerDeleteButton: 'headerDeleteButton',
+      headerFitToScreenButton: 'headerFitToScreenButton',
+      headerLargeButton: 'headerLargeButton',
+      headerMediumButton: 'headerMediumButton',
+      headerSmallButton: 'headerSmallButton',
+      layoutInfoLg: 'layoutInfoLg',
+      layoutInfoMd: 'layoutInfoMd',
+      layoutInfoSm: 'layoutInfoSm',
 
-        // card strings
-        noDataLabel: 'noDataLabel',
-        defaultCardTitle: 'defaultCardTitle',
-        cloneCardLabel: 'cloneCardLabel',
-        deleteCardLabel: 'deleteCardLabel',
-        titlePlaceholderText: 'titlePlaceholderText',
-        titleEditableHintText: 'titleEditableHintText',
+      // card strings
+      noDataLabel: 'noDataLabel',
+      defaultCardTitle: 'defaultCardTitle',
+      cloneCardLabel: 'cloneCardLabel',
+      deleteCardLabel: 'deleteCardLabel',
+      titlePlaceholderText: 'titlePlaceholderText',
+      titleEditableHintText: 'titleEditableHintText',
 
-        // card gallery
-        galleryHeader: 'galleryHeader',
-        addCardButton: 'addCardButton',
-        openGalleryButton: 'openGalleryButton',
-        closeGalleryButton: 'closeGalleryButton',
-        openJSONButton: 'openJSONButton',
-        searchPlaceholderText: 'searchPlaceholderText',
-        TIMESERIES: 'TIMESERIES',
-        SIMPLE_BAR: 'SIMPLE_BAR',
-        GROUPED_BAR: 'GROUPED_BAR',
-        STACKED_BAR: 'STACKED_BAR',
-        VALUE: 'VALUE',
-        IMAGE: 'IMAGE',
-        TABLE: 'TABLE',
-        ALERT: 'ALERT',
-        LIST: 'LIST',
+      // card gallery
+      galleryHeader: 'galleryHeader',
+      addCardButton: 'addCardButton',
+      openGalleryButton: 'openGalleryButton',
+      closeGalleryButton: 'closeGalleryButton',
+      openJSONButton: 'openJSONButton',
+      searchPlaceholderText: 'searchPlaceholderText',
+      TIMESERIES: 'TIMESERIES',
+      SIMPLE_BAR: 'SIMPLE_BAR',
+      GROUPED_BAR: 'GROUPED_BAR',
+      STACKED_BAR: 'STACKED_BAR',
+      VALUE: 'VALUE',
+      IMAGE: 'IMAGE',
+      TABLE: 'TABLE',
+      ALERT: 'ALERT',
+      LIST: 'LIST',
 
-        // card form
-        openEditorButton: 'openEditorButton',
-        contentTabLabel: 'contentTabLabel',
-        settingsTabLabel: 'settingsTabLabel',
-        cardSize_SMALL: 'cardSize_small',
-        cardSize_SMALLWIDE: 'cardSize_smallwide',
-        cardSize_MEDIUM: 'cardSize_medium',
-        cardSize_MEDIUMTHIN: 'cardSize_mediumthin',
-        cardSize_MEDIUMWIDE: 'cardSize_medium wide',
-        cardSize_LARGE: 'cardSize_large',
-        cardSize_LARGETHIN: 'cardSize_largethin',
-        cardSize_LARGEWIDE: 'cardSize_largewide',
-        chartType_BAR: 'chartType_bar',
-        chartType_LINE: 'chartType_line',
-        barChartType_SIMPLE: 'barChartType_simple',
-        barChartType_GROUPED: 'barChartType_grouped',
-        barChartType_STACKED: 'barChartType_stacked',
-        barChartLayout_HORIZONTAL: 'barChartType_horizontal',
-        barChartLayout_VERTICAL: 'barChartType_vertical',
-        errorTitle: 'errorTitle',
-        modalTitle: 'modalTitle',
-        modalLabel: 'modalLabel',
-        modalHelpText: 'modalHelpText',
-        modalIconDescription: 'modalIconDescription',
-        expandBtnLabel: 'expandBtnLabel',
-        modalPrimaryButtonLabel: 'modalPrimaryButtonLabel',
-        modalSecondaryButtonLabel: 'modalSecondaryButtonLabel',
-        cardTitle: 'cardTitle',
-        description: 'description',
-        size: 'size',
-        selectASize: 'selectASize',
-        timeRange: 'timeRange',
-        selectATimeRange: 'selectATimeRange',
-        last24HoursLabel: 'Last24hours',
-        last7DaysLabel: 'Last7days',
-        lastMonthLabel: 'Lastmonth',
-        lastQuarterLabel: 'Lastquarter',
-        lastYearLabel: 'Lastyear',
-        thisWeekLabel: 'Thisweek',
-        thisMonthLabel: 'Thismonth',
-        thisQuarterLabel: 'Thisquarter',
-        thisYearLabel: 'Thisyear',
-        dataItemEditorTitle: 'dataItemEditorTitle',
-        dataItemEditorDataItemTitle: 'dataItemEditorDataItemTitle',
-        dataItemEditorDataItemLabel: 'dataItemEditorDataItemLabel',
-        dataItemEditorLegendColor: 'dataItemEditorLegendColor',
-        dataSeriesTitle: 'dataSeriesTitle',
-        selectDataItems: 'selectDataItems',
-        selectDataItem: 'selectDataItem',
-        dataItem: 'dataItem',
-        edit: 'edit',
-        remove: 'remove',
-        customize: 'customize',
-        clearSelectionText: 'clearSelectionText',
-        clearAllText: 'clearAllText',
-        openMenuText: 'openMenuText',
-        closeMenuText: 'closeMenuText',
+      // card form
+      openEditorButton: 'openEditorButton',
+      contentTabLabel: 'contentTabLabel',
+      settingsTabLabel: 'settingsTabLabel',
+      cardSize_SMALL: 'cardSize_small',
+      cardSize_SMALLWIDE: 'cardSize_smallwide',
+      cardSize_MEDIUM: 'cardSize_medium',
+      cardSize_MEDIUMTHIN: 'cardSize_mediumthin',
+      cardSize_MEDIUMWIDE: 'cardSize_medium wide',
+      cardSize_LARGE: 'cardSize_large',
+      cardSize_LARGETHIN: 'cardSize_largethin',
+      cardSize_LARGEWIDE: 'cardSize_largewide',
+      chartType_BAR: 'chartType_bar',
+      chartType_LINE: 'chartType_line',
+      barChartType_SIMPLE: 'barChartType_simple',
+      barChartType_GROUPED: 'barChartType_grouped',
+      barChartType_STACKED: 'barChartType_stacked',
+      barChartLayout_HORIZONTAL: 'barChartType_horizontal',
+      barChartLayout_VERTICAL: 'barChartType_vertical',
+      errorTitle: 'errorTitle',
+      modalTitle: 'modalTitle',
+      modalLabel: 'modalLabel',
+      modalHelpText: 'modalHelpText',
+      modalIconDescription: 'modalIconDescription',
+      expandBtnLabel: 'expandBtnLabel',
+      modalPrimaryButtonLabel: 'modalPrimaryButtonLabel',
+      modalSecondaryButtonLabel: 'modalSecondaryButtonLabel',
+      cardTitle: 'cardTitle',
+      description: 'description',
+      size: 'size',
+      selectASize: 'selectASize',
+      timeRange: 'timeRange',
+      selectATimeRange: 'selectATimeRange',
+      last24HoursLabel: 'Last24hours',
+      last7DaysLabel: 'Last7days',
+      lastMonthLabel: 'Lastmonth',
+      lastQuarterLabel: 'Lastquarter',
+      lastYearLabel: 'Lastyear',
+      thisWeekLabel: 'Thisweek',
+      thisMonthLabel: 'Thismonth',
+      thisQuarterLabel: 'Thisquarter',
+      thisYearLabel: 'Thisyear',
+      dataItemEditorTitle: 'dataItemEditorTitle',
+      dataItemEditorDataItemTitle: 'dataItemEditorDataItemTitle',
+      dataItemEditorDataItemLabel: 'dataItemEditorDataItemLabel',
+      dataItemEditorLegendColor: 'dataItemEditorLegendColor',
+      dataSeriesTitle: 'dataSeriesTitle',
+      selectDataItems: 'selectDataItems',
+      selectDataItem: 'selectDataItem',
+      dataItem: 'dataItem',
+      edit: 'edit',
+      remove: 'remove',
+      customize: 'customize',
+      clearSelectionText: 'clearSelectionText',
+      clearAllText: 'clearAllText',
+      openMenuText: 'openMenuText',
+      closeMenuText: 'closeMenuText',
 
-        dataItemEditorDataSeriesTitle: 'dataItemEditorDataSeriesTitle',
-        dataItemEditorValueCardTitle: 'dataItemEditorValueCardTitle',
-        dataItemEditorDataItemCustomLabel: 'dataItemEditorDataItemCustomLabel',
-        dataItemEditorDataItemUnit: 'dataItemEditorDataItemUnit',
-        dataItemEditorDataItemFilter: 'dataItemEditorDataItemFilter',
-        dataItemEditorDataItemThresholds: 'dataItemEditorDataItemThresholds',
-        dataItemEditorDataItemAddThreshold:
-          'dataItemEditorDataItemAddThreshold',
-        dataItemEditorDataItemRemove: 'dataItemEditorDataItemRemove',
-        dataItemEditorBarColor: 'dataItemEditorBarColor',
-        dataItemEditorLineColor: 'dataItemEditorLineColor',
-        source: 'source',
-        closeButtonLabelText: 'closeButtonLabelText',
-        primaryButtonLabelText: 'primaryButtonLabelText',
-        secondaryButtonLabelText: 'secondaryButtonLabelText',
+      dataItemEditorDataSeriesTitle: 'dataItemEditorDataSeriesTitle',
+      dataItemEditorValueCardTitle: 'dataItemEditorValueCardTitle',
+      dataItemEditorDataItemCustomLabel: 'dataItemEditorDataItemCustomLabel',
+      dataItemEditorDataItemUnit: 'dataItemEditorDataItemUnit',
+      dataItemEditorDataItemFilter: 'dataItemEditorDataItemFilter',
+      dataItemEditorDataItemThresholds: 'dataItemEditorDataItemThresholds',
+      dataItemEditorDataItemAddThreshold: 'dataItemEditorDataItemAddThreshold',
+      dataItemEditorDataItemRemove: 'dataItemEditorDataItemRemove',
+      dataItemEditorBarColor: 'dataItemEditorBarColor',
+      dataItemEditorLineColor: 'dataItemEditorLineColor',
+      source: 'source',
+      closeButtonLabelText: 'closeButtonLabelText',
+      primaryButtonLabelText: 'primaryButtonLabelText',
+      secondaryButtonLabelText: 'secondaryButtonLabelText',
 
-        // settings for Value card
-        notSet: 'notSet',
+      // settings for Value card
+      notSet: 'notSet',
 
-        // Settings for Data Series
-        xAxisLabel: 'xAxisLabel',
-        yAxisLabel: 'yAxisLabel',
-        unitLabel: 'unitLabel',
-        decimalPrecisionLabel: 'decimalPrecisionLabel',
-        precisionLabel: 'precisionLabel',
-        showLegendLabel: 'showLegendLabel',
-        fontSize: 'fontSize',
+      // Settings for Data Series
+      xAxisLabel: 'xAxisLabel',
+      yAxisLabel: 'yAxisLabel',
+      unitLabel: 'unitLabel',
+      decimalPrecisionLabel: 'decimalPrecisionLabel',
+      precisionLabel: 'precisionLabel',
+      showLegendLabel: 'showLegendLabel',
+      fontSize: 'fontSize',
 
-        // Additional fields for Bar Chart
-        selectGroupBy: 'selectGroupBy',
-        selectCategory: 'selectCategory',
-        groupBy: 'groupBy',
-        subGroup: 'subGroup',
-        timeInterval: 'timeInterval',
-        decimalPlacesLabel: 'decimalPlacesLabel',
-        layoutLabel: 'layoutLabel',
-        horizontal: 'horizontal',
-        vertical: 'vertical',
+      // Additional fields for Bar Chart
+      selectGroupBy: 'selectGroupBy',
+      selectCategory: 'selectCategory',
+      groupBy: 'groupBy',
+      subGroup: 'subGroup',
+      timeInterval: 'timeInterval',
+      decimalPlacesLabel: 'decimalPlacesLabel',
+      layoutLabel: 'layoutLabel',
+      horizontal: 'horizontal',
+      vertical: 'vertical',
 
-        // settings for Image card form
-        imageFile: 'imageFile',
-        editImage: 'editImage',
-        image: 'image',
-        close: 'close',
+      // settings for Image card form
+      imageFile: 'imageFile',
+      editImage: 'editImage',
+      image: 'image',
+      close: 'close',
 
-        displayOptions: 'displayOptions',
-        colorTitleText: 'colorTitleText',
-        hideMap: 'hideMap',
-        hideZoom: 'hideZoom',
-        zoomLevel: 'zoomLevel',
-        fit: 'fit',
-        fill: 'fill',
-        stretch: 'stretch',
-        selectAColor: 'selectAColor',
+      displayOptions: 'displayOptions',
+      colorTitleText: 'colorTitleText',
+      hideMap: 'hideMap',
+      hideZoom: 'hideZoom',
+      zoomLevel: 'zoomLevel',
+      fit: 'fit',
+      fill: 'fill',
+      stretch: 'stretch',
+      selectAColor: 'selectAColor',
 
-        // image card strings
-        dropContainerLabelText: 'dropContainerLabelText',
-        dropContainerDescText: 'dropContainerDescText',
-        uploadByURLCancel: 'uploadByURLCancel',
-        uploadByURLButton: 'uploadByURLButton',
-        browseImages: 'browseImages',
-        insertUrl: 'insertUrl',
-        urlInput: 'urlInput',
-        fileTooLarge: 'fileTooLarge',
-        wrongFileType: (accept) =>
-          `This file is not one of the accepted file types, ${accept.join(
-            ', '
-          )}`,
-        // image gallery strings
-        imageGalleryDeleteLabelText: 'imageGalleryDeleteLabelText',
-        imageGalleryDeleteModalLabelText: 'imageGalleryDeleteModalLabelText',
-        imageGalleryDeleteModalTitleText: (image) =>
-          `imageGalleryDeleteModalTitleText: ${image}?`,
-        imageGalleryGridButtonText: 'imageGalleryGridButtonText',
-        imageGalleryInstructionText: 'imageGalleryInstructionText',
-        imageGalleryListButtonText: 'imageGalleryListButtonText',
-        imageGalleryModalLabelText: 'imageGalleryModalLabelText',
-        imageGalleryModalTitleText: 'imageGalleryModalTitleText',
-        imageGalleryModalPrimaryButtonLabelText:
-          'imageGalleryModalPrimaryButtonLabelText',
-        imageGalleryModalSecondaryButtonLabelText:
-          'imageGalleryModalSecondaryButtonLabelText',
-        imageGalleryModalCloseIconDescriptionText:
-          'imageGalleryModalCloseIconDescriptionText',
-        imageGallerySearchPlaceHolderText: 'imageGallerySearchPlaceHolderText',
+      // image card strings
+      dropContainerLabelText: 'dropContainerLabelText',
+      dropContainerDescText: 'dropContainerDescText',
+      uploadByURLCancel: 'uploadByURLCancel',
+      uploadByURLButton: 'uploadByURLButton',
+      browseImages: 'browseImages',
+      insertUrl: 'insertUrl',
+      urlInput: 'urlInput',
+      fileTooLarge: 'fileTooLarge',
+      wrongFileType: (accept) =>
+        `This file is not one of the accepted file types, ${accept.join(', ')}`,
+      // image gallery strings
+      imageGalleryDeleteLabelText: 'imageGalleryDeleteLabelText',
+      imageGalleryDeleteModalLabelText: 'imageGalleryDeleteModalLabelText',
+      imageGalleryDeleteModalTitleText: (image) =>
+        `imageGalleryDeleteModalTitleText: ${image}?`,
+      imageGalleryGridButtonText: 'imageGalleryGridButtonText',
+      imageGalleryInstructionText: 'imageGalleryInstructionText',
+      imageGalleryListButtonText: 'imageGalleryListButtonText',
+      imageGalleryModalLabelText: 'imageGalleryModalLabelText',
+      imageGalleryModalTitleText: 'imageGalleryModalTitleText',
+      imageGalleryModalPrimaryButtonLabelText:
+        'imageGalleryModalPrimaryButtonLabelText',
+      imageGalleryModalSecondaryButtonLabelText:
+        'imageGalleryModalSecondaryButtonLabelText',
+      imageGalleryModalCloseIconDescriptionText:
+        'imageGalleryModalCloseIconDescriptionText',
+      imageGallerySearchPlaceHolderText: 'imageGallerySearchPlaceHolderText',
 
-        // table card settings
-        selectGroupByDimensions: 'selectGroupByDimensions',
-        dataItemEditorDimensionTitle: 'dataItemEditorDimensionTitle',
-        rowsPerPage: 'rowsPerPage',
-        sortBy: 'sortBy',
-        sortByTitle: 'sortByTitle',
-        ascending: 'ascending',
-        descending: 'descending',
-        showHeader: 'showHeader',
-        allowNavigation: 'allowNavigation',
+      // table card settings
+      selectGroupByDimensions: 'selectGroupByDimensions',
+      dataItemEditorDimensionTitle: 'dataItemEditorDimensionTitle',
+      rowsPerPage: 'rowsPerPage',
+      sortBy: 'sortBy',
+      sortByTitle: 'sortByTitle',
+      ascending: 'ascending',
+      descending: 'descending',
+      showHeader: 'showHeader',
+      allowNavigation: 'allowNavigation',
 
-        // HotspotEditorModal strings
-        backgroundLabelText: 'backgroundLabelText',
-        boldLabelText: 'boldLabelText',
-        borderLabelText: 'borderLabelText',
-        borderWidthInvalidText: 'borderWidthInvalidText',
-        cancelButtonLabelText: 'cancelButtonLabelText',
-        colorDropdownLabelText: 'colorDropdownLabelText',
-        colorDropdownTitleText: 'colorDropdownTitleText',
-        deleteButtonIconDescriptionText: 'deleteButtonIconDescriptionText',
-        deleteButtonLabelText: 'deleteButtonLabelText',
-        descriptionTextareaLabelText: 'descriptionTextareaLabelText',
-        descriptionTextareaPlaceholderText:
-          'descriptionTextareaPlaceholderText',
-        fillOpacityInvalidText: 'fillOpacityInvalidText',
-        fillOpacityLabelText: 'fillOpacityLabelText',
-        fixedTypeDataSourceTabLabelText: 'fixedTypeDataSourceTabLabelText',
-        fixedTypeTooltipTabLabelText: 'fixedTypeTooltipTabLabelText',
-        fontSizeInvalidText: 'fontSizeInvalidText',
-        hotspotsText: 'hotspotsText',
-        iconDropdownLabelText: 'iconDropdownLabelText',
-        iconDropdownTitleText: 'iconDropdownTitleText',
-        italicLabelText: 'italicLabelText',
-        labelsText: 'labelsText',
-        loadingDynamicHotspotsText: 'loadingDynamicHotspotsText',
-        modalHeaderTitleText: 'modalHeaderTitleText',
-        modalIconDescriptionText: 'modalIconDescriptionText',
-        saveButtonLabelText: 'saveButtonLabelText',
-        textStyleLabelText: 'textStyleLabelText',
-        textTypeDataSourceTabLabelText: 'textTypeDataSourceTabLabelText',
-        titleInputLabelText: 'titleInputLabelText',
-        titleInputPlaceholderText: 'titleInputPlaceholderText',
-        tooManyHotspotsInfoText: 'tooManyHotspotsInfoText',
-        underlineLabelText: 'underlineLabelText',
-        fixedTypeTooltipInfoText: 'fixedTypeTooltipInfoText',
-        clearIconDescription: 'clearIconDescription',
-        xCoordinateDropdownTitleText: 'xCoordinateDropdownTitleText',
-        xCoordinateDropdownLabelText: 'xCoordinateDropdownLabelText',
-        yCoordinateDropdownTitleText: 'yCoordinateDropdownTitleText',
-        yCoordinateDropdownLabelText: 'yCoordinateDropdownLabelText',
-        selectDataItemsText: 'selectDataItemsText',
-        dataItemText: 'dataItemText',
-        editText: 'editText',
-        // Hotspot Text Style Tab fields
-        textTypeStyleInfoText: 'textTypeStyleInfoText',
-        fontColorLabelText: 'fontColorLabelText',
-        fontSizeLabelText: 'fontSizeLabelText',
-        borderWidthLabelText: 'borderWidthLabelText',
-        deleteButtonIconDescription: 'deleteButtonIconDescription',
-      }}
-      breakpointSwitcher={{ enabled: true }}
-      headerBreadcrumbs={[
-        <Link href="www.ibm.com">Dashboard library</Link>,
-        <Link href="www.ibm.com">Favorites</Link>,
-      ]}
-      isLoading={boolean('isLoading', false)}
-    />
-  </div>
+      // HotspotEditorModal strings
+      backgroundLabelText: 'backgroundLabelText',
+      boldLabelText: 'boldLabelText',
+      borderLabelText: 'borderLabelText',
+      borderWidthInvalidText: 'borderWidthInvalidText',
+      cancelButtonLabelText: 'cancelButtonLabelText',
+      colorDropdownLabelText: 'colorDropdownLabelText',
+      colorDropdownTitleText: 'colorDropdownTitleText',
+      deleteButtonIconDescriptionText: 'deleteButtonIconDescriptionText',
+      deleteButtonLabelText: 'deleteButtonLabelText',
+      descriptionTextareaLabelText: 'descriptionTextareaLabelText',
+      descriptionTextareaPlaceholderText: 'descriptionTextareaPlaceholderText',
+      fillOpacityInvalidText: 'fillOpacityInvalidText',
+      fillOpacityLabelText: 'fillOpacityLabelText',
+      fixedTypeDataSourceTabLabelText: 'fixedTypeDataSourceTabLabelText',
+      fixedTypeTooltipTabLabelText: 'fixedTypeTooltipTabLabelText',
+      fontSizeInvalidText: 'fontSizeInvalidText',
+      hotspotsText: 'hotspotsText',
+      iconDropdownLabelText: 'iconDropdownLabelText',
+      iconDropdownTitleText: 'iconDropdownTitleText',
+      italicLabelText: 'italicLabelText',
+      labelsText: 'labelsText',
+      loadingDynamicHotspotsText: 'loadingDynamicHotspotsText',
+      modalHeaderTitleText: 'modalHeaderTitleText',
+      modalIconDescriptionText: 'modalIconDescriptionText',
+      saveButtonLabelText: 'saveButtonLabelText',
+      textStyleLabelText: 'textStyleLabelText',
+      textTypeDataSourceTabLabelText: 'textTypeDataSourceTabLabelText',
+      titleInputLabelText: 'titleInputLabelText',
+      titleInputPlaceholderText: 'titleInputPlaceholderText',
+      tooManyHotspotsInfoText: 'tooManyHotspotsInfoText',
+      underlineLabelText: 'underlineLabelText',
+      fixedTypeTooltipInfoText: 'fixedTypeTooltipInfoText',
+      clearIconDescription: 'clearIconDescription',
+      xCoordinateDropdownTitleText: 'xCoordinateDropdownTitleText',
+      xCoordinateDropdownLabelText: 'xCoordinateDropdownLabelText',
+      yCoordinateDropdownTitleText: 'yCoordinateDropdownTitleText',
+      yCoordinateDropdownLabelText: 'yCoordinateDropdownLabelText',
+      selectDataItemsText: 'selectDataItemsText',
+      dataItemText: 'dataItemText',
+      editText: 'editText',
+      // Hotspot Text Style Tab fields
+      textTypeStyleInfoText: 'textTypeStyleInfoText',
+      fontColorLabelText: 'fontColorLabelText',
+      fontSizeLabelText: 'fontSizeLabelText',
+      borderWidthLabelText: 'borderWidthLabelText',
+      deleteButtonIconDescription: 'deleteButtonIconDescription',
+    }}
+    breakpointSwitcher={{ enabled: true }}
+    headerBreadcrumbs={[
+      <Link href="www.ibm.com">Dashboard library</Link>,
+      <Link href="www.ibm.com">Favorites</Link>,
+    ]}
+    isLoading={boolean('isLoading', false)}
+  />
 );
 
 I18N.story = {

--- a/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -13,239 +13,476 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
     }
   >
     <div
-      style={
-        Object {
-          "height": "calc(100vh - 6rem)",
-        }
-      }
+      className="iot--dashboard-editor"
     >
       <div
-        className="iot--dashboard-editor"
+        className="iot--dashboard-editor--content"
       >
         <div
-          className="iot--dashboard-editor--content"
+          className="page-title-bar"
         >
           <div
-            className="page-title-bar"
+            className="page-title-bar-header"
           >
             <div
-              className="page-title-bar-header"
+              className="page-title-bar-header-left"
             >
               <div
-                className="page-title-bar-header-left"
+                className="page-title-bar-breadcrumb"
+              >
+                <nav
+                  aria-label="Breadcrumb"
+                >
+                  <ol
+                    className="bx--breadcrumb"
+                  >
+                    <li
+                      className="bx--breadcrumb-item"
+                    >
+                      <a
+                        className="bx--link bx--link"
+                        href="www.ibm.com"
+                      >
+                        Dashboard library
+                      </a>
+                    </li>
+                    <li
+                      className="bx--breadcrumb-item"
+                    >
+                      <a
+                        className="bx--link bx--link"
+                        href="www.ibm.com"
+                      >
+                        Favorites
+                      </a>
+                    </li>
+                  </ol>
+                </nav>
+              </div>
+              <div
+                className="page-title-bar-title"
               >
                 <div
-                  className="page-title-bar-breadcrumb"
+                  className="page-title-bar-title--text"
                 >
-                  <nav
-                    aria-label="Breadcrumb"
+                  <h2>
+                    Custom dashboard
+                  </h2>
+                  <button
+                    className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
                   >
-                    <ol
-                      className="bx--breadcrumb"
+                    <span
+                      className="bx--assistive-text"
                     >
-                      <li
-                        className="bx--breadcrumb-item"
-                      >
-                        <a
-                          className="bx--link bx--link"
-                          href="www.ibm.com"
-                        >
-                          Dashboard library
-                        </a>
-                      </li>
-                      <li
-                        className="bx--breadcrumb-item"
-                      >
-                        <a
-                          className="bx--link bx--link"
-                          href="www.ibm.com"
-                        >
-                          Favorites
-                        </a>
-                      </li>
-                    </ol>
-                  </nav>
+                      Edit title
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Edit title"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                      />
+                    </svg>
+                  </button>
                 </div>
+              </div>
+            </div>
+            <div
+              className="page-title-bar-header-right"
+            >
+              <div
+                className="iot--dashboard-editor-header--right"
+              >
                 <div
-                  className="page-title-bar-title"
+                  className="iot--dashboard-editor-header--top"
+                />
+                <div
+                  className="iot--dashboard-editor-header--bottom"
                 >
-                  <div
-                    className="page-title-bar-title--text"
+                  <button
+                    aria-describedby="icon-tooltip-6"
+                    className="bx--tooltip__trigger bx--tooltip--a11y iot--dashboard-editor-header--bottom__import bx--tooltip--bottom bx--tooltip--align-center"
+                    onFocus={[Function]}
+                    onMouseEnter={[Function]}
+                    type="button"
                   >
-                    <h2>
-                      Custom dashboard
-                    </h2>
-                    <button
-                      className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                      disabled={false}
-                      onClick={[Function]}
+                    <span
+                      className="bx--assistive-text"
+                      id="icon-tooltip-6"
+                    >
+                      Import
+                    </span>
+                    <label
+                      accepts={
+                        Array [
+                          ".json",
+                        ]
+                      }
+                      aria-disabled={false}
+                      className="bx--btn bx--btn--ghost bx--btn--field"
+                      htmlFor="id6"
+                      onKeyDown={[Function]}
                       tabIndex={0}
-                      type="button"
                     >
                       <span
-                        className="bx--assistive-text"
+                        role="button"
                       >
-                        Edit title
+                        <svg
+                          aria-hidden={true}
+                          fill="#161616"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M28 19L14.83 19 17.41 16.41 16 15 11 20 16 25 17.41 23.59 14.83 21 28 21 28 19z"
+                          />
+                          <path
+                            d="M24,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,16,2H6A2,2,0,0,0,4,4V28a2,2,0,0,0,2,2H22a2,2,0,0,0,2-2V26H22v2H6V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L21.59,10Z"
+                          />
+                        </svg>
                       </span>
+                    </label>
+                    <input
+                      className="bx--visually-hidden"
+                      disabled={false}
+                      id="id6"
+                      multiple={false}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      tabIndex="-1"
+                      type="file"
+                    />
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Export
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Export"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M13 21L26.17 21 23.59 23.59 25 25 30 20 25 15 23.59 16.41 26.17 19 13 19 13 21z"
+                      />
+                      <path
+                        d="M22,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,14,2H4A2,2,0,0,0,2,4V28a2,2,0,0,0,2,2H20a2,2,0,0,0,2-2V26H20v2H4V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L19.59,10Z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Delete
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Delete"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M12 12H14V24H12zM18 12H20V24H18z"
+                      />
+                      <path
+                        d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--secondary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Save and close
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--dashboard-editor--preview"
+        >
+          <div
+            className=""
+          >
+            <div
+              className="iot--dashboard-editor--preview__grid-container"
+            >
+              <div
+                className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
+                data-floating-menu-container={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onClose={[Function]}
+                onKeyDown={[Function]}
+                open={false}
+                role="presentation"
+              >
+                <span
+                  className="bx--visually-hidden"
+                  role="link"
+                  tabIndex="0"
+                >
+                  Focus sentinel
+                </span>
+                <div
+                  className="bx--modal-container"
+                  role="dialog"
+                >
+                  <div
+                    className="bx--modal-header"
+                  >
+                    <p
+                      className="bx--modal-header__label bx--type-delta"
+                    >
+                      New image card
+                    </p>
+                    <p
+                      className="bx--modal-header__heading bx--type-beta"
+                    >
+                      Image gallery
+                    </p>
+                    <button
+                      aria-label="Close"
+                      className="bx--modal-close"
+                      onClick={[Function]}
+                      title="Close"
+                      type="button"
+                    >
                       <svg
-                        aria-hidden="true"
-                        aria-label="Edit title"
-                        className="bx--btn__icon"
+                        aria-hidden={true}
+                        className="bx--modal-close__icon"
                         fill="currentColor"
                         focusable="false"
                         height={20}
                         preserveAspectRatio="xMidYMid meet"
-                        role="img"
                         viewBox="0 0 32 32"
                         width={20}
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
                         />
                       </svg>
                     </button>
                   </div>
-                </div>
-              </div>
-              <div
-                className="page-title-bar-header-right"
-              >
-                <div
-                  className="iot--dashboard-editor-header--right"
-                >
                   <div
-                    className="iot--dashboard-editor-header--top"
-                  />
-                  <div
-                    className="iot--dashboard-editor-header--bottom"
+                    className="bx--modal-content"
                   >
-                    <button
-                      aria-describedby="icon-tooltip-6"
-                      className="bx--tooltip__trigger bx--tooltip--a11y iot--dashboard-editor-header--bottom__import bx--tooltip--bottom bx--tooltip--align-center"
-                      onFocus={[Function]}
-                      onMouseEnter={[Function]}
-                      type="button"
+                    <div
+                      className="iot--image-gallery-modal__top-section"
                     >
-                      <span
-                        className="bx--assistive-text"
-                        id="icon-tooltip-6"
+                      <p
+                        alt="Select the image that you want to display on this card."
+                        className="iot--image-gallery-modal__instruction-text"
                       >
-                        Import
-                      </span>
-                      <label
-                        accepts={
-                          Array [
-                            ".json",
-                          ]
-                        }
-                        aria-disabled={false}
-                        className="bx--btn bx--btn--ghost bx--btn--field"
-                        htmlFor="id6"
-                        onKeyDown={[Function]}
-                        tabIndex={0}
+                        Select the image that you want to display on this card.
+                      </p>
+                      <div
+                        className="iot--image-gallery-modal__search-list-view-container"
                       >
-                        <span
-                          role="button"
+                        <div
+                          aria-labelledby="iot--image-gallery-modal--search-search"
+                          className="bx--search bx--search--xl bx--search--light"
+                          role="search"
                         >
                           <svg
                             aria-hidden={true}
-                            fill="#161616"
+                            className="bx--search-magnifier"
+                            fill="currentColor"
                             focusable="false"
                             height={16}
                             preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
+                            viewBox="0 0 16 16"
                             width={16}
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <path
-                              d="M28 19L14.83 19 17.41 16.41 16 15 11 20 16 25 17.41 23.59 14.83 21 28 21 28 19z"
-                            />
-                            <path
-                              d="M24,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,16,2H6A2,2,0,0,0,4,4V28a2,2,0,0,0,2,2H22a2,2,0,0,0,2-2V26H22v2H6V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L21.59,10Z"
+                              d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                             />
                           </svg>
-                        </span>
-                      </label>
-                      <input
-                        className="bx--visually-hidden"
-                        disabled={false}
-                        id="id6"
-                        multiple={false}
-                        onChange={[Function]}
-                        onClick={[Function]}
-                        tabIndex="-1"
-                        type="file"
+                          <label
+                            className="bx--label"
+                            htmlFor="iot--image-gallery-modal--search"
+                            id="iot--image-gallery-modal--search-search"
+                          >
+                            
+                          </label>
+                          <input
+                            autoComplete="off"
+                            className="bx--search-input"
+                            id="iot--image-gallery-modal--search"
+                            onChange={[Function]}
+                            placeholder="Search image by file name"
+                            role="searchbox"
+                            type="text"
+                          />
+                          <button
+                            aria-label="Clear search input"
+                            className="bx--search-close bx--search-close--hidden"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <div
+                          className="bx--content-switcher iot--image-gallery-modal__content-switcher"
+                          onChange={[Function]}
+                          role="tablist"
+                        >
+                          <button
+                            className="iot--icon-switch iot--icon-switch--large bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                            disabled={false}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            tabIndex={0}
+                            type="button"
+                          >
+                            <span
+                              className="bx--assistive-text"
+                            >
+                              Grid
+                            </span>
+                            <svg
+                              aria-hidden="true"
+                              aria-label="Grid"
+                              className="bx--btn__icon"
+                              fill="currentColor"
+                              focusable="false"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M12 4H6A2 2 0 004 6v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0012 4zm0 8H6V6h6zM26 4H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0026 4zm0 8H20V6h6zM12 18H6a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0012 18zm0 8H6V20h6zM26 18H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0026 18zm0 8H20V20h6z"
+                              />
+                            </svg>
+                          </button>
+                          <button
+                            className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                            disabled={false}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            tabIndex={0}
+                            type="button"
+                          >
+                            <span
+                              className="bx--assistive-text"
+                            >
+                              List
+                            </span>
+                            <svg
+                              aria-hidden="true"
+                              aria-label="List"
+                              className="bx--btn__icon"
+                              fill="currentColor"
+                              focusable="false"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M10 6H28V8H10zM10 24H28V26H10zM10 15H28V17H10zM4 15H6V17H4zM4 6H6V8H4zM4 24H6V26H4z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="iot--image-gallery-modal__flex-wrapper"
+                    >
+                      <div
+                        className="iot--image-gallery-modal__scroll-panel iot--image-gallery-modal__scroll-panel--grid"
                       />
-                    </button>
+                    </div>
+                  </div>
+                  <div
+                    className="bx--modal-footer iot--composed-modal-footer"
+                  >
                     <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      <span
-                        className="bx--assistive-text"
-                      >
-                        Export
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Export"
-                        className="bx--btn__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M13 21L26.17 21 23.59 23.59 25 25 30 20 25 15 23.59 16.41 26.17 19 13 19 13 21z"
-                        />
-                        <path
-                          d="M22,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,14,2H4A2,2,0,0,0,2,4V28a2,2,0,0,0,2,2H20a2,2,0,0,0,2-2V26H20v2H4V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L19.59,10Z"
-                        />
-                      </svg>
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      <span
-                        className="bx--assistive-text"
-                      >
-                        Delete
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Delete"
-                        className="bx--btn__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M12 12H14V24H12zM18 12H20V24H18z"
-                        />
-                        <path
-                          d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                        />
-                      </svg>
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--secondary"
+                      className="iot--btn bx--btn bx--btn--secondary"
                       disabled={false}
                       onClick={[Function]}
                       tabIndex={0}
@@ -254,596 +491,351 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                       Cancel
                     </button>
                     <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--primary"
-                      disabled={false}
+                      className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                      disabled={true}
                       onClick={[Function]}
                       tabIndex={0}
                       type="button"
                     >
-                      Save and close
+                      Select
                     </button>
                   </div>
                 </div>
+                <span
+                  className="bx--visually-hidden"
+                  role="link"
+                  tabIndex="0"
+                >
+                  Focus sentinel
+                </span>
               </div>
-            </div>
-          </div>
-          <div
-            className="iot--dashboard-editor--preview"
-          >
-            <div
-              className=""
-            >
               <div
-                className="iot--dashboard-editor--preview__grid-container"
+                style={
+                  Object {
+                    "flex": 1,
+                  }
+                }
               >
                 <div
-                  className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
-                  data-floating-menu-container={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onClose={[Function]}
-                  onKeyDown={[Function]}
-                  open={false}
-                  role="presentation"
-                >
-                  <span
-                    className="bx--visually-hidden"
-                    role="link"
-                    tabIndex="0"
-                  >
-                    Focus sentinel
-                  </span>
-                  <div
-                    className="bx--modal-container"
-                    role="dialog"
-                  >
-                    <div
-                      className="bx--modal-header"
-                    >
-                      <p
-                        className="bx--modal-header__label bx--type-delta"
-                      >
-                        New image card
-                      </p>
-                      <p
-                        className="bx--modal-header__heading bx--type-beta"
-                      >
-                        Image gallery
-                      </p>
-                      <button
-                        aria-label="Close"
-                        className="bx--modal-close"
-                        onClick={[Function]}
-                        title="Close"
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="bx--modal-close__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      className="bx--modal-content"
-                    >
-                      <div
-                        className="iot--image-gallery-modal__top-section"
-                      >
-                        <p
-                          alt="Select the image that you want to display on this card."
-                          className="iot--image-gallery-modal__instruction-text"
-                        >
-                          Select the image that you want to display on this card.
-                        </p>
-                        <div
-                          className="iot--image-gallery-modal__search-list-view-container"
-                        >
-                          <div
-                            aria-labelledby="iot--image-gallery-modal--search-search"
-                            className="bx--search bx--search--xl bx--search--light"
-                            role="search"
-                          >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              fill="currentColor"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="iot--image-gallery-modal--search"
-                              id="iot--image-gallery-modal--search-search"
-                            >
-                              
-                            </label>
-                            <input
-                              autoComplete="off"
-                              className="bx--search-input"
-                              id="iot--image-gallery-modal--search"
-                              onChange={[Function]}
-                              placeholder="Search image by file name"
-                              role="searchbox"
-                              type="text"
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 32 32"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                                />
-                              </svg>
-                            </button>
-                          </div>
-                          <div
-                            className="bx--content-switcher iot--image-gallery-modal__content-switcher"
-                            onChange={[Function]}
-                            role="tablist"
-                          >
-                            <button
-                              className="iot--icon-switch iot--icon-switch--large bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
-                              disabled={false}
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              tabIndex={0}
-                              type="button"
-                            >
-                              <span
-                                className="bx--assistive-text"
-                              >
-                                Grid
-                              </span>
-                              <svg
-                                aria-hidden="true"
-                                aria-label="Grid"
-                                className="bx--btn__icon"
-                                fill="currentColor"
-                                focusable="false"
-                                height={20}
-                                preserveAspectRatio="xMidYMid meet"
-                                role="img"
-                                viewBox="0 0 32 32"
-                                width={20}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M12 4H6A2 2 0 004 6v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0012 4zm0 8H6V6h6zM26 4H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0026 4zm0 8H20V6h6zM12 18H6a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0012 18zm0 8H6V20h6zM26 18H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0026 18zm0 8H20V20h6z"
-                                />
-                              </svg>
-                            </button>
-                            <button
-                              className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
-                              disabled={false}
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              tabIndex={0}
-                              type="button"
-                            >
-                              <span
-                                className="bx--assistive-text"
-                              >
-                                List
-                              </span>
-                              <svg
-                                aria-hidden="true"
-                                aria-label="List"
-                                className="bx--btn__icon"
-                                fill="currentColor"
-                                focusable="false"
-                                height={20}
-                                preserveAspectRatio="xMidYMid meet"
-                                role="img"
-                                viewBox="0 0 32 32"
-                                width={20}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M10 6H28V8H10zM10 24H28V26H10zM10 15H28V17H10zM4 15H6V17H4zM4 6H6V8H4zM4 24H6V26H4z"
-                                />
-                              </svg>
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        className="iot--image-gallery-modal__flex-wrapper"
-                      >
-                        <div
-                          className="iot--image-gallery-modal__scroll-panel iot--image-gallery-modal__scroll-panel--grid"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      className="bx--modal-footer iot--composed-modal-footer"
-                    >
-                      <button
-                        className="iot--btn bx--btn bx--btn--secondary"
-                        disabled={false}
-                        onClick={[Function]}
-                        tabIndex={0}
-                        type="button"
-                      >
-                        Cancel
-                      </button>
-                      <button
-                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                        disabled={true}
-                        onClick={[Function]}
-                        tabIndex={0}
-                        type="button"
-                      >
-                        Select
-                      </button>
-                    </div>
-                  </div>
-                  <span
-                    className="bx--visually-hidden"
-                    role="link"
-                    tabIndex="0"
-                  >
-                    Focus sentinel
-                  </span>
-                </div>
-                <div
+                  className="react-grid-layout DashboardGrid__StyledGridLayout-vxs00g-0 ANzdO"
+                  onDragEnter={[Function]}
+                  onDragLeave={[Function]}
+                  onDragOver={[Function]}
+                  onDrop={[Function]}
                   style={
                     Object {
-                      "flex": 1,
+                      "height": "304px",
                     }
                   }
                 >
                   <div
-                    className="react-grid-layout DashboardGrid__StyledGridLayout-vxs00g-0 ANzdO"
-                    onDragEnter={[Function]}
-                    onDragLeave={[Function]}
-                    onDragOver={[Function]}
-                    onDrop={[Function]}
+                    className="iot--card react-grid-item iot--dashboard-editor--preview__card react-draggable react-resizable-hide react-resizable iot--card--wrapper"
+                    data-testid="Card"
+                    id="Custom"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    role="presentation"
                     style={
                       Object {
+                        "--card-default-height": "304px",
                         "height": "304px",
+                        "left": "0%",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": "49.375%",
                       }
                     }
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--card react-grid-item iot--dashboard-editor--preview__card react-draggable react-resizable-hide react-resizable iot--card--wrapper"
-                      data-testid="Card"
-                      id="Custom"
-                      onClick={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchEnd={[Function]}
-                      role="presentation"
-                      style={
-                        Object {
-                          "--card-default-height": "304px",
-                          "height": "304px",
-                          "left": "0%",
-                          "position": "absolute",
-                          "top": "0px",
-                          "width": "49.375%",
-                        }
-                      }
-                      tabIndex={0}
+                      className="iot--card--header"
                     >
-                      <div
-                        className="iot--card--header"
+                      <span
+                        className="iot--card--title"
+                        title="Custom rendered card"
                       >
-                        <span
-                          className="iot--card--title"
-                          title="Custom rendered card"
-                        >
-                          <div
-                            className="iot--card--title--text"
-                          >
-                            Custom rendered card
-                          </div>
-                        </span>
                         <div
-                          className="iot--card--toolbar"
+                          className="iot--card--title--text"
                         >
-                          <button
-                            aria-expanded={false}
-                            aria-haspopup={true}
-                            aria-label="Menu"
-                            className="bx--overflow-menu"
+                          Custom rendered card
+                        </div>
+                      </span>
+                      <div
+                        className="iot--card--toolbar"
+                      >
+                        <button
+                          aria-expanded={false}
+                          aria-haspopup={true}
+                          aria-label="Menu"
+                          className="bx--overflow-menu"
+                          onClick={[Function]}
+                          onClose={[Function]}
+                          onKeyDown={[Function]}
+                          open={false}
+                          tabIndex={0}
+                          title="Open and close list of options"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="open and close list of options"
+                            className="bx--overflow-menu__icon"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
                             onClick={[Function]}
-                            onClose={[Function]}
                             onKeyDown={[Function]}
-                            open={false}
-                            tabIndex={0}
-                            title="Open and close list of options"
-                            type="button"
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              aria-label="open and close list of options"
-                              className="bx--overflow-menu__icon"
-                              fill="currentColor"
-                              focusable="false"
-                              height={16}
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              preserveAspectRatio="xMidYMid meet"
-                              role="img"
-                              viewBox="0 0 32 32"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <circle
-                                cx="16"
-                                cy="8"
-                                r="2"
-                              />
-                              <circle
-                                cx="16"
-                                cy="16"
-                                r="2"
-                              />
-                              <circle
-                                cx="16"
-                                cy="24"
-                                r="2"
-                              />
-                              <title>
-                                open and close list of options
-                              </title>
-                            </svg>
-                          </button>
-                        </div>
-                      </div>
-                      <div
-                        className="iot--card--content"
-                        style={
-                          Object {
-                            "--card-content-height": "256px",
-                          }
-                        }
-                      >
-                        <div
-                          style={
-                            Object {
-                              "padding": "1rem",
-                            }
-                          }
-                        >
-                          This content is rendered by the renderCardPreview function. The "value" property on the card will be rendered here:
-                          <h3>
-                            35
-                          </h3>
-                        </div>
-                        <span
-                          className="react-resizable-handle react-resizable-handle-se"
-                          onMouseDown={[Function]}
-                          onMouseUp={[Function]}
-                          onTouchEnd={[Function]}
-                          onTouchStart={[Function]}
-                          style={
-                            Object {
-                              "touchAction": "none",
-                            }
-                          }
-                        />
+                            <circle
+                              cx="16"
+                              cy="8"
+                              r="2"
+                            />
+                            <circle
+                              cx="16"
+                              cy="16"
+                              r="2"
+                            />
+                            <circle
+                              cx="16"
+                              cy="24"
+                              r="2"
+                            />
+                            <title>
+                              open and close list of options
+                            </title>
+                          </svg>
+                        </button>
                       </div>
                     </div>
                     <div
-                      className="iot--card react-grid-item iot--dashboard-editor--preview__card react-draggable react-resizable-hide react-resizable iot--card--wrapper"
-                      data-testid="Card"
-                      id="Standard"
-                      onClick={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchEnd={[Function]}
-                      role="presentation"
+                      className="iot--card--content"
                       style={
                         Object {
-                          "--card-default-height": "304px",
-                          "height": "304px",
-                          "left": "50.625%",
-                          "position": "absolute",
-                          "top": "0px",
-                          "width": "49.375%",
+                          "--card-content-height": "256px",
                         }
                       }
-                      tabIndex={0}
-                      type="VALUE"
                     >
                       <div
-                        className="iot--card--header"
-                      >
-                        <span
-                          className="iot--card--title"
-                          title="Default rendered card"
-                        >
-                          <div
-                            className="iot--card--title--text"
-                          >
-                            Default rendered card
-                          </div>
-                        </span>
-                        <div
-                          className="iot--card--toolbar"
-                        >
-                          <button
-                            aria-expanded={false}
-                            aria-haspopup={true}
-                            aria-label="Menu"
-                            className="bx--overflow-menu"
-                            onClick={[Function]}
-                            onClose={[Function]}
-                            onKeyDown={[Function]}
-                            open={false}
-                            tabIndex={0}
-                            title="Open and close list of options"
-                            type="button"
-                          >
-                            <svg
-                              aria-label="open and close list of options"
-                              className="bx--overflow-menu__icon"
-                              fill="currentColor"
-                              focusable="false"
-                              height={16}
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              preserveAspectRatio="xMidYMid meet"
-                              role="img"
-                              viewBox="0 0 32 32"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <circle
-                                cx="16"
-                                cy="8"
-                                r="2"
-                              />
-                              <circle
-                                cx="16"
-                                cy="16"
-                                r="2"
-                              />
-                              <circle
-                                cx="16"
-                                cy="24"
-                                r="2"
-                              />
-                              <title>
-                                open and close list of options
-                              </title>
-                            </svg>
-                          </button>
-                        </div>
-                      </div>
-                      <div
-                        className="iot--card--content"
                         style={
                           Object {
-                            "--card-content-height": "256px",
+                            "padding": "1rem",
                           }
                         }
                       >
+                        This content is rendered by the renderCardPreview function. The "value" property on the card will be rendered here:
+                        <h3>
+                          35
+                        </h3>
+                      </div>
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="iot--card react-grid-item iot--dashboard-editor--preview__card react-draggable react-resizable-hide react-resizable iot--card--wrapper"
+                    data-testid="Card"
+                    id="Standard"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    role="presentation"
+                    style={
+                      Object {
+                        "--card-default-height": "304px",
+                        "height": "304px",
+                        "left": "50.625%",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": "49.375%",
+                      }
+                    }
+                    tabIndex={0}
+                    type="VALUE"
+                  >
+                    <div
+                      className="iot--card--header"
+                    >
+                      <span
+                        className="iot--card--title"
+                        title="Default rendered card"
+                      >
                         <div
-                          className="ValueCard__ContentWrapper-hyxf2q-0 jWmKBV"
+                          className="iot--card--title--text"
+                        >
+                          Default rendered card
+                        </div>
+                      </span>
+                      <div
+                        className="iot--card--toolbar"
+                      >
+                        <button
+                          aria-expanded={false}
+                          aria-haspopup={true}
+                          aria-label="Menu"
+                          className="bx--overflow-menu"
+                          onClick={[Function]}
+                          onClose={[Function]}
+                          onKeyDown={[Function]}
+                          open={false}
+                          tabIndex={0}
+                          title="Open and close list of options"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="open and close list of options"
+                            className="bx--overflow-menu__icon"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <circle
+                              cx="16"
+                              cy="8"
+                              r="2"
+                            />
+                            <circle
+                              cx="16"
+                              cy="16"
+                              r="2"
+                            />
+                            <circle
+                              cx="16"
+                              cy="24"
+                              r="2"
+                            />
+                            <title>
+                              open and close list of options
+                            </title>
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      className="iot--card--content"
+                      style={
+                        Object {
+                          "--card-content-height": "256px",
+                        }
+                      }
+                    >
+                      <div
+                        className="ValueCard__ContentWrapper-hyxf2q-0 jWmKBV"
+                      >
+                        <div
+                          className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                          size="MEDIUM"
                         >
                           <div
-                            className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                            className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
+                            label="Key 1"
                             size="MEDIUM"
                           >
                             <div
-                              className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
-                              label="Key 1"
-                              size="MEDIUM"
+                              className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                              color={null}
                             >
-                              <div
-                                className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                                color={null}
-                              >
-                                <span
-                                  className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
-                                  size="MEDIUM"
-                                  title="-- %"
-                                  value="--"
-                                >
-                                  --
-                                </span>
-                              </div>
                               <span
-                                className="iot--value-card__attribute-unit"
-                                style={
-                                  Object {
-                                    "--default-font-size": "1.5rem",
-                                  }
-                                }
+                                className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
+                                size="MEDIUM"
+                                title="-- %"
+                                value="--"
                               >
-                                %
+                                --
                               </span>
                             </div>
-                            <div
-                              className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="MEDIUM"
-                              title="Key 1"
-                            >
-                              Key 1
-                            </div>
-                          </div>
-                          <div
-                            className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUM"
-                          >
-                            <hr
-                              className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
-                            />
-                          </div>
-                          <div
-                            className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUM"
-                          >
-                            <div
-                              className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
-                              label="Key 2"
-                              size="MEDIUM"
-                            >
-                              <div
-                                className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                                color={null}
-                              >
-                                <span
-                                  className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
-                                  size="MEDIUM"
-                                  title="-- lb"
-                                  value="--"
-                                >
-                                  --
-                                </span>
-                              </div>
-                              <span
-                                className="iot--value-card__attribute-unit"
-                                style={
-                                  Object {
-                                    "--default-font-size": "1.5rem",
-                                  }
+                            <span
+                              className="iot--value-card__attribute-unit"
+                              style={
+                                Object {
+                                  "--default-font-size": "1.5rem",
                                 }
+                              }
+                            >
+                              %
+                            </span>
+                          </div>
+                          <div
+                            className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
+                            size="MEDIUM"
+                            title="Key 1"
+                          >
+                            Key 1
+                          </div>
+                        </div>
+                        <div
+                          className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                          size="MEDIUM"
+                        >
+                          <hr
+                            className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
+                          />
+                        </div>
+                        <div
+                          className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                          size="MEDIUM"
+                        >
+                          <div
+                            className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
+                            label="Key 2"
+                            size="MEDIUM"
+                          >
+                            <div
+                              className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                              color={null}
+                            >
+                              <span
+                                className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
+                                size="MEDIUM"
+                                title="-- lb"
+                                value="--"
                               >
-                                lb
+                                --
                               </span>
                             </div>
-                            <div
-                              className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="MEDIUM"
-                              title="Key 2"
+                            <span
+                              className="iot--value-card__attribute-unit"
+                              style={
+                                Object {
+                                  "--default-font-size": "1.5rem",
+                                }
+                              }
                             >
-                              Key 2
-                            </div>
+                              lb
+                            </span>
+                          </div>
+                          <div
+                            className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
+                            size="MEDIUM"
+                            title="Key 2"
+                          >
+                            Key 2
                           </div>
                         </div>
                       </div>
@@ -854,702 +846,702 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </div>
           </div>
         </div>
+      </div>
+      <div
+        className="iot--dashboard-editor--sidebar"
+      >
         <div
-          className="iot--dashboard-editor--sidebar"
+          className="iot--card-editor"
+          data-testid="card-editor"
         >
           <div
-            className="iot--card-editor"
-            data-testid="card-editor"
+            className="iot--card-editor--header"
+          >
+            <h2
+              className="iot--card-editor--header--title"
+            >
+              Gallery
+            </h2>
+          </div>
+          <div
+            className="iot--card-editor--content"
           >
             <div
-              className="iot--card-editor--header"
-            >
-              <h2
-                className="iot--card-editor--header--title"
-              >
-                Gallery
-              </h2>
-            </div>
-            <div
-              className="iot--card-editor--content"
+              className="iot--list iot--list__full-height"
             >
               <div
-                className="iot--list iot--list__full-height"
+                className="iot--list-header-container"
               >
                 <div
-                  className="iot--list-header-container"
+                  className="iot--list-header--search"
                 >
                   <div
-                    className="iot--list-header--search"
+                    aria-labelledby="iot--list-header--search-search"
+                    className="bx--search bx--search--sm"
+                    role="search"
                   >
-                    <div
-                      aria-labelledby="iot--list-header--search-search"
-                      className="bx--search bx--search--sm"
-                      role="search"
+                    <svg
+                      aria-hidden={true}
+                      className="bx--search-magnifier"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                      />
+                    </svg>
+                    <label
+                      className="bx--label"
+                      htmlFor="iot--list-header--search"
+                      id="iot--list-header--search-search"
+                    >
+                      Enter a value
+                    </label>
+                    <input
+                      autoComplete="off"
+                      className="bx--search-input"
+                      id="iot--list-header--search"
+                      onChange={[Function]}
+                      placeholder="Enter a value"
+                      role="searchbox"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
                     >
                       <svg
                         aria-hidden={true}
-                        className="bx--search-magnifier"
                         fill="currentColor"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 16 16"
+                        viewBox="0 0 32 32"
                         width={16}
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
                         />
                       </svg>
-                      <label
-                        className="bx--label"
-                        htmlFor="iot--list-header--search"
-                        id="iot--list-header--search-search"
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--list--content__full-height iot--list--content"
+              >
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
+                  <div
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <div
+                      className="iot--list-item--content"
+                    >
+                      <div
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
-                        Enter a value
-                      </label>
-                      <input
-                        autoComplete="off"
-                        className="bx--search-input"
-                        id="iot--list-header--search"
-                        onChange={[Function]}
-                        placeholder="Enter a value"
-                        role="searchbox"
-                        type="text"
-                        value=""
-                      />
-                      <button
-                        aria-label="Clear search input"
-                        className="bx--search-close bx--search-close--hidden"
-                        onClick={[Function]}
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="currentColor"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          className="iot--card-gallery-list__icon"
                         >
-                          <path
-                            d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                          />
-                        </svg>
-                      </button>
+                          <svg
+                            height={34}
+                            width={40}
+                          >
+                            <g
+                              fill="none"
+                              fillRule="nonzero"
+                              transform="translate(0 1)"
+                            >
+                              <path
+                                d="M20.556 1.233L32.28 7.368l.033.013 7.299 1.68v-.453l-7.193-1.675L20.376.63 7.546 30.883.519 28.516l-.002.483 7.23 2.436z"
+                                fill="#0062FF"
+                              />
+                              <circle
+                                cx={7.382}
+                                cy={31.154}
+                                fill="#FFF"
+                                r={1}
+                                stroke="#0062FF"
+                                strokeWidth={1.5}
+                              />
+                              <circle
+                                cx={20.455}
+                                cy={0.966}
+                                fill="#FFF"
+                                r={1}
+                                stroke="#0062FF"
+                                strokeWidth={1.5}
+                              />
+                              <circle
+                                cx={32.904}
+                                cy={7.365}
+                                fill="#FFF"
+                                r={1}
+                                stroke="#0062FF"
+                                strokeWidth={1.5}
+                              />
+                              <path
+                                d="M.13 13.592h.776v-.155H.13zM1.424 13.592H2.2v-.155h-.777zM2.718 13.592h.777v-.155h-.777zM4.013 13.592h.777v-.155h-.777zM5.307 13.592h.777v-.155h-.777zM6.602 13.592h.777v-.155h-.777zM7.896 13.592h.777v-.155h-.777zM9.19 13.592h.778v-.155H9.19zM10.485 13.592h.777v-.155h-.777zM11.78 13.592h.777v-.155h-.777zM13.074 13.592h.777v-.155h-.777zM14.369 13.592h.777v-.155h-.777zM15.663 13.592h.777v-.155h-.777zM16.958 13.592h.777v-.155h-.777zM18.252 13.592h.777v-.155h-.777zM19.547 13.592h.777v-.155h-.777zM20.841 13.592h.777v-.155h-.777zM22.136 13.592h.777v-.155h-.777zM23.43 13.592h.777v-.155h-.777zM24.725 13.592h.777v-.155h-.777zM26.02 13.592h.776v-.155h-.777zM27.314 13.592h.777v-.155h-.777zM28.608 13.592h.777v-.155h-.777zM29.903 13.592h.777v-.155h-.777zM31.197 13.592h.777v-.155h-.777zM32.492 13.592h.777v-.155h-.777zM33.786 13.592h.777v-.155h-.777zM35.08 13.592h.778v-.155h-.777zM36.375 13.592h.777v-.155h-.777zM37.67 13.592h.777v-.155h-.777zM38.964 13.592h.389v-.155h-.389z"
+                                fill="#0062FF"
+                              />
+                            </g>
+                          </svg>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
+                        <div
+                          className="iot--list-item--content--values--main"
+                        >
+                          <div
+                            className="iot--list-item--content--values--value"
+                            title="Time series line"
+                          >
+                            Time series line
+                          </div>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  className="iot--list--content__full-height iot--list--content"
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
                 >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={34}
-                              width={40}
-                            >
-                              <g
-                                fill="none"
-                                fillRule="nonzero"
-                                transform="translate(0 1)"
-                              >
-                                <path
-                                  d="M20.556 1.233L32.28 7.368l.033.013 7.299 1.68v-.453l-7.193-1.675L20.376.63 7.546 30.883.519 28.516l-.002.483 7.23 2.436z"
-                                  fill="#0062FF"
-                                />
-                                <circle
-                                  cx={7.382}
-                                  cy={31.154}
-                                  fill="#FFF"
-                                  r={1}
-                                  stroke="#0062FF"
-                                  strokeWidth={1.5}
-                                />
-                                <circle
-                                  cx={20.455}
-                                  cy={0.966}
-                                  fill="#FFF"
-                                  r={1}
-                                  stroke="#0062FF"
-                                  strokeWidth={1.5}
-                                />
-                                <circle
-                                  cx={32.904}
-                                  cy={7.365}
-                                  fill="#FFF"
-                                  r={1}
-                                  stroke="#0062FF"
-                                  strokeWidth={1.5}
-                                />
-                                <path
-                                  d="M.13 13.592h.776v-.155H.13zM1.424 13.592H2.2v-.155h-.777zM2.718 13.592h.777v-.155h-.777zM4.013 13.592h.777v-.155h-.777zM5.307 13.592h.777v-.155h-.777zM6.602 13.592h.777v-.155h-.777zM7.896 13.592h.777v-.155h-.777zM9.19 13.592h.778v-.155H9.19zM10.485 13.592h.777v-.155h-.777zM11.78 13.592h.777v-.155h-.777zM13.074 13.592h.777v-.155h-.777zM14.369 13.592h.777v-.155h-.777zM15.663 13.592h.777v-.155h-.777zM16.958 13.592h.777v-.155h-.777zM18.252 13.592h.777v-.155h-.777zM19.547 13.592h.777v-.155h-.777zM20.841 13.592h.777v-.155h-.777zM22.136 13.592h.777v-.155h-.777zM23.43 13.592h.777v-.155h-.777zM24.725 13.592h.777v-.155h-.777zM26.02 13.592h.776v-.155h-.777zM27.314 13.592h.777v-.155h-.777zM28.608 13.592h.777v-.155h-.777zM29.903 13.592h.777v-.155h-.777zM31.197 13.592h.777v-.155h-.777zM32.492 13.592h.777v-.155h-.777zM33.786 13.592h.777v-.155h-.777zM35.08 13.592h.778v-.155h-.777zM36.375 13.592h.777v-.155h-.777zM37.67 13.592h.777v-.155h-.777zM38.964 13.592h.389v-.155h-.389z"
-                                  fill="#0062FF"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                            <path
+                              d="M0 0h1.111v32H0zm31.111 2.963h1.111V32h-1.111zM7.778 19.259h1.111V32H7.778zm7.778-7.407h1.111V32h-1.111zM38.889 26.37H40V32h-1.111zM23.333 14.222h1.111V32h-1.111z"
+                              fill="#0062FF"
+                            />
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Simple bar"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Time series line"
-                            >
-                              Time series line
-                            </div>
+                            Simple bar
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
                             >
                               <path
-                                d="M0 0h1.111v32H0zm31.111 2.963h1.111V32h-1.111zM7.778 19.259h1.111V32H7.778zm7.778-7.407h1.111V32h-1.111zM38.889 26.37H40V32h-1.111zM23.333 14.222h1.111V32h-1.111z"
+                                d="M38.926 7.822H40V32h-1.074z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M37.584 17.422h1.074V32h-1.074z"
                                 fill="#0062FF"
                               />
-                            </svg>
-                          </div>
+                              <path
+                                d="M31.41 3.2h1.073V32H31.41z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M30.067 9.956h1.074V32h-1.074z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M23.893 14.578h1.073V32h-1.073z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M22.55 21.333h1.074V32H22.55z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M16.644 12.089h1.074V32h-1.074z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M15.302 25.6h1.074V32h-1.074z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M8.86 20.267h1.073V32H8.859z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M7.517 23.111h1.074V32H7.517z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M1.342 0h1.074v32H1.342z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M0 14.222h1.074V32H0z"
+                                fill="#0062FF"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Grouped bar"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Simple bar"
-                            >
-                              Simple bar
-                            </div>
+                            Grouped bar
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
                             >
-                              <g
-                                fill="none"
-                              >
-                                <path
-                                  d="M38.926 7.822H40V32h-1.074z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M37.584 17.422h1.074V32h-1.074z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M31.41 3.2h1.073V32H31.41z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M30.067 9.956h1.074V32h-1.074z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M23.893 14.578h1.073V32h-1.073z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M22.55 21.333h1.074V32H22.55z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M16.644 12.089h1.074V32h-1.074z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M15.302 25.6h1.074V32h-1.074z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M8.86 20.267h1.073V32H8.859z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M7.517 23.111h1.074V32H7.517z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M1.342 0h1.074v32H1.342z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M0 14.222h1.074V32H0z"
-                                  fill="#0062FF"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M38.108 7.467H40v24.178h-1.892z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M38.108 17.067H40v14.578h-1.892z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M38.108 16.711H40v1h-1.892z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M30.27 2.844h1.892v28.8H30.27z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M30.27 9.956h1.892V32H30.27z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M30.27 9.6h1.892v1H30.27z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M22.703 14.578h1.892V32h-1.892z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M22.703 21.333h1.892V32h-1.892z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M22.703 20.978h1.892v1h-1.892z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M15.405 12.089h1.892V32h-1.892z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M15.405 25.6h1.892V32h-1.892z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M15.405 25.244h1.892v1h-1.892z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M7.838 20.267H9.73V32H7.838z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M7.838 23.111H9.73V32H7.838z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M7.838 22.756H9.73v1H7.838z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M0 0h1.892v32H0z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M0 14.222h1.892V32H0z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M0 13.867h1.892v1H0z"
+                                fill="#FFF"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Stacked bar"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Grouped bar"
-                            >
-                              Grouped bar
-                            </div>
+                            Stacked bar
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
+                              <path
+                                d="M.5.5h38.752v31H.5z"
+                                stroke="#2160F8"
+                              />
+                              <path
+                                d="M4.969 21.714h21.863v4.571H4.969zm26.832 0l1.988 4.572h-3.975z"
+                                fill="#8EC1FF"
+                              />
+                              <text
+                                fill="#2160F8"
+                                fontFamily="IBMPlexSans, IBM Plex Sans"
+                                fontSize={10}
                               >
-                                <path
-                                  d="M38.108 7.467H40v24.178h-1.892z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M38.108 17.067H40v14.578h-1.892z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M38.108 16.711H40v1h-1.892z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M30.27 2.844h1.892v28.8H30.27z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M30.27 9.956h1.892V32H30.27z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M30.27 9.6h1.892v1H30.27z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M22.703 14.578h1.892V32h-1.892z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M22.703 21.333h1.892V32h-1.892z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M22.703 20.978h1.892v1h-1.892z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M15.405 12.089h1.892V32h-1.892z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M15.405 25.6h1.892V32h-1.892z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M15.405 25.244h1.892v1h-1.892z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M7.838 20.267H9.73V32H7.838z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M7.838 23.111H9.73V32H7.838z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M7.838 22.756H9.73v1H7.838z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M0 0h1.892v32H0z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M0 14.222h1.892V32H0z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M0 13.867h1.892v1H0z"
-                                  fill="#FFF"
-                                />
-                              </g>
-                            </svg>
-                          </div>
-                        </div>
-                        <div
-                          className="iot--list-item--content--values"
-                        >
-                          <div
-                            className="iot--list-item--content--values--main"
-                          >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Stacked bar"
-                            >
-                              Stacked bar
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
-                  >
-                    <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
-                    >
-                      <div
-                        className="iot--list-item--content"
-                      >
-                        <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
-                        >
-                          <div
-                            className="iot--card-gallery-list__icon"
-                          >
-                            <svg
-                              height={32}
-                              width={40}
-                            >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M.5.5h38.752v31H.5z"
-                                  stroke="#2160F8"
-                                />
-                                <path
-                                  d="M4.969 21.714h21.863v4.571H4.969zm26.832 0l1.988 4.572h-3.975z"
-                                  fill="#8EC1FF"
-                                />
-                                <text
-                                  fill="#2160F8"
-                                  fontFamily="IBMPlexSans, IBM Plex Sans"
-                                  fontSize={10}
+                                <tspan
+                                  x={4.969}
+                                  y={15.5}
                                 >
-                                  <tspan
-                                    x={4.969}
-                                    y={15.5}
-                                  >
-                                    25%
-                                  </tspan>
-                                </text>
-                              </g>
-                            </svg>
-                          </div>
+                                  25%
+                                </tspan>
+                              </text>
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Value / KPI"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Value / KPI"
-                            >
-                              Value / KPI
-                            </div>
+                            Value / KPI
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M1.29 21.57L13 10.477l11.2 12.347L30.5 16l8.21 9.6"
-                                  stroke="#0062FF"
-                                />
-                                <ellipse
-                                  cx={25.835}
-                                  cy={7.62}
-                                  rx={3.19}
-                                  ry={3.5}
-                                  stroke="#005BFF"
-                                />
-                                <path
-                                  d="M.5.5h39v31H.5z"
-                                  stroke="#2160F8"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M1.29 21.57L13 10.477l11.2 12.347L30.5 16l8.21 9.6"
+                                stroke="#0062FF"
+                              />
+                              <ellipse
+                                cx={25.835}
+                                cy={7.62}
+                                rx={3.19}
+                                ry={3.5}
+                                stroke="#005BFF"
+                              />
+                              <path
+                                d="M.5.5h39v31H.5z"
+                                stroke="#2160F8"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Image"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Image"
-                            >
-                              Image
-                            </div>
+                            Image
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M0 0h40v2.759H0z"
-                                  fill="#0058FF"
-                                />
-                                <path
-                                  d="M.5 3.259h39V31.5H.5z"
-                                  stroke="#005BFF"
-                                />
-                                <path
-                                  d="M3.5 6.621h19V9.38h-19zm21.5 0h11V9.38H25zM3.5 18.759h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 12.69h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 24.828h19v2.759h-19zm21.5 0h11v2.759H25z"
-                                  fill="#D8D8D8"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M0 0h40v2.759H0z"
+                                fill="#0058FF"
+                              />
+                              <path
+                                d="M.5 3.259h39V31.5H.5z"
+                                stroke="#005BFF"
+                              />
+                              <path
+                                d="M3.5 6.621h19V9.38h-19zm21.5 0h11V9.38H25zM3.5 18.759h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 12.69h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 24.828h19v2.759h-19zm21.5 0h11v2.759H25z"
+                                fill="#D8D8D8"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Data table"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Data table"
-                            >
-                              Data table
-                            </div>
+                            Data table
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M.5.5h39v31H.5z"
-                                  stroke="#2160F8"
-                                />
-                                <path
-                                  d="M25 5h11v3H25zm0 6h11v3H25zm0 12h11v3H25zm0-6h11v3H25z"
-                                  fill="#D8D8D8"
-                                />
-                                <path
-                                  d="M18.415 19.585l-2.915-2.92V14.5a.5.5 0 00-.145-.355l-5-5a.5.5 0 00-.71 0l-4.5 4.5a.5.5 0 000 .71l5 5a.5.5 0 00.355.145h2.17l2.915 2.92a2.001 2.001 0 002.83-2.83v-.005zM7 13.205l1.145 1.15.71-.71-1.15-1.145.795-.795 2.145 2.15.71-.71L9.205 11l.795-.795 3.295 3.295L9.5 17.295 6.205 14 7 13.205zm10.705 8.5a1 1 0 01-1.41 0l-3.065-3.06a.9.9 0 00-.355-.145h-2.17l-.5-.5L14 14.205l.5.5v2.17a.5.5 0 00.145.35l3.06 3.07a1 1 0 010 1.41z"
-                                  fill="#0F62FE"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M.5.5h39v31H.5z"
+                                stroke="#2160F8"
+                              />
+                              <path
+                                d="M25 5h11v3H25zm0 6h11v3H25zm0 12h11v3H25zm0-6h11v3H25z"
+                                fill="#D8D8D8"
+                              />
+                              <path
+                                d="M18.415 19.585l-2.915-2.92V14.5a.5.5 0 00-.145-.355l-5-5a.5.5 0 00-.71 0l-4.5 4.5a.5.5 0 000 .71l5 5a.5.5 0 00.355.145h2.17l2.915 2.92a2.001 2.001 0 002.83-2.83v-.005zM7 13.205l1.145 1.15.71-.71-1.15-1.145.795-.795 2.145 2.15.71-.71L9.205 11l.795-.795 3.295 3.295L9.5 17.295 6.205 14 7 13.205zm10.705 8.5a1 1 0 01-1.41 0l-3.065-3.06a.9.9 0 00-.355-.145h-2.17l-.5-.5L14 14.205l.5.5v2.17a.5.5 0 00.145.35l3.06 3.07a1 1 0 010 1.41z"
+                                fill="#0F62FE"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Custom"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Custom"
-                            >
-                              Custom
-                            </div>
+                            Custom
                           </div>
                         </div>
                       </div>
@@ -2719,350 +2711,492 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
     }
   >
     <div
-      style={
-        Object {
-          "height": "calc(100vh - 6rem)",
-        }
-      }
+      className="iot--dashboard-editor"
     >
       <div
-        className="iot--dashboard-editor"
+        className="iot--dashboard-editor--content"
       >
         <div
-          className="iot--dashboard-editor--content"
+          className="page-title-bar"
         >
           <div
-            className="page-title-bar"
+            className="page-title-bar-header"
           >
             <div
-              className="page-title-bar-header"
+              className="page-title-bar-header-left"
             >
               <div
-                className="page-title-bar-header-left"
+                className="page-title-bar-breadcrumb"
+              >
+                <nav
+                  aria-label="Breadcrumb"
+                >
+                  <ol
+                    className="bx--breadcrumb"
+                  >
+                    <li
+                      className="bx--breadcrumb-item"
+                    >
+                      <a
+                        className="bx--link bx--link"
+                        href="www.ibm.com"
+                      >
+                        Dashboard library
+                      </a>
+                    </li>
+                    <li
+                      className="bx--breadcrumb-item"
+                    >
+                      <a
+                        className="bx--link bx--link"
+                        href="www.ibm.com"
+                      >
+                        Favorites
+                      </a>
+                    </li>
+                  </ol>
+                </nav>
+              </div>
+              <div
+                className="page-title-bar-title"
               >
                 <div
-                  className="page-title-bar-breadcrumb"
+                  className="page-title-bar-title--text"
                 >
-                  <nav
-                    aria-label="Breadcrumb"
+                  <h2>
+                    My dashboard
+                  </h2>
+                  <button
+                    className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
                   >
-                    <ol
-                      className="bx--breadcrumb"
+                    <span
+                      className="bx--assistive-text"
                     >
-                      <li
-                        className="bx--breadcrumb-item"
-                      >
-                        <a
-                          className="bx--link bx--link"
-                          href="www.ibm.com"
-                        >
-                          Dashboard library
-                        </a>
-                      </li>
-                      <li
-                        className="bx--breadcrumb-item"
-                      >
-                        <a
-                          className="bx--link bx--link"
-                          href="www.ibm.com"
-                        >
-                          Favorites
-                        </a>
-                      </li>
-                    </ol>
-                  </nav>
+                      Edit title updated
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Edit title updated"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                      />
+                    </svg>
+                  </button>
                 </div>
+              </div>
+            </div>
+            <div
+              className="page-title-bar-header-right"
+            >
+              <div
+                className="iot--dashboard-editor-header--right"
+              >
                 <div
-                  className="page-title-bar-title"
+                  className="iot--dashboard-editor-header--top"
+                />
+                <div
+                  className="iot--dashboard-editor-header--bottom"
                 >
-                  <div
-                    className="page-title-bar-title--text"
+                  <button
+                    aria-describedby="icon-tooltip-1"
+                    className="bx--tooltip__trigger bx--tooltip--a11y iot--dashboard-editor-header--bottom__import bx--tooltip--bottom bx--tooltip--align-center"
+                    onFocus={[Function]}
+                    onMouseEnter={[Function]}
+                    type="button"
                   >
-                    <h2>
-                      My dashboard
-                    </h2>
-                    <button
-                      className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                      disabled={false}
-                      onClick={[Function]}
+                    <span
+                      className="bx--assistive-text"
+                      id="icon-tooltip-1"
+                    >
+                      Import
+                    </span>
+                    <label
+                      accepts={
+                        Array [
+                          ".json",
+                        ]
+                      }
+                      aria-disabled={false}
+                      className="bx--btn bx--btn--ghost bx--btn--field"
+                      htmlFor="id1"
+                      onKeyDown={[Function]}
                       tabIndex={0}
-                      type="button"
                     >
                       <span
-                        className="bx--assistive-text"
+                        role="button"
                       >
-                        Edit title updated
+                        <svg
+                          aria-hidden={true}
+                          fill="#161616"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M28 19L14.83 19 17.41 16.41 16 15 11 20 16 25 17.41 23.59 14.83 21 28 21 28 19z"
+                          />
+                          <path
+                            d="M24,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,16,2H6A2,2,0,0,0,4,4V28a2,2,0,0,0,2,2H22a2,2,0,0,0,2-2V26H22v2H6V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L21.59,10Z"
+                          />
+                        </svg>
                       </span>
+                    </label>
+                    <input
+                      className="bx--visually-hidden"
+                      disabled={false}
+                      id="id1"
+                      multiple={false}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      tabIndex="-1"
+                      type="file"
+                    />
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Export
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Export"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M13 21L26.17 21 23.59 23.59 25 25 30 20 25 15 23.59 16.41 26.17 19 13 19 13 21z"
+                      />
+                      <path
+                        d="M22,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,14,2H4A2,2,0,0,0,2,4V28a2,2,0,0,0,2,2H20a2,2,0,0,0,2-2V26H20v2H4V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L19.59,10Z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Delete
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Delete"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M12 12H14V24H12zM18 12H20V24H18z"
+                      />
+                      <path
+                        d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--secondary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Save and close
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--dashboard-editor--preview"
+        >
+          <div
+            className=""
+          >
+            <div
+              className="iot--dashboard-editor--preview__grid-container"
+            >
+              <div
+                className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
+                data-floating-menu-container={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onClose={[Function]}
+                onKeyDown={[Function]}
+                open={false}
+                role="presentation"
+              >
+                <span
+                  className="bx--visually-hidden"
+                  role="link"
+                  tabIndex="0"
+                >
+                  Focus sentinel
+                </span>
+                <div
+                  className="bx--modal-container"
+                  role="dialog"
+                >
+                  <div
+                    className="bx--modal-header"
+                  >
+                    <p
+                      className="bx--modal-header__label bx--type-delta"
+                    >
+                      New image card
+                    </p>
+                    <p
+                      className="bx--modal-header__heading bx--type-beta"
+                    >
+                      Image gallery
+                    </p>
+                    <button
+                      aria-label="Close"
+                      className="bx--modal-close"
+                      onClick={[Function]}
+                      title="Close"
+                      type="button"
+                    >
                       <svg
-                        aria-hidden="true"
-                        aria-label="Edit title updated"
-                        className="bx--btn__icon"
+                        aria-hidden={true}
+                        className="bx--modal-close__icon"
                         fill="currentColor"
                         focusable="false"
                         height={20}
                         preserveAspectRatio="xMidYMid meet"
-                        role="img"
                         viewBox="0 0 32 32"
                         width={20}
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
                         />
                       </svg>
                     </button>
                   </div>
-                </div>
-              </div>
-              <div
-                className="page-title-bar-header-right"
-              >
-                <div
-                  className="iot--dashboard-editor-header--right"
-                >
                   <div
-                    className="iot--dashboard-editor-header--top"
-                  />
-                  <div
-                    className="iot--dashboard-editor-header--bottom"
+                    className="bx--modal-content"
                   >
-                    <button
-                      aria-describedby="icon-tooltip-1"
-                      className="bx--tooltip__trigger bx--tooltip--a11y iot--dashboard-editor-header--bottom__import bx--tooltip--bottom bx--tooltip--align-center"
-                      onFocus={[Function]}
-                      onMouseEnter={[Function]}
-                      type="button"
+                    <div
+                      className="iot--image-gallery-modal__top-section"
                     >
-                      <span
-                        className="bx--assistive-text"
-                        id="icon-tooltip-1"
+                      <p
+                        alt="Select the image that you want to display on this card."
+                        className="iot--image-gallery-modal__instruction-text"
                       >
-                        Import
-                      </span>
-                      <label
-                        accepts={
-                          Array [
-                            ".json",
-                          ]
-                        }
-                        aria-disabled={false}
-                        className="bx--btn bx--btn--ghost bx--btn--field"
-                        htmlFor="id1"
-                        onKeyDown={[Function]}
-                        tabIndex={0}
+                        Select the image that you want to display on this card.
+                      </p>
+                      <div
+                        className="iot--image-gallery-modal__search-list-view-container"
                       >
-                        <span
-                          role="button"
+                        <div
+                          aria-labelledby="iot--image-gallery-modal--search-search"
+                          className="bx--search bx--search--xl bx--search--light"
+                          role="search"
                         >
                           <svg
                             aria-hidden={true}
-                            fill="#161616"
+                            className="bx--search-magnifier"
+                            fill="currentColor"
                             focusable="false"
                             height={16}
                             preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
+                            viewBox="0 0 16 16"
                             width={16}
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <path
-                              d="M28 19L14.83 19 17.41 16.41 16 15 11 20 16 25 17.41 23.59 14.83 21 28 21 28 19z"
-                            />
-                            <path
-                              d="M24,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,16,2H6A2,2,0,0,0,4,4V28a2,2,0,0,0,2,2H22a2,2,0,0,0,2-2V26H22v2H6V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L21.59,10Z"
+                              d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                             />
                           </svg>
-                        </span>
-                      </label>
-                      <input
-                        className="bx--visually-hidden"
-                        disabled={false}
-                        id="id1"
-                        multiple={false}
-                        onChange={[Function]}
-                        onClick={[Function]}
-                        tabIndex="-1"
-                        type="file"
-                      />
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      <span
-                        className="bx--assistive-text"
-                      >
-                        Export
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Export"
-                        className="bx--btn__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M13 21L26.17 21 23.59 23.59 25 25 30 20 25 15 23.59 16.41 26.17 19 13 19 13 21z"
-                        />
-                        <path
-                          d="M22,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,14,2H4A2,2,0,0,0,2,4V28a2,2,0,0,0,2,2H20a2,2,0,0,0,2-2V26H20v2H4V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L19.59,10Z"
-                        />
-                      </svg>
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      <span
-                        className="bx--assistive-text"
-                      >
-                        Delete
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Delete"
-                        className="bx--btn__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M12 12H14V24H12zM18 12H20V24H18z"
-                        />
-                        <path
-                          d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                        />
-                      </svg>
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--secondary"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--primary"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      Save and close
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--dashboard-editor--preview"
-          >
-            <div
-              className=""
-            >
-              <div
-                className="iot--dashboard-editor--preview__grid-container"
-              >
-                <div
-                  className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
-                  data-floating-menu-container={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onClose={[Function]}
-                  onKeyDown={[Function]}
-                  open={false}
-                  role="presentation"
-                >
-                  <span
-                    className="bx--visually-hidden"
-                    role="link"
-                    tabIndex="0"
-                  >
-                    Focus sentinel
-                  </span>
-                  <div
-                    className="bx--modal-container"
-                    role="dialog"
-                  >
-                    <div
-                      className="bx--modal-header"
-                    >
-                      <p
-                        className="bx--modal-header__label bx--type-delta"
-                      >
-                        New image card
-                      </p>
-                      <p
-                        className="bx--modal-header__heading bx--type-beta"
-                      >
-                        Image gallery
-                      </p>
-                      <button
-                        aria-label="Close"
-                        className="bx--modal-close"
-                        onClick={[Function]}
-                        title="Close"
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="bx--modal-close__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                          <label
+                            className="bx--label"
+                            htmlFor="iot--image-gallery-modal--search"
+                            id="iot--image-gallery-modal--search-search"
+                          >
+                            
+                          </label>
+                          <input
+                            autoComplete="off"
+                            className="bx--search-input"
+                            id="iot--image-gallery-modal--search"
+                            onChange={[Function]}
+                            placeholder="Search image by file name"
+                            role="searchbox"
+                            type="text"
                           />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      className="bx--modal-content"
-                    >
-                      <div
-                        className="iot--image-gallery-modal__top-section"
-                      >
-                        <p
-                          alt="Select the image that you want to display on this card."
-                          className="iot--image-gallery-modal__instruction-text"
-                        >
-                          Select the image that you want to display on this card.
-                        </p>
-                        <div
-                          className="iot--image-gallery-modal__search-list-view-container"
-                        >
-                          <div
-                            aria-labelledby="iot--image-gallery-modal--search-search"
-                            className="bx--search bx--search--xl bx--search--light"
-                            role="search"
+                          <button
+                            aria-label="Clear search input"
+                            className="bx--search-close bx--search-close--hidden"
+                            onClick={[Function]}
+                            type="button"
                           >
                             <svg
                               aria-hidden={true}
-                              className="bx--search-magnifier"
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <div
+                          className="bx--content-switcher iot--image-gallery-modal__content-switcher"
+                          onChange={[Function]}
+                          role="tablist"
+                        >
+                          <button
+                            className="iot--icon-switch iot--icon-switch--large bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                            disabled={false}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            tabIndex={0}
+                            type="button"
+                          >
+                            <span
+                              className="bx--assistive-text"
+                            >
+                              Grid
+                            </span>
+                            <svg
+                              aria-hidden="true"
+                              aria-label="Grid"
+                              className="bx--btn__icon"
+                              fill="currentColor"
+                              focusable="false"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M12 4H6A2 2 0 004 6v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0012 4zm0 8H6V6h6zM26 4H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0026 4zm0 8H20V6h6zM12 18H6a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0012 18zm0 8H6V20h6zM26 18H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0026 18zm0 8H20V20h6z"
+                              />
+                            </svg>
+                          </button>
+                          <button
+                            className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                            disabled={false}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            tabIndex={0}
+                            type="button"
+                          >
+                            <span
+                              className="bx--assistive-text"
+                            >
+                              List
+                            </span>
+                            <svg
+                              aria-hidden="true"
+                              aria-label="List"
+                              className="bx--btn__icon"
+                              fill="currentColor"
+                              focusable="false"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M10 6H28V8H10zM10 24H28V26H10zM10 15H28V17H10zM4 15H6V17H4zM4 6H6V8H4zM4 24H6V26H4z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="iot--image-gallery-modal__flex-wrapper"
+                    >
+                      <div
+                        className="iot--image-gallery-modal__scroll-panel iot--image-gallery-modal__scroll-panel--grid"
+                      >
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="assemblyline"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="assemblyline"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
+                          >
+                            <svg
+                              aria-hidden={true}
                               fill="currentColor"
                               focusable="false"
                               height={16}
@@ -3072,1726 +3206,1576 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
-                                d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
                               />
                             </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="iot--image-gallery-modal--search"
-                              id="iot--image-gallery-modal--search-search"
-                            >
-                              
-                            </label>
-                            <input
-                              autoComplete="off"
-                              className="bx--search-input"
-                              id="iot--image-gallery-modal--search"
-                              onChange={[Function]}
-                              placeholder="Search image by file name"
-                              role="searchbox"
-                              type="text"
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 32 32"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                                />
-                              </svg>
-                            </button>
-                          </div>
-                          <div
-                            className="bx--content-switcher iot--image-gallery-modal__content-switcher"
-                            onChange={[Function]}
-                            role="tablist"
+                          </span>
+                          <span
+                            className="bx--tile-content"
                           >
-                            <button
-                              className="iot--icon-switch iot--icon-switch--large bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
-                              disabled={false}
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              tabIndex={0}
-                              type="button"
+                            <div
+                              className="iot--image-tile__title"
                             >
-                              <span
-                                className="bx--assistive-text"
-                              >
-                                Grid
-                              </span>
-                              <svg
-                                aria-hidden="true"
-                                aria-label="Grid"
-                                className="bx--btn__icon"
-                                fill="currentColor"
-                                focusable="false"
-                                height={20}
-                                preserveAspectRatio="xMidYMid meet"
-                                role="img"
-                                viewBox="0 0 32 32"
-                                width={20}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M12 4H6A2 2 0 004 6v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0012 4zm0 8H6V6h6zM26 4H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0026 4zm0 8H20V6h6zM12 18H6a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0012 18zm0 8H6V20h6zM26 18H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0026 18zm0 8H20V20h6z"
-                                />
-                              </svg>
-                            </button>
-                            <button
-                              className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
-                              disabled={false}
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              tabIndex={0}
-                              type="button"
-                            >
-                              <span
-                                className="bx--assistive-text"
-                              >
-                                List
-                              </span>
-                              <svg
-                                aria-hidden="true"
-                                aria-label="List"
-                                className="bx--btn__icon"
-                                fill="currentColor"
-                                focusable="false"
-                                height={20}
-                                preserveAspectRatio="xMidYMid meet"
-                                role="img"
-                                viewBox="0 0 32 32"
-                                width={20}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M10 6H28V8H10zM10 24H28V26H10zM10 15H28V17H10zM4 15H6V17H4zM4 6H6V8H4zM4 24H6V26H4z"
-                                />
-                              </svg>
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        className="iot--image-gallery-modal__flex-wrapper"
-                      >
-                        <div
-                          className="iot--image-gallery-modal__scroll-panel iot--image-gallery-modal__scroll-panel--grid"
-                        >
-                          <input
-                            checked={false}
-                            className="bx--tile-input"
-                            id="assemblyline"
-                            onChange={[Function]}
-                            tabIndex={-1}
-                            title="title"
-                            type="checkbox"
-                            value="value"
-                          />
-                          <label
-                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                            htmlFor="assemblyline"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            selected={false}
-                            tabIndex={0}
-                          >
-                            <span
-                              className="bx--tile__checkmark"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                />
-                                <path
-                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                  data-icon-path="inner-path"
-                                  opacity="0"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              className="bx--tile-content"
-                            >
-                              <div
-                                className="iot--image-tile__title"
-                              >
-                                <span>
-                                  custom title assemblyline that is very long a and must be managed. 
+                              <span>
+                                custom title assemblyline that is very long a and must be managed. 
       Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do 
       eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim 
       ad minim veniam.
-                                </span>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
+                            >
+                              <img
+                                alt="assemblyline"
+                                src="assemblyline.jpg"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
                               >
-                                <img
-                                  alt="assemblyline"
-                                  src="assemblyline.jpg"
-                                />
-                                <button
-                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
+                                <span
+                                  className="bx--assistive-text"
                                 >
-                                  <span
-                                    className="bx--assistive-text"
-                                  >
-                                    Delete
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-label="Delete"
-                                    className="bx--btn__icon"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M12 12H14V24H12zM18 12H20V24H18z"
-                                    />
-                                    <path
-                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </span>
-                          </label>
-                          <input
-                            checked={false}
-                            className="bx--tile-input"
-                            id="floow_plan"
-                            onChange={[Function]}
-                            tabIndex={-1}
-                            title="title"
-                            type="checkbox"
-                            value="value"
-                          />
-                          <label
-                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                            htmlFor="floow_plan"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            selected={false}
-                            tabIndex={0}
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="floow_plan"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="floow_plan"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
                           >
-                            <span
-                              className="bx--tile__checkmark"
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                />
-                                <path
-                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                  data-icon-path="inner-path"
-                                  opacity="0"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              className="bx--tile-content"
-                            >
-                              <div
-                                className="iot--image-tile__title"
-                              >
-                                <span>
-                                  floow_plan
-                                </span>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="floow plan"
-                                  src="floow_plan.png"
-                                />
-                                <button
-                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
-                                >
-                                  <span
-                                    className="bx--assistive-text"
-                                  >
-                                    Delete
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-label="Delete"
-                                    className="bx--btn__icon"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M12 12H14V24H12zM18 12H20V24H18z"
-                                    />
-                                    <path
-                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </span>
-                          </label>
-                          <input
-                            checked={false}
-                            className="bx--tile-input"
-                            id="manufacturing_plant"
-                            onChange={[Function]}
-                            tabIndex={-1}
-                            title="title"
-                            type="checkbox"
-                            value="value"
-                          />
-                          <label
-                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                            htmlFor="manufacturing_plant"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            selected={false}
-                            tabIndex={0}
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
                           >
-                            <span
-                              className="bx--tile__checkmark"
+                            <div
+                              className="iot--image-tile__title"
                             >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                />
-                                <path
-                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                  data-icon-path="inner-path"
-                                  opacity="0"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              className="bx--tile-content"
+                              <span>
+                                floow_plan
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
                             >
-                              <div
-                                className="iot--image-tile__title"
+                              <img
+                                alt="floow plan"
+                                src="floow_plan.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
                               >
-                                <span>
-                                  Manufacturing_plant
-                                </span>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="manufacturing plant"
-                                  src="Manufacturing_plant.png"
-                                />
-                                <button
-                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
+                                <span
+                                  className="bx--assistive-text"
                                 >
-                                  <span
-                                    className="bx--assistive-text"
-                                  >
-                                    Delete
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-label="Delete"
-                                    className="bx--btn__icon"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M12 12H14V24H12zM18 12H20V24H18z"
-                                    />
-                                    <path
-                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </span>
-                          </label>
-                          <input
-                            checked={false}
-                            className="bx--tile-input"
-                            id="robot_arm"
-                            onChange={[Function]}
-                            tabIndex={-1}
-                            title="title"
-                            type="checkbox"
-                            value="value"
-                          />
-                          <label
-                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                            htmlFor="robot_arm"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            selected={false}
-                            tabIndex={0}
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="manufacturing_plant"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="manufacturing_plant"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
                           >
-                            <span
-                              className="bx--tile__checkmark"
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                />
-                                <path
-                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                  data-icon-path="inner-path"
-                                  opacity="0"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              className="bx--tile-content"
-                            >
-                              <div
-                                className="iot--image-tile__title"
-                              >
-                                <span>
-                                  robot_arm
-                                </span>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="robot arm"
-                                  src="robot_arm.png"
-                                />
-                                <button
-                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
-                                >
-                                  <span
-                                    className="bx--assistive-text"
-                                  >
-                                    Delete
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-label="Delete"
-                                    className="bx--btn__icon"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M12 12H14V24H12zM18 12H20V24H18z"
-                                    />
-                                    <path
-                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </span>
-                          </label>
-                          <input
-                            checked={false}
-                            className="bx--tile-input"
-                            id="tankmodal"
-                            onChange={[Function]}
-                            tabIndex={-1}
-                            title="title"
-                            type="checkbox"
-                            value="value"
-                          />
-                          <label
-                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                            htmlFor="tankmodal"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            selected={false}
-                            tabIndex={0}
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
                           >
-                            <span
-                              className="bx--tile__checkmark"
+                            <div
+                              className="iot--image-tile__title"
                             >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                />
-                                <path
-                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                  data-icon-path="inner-path"
-                                  opacity="0"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              className="bx--tile-content"
+                              <span>
+                                Manufacturing_plant
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
                             >
-                              <div
-                                className="iot--image-tile__title"
+                              <img
+                                alt="manufacturing plant"
+                                src="Manufacturing_plant.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
                               >
-                                <span>
-                                  tankmodal
-                                </span>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="tankmodal"
-                                  src="tankmodal.png"
-                                />
-                                <button
-                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
+                                <span
+                                  className="bx--assistive-text"
                                 >
-                                  <span
-                                    className="bx--assistive-text"
-                                  >
-                                    Delete
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-label="Delete"
-                                    className="bx--btn__icon"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M12 12H14V24H12zM18 12H20V24H18z"
-                                    />
-                                    <path
-                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </span>
-                          </label>
-                          <input
-                            checked={false}
-                            className="bx--tile-input"
-                            id="turbines"
-                            onChange={[Function]}
-                            tabIndex={-1}
-                            title="title"
-                            type="checkbox"
-                            value="value"
-                          />
-                          <label
-                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                            htmlFor="turbines"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            selected={false}
-                            tabIndex={0}
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="robot_arm"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="robot_arm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
                           >
-                            <span
-                              className="bx--tile__checkmark"
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                />
-                                <path
-                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                  data-icon-path="inner-path"
-                                  opacity="0"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              className="bx--tile-content"
-                            >
-                              <div
-                                className="iot--image-tile__title"
-                              >
-                                <span>
-                                  turbines
-                                </span>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="turbines"
-                                  src="turbines.png"
-                                />
-                                <button
-                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
-                                >
-                                  <span
-                                    className="bx--assistive-text"
-                                  >
-                                    Delete
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-label="Delete"
-                                    className="bx--btn__icon"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M12 12H14V24H12zM18 12H20V24H18z"
-                                    />
-                                    <path
-                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </span>
-                          </label>
-                          <input
-                            checked={false}
-                            className="bx--tile-input"
-                            id="extra-wide-image"
-                            onChange={[Function]}
-                            tabIndex={-1}
-                            title="title"
-                            type="checkbox"
-                            value="value"
-                          />
-                          <label
-                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                            htmlFor="extra-wide-image"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            selected={false}
-                            tabIndex={0}
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
                           >
-                            <span
-                              className="bx--tile__checkmark"
+                            <div
+                              className="iot--image-tile__title"
                             >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                />
-                                <path
-                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                  data-icon-path="inner-path"
-                                  opacity="0"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              className="bx--tile-content"
+                              <span>
+                                robot_arm
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
                             >
-                              <div
-                                className="iot--image-tile__title"
+                              <img
+                                alt="robot arm"
+                                src="robot_arm.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
                               >
-                                <span>
-                                  extra-wide-image
-                                </span>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="extra wide image"
-                                  src="extra-wide-image.png"
-                                />
-                                <button
-                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
+                                <span
+                                  className="bx--assistive-text"
                                 >
-                                  <span
-                                    className="bx--assistive-text"
-                                  >
-                                    Delete
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-label="Delete"
-                                    className="bx--btn__icon"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M12 12H14V24H12zM18 12H20V24H18z"
-                                    />
-                                    <path
-                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </span>
-                          </label>
-                          <input
-                            checked={false}
-                            className="bx--tile-input"
-                            id="large"
-                            onChange={[Function]}
-                            tabIndex={-1}
-                            title="title"
-                            type="checkbox"
-                            value="value"
-                          />
-                          <label
-                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                            htmlFor="large"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            selected={false}
-                            tabIndex={0}
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="tankmodal"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="tankmodal"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
                           >
-                            <span
-                              className="bx--tile__checkmark"
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                />
-                                <path
-                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                  data-icon-path="inner-path"
-                                  opacity="0"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              className="bx--tile-content"
-                            >
-                              <div
-                                className="iot--image-tile__title"
-                              >
-                                <span>
-                                  large
-                                </span>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="large image"
-                                  src="large.png"
-                                />
-                                <button
-                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
-                                >
-                                  <span
-                                    className="bx--assistive-text"
-                                  >
-                                    Delete
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-label="Delete"
-                                    className="bx--btn__icon"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M12 12H14V24H12zM18 12H20V24H18z"
-                                    />
-                                    <path
-                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </span>
-                          </label>
-                          <input
-                            checked={false}
-                            className="bx--tile-input"
-                            id="large_portrait"
-                            onChange={[Function]}
-                            tabIndex={-1}
-                            title="title"
-                            type="checkbox"
-                            value="value"
-                          />
-                          <label
-                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                            htmlFor="large_portrait"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            selected={false}
-                            tabIndex={0}
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
                           >
-                            <span
-                              className="bx--tile__checkmark"
+                            <div
+                              className="iot--image-tile__title"
                             >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                />
-                                <path
-                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                  data-icon-path="inner-path"
-                                  opacity="0"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              className="bx--tile-content"
+                              <span>
+                                tankmodal
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
                             >
-                              <div
-                                className="iot--image-tile__title"
+                              <img
+                                alt="tankmodal"
+                                src="tankmodal.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
                               >
-                                <span>
-                                  large_portrait
-                                </span>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="large image portrait"
-                                  src="large_portrait.png"
-                                />
-                                <button
-                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
+                                <span
+                                  className="bx--assistive-text"
                                 >
-                                  <span
-                                    className="bx--assistive-text"
-                                  >
-                                    Delete
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-label="Delete"
-                                    className="bx--btn__icon"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M12 12H14V24H12zM18 12H20V24H18z"
-                                    />
-                                    <path
-                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="turbines"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="turbines"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
+                          >
+                            <div
+                              className="iot--image-tile__title"
+                            >
+                              <span>
+                                turbines
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
+                            >
+                              <img
+                                alt="turbines"
+                                src="turbines.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--assistive-text"
+                                >
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="extra-wide-image"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="extra-wide-image"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
+                          >
+                            <div
+                              className="iot--image-tile__title"
+                            >
+                              <span>
+                                extra-wide-image
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
+                            >
+                              <img
+                                alt="extra wide image"
+                                src="extra-wide-image.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--assistive-text"
+                                >
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="large"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="large"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
+                          >
+                            <div
+                              className="iot--image-tile__title"
+                            >
+                              <span>
+                                large
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
+                            >
+                              <img
+                                alt="large image"
+                                src="large.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--assistive-text"
+                                >
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="large_portrait"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="large_portrait"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
+                          >
+                            <div
+                              className="iot--image-tile__title"
+                            >
+                              <span>
+                                large_portrait
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
+                            >
+                              <img
+                                alt="large image portrait"
+                                src="large_portrait.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--assistive-text"
+                                >
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
                       </div>
                     </div>
-                    <div
-                      className="bx--modal-footer iot--composed-modal-footer"
-                    >
-                      <button
-                        className="iot--btn bx--btn bx--btn--secondary"
-                        disabled={false}
-                        onClick={[Function]}
-                        tabIndex={0}
-                        type="button"
-                      >
-                        Cancel
-                      </button>
-                      <button
-                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                        disabled={true}
-                        onClick={[Function]}
-                        tabIndex={0}
-                        type="button"
-                      >
-                        Select
-                      </button>
-                    </div>
                   </div>
-                  <span
-                    className="bx--visually-hidden"
-                    role="link"
-                    tabIndex="0"
+                  <div
+                    className="bx--modal-footer iot--composed-modal-footer"
                   >
-                    Focus sentinel
-                  </span>
+                    <button
+                      className="iot--btn bx--btn bx--btn--secondary"
+                      disabled={false}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                      disabled={true}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      Select
+                    </button>
+                  </div>
                 </div>
+                <span
+                  className="bx--visually-hidden"
+                  role="link"
+                  tabIndex="0"
+                >
+                  Focus sentinel
+                </span>
+              </div>
+              <div
+                style={
+                  Object {
+                    "flex": 1,
+                  }
+                }
+              >
                 <div
+                  className="react-grid-layout DashboardGrid__StyledGridLayout-vxs00g-0 ANzdO"
+                  onDragEnter={[Function]}
+                  onDragLeave={[Function]}
+                  onDragOver={[Function]}
+                  onDrop={[Function]}
                   style={
                     Object {
-                      "flex": 1,
+                      "height": "-16px",
                     }
                   }
-                >
-                  <div
-                    className="react-grid-layout DashboardGrid__StyledGridLayout-vxs00g-0 ANzdO"
-                    onDragEnter={[Function]}
-                    onDragLeave={[Function]}
-                    onDragOver={[Function]}
-                    onDrop={[Function]}
-                    style={
-                      Object {
-                        "height": "-16px",
-                      }
-                    }
-                  />
-                </div>
+                />
               </div>
             </div>
           </div>
         </div>
+      </div>
+      <div
+        className="iot--dashboard-editor--sidebar"
+      >
         <div
-          className="iot--dashboard-editor--sidebar"
+          className="iot--card-editor"
+          data-testid="card-editor"
         >
           <div
-            className="iot--card-editor"
-            data-testid="card-editor"
+            className="iot--card-editor--header"
+          >
+            <h2
+              className="iot--card-editor--header--title"
+            >
+              Gallery
+            </h2>
+          </div>
+          <div
+            className="iot--card-editor--content"
           >
             <div
-              className="iot--card-editor--header"
-            >
-              <h2
-                className="iot--card-editor--header--title"
-              >
-                Gallery
-              </h2>
-            </div>
-            <div
-              className="iot--card-editor--content"
+              className="iot--list iot--list__full-height"
             >
               <div
-                className="iot--list iot--list__full-height"
+                className="iot--list-header-container"
               >
                 <div
-                  className="iot--list-header-container"
+                  className="iot--list-header--search"
                 >
                   <div
-                    className="iot--list-header--search"
+                    aria-labelledby="iot--list-header--search-search"
+                    className="bx--search bx--search--sm"
+                    role="search"
                   >
-                    <div
-                      aria-labelledby="iot--list-header--search-search"
-                      className="bx--search bx--search--sm"
-                      role="search"
+                    <svg
+                      aria-hidden={true}
+                      className="bx--search-magnifier"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                      />
+                    </svg>
+                    <label
+                      className="bx--label"
+                      htmlFor="iot--list-header--search"
+                      id="iot--list-header--search-search"
+                    >
+                      Enter a value
+                    </label>
+                    <input
+                      autoComplete="off"
+                      className="bx--search-input"
+                      id="iot--list-header--search"
+                      onChange={[Function]}
+                      placeholder="Enter a value"
+                      role="searchbox"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
                     >
                       <svg
                         aria-hidden={true}
-                        className="bx--search-magnifier"
                         fill="currentColor"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 16 16"
+                        viewBox="0 0 32 32"
                         width={16}
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
                         />
                       </svg>
-                      <label
-                        className="bx--label"
-                        htmlFor="iot--list-header--search"
-                        id="iot--list-header--search-search"
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--list--content__full-height iot--list--content"
+              >
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
+                  <div
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <div
+                      className="iot--list-item--content"
+                    >
+                      <div
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
-                        Enter a value
-                      </label>
-                      <input
-                        autoComplete="off"
-                        className="bx--search-input"
-                        id="iot--list-header--search"
-                        onChange={[Function]}
-                        placeholder="Enter a value"
-                        role="searchbox"
-                        type="text"
-                        value=""
-                      />
-                      <button
-                        aria-label="Clear search input"
-                        className="bx--search-close bx--search-close--hidden"
-                        onClick={[Function]}
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="currentColor"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          className="iot--card-gallery-list__icon"
                         >
-                          <path
-                            d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                          />
-                        </svg>
-                      </button>
+                          <svg
+                            height={34}
+                            width={40}
+                          >
+                            <g
+                              fill="none"
+                              fillRule="nonzero"
+                              transform="translate(0 1)"
+                            >
+                              <path
+                                d="M20.556 1.233L32.28 7.368l.033.013 7.299 1.68v-.453l-7.193-1.675L20.376.63 7.546 30.883.519 28.516l-.002.483 7.23 2.436z"
+                                fill="#0062FF"
+                              />
+                              <circle
+                                cx={7.382}
+                                cy={31.154}
+                                fill="#FFF"
+                                r={1}
+                                stroke="#0062FF"
+                                strokeWidth={1.5}
+                              />
+                              <circle
+                                cx={20.455}
+                                cy={0.966}
+                                fill="#FFF"
+                                r={1}
+                                stroke="#0062FF"
+                                strokeWidth={1.5}
+                              />
+                              <circle
+                                cx={32.904}
+                                cy={7.365}
+                                fill="#FFF"
+                                r={1}
+                                stroke="#0062FF"
+                                strokeWidth={1.5}
+                              />
+                              <path
+                                d="M.13 13.592h.776v-.155H.13zM1.424 13.592H2.2v-.155h-.777zM2.718 13.592h.777v-.155h-.777zM4.013 13.592h.777v-.155h-.777zM5.307 13.592h.777v-.155h-.777zM6.602 13.592h.777v-.155h-.777zM7.896 13.592h.777v-.155h-.777zM9.19 13.592h.778v-.155H9.19zM10.485 13.592h.777v-.155h-.777zM11.78 13.592h.777v-.155h-.777zM13.074 13.592h.777v-.155h-.777zM14.369 13.592h.777v-.155h-.777zM15.663 13.592h.777v-.155h-.777zM16.958 13.592h.777v-.155h-.777zM18.252 13.592h.777v-.155h-.777zM19.547 13.592h.777v-.155h-.777zM20.841 13.592h.777v-.155h-.777zM22.136 13.592h.777v-.155h-.777zM23.43 13.592h.777v-.155h-.777zM24.725 13.592h.777v-.155h-.777zM26.02 13.592h.776v-.155h-.777zM27.314 13.592h.777v-.155h-.777zM28.608 13.592h.777v-.155h-.777zM29.903 13.592h.777v-.155h-.777zM31.197 13.592h.777v-.155h-.777zM32.492 13.592h.777v-.155h-.777zM33.786 13.592h.777v-.155h-.777zM35.08 13.592h.778v-.155h-.777zM36.375 13.592h.777v-.155h-.777zM37.67 13.592h.777v-.155h-.777zM38.964 13.592h.389v-.155h-.389z"
+                                fill="#0062FF"
+                              />
+                            </g>
+                          </svg>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
+                        <div
+                          className="iot--list-item--content--values--main"
+                        >
+                          <div
+                            className="iot--list-item--content--values--value"
+                            title="Time series line"
+                          >
+                            Time series line
+                          </div>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  className="iot--list--content__full-height iot--list--content"
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
                 >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={34}
-                              width={40}
-                            >
-                              <g
-                                fill="none"
-                                fillRule="nonzero"
-                                transform="translate(0 1)"
-                              >
-                                <path
-                                  d="M20.556 1.233L32.28 7.368l.033.013 7.299 1.68v-.453l-7.193-1.675L20.376.63 7.546 30.883.519 28.516l-.002.483 7.23 2.436z"
-                                  fill="#0062FF"
-                                />
-                                <circle
-                                  cx={7.382}
-                                  cy={31.154}
-                                  fill="#FFF"
-                                  r={1}
-                                  stroke="#0062FF"
-                                  strokeWidth={1.5}
-                                />
-                                <circle
-                                  cx={20.455}
-                                  cy={0.966}
-                                  fill="#FFF"
-                                  r={1}
-                                  stroke="#0062FF"
-                                  strokeWidth={1.5}
-                                />
-                                <circle
-                                  cx={32.904}
-                                  cy={7.365}
-                                  fill="#FFF"
-                                  r={1}
-                                  stroke="#0062FF"
-                                  strokeWidth={1.5}
-                                />
-                                <path
-                                  d="M.13 13.592h.776v-.155H.13zM1.424 13.592H2.2v-.155h-.777zM2.718 13.592h.777v-.155h-.777zM4.013 13.592h.777v-.155h-.777zM5.307 13.592h.777v-.155h-.777zM6.602 13.592h.777v-.155h-.777zM7.896 13.592h.777v-.155h-.777zM9.19 13.592h.778v-.155H9.19zM10.485 13.592h.777v-.155h-.777zM11.78 13.592h.777v-.155h-.777zM13.074 13.592h.777v-.155h-.777zM14.369 13.592h.777v-.155h-.777zM15.663 13.592h.777v-.155h-.777zM16.958 13.592h.777v-.155h-.777zM18.252 13.592h.777v-.155h-.777zM19.547 13.592h.777v-.155h-.777zM20.841 13.592h.777v-.155h-.777zM22.136 13.592h.777v-.155h-.777zM23.43 13.592h.777v-.155h-.777zM24.725 13.592h.777v-.155h-.777zM26.02 13.592h.776v-.155h-.777zM27.314 13.592h.777v-.155h-.777zM28.608 13.592h.777v-.155h-.777zM29.903 13.592h.777v-.155h-.777zM31.197 13.592h.777v-.155h-.777zM32.492 13.592h.777v-.155h-.777zM33.786 13.592h.777v-.155h-.777zM35.08 13.592h.778v-.155h-.777zM36.375 13.592h.777v-.155h-.777zM37.67 13.592h.777v-.155h-.777zM38.964 13.592h.389v-.155h-.389z"
-                                  fill="#0062FF"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                            <path
+                              d="M0 0h1.111v32H0zm31.111 2.963h1.111V32h-1.111zM7.778 19.259h1.111V32H7.778zm7.778-7.407h1.111V32h-1.111zM38.889 26.37H40V32h-1.111zM23.333 14.222h1.111V32h-1.111z"
+                              fill="#0062FF"
+                            />
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Simple bar"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Time series line"
-                            >
-                              Time series line
-                            </div>
+                            Simple bar
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
                             >
                               <path
-                                d="M0 0h1.111v32H0zm31.111 2.963h1.111V32h-1.111zM7.778 19.259h1.111V32H7.778zm7.778-7.407h1.111V32h-1.111zM38.889 26.37H40V32h-1.111zM23.333 14.222h1.111V32h-1.111z"
+                                d="M38.926 7.822H40V32h-1.074z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M37.584 17.422h1.074V32h-1.074z"
                                 fill="#0062FF"
                               />
-                            </svg>
-                          </div>
+                              <path
+                                d="M31.41 3.2h1.073V32H31.41z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M30.067 9.956h1.074V32h-1.074z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M23.893 14.578h1.073V32h-1.073z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M22.55 21.333h1.074V32H22.55z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M16.644 12.089h1.074V32h-1.074z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M15.302 25.6h1.074V32h-1.074z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M8.86 20.267h1.073V32H8.859z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M7.517 23.111h1.074V32H7.517z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M1.342 0h1.074v32H1.342z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M0 14.222h1.074V32H0z"
+                                fill="#0062FF"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Grouped bar"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Simple bar"
-                            >
-                              Simple bar
-                            </div>
+                            Grouped bar
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
                             >
-                              <g
-                                fill="none"
-                              >
-                                <path
-                                  d="M38.926 7.822H40V32h-1.074z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M37.584 17.422h1.074V32h-1.074z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M31.41 3.2h1.073V32H31.41z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M30.067 9.956h1.074V32h-1.074z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M23.893 14.578h1.073V32h-1.073z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M22.55 21.333h1.074V32H22.55z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M16.644 12.089h1.074V32h-1.074z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M15.302 25.6h1.074V32h-1.074z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M8.86 20.267h1.073V32H8.859z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M7.517 23.111h1.074V32H7.517z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M1.342 0h1.074v32H1.342z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M0 14.222h1.074V32H0z"
-                                  fill="#0062FF"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M38.108 7.467H40v24.178h-1.892z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M38.108 17.067H40v14.578h-1.892z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M38.108 16.711H40v1h-1.892z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M30.27 2.844h1.892v28.8H30.27z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M30.27 9.956h1.892V32H30.27z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M30.27 9.6h1.892v1H30.27z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M22.703 14.578h1.892V32h-1.892z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M22.703 21.333h1.892V32h-1.892z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M22.703 20.978h1.892v1h-1.892z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M15.405 12.089h1.892V32h-1.892z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M15.405 25.6h1.892V32h-1.892z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M15.405 25.244h1.892v1h-1.892z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M7.838 20.267H9.73V32H7.838z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M7.838 23.111H9.73V32H7.838z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M7.838 22.756H9.73v1H7.838z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M0 0h1.892v32H0z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M0 14.222h1.892V32H0z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M0 13.867h1.892v1H0z"
+                                fill="#FFF"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Stacked bar"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Grouped bar"
-                            >
-                              Grouped bar
-                            </div>
+                            Stacked bar
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
+                              <path
+                                d="M.5.5h38.752v31H.5z"
+                                stroke="#2160F8"
+                              />
+                              <path
+                                d="M4.969 21.714h21.863v4.571H4.969zm26.832 0l1.988 4.572h-3.975z"
+                                fill="#8EC1FF"
+                              />
+                              <text
+                                fill="#2160F8"
+                                fontFamily="IBMPlexSans, IBM Plex Sans"
+                                fontSize={10}
                               >
-                                <path
-                                  d="M38.108 7.467H40v24.178h-1.892z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M38.108 17.067H40v14.578h-1.892z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M38.108 16.711H40v1h-1.892z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M30.27 2.844h1.892v28.8H30.27z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M30.27 9.956h1.892V32H30.27z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M30.27 9.6h1.892v1H30.27z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M22.703 14.578h1.892V32h-1.892z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M22.703 21.333h1.892V32h-1.892z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M22.703 20.978h1.892v1h-1.892z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M15.405 12.089h1.892V32h-1.892z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M15.405 25.6h1.892V32h-1.892z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M15.405 25.244h1.892v1h-1.892z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M7.838 20.267H9.73V32H7.838z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M7.838 23.111H9.73V32H7.838z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M7.838 22.756H9.73v1H7.838z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M0 0h1.892v32H0z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M0 14.222h1.892V32H0z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M0 13.867h1.892v1H0z"
-                                  fill="#FFF"
-                                />
-                              </g>
-                            </svg>
-                          </div>
-                        </div>
-                        <div
-                          className="iot--list-item--content--values"
-                        >
-                          <div
-                            className="iot--list-item--content--values--main"
-                          >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Stacked bar"
-                            >
-                              Stacked bar
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
-                  >
-                    <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
-                    >
-                      <div
-                        className="iot--list-item--content"
-                      >
-                        <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
-                        >
-                          <div
-                            className="iot--card-gallery-list__icon"
-                          >
-                            <svg
-                              height={32}
-                              width={40}
-                            >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M.5.5h38.752v31H.5z"
-                                  stroke="#2160F8"
-                                />
-                                <path
-                                  d="M4.969 21.714h21.863v4.571H4.969zm26.832 0l1.988 4.572h-3.975z"
-                                  fill="#8EC1FF"
-                                />
-                                <text
-                                  fill="#2160F8"
-                                  fontFamily="IBMPlexSans, IBM Plex Sans"
-                                  fontSize={10}
+                                <tspan
+                                  x={4.969}
+                                  y={15.5}
                                 >
-                                  <tspan
-                                    x={4.969}
-                                    y={15.5}
-                                  >
-                                    25%
-                                  </tspan>
-                                </text>
-                              </g>
-                            </svg>
-                          </div>
+                                  25%
+                                </tspan>
+                              </text>
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Value / KPI"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Value / KPI"
-                            >
-                              Value / KPI
-                            </div>
+                            Value / KPI
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M1.29 21.57L13 10.477l11.2 12.347L30.5 16l8.21 9.6"
-                                  stroke="#0062FF"
-                                />
-                                <ellipse
-                                  cx={25.835}
-                                  cy={7.62}
-                                  rx={3.19}
-                                  ry={3.5}
-                                  stroke="#005BFF"
-                                />
-                                <path
-                                  d="M.5.5h39v31H.5z"
-                                  stroke="#2160F8"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M1.29 21.57L13 10.477l11.2 12.347L30.5 16l8.21 9.6"
+                                stroke="#0062FF"
+                              />
+                              <ellipse
+                                cx={25.835}
+                                cy={7.62}
+                                rx={3.19}
+                                ry={3.5}
+                                stroke="#005BFF"
+                              />
+                              <path
+                                d="M.5.5h39v31H.5z"
+                                stroke="#2160F8"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Image"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Image"
-                            >
-                              Image
-                            </div>
+                            Image
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M0 0h40v2.759H0z"
-                                  fill="#0058FF"
-                                />
-                                <path
-                                  d="M.5 3.259h39V31.5H.5z"
-                                  stroke="#005BFF"
-                                />
-                                <path
-                                  d="M3.5 6.621h19V9.38h-19zm21.5 0h11V9.38H25zM3.5 18.759h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 12.69h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 24.828h19v2.759h-19zm21.5 0h11v2.759H25z"
-                                  fill="#D8D8D8"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M0 0h40v2.759H0z"
+                                fill="#0058FF"
+                              />
+                              <path
+                                d="M.5 3.259h39V31.5H.5z"
+                                stroke="#005BFF"
+                              />
+                              <path
+                                d="M3.5 6.621h19V9.38h-19zm21.5 0h11V9.38H25zM3.5 18.759h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 12.69h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 24.828h19v2.759h-19zm21.5 0h11v2.759H25z"
+                                fill="#D8D8D8"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Data table"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Data table"
-                            >
-                              Data table
-                            </div>
+                            Data table
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M.5.5h39v31H.5z"
-                                  stroke="#2160F8"
-                                />
-                                <path
-                                  d="M25 5h11v3H25zm0 6h11v3H25zm0 12h11v3H25zm0-6h11v3H25z"
-                                  fill="#D8D8D8"
-                                />
-                                <path
-                                  d="M18.415 19.585l-2.915-2.92V14.5a.5.5 0 00-.145-.355l-5-5a.5.5 0 00-.71 0l-4.5 4.5a.5.5 0 000 .71l5 5a.5.5 0 00.355.145h2.17l2.915 2.92a2.001 2.001 0 002.83-2.83v-.005zM7 13.205l1.145 1.15.71-.71-1.15-1.145.795-.795 2.145 2.15.71-.71L9.205 11l.795-.795 3.295 3.295L9.5 17.295 6.205 14 7 13.205zm10.705 8.5a1 1 0 01-1.41 0l-3.065-3.06a.9.9 0 00-.355-.145h-2.17l-.5-.5L14 14.205l.5.5v2.17a.5.5 0 00.145.35l3.06 3.07a1 1 0 010 1.41z"
-                                  fill="#0F62FE"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M.5.5h39v31H.5z"
+                                stroke="#2160F8"
+                              />
+                              <path
+                                d="M25 5h11v3H25zm0 6h11v3H25zm0 12h11v3H25zm0-6h11v3H25z"
+                                fill="#D8D8D8"
+                              />
+                              <path
+                                d="M18.415 19.585l-2.915-2.92V14.5a.5.5 0 00-.145-.355l-5-5a.5.5 0 00-.71 0l-4.5 4.5a.5.5 0 000 .71l5 5a.5.5 0 00.355.145h2.17l2.915 2.92a2.001 2.001 0 002.83-2.83v-.005zM7 13.205l1.145 1.15.71-.71-1.15-1.145.795-.795 2.145 2.15.71-.71L9.205 11l.795-.795 3.295 3.295L9.5 17.295 6.205 14 7 13.205zm10.705 8.5a1 1 0 01-1.41 0l-3.065-3.06a.9.9 0 00-.355-.145h-2.17l-.5-.5L14 14.205l.5.5v2.17a.5.5 0 00.145.35l3.06 3.07a1 1 0 010 1.41z"
+                                fill="#0F62FE"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Custom"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Custom"
-                            >
-                              Custom
-                            </div>
+                            Custom
                           </div>
                         </div>
                       </div>
@@ -4844,488 +4828,630 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
     }
   >
     <div
-      style={
-        Object {
-          "height": "calc(100vh - 6rem)",
-        }
-      }
+      className="iot--dashboard-editor"
     >
       <div
-        className="iot--dashboard-editor"
+        className="iot--dashboard-editor--content"
       >
         <div
-          className="iot--dashboard-editor--content"
+          className="page-title-bar"
         >
           <div
-            className="page-title-bar"
+            className="page-title-bar-header"
           >
             <div
-              className="page-title-bar-header"
+              className="page-title-bar-header-left"
             >
               <div
-                className="page-title-bar-header-left"
+                className="page-title-bar-breadcrumb"
+              >
+                <nav
+                  aria-label="Breadcrumb"
+                >
+                  <ol
+                    className="bx--breadcrumb"
+                  >
+                    <li
+                      className="bx--breadcrumb-item"
+                    >
+                      <a
+                        className="bx--link bx--link"
+                        href="www.ibm.com"
+                      >
+                        Dashboard library
+                      </a>
+                    </li>
+                    <li
+                      className="bx--breadcrumb-item"
+                    >
+                      <a
+                        className="bx--link bx--link"
+                        href="www.ibm.com"
+                      >
+                        Favorites
+                      </a>
+                    </li>
+                  </ol>
+                </nav>
+              </div>
+              <div
+                className="page-title-bar-title"
               >
                 <div
-                  className="page-title-bar-breadcrumb"
+                  className="page-title-bar-title--text"
                 >
-                  <nav
-                    aria-label="Breadcrumb"
+                  <h2>
+                    My dashboard
+                  </h2>
+                  <button
+                    className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
                   >
-                    <ol
-                      className="bx--breadcrumb"
+                    <span
+                      className="bx--assistive-text"
                     >
-                      <li
-                        className="bx--breadcrumb-item"
-                      >
-                        <a
-                          className="bx--link bx--link"
-                          href="www.ibm.com"
-                        >
-                          Dashboard library
-                        </a>
-                      </li>
-                      <li
-                        className="bx--breadcrumb-item"
-                      >
-                        <a
-                          className="bx--link bx--link"
-                          href="www.ibm.com"
-                        >
-                          Favorites
-                        </a>
-                      </li>
-                    </ol>
-                  </nav>
+                      headerEditTitleButton
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="headerEditTitleButton"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                      />
+                    </svg>
+                  </button>
                 </div>
+              </div>
+            </div>
+            <div
+              className="page-title-bar-header-right"
+            >
+              <div
+                className="iot--dashboard-editor-header--right"
+              >
                 <div
-                  className="page-title-bar-title"
+                  className="iot--dashboard-editor-header--top"
+                />
+                <div
+                  className="iot--dashboard-editor-header--bottom"
                 >
                   <div
-                    className="page-title-bar-title--text"
+                    className="bx--content-switcher iot--dashboard-editor-header--bottom__switcher"
+                    onChange={[Function]}
+                    role="tablist"
                   >
-                    <h2>
-                      My dashboard
-                    </h2>
                     <button
-                      className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                      className="iot--icon-switch iot--icon-switch--default bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
                       disabled={false}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
                       tabIndex={0}
                       type="button"
                     >
                       <span
                         className="bx--assistive-text"
                       >
-                        headerEditTitleButton
+                        headerFitToScreenButton
                       </span>
                       <svg
                         aria-hidden="true"
-                        aria-label="headerEditTitleButton"
+                        aria-label="headerFitToScreenButton"
                         className="bx--btn__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M6 15L6 14 2.7 14 7 9.7 6.3 9 2 13.3 2 10 1 10 1 15zM10 1L10 2 13.3 2 9 6.3 9.7 7 14 2.7 14 6 15 6 15 1z"
+                        />
+                      </svg>
+                    </button>
+                    <button
+                      className="iot--icon-switch iot--icon-switch--default iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                      disabled={false}
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="bx--assistive-text"
+                      >
+                        headerLargeButton
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="headerLargeButton"
+                        className="bx--btn__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M28,4H4A2,2,0,0,0,2,6V22a2,2,0,0,0,2,2h8v4H8v2H24V28H20V24h8a2,2,0,0,0,2-2V6A2,2,0,0,0,28,4ZM18,28H14V24h4Zm10-6H4V6H28Z"
+                        />
+                      </svg>
+                    </button>
+                    <button
+                      className="iot--icon-switch iot--icon-switch--default iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                      disabled={false}
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="bx--assistive-text"
+                      >
+                        headerMediumButton
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="headerMediumButton"
+                        className="bx--btn__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M26,24H6a2.0023,2.0023,0,0,1-2-2V8A2.002,2.002,0,0,1,6,6H26a2.0023,2.0023,0,0,1,2,2V22A2.0027,2.0027,0,0,1,26,24ZM6,8V22H26V8Z"
+                          transform="translate(0 .005)"
+                        />
+                        <path
+                          d="M2 26.005H30V28.005H2z"
+                        />
+                      </svg>
+                    </button>
+                    <button
+                      className="iot--icon-switch iot--icon-switch--default iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                      disabled={false}
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="bx--assistive-text"
+                      >
+                        headerSmallButton
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="headerSmallButton"
+                        className="bx--btn__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M15 22H17V28H15z"
+                          transform="rotate(90 16 25)"
+                        />
+                        <path
+                          d="M25,30H7a2.0023,2.0023,0,0,1-2-2V4A2.002,2.002,0,0,1,7,2H25a2.0023,2.0023,0,0,1,2,2V28A2.0027,2.0027,0,0,1,25,30ZM7,4V28H25V4Z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                  <button
+                    aria-describedby="icon-tooltip-7"
+                    className="bx--tooltip__trigger bx--tooltip--a11y iot--dashboard-editor-header--bottom__import bx--tooltip--bottom bx--tooltip--align-center"
+                    onFocus={[Function]}
+                    onMouseEnter={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                      id="icon-tooltip-7"
+                    >
+                      headerImportButton
+                    </span>
+                    <label
+                      accepts={
+                        Array [
+                          ".json",
+                        ]
+                      }
+                      aria-disabled={false}
+                      className="bx--btn bx--btn--ghost bx--btn--field"
+                      htmlFor="id7"
+                      onKeyDown={[Function]}
+                      tabIndex={0}
+                    >
+                      <span
+                        role="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          fill="#161616"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M28 19L14.83 19 17.41 16.41 16 15 11 20 16 25 17.41 23.59 14.83 21 28 21 28 19z"
+                          />
+                          <path
+                            d="M24,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,16,2H6A2,2,0,0,0,4,4V28a2,2,0,0,0,2,2H22a2,2,0,0,0,2-2V26H22v2H6V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L21.59,10Z"
+                          />
+                        </svg>
+                      </span>
+                    </label>
+                    <input
+                      className="bx--visually-hidden"
+                      disabled={false}
+                      id="id7"
+                      multiple={false}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      tabIndex="-1"
+                      type="file"
+                    />
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      headerExportButton
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="headerExportButton"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M13 21L26.17 21 23.59 23.59 25 25 30 20 25 15 23.59 16.41 26.17 19 13 19 13 21z"
+                      />
+                      <path
+                        d="M22,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,14,2H4A2,2,0,0,0,2,4V28a2,2,0,0,0,2,2H20a2,2,0,0,0,2-2V26H20v2H4V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L19.59,10Z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      headerDeleteButton
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="headerDeleteButton"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M12 12H14V24H12zM18 12H20V24H18z"
+                      />
+                      <path
+                        d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--secondary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    headerCancelButton
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    headerSubmitButton
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--dashboard-editor--preview"
+        >
+          <div
+            className=""
+          >
+            <div
+              className="iot--dashboard-editor--preview__grid-container"
+            >
+              <div
+                className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
+                data-floating-menu-container={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onClose={[Function]}
+                onKeyDown={[Function]}
+                open={false}
+                role="presentation"
+              >
+                <span
+                  className="bx--visually-hidden"
+                  role="link"
+                  tabIndex="0"
+                >
+                  Focus sentinel
+                </span>
+                <div
+                  className="bx--modal-container"
+                  role="dialog"
+                >
+                  <div
+                    className="bx--modal-header"
+                  >
+                    <p
+                      className="bx--modal-header__label bx--type-delta"
+                    >
+                      imageGalleryModalLabelText
+                    </p>
+                    <p
+                      className="bx--modal-header__heading bx--type-beta"
+                    >
+                      imageGalleryModalTitleText
+                    </p>
+                    <button
+                      aria-label="imageGalleryModalCloseIconDescriptionText"
+                      className="bx--modal-close"
+                      onClick={[Function]}
+                      title="imageGalleryModalCloseIconDescriptionText"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="bx--modal-close__icon"
                         fill="currentColor"
                         focusable="false"
                         height={20}
                         preserveAspectRatio="xMidYMid meet"
-                        role="img"
                         viewBox="0 0 32 32"
                         width={20}
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
                         />
                       </svg>
                     </button>
                   </div>
-                </div>
-              </div>
-              <div
-                className="page-title-bar-header-right"
-              >
-                <div
-                  className="iot--dashboard-editor-header--right"
-                >
                   <div
-                    className="iot--dashboard-editor-header--top"
-                  />
-                  <div
-                    className="iot--dashboard-editor-header--bottom"
+                    className="bx--modal-content"
                   >
                     <div
-                      className="bx--content-switcher iot--dashboard-editor-header--bottom__switcher"
-                      onChange={[Function]}
-                      role="tablist"
+                      className="iot--image-gallery-modal__top-section"
                     >
-                      <button
-                        className="iot--icon-switch iot--icon-switch--default bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
-                        disabled={false}
-                        onClick={[Function]}
-                        onKeyDown={[Function]}
-                        tabIndex={0}
-                        type="button"
+                      <p
+                        alt="imageGalleryInstructionText"
+                        className="iot--image-gallery-modal__instruction-text"
                       >
-                        <span
-                          className="bx--assistive-text"
-                        >
-                          headerFitToScreenButton
-                        </span>
-                        <svg
-                          aria-hidden="true"
-                          aria-label="headerFitToScreenButton"
-                          className="bx--btn__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M6 15L6 14 2.7 14 7 9.7 6.3 9 2 13.3 2 10 1 10 1 15zM10 1L10 2 13.3 2 9 6.3 9.7 7 14 2.7 14 6 15 6 15 1z"
-                          />
-                        </svg>
-                      </button>
-                      <button
-                        className="iot--icon-switch iot--icon-switch--default iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
-                        disabled={false}
-                        onClick={[Function]}
-                        onKeyDown={[Function]}
-                        tabIndex={0}
-                        type="button"
+                        imageGalleryInstructionText
+                      </p>
+                      <div
+                        className="iot--image-gallery-modal__search-list-view-container"
                       >
-                        <span
-                          className="bx--assistive-text"
-                        >
-                          headerLargeButton
-                        </span>
-                        <svg
-                          aria-hidden="true"
-                          aria-label="headerLargeButton"
-                          className="bx--btn__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M28,4H4A2,2,0,0,0,2,6V22a2,2,0,0,0,2,2h8v4H8v2H24V28H20V24h8a2,2,0,0,0,2-2V6A2,2,0,0,0,28,4ZM18,28H14V24h4Zm10-6H4V6H28Z"
-                          />
-                        </svg>
-                      </button>
-                      <button
-                        className="iot--icon-switch iot--icon-switch--default iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
-                        disabled={false}
-                        onClick={[Function]}
-                        onKeyDown={[Function]}
-                        tabIndex={0}
-                        type="button"
-                      >
-                        <span
-                          className="bx--assistive-text"
-                        >
-                          headerMediumButton
-                        </span>
-                        <svg
-                          aria-hidden="true"
-                          aria-label="headerMediumButton"
-                          className="bx--btn__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M26,24H6a2.0023,2.0023,0,0,1-2-2V8A2.002,2.002,0,0,1,6,6H26a2.0023,2.0023,0,0,1,2,2V22A2.0027,2.0027,0,0,1,26,24ZM6,8V22H26V8Z"
-                            transform="translate(0 .005)"
-                          />
-                          <path
-                            d="M2 26.005H30V28.005H2z"
-                          />
-                        </svg>
-                      </button>
-                      <button
-                        className="iot--icon-switch iot--icon-switch--default iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
-                        disabled={false}
-                        onClick={[Function]}
-                        onKeyDown={[Function]}
-                        tabIndex={0}
-                        type="button"
-                      >
-                        <span
-                          className="bx--assistive-text"
-                        >
-                          headerSmallButton
-                        </span>
-                        <svg
-                          aria-hidden="true"
-                          aria-label="headerSmallButton"
-                          className="bx--btn__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M15 22H17V28H15z"
-                            transform="rotate(90 16 25)"
-                          />
-                          <path
-                            d="M25,30H7a2.0023,2.0023,0,0,1-2-2V4A2.002,2.002,0,0,1,7,2H25a2.0023,2.0023,0,0,1,2,2V28A2.0027,2.0027,0,0,1,25,30ZM7,4V28H25V4Z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                    <button
-                      aria-describedby="icon-tooltip-7"
-                      className="bx--tooltip__trigger bx--tooltip--a11y iot--dashboard-editor-header--bottom__import bx--tooltip--bottom bx--tooltip--align-center"
-                      onFocus={[Function]}
-                      onMouseEnter={[Function]}
-                      type="button"
-                    >
-                      <span
-                        className="bx--assistive-text"
-                        id="icon-tooltip-7"
-                      >
-                        headerImportButton
-                      </span>
-                      <label
-                        accepts={
-                          Array [
-                            ".json",
-                          ]
-                        }
-                        aria-disabled={false}
-                        className="bx--btn bx--btn--ghost bx--btn--field"
-                        htmlFor="id7"
-                        onKeyDown={[Function]}
-                        tabIndex={0}
-                      >
-                        <span
-                          role="button"
+                        <div
+                          aria-labelledby="iot--image-gallery-modal--search-search"
+                          className="bx--search bx--search--xl bx--search--light"
+                          role="search"
                         >
                           <svg
                             aria-hidden={true}
-                            fill="#161616"
+                            className="bx--search-magnifier"
+                            fill="currentColor"
                             focusable="false"
                             height={16}
                             preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
+                            viewBox="0 0 16 16"
                             width={16}
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <path
-                              d="M28 19L14.83 19 17.41 16.41 16 15 11 20 16 25 17.41 23.59 14.83 21 28 21 28 19z"
-                            />
-                            <path
-                              d="M24,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,16,2H6A2,2,0,0,0,4,4V28a2,2,0,0,0,2,2H22a2,2,0,0,0,2-2V26H22v2H6V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L21.59,10Z"
+                              d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                             />
                           </svg>
-                        </span>
-                      </label>
-                      <input
-                        className="bx--visually-hidden"
-                        disabled={false}
-                        id="id7"
-                        multiple={false}
-                        onChange={[Function]}
-                        onClick={[Function]}
-                        tabIndex="-1"
-                        type="file"
-                      />
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      <span
-                        className="bx--assistive-text"
-                      >
-                        headerExportButton
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="headerExportButton"
-                        className="bx--btn__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M13 21L26.17 21 23.59 23.59 25 25 30 20 25 15 23.59 16.41 26.17 19 13 19 13 21z"
-                        />
-                        <path
-                          d="M22,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,14,2H4A2,2,0,0,0,2,4V28a2,2,0,0,0,2,2H20a2,2,0,0,0,2-2V26H20v2H4V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L19.59,10Z"
-                        />
-                      </svg>
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      <span
-                        className="bx--assistive-text"
-                      >
-                        headerDeleteButton
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="headerDeleteButton"
-                        className="bx--btn__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M12 12H14V24H12zM18 12H20V24H18z"
-                        />
-                        <path
-                          d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                        />
-                      </svg>
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--secondary"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      headerCancelButton
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--primary"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      headerSubmitButton
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="iot--dashboard-editor--preview"
-          >
-            <div
-              className=""
-            >
-              <div
-                className="iot--dashboard-editor--preview__grid-container"
-              >
-                <div
-                  className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
-                  data-floating-menu-container={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onClose={[Function]}
-                  onKeyDown={[Function]}
-                  open={false}
-                  role="presentation"
-                >
-                  <span
-                    className="bx--visually-hidden"
-                    role="link"
-                    tabIndex="0"
-                  >
-                    Focus sentinel
-                  </span>
-                  <div
-                    className="bx--modal-container"
-                    role="dialog"
-                  >
-                    <div
-                      className="bx--modal-header"
-                    >
-                      <p
-                        className="bx--modal-header__label bx--type-delta"
-                      >
-                        imageGalleryModalLabelText
-                      </p>
-                      <p
-                        className="bx--modal-header__heading bx--type-beta"
-                      >
-                        imageGalleryModalTitleText
-                      </p>
-                      <button
-                        aria-label="imageGalleryModalCloseIconDescriptionText"
-                        className="bx--modal-close"
-                        onClick={[Function]}
-                        title="imageGalleryModalCloseIconDescriptionText"
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="bx--modal-close__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                          <label
+                            className="bx--label"
+                            htmlFor="iot--image-gallery-modal--search"
+                            id="iot--image-gallery-modal--search-search"
+                          >
+                            
+                          </label>
+                          <input
+                            autoComplete="off"
+                            className="bx--search-input"
+                            id="iot--image-gallery-modal--search"
+                            onChange={[Function]}
+                            placeholder="imageGallerySearchPlaceHolderText"
+                            role="searchbox"
+                            type="text"
                           />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      className="bx--modal-content"
-                    >
-                      <div
-                        className="iot--image-gallery-modal__top-section"
-                      >
-                        <p
-                          alt="imageGalleryInstructionText"
-                          className="iot--image-gallery-modal__instruction-text"
-                        >
-                          imageGalleryInstructionText
-                        </p>
-                        <div
-                          className="iot--image-gallery-modal__search-list-view-container"
-                        >
-                          <div
-                            aria-labelledby="iot--image-gallery-modal--search-search"
-                            className="bx--search bx--search--xl bx--search--light"
-                            role="search"
+                          <button
+                            aria-label="Clear search input"
+                            className="bx--search-close bx--search-close--hidden"
+                            onClick={[Function]}
+                            type="button"
                           >
                             <svg
                               aria-hidden={true}
-                              className="bx--search-magnifier"
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <div
+                          className="bx--content-switcher iot--image-gallery-modal__content-switcher"
+                          onChange={[Function]}
+                          role="tablist"
+                        >
+                          <button
+                            className="iot--icon-switch iot--icon-switch--large bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                            disabled={false}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            tabIndex={0}
+                            type="button"
+                          >
+                            <span
+                              className="bx--assistive-text"
+                            >
+                              imageGalleryGridButtonText
+                            </span>
+                            <svg
+                              aria-hidden="true"
+                              aria-label="imageGalleryGridButtonText"
+                              className="bx--btn__icon"
+                              fill="currentColor"
+                              focusable="false"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M12 4H6A2 2 0 004 6v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0012 4zm0 8H6V6h6zM26 4H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0026 4zm0 8H20V6h6zM12 18H6a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0012 18zm0 8H6V20h6zM26 18H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0026 18zm0 8H20V20h6z"
+                              />
+                            </svg>
+                          </button>
+                          <button
+                            className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                            disabled={false}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            tabIndex={0}
+                            type="button"
+                          >
+                            <span
+                              className="bx--assistive-text"
+                            >
+                              imageGalleryListButtonText
+                            </span>
+                            <svg
+                              aria-hidden="true"
+                              aria-label="imageGalleryListButtonText"
+                              className="bx--btn__icon"
+                              fill="currentColor"
+                              focusable="false"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M10 6H28V8H10zM10 24H28V26H10zM10 15H28V17H10zM4 15H6V17H4zM4 6H6V8H4zM4 24H6V26H4z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="iot--image-gallery-modal__flex-wrapper"
+                    >
+                      <div
+                        className="iot--image-gallery-modal__scroll-panel iot--image-gallery-modal__scroll-panel--grid"
+                      >
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="assemblyline"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="assemblyline"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
+                          >
+                            <svg
+                              aria-hidden={true}
                               fill="currentColor"
                               focusable="false"
                               height={16}
@@ -5335,1726 +5461,1576 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
-                                d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
                               />
                             </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="iot--image-gallery-modal--search"
-                              id="iot--image-gallery-modal--search-search"
-                            >
-                              
-                            </label>
-                            <input
-                              autoComplete="off"
-                              className="bx--search-input"
-                              id="iot--image-gallery-modal--search"
-                              onChange={[Function]}
-                              placeholder="imageGallerySearchPlaceHolderText"
-                              role="searchbox"
-                              type="text"
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 32 32"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                                />
-                              </svg>
-                            </button>
-                          </div>
-                          <div
-                            className="bx--content-switcher iot--image-gallery-modal__content-switcher"
-                            onChange={[Function]}
-                            role="tablist"
+                          </span>
+                          <span
+                            className="bx--tile-content"
                           >
-                            <button
-                              className="iot--icon-switch iot--icon-switch--large bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
-                              disabled={false}
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              tabIndex={0}
-                              type="button"
+                            <div
+                              className="iot--image-tile__title"
                             >
-                              <span
-                                className="bx--assistive-text"
-                              >
-                                imageGalleryGridButtonText
-                              </span>
-                              <svg
-                                aria-hidden="true"
-                                aria-label="imageGalleryGridButtonText"
-                                className="bx--btn__icon"
-                                fill="currentColor"
-                                focusable="false"
-                                height={20}
-                                preserveAspectRatio="xMidYMid meet"
-                                role="img"
-                                viewBox="0 0 32 32"
-                                width={20}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M12 4H6A2 2 0 004 6v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0012 4zm0 8H6V6h6zM26 4H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0026 4zm0 8H20V6h6zM12 18H6a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0012 18zm0 8H6V20h6zM26 18H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0026 18zm0 8H20V20h6z"
-                                />
-                              </svg>
-                            </button>
-                            <button
-                              className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
-                              disabled={false}
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              tabIndex={0}
-                              type="button"
-                            >
-                              <span
-                                className="bx--assistive-text"
-                              >
-                                imageGalleryListButtonText
-                              </span>
-                              <svg
-                                aria-hidden="true"
-                                aria-label="imageGalleryListButtonText"
-                                className="bx--btn__icon"
-                                fill="currentColor"
-                                focusable="false"
-                                height={20}
-                                preserveAspectRatio="xMidYMid meet"
-                                role="img"
-                                viewBox="0 0 32 32"
-                                width={20}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M10 6H28V8H10zM10 24H28V26H10zM10 15H28V17H10zM4 15H6V17H4zM4 6H6V8H4zM4 24H6V26H4z"
-                                />
-                              </svg>
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        className="iot--image-gallery-modal__flex-wrapper"
-                      >
-                        <div
-                          className="iot--image-gallery-modal__scroll-panel iot--image-gallery-modal__scroll-panel--grid"
-                        >
-                          <input
-                            checked={false}
-                            className="bx--tile-input"
-                            id="assemblyline"
-                            onChange={[Function]}
-                            tabIndex={-1}
-                            title="title"
-                            type="checkbox"
-                            value="value"
-                          />
-                          <label
-                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                            htmlFor="assemblyline"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            selected={false}
-                            tabIndex={0}
-                          >
-                            <span
-                              className="bx--tile__checkmark"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                />
-                                <path
-                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                  data-icon-path="inner-path"
-                                  opacity="0"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              className="bx--tile-content"
-                            >
-                              <div
-                                className="iot--image-tile__title"
-                              >
-                                <span>
-                                  custom title assemblyline that is very long a and must be managed. 
+                              <span>
+                                custom title assemblyline that is very long a and must be managed. 
       Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do 
       eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim 
       ad minim veniam.
-                                </span>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
+                            >
+                              <img
+                                alt="assemblyline"
+                                src="assemblyline.jpg"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
                               >
-                                <img
-                                  alt="assemblyline"
-                                  src="assemblyline.jpg"
-                                />
-                                <button
-                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
+                                <span
+                                  className="bx--assistive-text"
                                 >
-                                  <span
-                                    className="bx--assistive-text"
-                                  >
-                                    Delete
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-label="Delete"
-                                    className="bx--btn__icon"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M12 12H14V24H12zM18 12H20V24H18z"
-                                    />
-                                    <path
-                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </span>
-                          </label>
-                          <input
-                            checked={false}
-                            className="bx--tile-input"
-                            id="floow_plan"
-                            onChange={[Function]}
-                            tabIndex={-1}
-                            title="title"
-                            type="checkbox"
-                            value="value"
-                          />
-                          <label
-                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                            htmlFor="floow_plan"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            selected={false}
-                            tabIndex={0}
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="floow_plan"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="floow_plan"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
                           >
-                            <span
-                              className="bx--tile__checkmark"
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                />
-                                <path
-                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                  data-icon-path="inner-path"
-                                  opacity="0"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              className="bx--tile-content"
-                            >
-                              <div
-                                className="iot--image-tile__title"
-                              >
-                                <span>
-                                  floow_plan
-                                </span>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="floow plan"
-                                  src="floow_plan.png"
-                                />
-                                <button
-                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
-                                >
-                                  <span
-                                    className="bx--assistive-text"
-                                  >
-                                    Delete
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-label="Delete"
-                                    className="bx--btn__icon"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M12 12H14V24H12zM18 12H20V24H18z"
-                                    />
-                                    <path
-                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </span>
-                          </label>
-                          <input
-                            checked={false}
-                            className="bx--tile-input"
-                            id="manufacturing_plant"
-                            onChange={[Function]}
-                            tabIndex={-1}
-                            title="title"
-                            type="checkbox"
-                            value="value"
-                          />
-                          <label
-                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                            htmlFor="manufacturing_plant"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            selected={false}
-                            tabIndex={0}
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
                           >
-                            <span
-                              className="bx--tile__checkmark"
+                            <div
+                              className="iot--image-tile__title"
                             >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                />
-                                <path
-                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                  data-icon-path="inner-path"
-                                  opacity="0"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              className="bx--tile-content"
+                              <span>
+                                floow_plan
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
                             >
-                              <div
-                                className="iot--image-tile__title"
+                              <img
+                                alt="floow plan"
+                                src="floow_plan.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
                               >
-                                <span>
-                                  Manufacturing_plant
-                                </span>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="manufacturing plant"
-                                  src="Manufacturing_plant.png"
-                                />
-                                <button
-                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
+                                <span
+                                  className="bx--assistive-text"
                                 >
-                                  <span
-                                    className="bx--assistive-text"
-                                  >
-                                    Delete
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-label="Delete"
-                                    className="bx--btn__icon"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M12 12H14V24H12zM18 12H20V24H18z"
-                                    />
-                                    <path
-                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </span>
-                          </label>
-                          <input
-                            checked={false}
-                            className="bx--tile-input"
-                            id="robot_arm"
-                            onChange={[Function]}
-                            tabIndex={-1}
-                            title="title"
-                            type="checkbox"
-                            value="value"
-                          />
-                          <label
-                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                            htmlFor="robot_arm"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            selected={false}
-                            tabIndex={0}
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="manufacturing_plant"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="manufacturing_plant"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
                           >
-                            <span
-                              className="bx--tile__checkmark"
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                />
-                                <path
-                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                  data-icon-path="inner-path"
-                                  opacity="0"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              className="bx--tile-content"
-                            >
-                              <div
-                                className="iot--image-tile__title"
-                              >
-                                <span>
-                                  robot_arm
-                                </span>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="robot arm"
-                                  src="robot_arm.png"
-                                />
-                                <button
-                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
-                                >
-                                  <span
-                                    className="bx--assistive-text"
-                                  >
-                                    Delete
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-label="Delete"
-                                    className="bx--btn__icon"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M12 12H14V24H12zM18 12H20V24H18z"
-                                    />
-                                    <path
-                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </span>
-                          </label>
-                          <input
-                            checked={false}
-                            className="bx--tile-input"
-                            id="tankmodal"
-                            onChange={[Function]}
-                            tabIndex={-1}
-                            title="title"
-                            type="checkbox"
-                            value="value"
-                          />
-                          <label
-                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                            htmlFor="tankmodal"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            selected={false}
-                            tabIndex={0}
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
                           >
-                            <span
-                              className="bx--tile__checkmark"
+                            <div
+                              className="iot--image-tile__title"
                             >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                />
-                                <path
-                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                  data-icon-path="inner-path"
-                                  opacity="0"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              className="bx--tile-content"
+                              <span>
+                                Manufacturing_plant
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
                             >
-                              <div
-                                className="iot--image-tile__title"
+                              <img
+                                alt="manufacturing plant"
+                                src="Manufacturing_plant.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
                               >
-                                <span>
-                                  tankmodal
-                                </span>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="tankmodal"
-                                  src="tankmodal.png"
-                                />
-                                <button
-                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
+                                <span
+                                  className="bx--assistive-text"
                                 >
-                                  <span
-                                    className="bx--assistive-text"
-                                  >
-                                    Delete
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-label="Delete"
-                                    className="bx--btn__icon"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M12 12H14V24H12zM18 12H20V24H18z"
-                                    />
-                                    <path
-                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </span>
-                          </label>
-                          <input
-                            checked={false}
-                            className="bx--tile-input"
-                            id="turbines"
-                            onChange={[Function]}
-                            tabIndex={-1}
-                            title="title"
-                            type="checkbox"
-                            value="value"
-                          />
-                          <label
-                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                            htmlFor="turbines"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            selected={false}
-                            tabIndex={0}
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="robot_arm"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="robot_arm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
                           >
-                            <span
-                              className="bx--tile__checkmark"
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                />
-                                <path
-                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                  data-icon-path="inner-path"
-                                  opacity="0"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              className="bx--tile-content"
-                            >
-                              <div
-                                className="iot--image-tile__title"
-                              >
-                                <span>
-                                  turbines
-                                </span>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="turbines"
-                                  src="turbines.png"
-                                />
-                                <button
-                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
-                                >
-                                  <span
-                                    className="bx--assistive-text"
-                                  >
-                                    Delete
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-label="Delete"
-                                    className="bx--btn__icon"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M12 12H14V24H12zM18 12H20V24H18z"
-                                    />
-                                    <path
-                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </span>
-                          </label>
-                          <input
-                            checked={false}
-                            className="bx--tile-input"
-                            id="extra-wide-image"
-                            onChange={[Function]}
-                            tabIndex={-1}
-                            title="title"
-                            type="checkbox"
-                            value="value"
-                          />
-                          <label
-                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                            htmlFor="extra-wide-image"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            selected={false}
-                            tabIndex={0}
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
                           >
-                            <span
-                              className="bx--tile__checkmark"
+                            <div
+                              className="iot--image-tile__title"
                             >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                />
-                                <path
-                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                  data-icon-path="inner-path"
-                                  opacity="0"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              className="bx--tile-content"
+                              <span>
+                                robot_arm
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
                             >
-                              <div
-                                className="iot--image-tile__title"
+                              <img
+                                alt="robot arm"
+                                src="robot_arm.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
                               >
-                                <span>
-                                  extra-wide-image
-                                </span>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="extra wide image"
-                                  src="extra-wide-image.png"
-                                />
-                                <button
-                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
+                                <span
+                                  className="bx--assistive-text"
                                 >
-                                  <span
-                                    className="bx--assistive-text"
-                                  >
-                                    Delete
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-label="Delete"
-                                    className="bx--btn__icon"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M12 12H14V24H12zM18 12H20V24H18z"
-                                    />
-                                    <path
-                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </span>
-                          </label>
-                          <input
-                            checked={false}
-                            className="bx--tile-input"
-                            id="large"
-                            onChange={[Function]}
-                            tabIndex={-1}
-                            title="title"
-                            type="checkbox"
-                            value="value"
-                          />
-                          <label
-                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                            htmlFor="large"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            selected={false}
-                            tabIndex={0}
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="tankmodal"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="tankmodal"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
                           >
-                            <span
-                              className="bx--tile__checkmark"
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                />
-                                <path
-                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                  data-icon-path="inner-path"
-                                  opacity="0"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              className="bx--tile-content"
-                            >
-                              <div
-                                className="iot--image-tile__title"
-                              >
-                                <span>
-                                  large
-                                </span>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="large image"
-                                  src="large.png"
-                                />
-                                <button
-                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
-                                >
-                                  <span
-                                    className="bx--assistive-text"
-                                  >
-                                    Delete
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-label="Delete"
-                                    className="bx--btn__icon"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M12 12H14V24H12zM18 12H20V24H18z"
-                                    />
-                                    <path
-                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </span>
-                          </label>
-                          <input
-                            checked={false}
-                            className="bx--tile-input"
-                            id="large_portrait"
-                            onChange={[Function]}
-                            tabIndex={-1}
-                            title="title"
-                            type="checkbox"
-                            value="value"
-                          />
-                          <label
-                            className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                            htmlFor="large_portrait"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            selected={false}
-                            tabIndex={0}
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
                           >
-                            <span
-                              className="bx--tile__checkmark"
+                            <div
+                              className="iot--image-tile__title"
                             >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                />
-                                <path
-                                  d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                                  data-icon-path="inner-path"
-                                  opacity="0"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              className="bx--tile-content"
+                              <span>
+                                tankmodal
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
                             >
-                              <div
-                                className="iot--image-tile__title"
+                              <img
+                                alt="tankmodal"
+                                src="tankmodal.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
                               >
-                                <span>
-                                  large_portrait
-                                </span>
-                              </div>
-                              <div
-                                className="iot--image-tile__image-container"
-                              >
-                                <img
-                                  alt="large image portrait"
-                                  src="large_portrait.png"
-                                />
-                                <button
-                                  className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
+                                <span
+                                  className="bx--assistive-text"
                                 >
-                                  <span
-                                    className="bx--assistive-text"
-                                  >
-                                    Delete
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-label="Delete"
-                                    className="bx--btn__icon"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M12 12H14V24H12zM18 12H20V24H18z"
-                                    />
-                                    <path
-                                      d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="turbines"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="turbines"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
+                          >
+                            <div
+                              className="iot--image-tile__title"
+                            >
+                              <span>
+                                turbines
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
+                            >
+                              <img
+                                alt="turbines"
+                                src="turbines.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--assistive-text"
+                                >
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="extra-wide-image"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="extra-wide-image"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
+                          >
+                            <div
+                              className="iot--image-tile__title"
+                            >
+                              <span>
+                                extra-wide-image
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
+                            >
+                              <img
+                                alt="extra wide image"
+                                src="extra-wide-image.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--assistive-text"
+                                >
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="large"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="large"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
+                          >
+                            <div
+                              className="iot--image-tile__title"
+                            >
+                              <span>
+                                large
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
+                            >
+                              <img
+                                alt="large image"
+                                src="large.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--assistive-text"
+                                >
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="large_portrait"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="large_portrait"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
+                          >
+                            <div
+                              className="iot--image-tile__title"
+                            >
+                              <span>
+                                large_portrait
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
+                            >
+                              <img
+                                alt="large image portrait"
+                                src="large_portrait.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--assistive-text"
+                                >
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
                       </div>
                     </div>
-                    <div
-                      className="bx--modal-footer iot--composed-modal-footer"
-                    >
-                      <button
-                        className="iot--btn bx--btn bx--btn--secondary"
-                        disabled={false}
-                        onClick={[Function]}
-                        tabIndex={0}
-                        type="button"
-                      >
-                        imageGalleryModalSecondaryButtonLabelText
-                      </button>
-                      <button
-                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                        disabled={true}
-                        onClick={[Function]}
-                        tabIndex={0}
-                        type="button"
-                      >
-                        imageGalleryModalPrimaryButtonLabelText
-                      </button>
-                    </div>
                   </div>
-                  <span
-                    className="bx--visually-hidden"
-                    role="link"
-                    tabIndex="0"
+                  <div
+                    className="bx--modal-footer iot--composed-modal-footer"
                   >
-                    Focus sentinel
-                  </span>
+                    <button
+                      className="iot--btn bx--btn bx--btn--secondary"
+                      disabled={false}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      imageGalleryModalSecondaryButtonLabelText
+                    </button>
+                    <button
+                      className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                      disabled={true}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      imageGalleryModalPrimaryButtonLabelText
+                    </button>
+                  </div>
                 </div>
+                <span
+                  className="bx--visually-hidden"
+                  role="link"
+                  tabIndex="0"
+                >
+                  Focus sentinel
+                </span>
+              </div>
+              <div
+                style={
+                  Object {
+                    "flex": 1,
+                  }
+                }
+              >
                 <div
+                  className="react-grid-layout DashboardGrid__StyledGridLayout-vxs00g-0 ANzdO"
+                  onDragEnter={[Function]}
+                  onDragLeave={[Function]}
+                  onDragOver={[Function]}
+                  onDrop={[Function]}
                   style={
                     Object {
-                      "flex": 1,
+                      "height": "-16px",
                     }
                   }
-                >
-                  <div
-                    className="react-grid-layout DashboardGrid__StyledGridLayout-vxs00g-0 ANzdO"
-                    onDragEnter={[Function]}
-                    onDragLeave={[Function]}
-                    onDragOver={[Function]}
-                    onDrop={[Function]}
-                    style={
-                      Object {
-                        "height": "-16px",
-                      }
-                    }
-                  />
-                </div>
+                />
               </div>
             </div>
           </div>
         </div>
+      </div>
+      <div
+        className="iot--dashboard-editor--sidebar"
+      >
         <div
-          className="iot--dashboard-editor--sidebar"
+          className="iot--card-editor"
+          data-testid="card-editor"
         >
           <div
-            className="iot--card-editor"
-            data-testid="card-editor"
+            className="iot--card-editor--header"
+          >
+            <h2
+              className="iot--card-editor--header--title"
+            >
+              galleryHeader
+            </h2>
+          </div>
+          <div
+            className="iot--card-editor--content"
           >
             <div
-              className="iot--card-editor--header"
-            >
-              <h2
-                className="iot--card-editor--header--title"
-              >
-                galleryHeader
-              </h2>
-            </div>
-            <div
-              className="iot--card-editor--content"
+              className="iot--list iot--list__full-height"
             >
               <div
-                className="iot--list iot--list__full-height"
+                className="iot--list-header-container"
               >
                 <div
-                  className="iot--list-header-container"
+                  className="iot--list-header--search"
                 >
                   <div
-                    className="iot--list-header--search"
+                    aria-labelledby="iot--list-header--search-search"
+                    className="bx--search bx--search--sm"
+                    role="search"
                   >
-                    <div
-                      aria-labelledby="iot--list-header--search-search"
-                      className="bx--search bx--search--sm"
-                      role="search"
+                    <svg
+                      aria-hidden={true}
+                      className="bx--search-magnifier"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                      />
+                    </svg>
+                    <label
+                      className="bx--label"
+                      htmlFor="iot--list-header--search"
+                      id="iot--list-header--search-search"
+                    >
+                      Enter a value
+                    </label>
+                    <input
+                      autoComplete="off"
+                      className="bx--search-input"
+                      id="iot--list-header--search"
+                      onChange={[Function]}
+                      placeholder="Enter a value"
+                      role="searchbox"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
                     >
                       <svg
                         aria-hidden={true}
-                        className="bx--search-magnifier"
                         fill="currentColor"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 16 16"
+                        viewBox="0 0 32 32"
                         width={16}
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
                         />
                       </svg>
-                      <label
-                        className="bx--label"
-                        htmlFor="iot--list-header--search"
-                        id="iot--list-header--search-search"
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--list--content__full-height iot--list--content"
+              >
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
+                  <div
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <div
+                      className="iot--list-item--content"
+                    >
+                      <div
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
-                        Enter a value
-                      </label>
-                      <input
-                        autoComplete="off"
-                        className="bx--search-input"
-                        id="iot--list-header--search"
-                        onChange={[Function]}
-                        placeholder="Enter a value"
-                        role="searchbox"
-                        type="text"
-                        value=""
-                      />
-                      <button
-                        aria-label="Clear search input"
-                        className="bx--search-close bx--search-close--hidden"
-                        onClick={[Function]}
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="currentColor"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          className="iot--card-gallery-list__icon"
                         >
-                          <path
-                            d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                          />
-                        </svg>
-                      </button>
+                          <svg
+                            height={34}
+                            width={40}
+                          >
+                            <g
+                              fill="none"
+                              fillRule="nonzero"
+                              transform="translate(0 1)"
+                            >
+                              <path
+                                d="M20.556 1.233L32.28 7.368l.033.013 7.299 1.68v-.453l-7.193-1.675L20.376.63 7.546 30.883.519 28.516l-.002.483 7.23 2.436z"
+                                fill="#0062FF"
+                              />
+                              <circle
+                                cx={7.382}
+                                cy={31.154}
+                                fill="#FFF"
+                                r={1}
+                                stroke="#0062FF"
+                                strokeWidth={1.5}
+                              />
+                              <circle
+                                cx={20.455}
+                                cy={0.966}
+                                fill="#FFF"
+                                r={1}
+                                stroke="#0062FF"
+                                strokeWidth={1.5}
+                              />
+                              <circle
+                                cx={32.904}
+                                cy={7.365}
+                                fill="#FFF"
+                                r={1}
+                                stroke="#0062FF"
+                                strokeWidth={1.5}
+                              />
+                              <path
+                                d="M.13 13.592h.776v-.155H.13zM1.424 13.592H2.2v-.155h-.777zM2.718 13.592h.777v-.155h-.777zM4.013 13.592h.777v-.155h-.777zM5.307 13.592h.777v-.155h-.777zM6.602 13.592h.777v-.155h-.777zM7.896 13.592h.777v-.155h-.777zM9.19 13.592h.778v-.155H9.19zM10.485 13.592h.777v-.155h-.777zM11.78 13.592h.777v-.155h-.777zM13.074 13.592h.777v-.155h-.777zM14.369 13.592h.777v-.155h-.777zM15.663 13.592h.777v-.155h-.777zM16.958 13.592h.777v-.155h-.777zM18.252 13.592h.777v-.155h-.777zM19.547 13.592h.777v-.155h-.777zM20.841 13.592h.777v-.155h-.777zM22.136 13.592h.777v-.155h-.777zM23.43 13.592h.777v-.155h-.777zM24.725 13.592h.777v-.155h-.777zM26.02 13.592h.776v-.155h-.777zM27.314 13.592h.777v-.155h-.777zM28.608 13.592h.777v-.155h-.777zM29.903 13.592h.777v-.155h-.777zM31.197 13.592h.777v-.155h-.777zM32.492 13.592h.777v-.155h-.777zM33.786 13.592h.777v-.155h-.777zM35.08 13.592h.778v-.155h-.777zM36.375 13.592h.777v-.155h-.777zM37.67 13.592h.777v-.155h-.777zM38.964 13.592h.389v-.155h-.389z"
+                                fill="#0062FF"
+                              />
+                            </g>
+                          </svg>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
+                        <div
+                          className="iot--list-item--content--values--main"
+                        >
+                          <div
+                            className="iot--list-item--content--values--value"
+                            title="TIMESERIES"
+                          >
+                            TIMESERIES
+                          </div>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  className="iot--list--content__full-height iot--list--content"
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
                 >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={34}
-                              width={40}
-                            >
-                              <g
-                                fill="none"
-                                fillRule="nonzero"
-                                transform="translate(0 1)"
-                              >
-                                <path
-                                  d="M20.556 1.233L32.28 7.368l.033.013 7.299 1.68v-.453l-7.193-1.675L20.376.63 7.546 30.883.519 28.516l-.002.483 7.23 2.436z"
-                                  fill="#0062FF"
-                                />
-                                <circle
-                                  cx={7.382}
-                                  cy={31.154}
-                                  fill="#FFF"
-                                  r={1}
-                                  stroke="#0062FF"
-                                  strokeWidth={1.5}
-                                />
-                                <circle
-                                  cx={20.455}
-                                  cy={0.966}
-                                  fill="#FFF"
-                                  r={1}
-                                  stroke="#0062FF"
-                                  strokeWidth={1.5}
-                                />
-                                <circle
-                                  cx={32.904}
-                                  cy={7.365}
-                                  fill="#FFF"
-                                  r={1}
-                                  stroke="#0062FF"
-                                  strokeWidth={1.5}
-                                />
-                                <path
-                                  d="M.13 13.592h.776v-.155H.13zM1.424 13.592H2.2v-.155h-.777zM2.718 13.592h.777v-.155h-.777zM4.013 13.592h.777v-.155h-.777zM5.307 13.592h.777v-.155h-.777zM6.602 13.592h.777v-.155h-.777zM7.896 13.592h.777v-.155h-.777zM9.19 13.592h.778v-.155H9.19zM10.485 13.592h.777v-.155h-.777zM11.78 13.592h.777v-.155h-.777zM13.074 13.592h.777v-.155h-.777zM14.369 13.592h.777v-.155h-.777zM15.663 13.592h.777v-.155h-.777zM16.958 13.592h.777v-.155h-.777zM18.252 13.592h.777v-.155h-.777zM19.547 13.592h.777v-.155h-.777zM20.841 13.592h.777v-.155h-.777zM22.136 13.592h.777v-.155h-.777zM23.43 13.592h.777v-.155h-.777zM24.725 13.592h.777v-.155h-.777zM26.02 13.592h.776v-.155h-.777zM27.314 13.592h.777v-.155h-.777zM28.608 13.592h.777v-.155h-.777zM29.903 13.592h.777v-.155h-.777zM31.197 13.592h.777v-.155h-.777zM32.492 13.592h.777v-.155h-.777zM33.786 13.592h.777v-.155h-.777zM35.08 13.592h.778v-.155h-.777zM36.375 13.592h.777v-.155h-.777zM37.67 13.592h.777v-.155h-.777zM38.964 13.592h.389v-.155h-.389z"
-                                  fill="#0062FF"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                            <path
+                              d="M0 0h1.111v32H0zm31.111 2.963h1.111V32h-1.111zM7.778 19.259h1.111V32H7.778zm7.778-7.407h1.111V32h-1.111zM38.889 26.37H40V32h-1.111zM23.333 14.222h1.111V32h-1.111z"
+                              fill="#0062FF"
+                            />
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="SIMPLE_BAR"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="TIMESERIES"
-                            >
-                              TIMESERIES
-                            </div>
+                            SIMPLE_BAR
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
                             >
                               <path
-                                d="M0 0h1.111v32H0zm31.111 2.963h1.111V32h-1.111zM7.778 19.259h1.111V32H7.778zm7.778-7.407h1.111V32h-1.111zM38.889 26.37H40V32h-1.111zM23.333 14.222h1.111V32h-1.111z"
+                                d="M38.926 7.822H40V32h-1.074z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M37.584 17.422h1.074V32h-1.074z"
                                 fill="#0062FF"
                               />
-                            </svg>
-                          </div>
+                              <path
+                                d="M31.41 3.2h1.073V32H31.41z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M30.067 9.956h1.074V32h-1.074z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M23.893 14.578h1.073V32h-1.073z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M22.55 21.333h1.074V32H22.55z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M16.644 12.089h1.074V32h-1.074z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M15.302 25.6h1.074V32h-1.074z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M8.86 20.267h1.073V32H8.859z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M7.517 23.111h1.074V32H7.517z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M1.342 0h1.074v32H1.342z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M0 14.222h1.074V32H0z"
+                                fill="#0062FF"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="GROUPED_BAR"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="SIMPLE_BAR"
-                            >
-                              SIMPLE_BAR
-                            </div>
+                            GROUPED_BAR
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
                             >
-                              <g
-                                fill="none"
-                              >
-                                <path
-                                  d="M38.926 7.822H40V32h-1.074z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M37.584 17.422h1.074V32h-1.074z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M31.41 3.2h1.073V32H31.41z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M30.067 9.956h1.074V32h-1.074z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M23.893 14.578h1.073V32h-1.073z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M22.55 21.333h1.074V32H22.55z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M16.644 12.089h1.074V32h-1.074z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M15.302 25.6h1.074V32h-1.074z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M8.86 20.267h1.073V32H8.859z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M7.517 23.111h1.074V32H7.517z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M1.342 0h1.074v32H1.342z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M0 14.222h1.074V32H0z"
-                                  fill="#0062FF"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M38.108 7.467H40v24.178h-1.892z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M38.108 17.067H40v14.578h-1.892z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M38.108 16.711H40v1h-1.892z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M30.27 2.844h1.892v28.8H30.27z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M30.27 9.956h1.892V32H30.27z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M30.27 9.6h1.892v1H30.27z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M22.703 14.578h1.892V32h-1.892z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M22.703 21.333h1.892V32h-1.892z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M22.703 20.978h1.892v1h-1.892z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M15.405 12.089h1.892V32h-1.892z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M15.405 25.6h1.892V32h-1.892z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M15.405 25.244h1.892v1h-1.892z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M7.838 20.267H9.73V32H7.838z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M7.838 23.111H9.73V32H7.838z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M7.838 22.756H9.73v1H7.838z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M0 0h1.892v32H0z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M0 14.222h1.892V32H0z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M0 13.867h1.892v1H0z"
+                                fill="#FFF"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="STACKED_BAR"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="GROUPED_BAR"
-                            >
-                              GROUPED_BAR
-                            </div>
+                            STACKED_BAR
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
+                              <path
+                                d="M.5.5h38.752v31H.5z"
+                                stroke="#2160F8"
+                              />
+                              <path
+                                d="M4.969 21.714h21.863v4.571H4.969zm26.832 0l1.988 4.572h-3.975z"
+                                fill="#8EC1FF"
+                              />
+                              <text
+                                fill="#2160F8"
+                                fontFamily="IBMPlexSans, IBM Plex Sans"
+                                fontSize={10}
                               >
-                                <path
-                                  d="M38.108 7.467H40v24.178h-1.892z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M38.108 17.067H40v14.578h-1.892z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M38.108 16.711H40v1h-1.892z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M30.27 2.844h1.892v28.8H30.27z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M30.27 9.956h1.892V32H30.27z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M30.27 9.6h1.892v1H30.27z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M22.703 14.578h1.892V32h-1.892z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M22.703 21.333h1.892V32h-1.892z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M22.703 20.978h1.892v1h-1.892z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M15.405 12.089h1.892V32h-1.892z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M15.405 25.6h1.892V32h-1.892z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M15.405 25.244h1.892v1h-1.892z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M7.838 20.267H9.73V32H7.838z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M7.838 23.111H9.73V32H7.838z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M7.838 22.756H9.73v1H7.838z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M0 0h1.892v32H0z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M0 14.222h1.892V32H0z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M0 13.867h1.892v1H0z"
-                                  fill="#FFF"
-                                />
-                              </g>
-                            </svg>
-                          </div>
-                        </div>
-                        <div
-                          className="iot--list-item--content--values"
-                        >
-                          <div
-                            className="iot--list-item--content--values--main"
-                          >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="STACKED_BAR"
-                            >
-                              STACKED_BAR
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
-                  >
-                    <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
-                    >
-                      <div
-                        className="iot--list-item--content"
-                      >
-                        <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
-                        >
-                          <div
-                            className="iot--card-gallery-list__icon"
-                          >
-                            <svg
-                              height={32}
-                              width={40}
-                            >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M.5.5h38.752v31H.5z"
-                                  stroke="#2160F8"
-                                />
-                                <path
-                                  d="M4.969 21.714h21.863v4.571H4.969zm26.832 0l1.988 4.572h-3.975z"
-                                  fill="#8EC1FF"
-                                />
-                                <text
-                                  fill="#2160F8"
-                                  fontFamily="IBMPlexSans, IBM Plex Sans"
-                                  fontSize={10}
+                                <tspan
+                                  x={4.969}
+                                  y={15.5}
                                 >
-                                  <tspan
-                                    x={4.969}
-                                    y={15.5}
-                                  >
-                                    25%
-                                  </tspan>
-                                </text>
-                              </g>
-                            </svg>
-                          </div>
+                                  25%
+                                </tspan>
+                              </text>
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="VALUE"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="VALUE"
-                            >
-                              VALUE
-                            </div>
+                            VALUE
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M1.29 21.57L13 10.477l11.2 12.347L30.5 16l8.21 9.6"
-                                  stroke="#0062FF"
-                                />
-                                <ellipse
-                                  cx={25.835}
-                                  cy={7.62}
-                                  rx={3.19}
-                                  ry={3.5}
-                                  stroke="#005BFF"
-                                />
-                                <path
-                                  d="M.5.5h39v31H.5z"
-                                  stroke="#2160F8"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M1.29 21.57L13 10.477l11.2 12.347L30.5 16l8.21 9.6"
+                                stroke="#0062FF"
+                              />
+                              <ellipse
+                                cx={25.835}
+                                cy={7.62}
+                                rx={3.19}
+                                ry={3.5}
+                                stroke="#005BFF"
+                              />
+                              <path
+                                d="M.5.5h39v31H.5z"
+                                stroke="#2160F8"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="IMAGE"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="IMAGE"
-                            >
-                              IMAGE
-                            </div>
+                            IMAGE
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M0 0h40v2.759H0z"
-                                  fill="#0058FF"
-                                />
-                                <path
-                                  d="M.5 3.259h39V31.5H.5z"
-                                  stroke="#005BFF"
-                                />
-                                <path
-                                  d="M3.5 6.621h19V9.38h-19zm21.5 0h11V9.38H25zM3.5 18.759h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 12.69h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 24.828h19v2.759h-19zm21.5 0h11v2.759H25z"
-                                  fill="#D8D8D8"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M0 0h40v2.759H0z"
+                                fill="#0058FF"
+                              />
+                              <path
+                                d="M.5 3.259h39V31.5H.5z"
+                                stroke="#005BFF"
+                              />
+                              <path
+                                d="M3.5 6.621h19V9.38h-19zm21.5 0h11V9.38H25zM3.5 18.759h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 12.69h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 24.828h19v2.759h-19zm21.5 0h11v2.759H25z"
+                                fill="#D8D8D8"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="TABLE"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="TABLE"
-                            >
-                              TABLE
-                            </div>
+                            TABLE
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M.5.5h39v31H.5z"
-                                  stroke="#2160F8"
-                                />
-                                <path
-                                  d="M25 5h11v3H25zm0 6h11v3H25zm0 12h11v3H25zm0-6h11v3H25z"
-                                  fill="#D8D8D8"
-                                />
-                                <path
-                                  d="M18.415 19.585l-2.915-2.92V14.5a.5.5 0 00-.145-.355l-5-5a.5.5 0 00-.71 0l-4.5 4.5a.5.5 0 000 .71l5 5a.5.5 0 00.355.145h2.17l2.915 2.92a2.001 2.001 0 002.83-2.83v-.005zM7 13.205l1.145 1.15.71-.71-1.15-1.145.795-.795 2.145 2.15.71-.71L9.205 11l.795-.795 3.295 3.295L9.5 17.295 6.205 14 7 13.205zm10.705 8.5a1 1 0 01-1.41 0l-3.065-3.06a.9.9 0 00-.355-.145h-2.17l-.5-.5L14 14.205l.5.5v2.17a.5.5 0 00.145.35l3.06 3.07a1 1 0 010 1.41z"
-                                  fill="#0F62FE"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M.5.5h39v31H.5z"
+                                stroke="#2160F8"
+                              />
+                              <path
+                                d="M25 5h11v3H25zm0 6h11v3H25zm0 12h11v3H25zm0-6h11v3H25z"
+                                fill="#D8D8D8"
+                              />
+                              <path
+                                d="M18.415 19.585l-2.915-2.92V14.5a.5.5 0 00-.145-.355l-5-5a.5.5 0 00-.71 0l-4.5 4.5a.5.5 0 000 .71l5 5a.5.5 0 00.355.145h2.17l2.915 2.92a2.001 2.001 0 002.83-2.83v-.005zM7 13.205l1.145 1.15.71-.71-1.15-1.145.795-.795 2.145 2.15.71-.71L9.205 11l.795-.795 3.295 3.295L9.5 17.295 6.205 14 7 13.205zm10.705 8.5a1 1 0 01-1.41 0l-3.065-3.06a.9.9 0 00-.355-.145h-2.17l-.5-.5L14 14.205l.5.5v2.17a.5.5 0 00.145.35l3.06 3.07a1 1 0 010 1.41z"
+                                fill="#0F62FE"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Custom"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Custom"
-                            >
-                              Custom
-                            </div>
+                            Custom
                           </div>
                         </div>
                       </div>
@@ -8518,713 +8494,137 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
     }
   >
     <div
-      style={
-        Object {
-          "height": "calc(100vh - 6rem)",
-        }
-      }
+      className="iot--dashboard-editor"
     >
       <div
-        className="iot--dashboard-editor"
+        className="iot--dashboard-editor--content"
       >
         <div
-          className="iot--dashboard-editor--content"
+          className="page-title-bar"
         >
           <div
-            className="page-title-bar"
+            className="page-title-bar-header"
           >
             <div
-              className="page-title-bar-header"
+              className="page-title-bar-header-left"
             >
               <div
-                className="page-title-bar-header-left"
+                className="page-title-bar-breadcrumb"
               >
-                <div
-                  className="page-title-bar-breadcrumb"
+                <nav
+                  aria-label="Breadcrumb"
                 >
-                  <nav
-                    aria-label="Breadcrumb"
+                  <ol
+                    className="bx--breadcrumb"
                   >
-                    <ol
-                      className="bx--breadcrumb"
+                    <li
+                      className="bx--breadcrumb-item"
                     >
-                      <li
-                        className="bx--breadcrumb-item"
+                      <a
+                        className="bx--link bx--link"
+                        href="www.ibm.com"
                       >
-                        <a
-                          className="bx--link bx--link"
-                          href="www.ibm.com"
-                        >
-                          Dashboard library
-                        </a>
-                      </li>
-                      <li
-                        className="bx--breadcrumb-item"
-                      >
-                        <a
-                          className="bx--link bx--link"
-                          href="www.ibm.com"
-                        >
-                          Favorites
-                        </a>
-                      </li>
-                    </ol>
-                  </nav>
-                </div>
-                <div
-                  className="page-title-bar-title"
-                >
-                  <div
-                    className="page-title-bar-title--text"
-                  >
-                    <h2>
-                      Custom dashboard
-                    </h2>
-                    <button
-                      className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
+                        Dashboard library
+                      </a>
+                    </li>
+                    <li
+                      className="bx--breadcrumb-item"
                     >
-                      <span
-                        className="bx--assistive-text"
+                      <a
+                        className="bx--link bx--link"
+                        href="www.ibm.com"
                       >
-                        Edit title
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Edit title"
-                        className="bx--btn__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
+                        Favorites
+                      </a>
+                    </li>
+                  </ol>
+                </nav>
               </div>
               <div
-                className="page-title-bar-header-right"
+                className="page-title-bar-title"
               >
                 <div
-                  className="iot--dashboard-editor-header--right"
+                  className="page-title-bar-title--text"
                 >
-                  <div
-                    className="iot--dashboard-editor-header--top"
-                  />
-                  <div
-                    className="iot--dashboard-editor-header--bottom"
+                  <h2>
+                    Custom dashboard
+                  </h2>
+                  <button
+                    className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
                   >
-                    <button
-                      aria-describedby="icon-tooltip-3"
-                      className="bx--tooltip__trigger bx--tooltip--a11y iot--dashboard-editor-header--bottom__import bx--tooltip--bottom bx--tooltip--align-center"
-                      onFocus={[Function]}
-                      onMouseEnter={[Function]}
-                      type="button"
+                    <span
+                      className="bx--assistive-text"
                     >
-                      <span
-                        className="bx--assistive-text"
-                        id="icon-tooltip-3"
-                      >
-                        Import
-                      </span>
-                      <label
-                        accepts={
-                          Array [
-                            ".json",
-                          ]
-                        }
-                        aria-disabled={false}
-                        className="bx--btn bx--btn--ghost bx--btn--field"
-                        htmlFor="id3"
-                        onKeyDown={[Function]}
-                        tabIndex={0}
-                      >
-                        <span
-                          role="button"
-                        >
-                          <svg
-                            aria-hidden={true}
-                            fill="#161616"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M28 19L14.83 19 17.41 16.41 16 15 11 20 16 25 17.41 23.59 14.83 21 28 21 28 19z"
-                            />
-                            <path
-                              d="M24,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,16,2H6A2,2,0,0,0,4,4V28a2,2,0,0,0,2,2H22a2,2,0,0,0,2-2V26H22v2H6V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L21.59,10Z"
-                            />
-                          </svg>
-                        </span>
-                      </label>
-                      <input
-                        className="bx--visually-hidden"
-                        disabled={false}
-                        id="id3"
-                        multiple={false}
-                        onChange={[Function]}
-                        onClick={[Function]}
-                        tabIndex="-1"
-                        type="file"
+                      Edit title
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Edit title"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
                       />
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      <span
-                        className="bx--assistive-text"
-                      >
-                        Export
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Export"
-                        className="bx--btn__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M13 21L26.17 21 23.59 23.59 25 25 30 20 25 15 23.59 16.41 26.17 19 13 19 13 21z"
-                        />
-                        <path
-                          d="M22,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,14,2H4A2,2,0,0,0,2,4V28a2,2,0,0,0,2,2H20a2,2,0,0,0,2-2V26H20v2H4V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L19.59,10Z"
-                        />
-                      </svg>
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      <span
-                        className="bx--assistive-text"
-                      >
-                        Delete
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Delete"
-                        className="bx--btn__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M12 12H14V24H12zM18 12H20V24H18z"
-                        />
-                        <path
-                          d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                        />
-                      </svg>
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--secondary"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--primary"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      Save and close
-                    </button>
-                  </div>
+                    </svg>
+                  </button>
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            className="iot--dashboard-editor--preview"
-          >
             <div
-              className=""
+              className="page-title-bar-header-right"
             >
               <div
-                className="iot--dashboard-editor--preview__grid-container"
+                className="iot--dashboard-editor-header--right"
               >
                 <div
-                  className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
-                  data-floating-menu-container={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onClose={[Function]}
-                  onKeyDown={[Function]}
-                  open={false}
-                  role="presentation"
-                >
-                  <span
-                    className="bx--visually-hidden"
-                    role="link"
-                    tabIndex="0"
-                  >
-                    Focus sentinel
-                  </span>
-                  <div
-                    className="bx--modal-container"
-                    role="dialog"
-                  >
-                    <div
-                      className="bx--modal-header"
-                    >
-                      <p
-                        className="bx--modal-header__label bx--type-delta"
-                      >
-                        New image card
-                      </p>
-                      <p
-                        className="bx--modal-header__heading bx--type-beta"
-                      >
-                        Image gallery
-                      </p>
-                      <button
-                        aria-label="Close"
-                        className="bx--modal-close"
-                        onClick={[Function]}
-                        title="Close"
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="bx--modal-close__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      className="bx--modal-content"
-                    >
-                      <div
-                        className="iot--image-gallery-modal__top-section"
-                      >
-                        <p
-                          alt="Select the image that you want to display on this card."
-                          className="iot--image-gallery-modal__instruction-text"
-                        >
-                          Select the image that you want to display on this card.
-                        </p>
-                        <div
-                          className="iot--image-gallery-modal__search-list-view-container"
-                        >
-                          <div
-                            aria-labelledby="iot--image-gallery-modal--search-search"
-                            className="bx--search bx--search--xl bx--search--light"
-                            role="search"
-                          >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              fill="currentColor"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="iot--image-gallery-modal--search"
-                              id="iot--image-gallery-modal--search-search"
-                            >
-                              
-                            </label>
-                            <input
-                              autoComplete="off"
-                              className="bx--search-input"
-                              id="iot--image-gallery-modal--search"
-                              onChange={[Function]}
-                              placeholder="Search image by file name"
-                              role="searchbox"
-                              type="text"
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 32 32"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                                />
-                              </svg>
-                            </button>
-                          </div>
-                          <div
-                            className="bx--content-switcher iot--image-gallery-modal__content-switcher"
-                            onChange={[Function]}
-                            role="tablist"
-                          >
-                            <button
-                              className="iot--icon-switch iot--icon-switch--large bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
-                              disabled={false}
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              tabIndex={0}
-                              type="button"
-                            >
-                              <span
-                                className="bx--assistive-text"
-                              >
-                                Grid
-                              </span>
-                              <svg
-                                aria-hidden="true"
-                                aria-label="Grid"
-                                className="bx--btn__icon"
-                                fill="currentColor"
-                                focusable="false"
-                                height={20}
-                                preserveAspectRatio="xMidYMid meet"
-                                role="img"
-                                viewBox="0 0 32 32"
-                                width={20}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M12 4H6A2 2 0 004 6v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0012 4zm0 8H6V6h6zM26 4H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0026 4zm0 8H20V6h6zM12 18H6a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0012 18zm0 8H6V20h6zM26 18H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0026 18zm0 8H20V20h6z"
-                                />
-                              </svg>
-                            </button>
-                            <button
-                              className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
-                              disabled={false}
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              tabIndex={0}
-                              type="button"
-                            >
-                              <span
-                                className="bx--assistive-text"
-                              >
-                                List
-                              </span>
-                              <svg
-                                aria-hidden="true"
-                                aria-label="List"
-                                className="bx--btn__icon"
-                                fill="currentColor"
-                                focusable="false"
-                                height={20}
-                                preserveAspectRatio="xMidYMid meet"
-                                role="img"
-                                viewBox="0 0 32 32"
-                                width={20}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M10 6H28V8H10zM10 24H28V26H10zM10 15H28V17H10zM4 15H6V17H4zM4 6H6V8H4zM4 24H6V26H4z"
-                                />
-                              </svg>
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        className="iot--image-gallery-modal__flex-wrapper"
-                      >
-                        <div
-                          className="iot--image-gallery-modal__scroll-panel iot--image-gallery-modal__scroll-panel--grid"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      className="bx--modal-footer iot--composed-modal-footer"
-                    >
-                      <button
-                        className="iot--btn bx--btn bx--btn--secondary"
-                        disabled={false}
-                        onClick={[Function]}
-                        tabIndex={0}
-                        type="button"
-                      >
-                        Cancel
-                      </button>
-                      <button
-                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                        disabled={true}
-                        onClick={[Function]}
-                        tabIndex={0}
-                        type="button"
-                      >
-                        Select
-                      </button>
-                    </div>
-                  </div>
-                  <span
-                    className="bx--visually-hidden"
-                    role="link"
-                    tabIndex="0"
-                  >
-                    Focus sentinel
-                  </span>
-                </div>
+                  className="iot--dashboard-editor-header--top"
+                />
                 <div
-                  style={
-                    Object {
-                      "flex": 1,
-                    }
-                  }
+                  className="iot--dashboard-editor-header--bottom"
                 >
-                  <div
-                    className="react-grid-layout DashboardGrid__StyledGridLayout-vxs00g-0 ANzdO"
-                    onDragEnter={[Function]}
-                    onDragLeave={[Function]}
-                    onDragOver={[Function]}
-                    onDrop={[Function]}
-                    style={
-                      Object {
-                        "height": "304px",
-                      }
-                    }
+                  <button
+                    aria-describedby="icon-tooltip-3"
+                    className="bx--tooltip__trigger bx--tooltip--a11y iot--dashboard-editor-header--bottom__import bx--tooltip--bottom bx--tooltip--align-center"
+                    onFocus={[Function]}
+                    onMouseEnter={[Function]}
+                    type="button"
                   >
-                    <div
-                      className="iot--card react-grid-item iot--dashboard-editor--preview__card react-draggable react-resizable-hide react-resizable iot--card--wrapper"
-                      data-testid="Card"
-                      id="Timeseries"
-                      onClick={[Function]}
+                    <span
+                      className="bx--assistive-text"
+                      id="icon-tooltip-3"
+                    >
+                      Import
+                    </span>
+                    <label
+                      accepts={
+                        Array [
+                          ".json",
+                        ]
+                      }
+                      aria-disabled={false}
+                      className="bx--btn bx--btn--ghost bx--btn--field"
+                      htmlFor="id3"
                       onKeyDown={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchEnd={[Function]}
-                      role="presentation"
-                      style={
-                        Object {
-                          "--card-default-height": "304px",
-                          "height": "304px",
-                          "left": "0%",
-                          "position": "absolute",
-                          "top": "0px",
-                          "width": "100%",
-                        }
-                      }
                       tabIndex={0}
-                      type="TIMESERIES"
                     >
-                      <div
-                        className="iot--card--header"
-                      >
-                        <span
-                          className="iot--card--title"
-                          title="Untitled"
-                        >
-                          <div
-                            className="iot--card--title--text"
-                          >
-                            Untitled
-                          </div>
-                        </span>
-                        <div
-                          className="iot--card--toolbar"
-                        >
-                          <button
-                            aria-expanded={false}
-                            aria-haspopup={true}
-                            aria-label="Menu"
-                            className="bx--overflow-menu"
-                            onClick={[Function]}
-                            onClose={[Function]}
-                            onKeyDown={[Function]}
-                            open={false}
-                            tabIndex={0}
-                            title="Open and close list of options"
-                            type="button"
-                          >
-                            <svg
-                              aria-label="open and close list of options"
-                              className="bx--overflow-menu__icon"
-                              fill="currentColor"
-                              focusable="false"
-                              height={16}
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              preserveAspectRatio="xMidYMid meet"
-                              role="img"
-                              viewBox="0 0 32 32"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <circle
-                                cx="16"
-                                cy="8"
-                                r="2"
-                              />
-                              <circle
-                                cx="16"
-                                cy="16"
-                                r="2"
-                              />
-                              <circle
-                                cx="16"
-                                cy="24"
-                                r="2"
-                              />
-                              <title>
-                                open and close list of options
-                              </title>
-                            </svg>
-                          </button>
-                        </div>
-                      </div>
-                      <div
-                        className="iot--card--content"
-                        style={
-                          Object {
-                            "--card-content-height": "256px",
-                          }
-                        }
-                      >
-                        <div
-                          className="iot--time-series-card--wrapper iot--time-series-card--wrapper__editable"
-                        >
-                          <div
-                            id="mock-line-chart"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="iot--dashboard-editor--sidebar"
-        >
-          <div
-            className="iot--card-editor"
-            data-testid="card-editor"
-          >
-            <div
-              className="iot--card-editor--header"
-            >
-              <h2
-                className="iot--card-editor--header--title"
-              >
-                Gallery
-              </h2>
-            </div>
-            <div
-              className="iot--card-editor--content"
-            >
-              <div
-                className="iot--list iot--list__full-height"
-              >
-                <div
-                  className="iot--list-header-container"
-                >
-                  <div
-                    className="iot--list-header--search"
-                  >
-                    <div
-                      aria-labelledby="iot--list-header--search-search"
-                      className="bx--search bx--search--sm"
-                      role="search"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="bx--search-magnifier"
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                        />
-                      </svg>
-                      <label
-                        className="bx--label"
-                        htmlFor="iot--list-header--search"
-                        id="iot--list-header--search-search"
-                      >
-                        Enter a value
-                      </label>
-                      <input
-                        autoComplete="off"
-                        className="bx--search-input"
-                        id="iot--list-header--search"
-                        onChange={[Function]}
-                        placeholder="Enter a value"
-                        role="searchbox"
-                        type="text"
-                        value=""
-                      />
-                      <button
-                        aria-label="Clear search input"
-                        className="bx--search-close bx--search-close--hidden"
-                        onClick={[Function]}
-                        type="button"
+                      <span
+                        role="button"
                       >
                         <svg
                           aria-hidden={true}
-                          fill="currentColor"
+                          fill="#161616"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -9233,558 +8633,1126 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <path
-                            d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                            d="M28 19L14.83 19 17.41 16.41 16 15 11 20 16 25 17.41 23.59 14.83 21 28 21 28 19z"
+                          />
+                          <path
+                            d="M24,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,16,2H6A2,2,0,0,0,4,4V28a2,2,0,0,0,2,2H22a2,2,0,0,0,2-2V26H22v2H6V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L21.59,10Z"
                           />
                         </svg>
-                      </button>
+                      </span>
+                    </label>
+                    <input
+                      className="bx--visually-hidden"
+                      disabled={false}
+                      id="id3"
+                      multiple={false}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      tabIndex="-1"
+                      type="file"
+                    />
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Export
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Export"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M13 21L26.17 21 23.59 23.59 25 25 30 20 25 15 23.59 16.41 26.17 19 13 19 13 21z"
+                      />
+                      <path
+                        d="M22,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,14,2H4A2,2,0,0,0,2,4V28a2,2,0,0,0,2,2H20a2,2,0,0,0,2-2V26H20v2H4V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L19.59,10Z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Delete
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Delete"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M12 12H14V24H12zM18 12H20V24H18z"
+                      />
+                      <path
+                        d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--secondary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Save and close
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--dashboard-editor--preview"
+        >
+          <div
+            className=""
+          >
+            <div
+              className="iot--dashboard-editor--preview__grid-container"
+            >
+              <div
+                className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
+                data-floating-menu-container={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onClose={[Function]}
+                onKeyDown={[Function]}
+                open={false}
+                role="presentation"
+              >
+                <span
+                  className="bx--visually-hidden"
+                  role="link"
+                  tabIndex="0"
+                >
+                  Focus sentinel
+                </span>
+                <div
+                  className="bx--modal-container"
+                  role="dialog"
+                >
+                  <div
+                    className="bx--modal-header"
+                  >
+                    <p
+                      className="bx--modal-header__label bx--type-delta"
+                    >
+                      New image card
+                    </p>
+                    <p
+                      className="bx--modal-header__heading bx--type-beta"
+                    >
+                      Image gallery
+                    </p>
+                    <button
+                      aria-label="Close"
+                      className="bx--modal-close"
+                      onClick={[Function]}
+                      title="Close"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="bx--modal-close__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                  <div
+                    className="bx--modal-content"
+                  >
+                    <div
+                      className="iot--image-gallery-modal__top-section"
+                    >
+                      <p
+                        alt="Select the image that you want to display on this card."
+                        className="iot--image-gallery-modal__instruction-text"
+                      >
+                        Select the image that you want to display on this card.
+                      </p>
+                      <div
+                        className="iot--image-gallery-modal__search-list-view-container"
+                      >
+                        <div
+                          aria-labelledby="iot--image-gallery-modal--search-search"
+                          className="bx--search bx--search--xl bx--search--light"
+                          role="search"
+                        >
+                          <svg
+                            aria-hidden={true}
+                            className="bx--search-magnifier"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                            />
+                          </svg>
+                          <label
+                            className="bx--label"
+                            htmlFor="iot--image-gallery-modal--search"
+                            id="iot--image-gallery-modal--search-search"
+                          >
+                            
+                          </label>
+                          <input
+                            autoComplete="off"
+                            className="bx--search-input"
+                            id="iot--image-gallery-modal--search"
+                            onChange={[Function]}
+                            placeholder="Search image by file name"
+                            role="searchbox"
+                            type="text"
+                          />
+                          <button
+                            aria-label="Clear search input"
+                            className="bx--search-close bx--search-close--hidden"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <div
+                          className="bx--content-switcher iot--image-gallery-modal__content-switcher"
+                          onChange={[Function]}
+                          role="tablist"
+                        >
+                          <button
+                            className="iot--icon-switch iot--icon-switch--large bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                            disabled={false}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            tabIndex={0}
+                            type="button"
+                          >
+                            <span
+                              className="bx--assistive-text"
+                            >
+                              Grid
+                            </span>
+                            <svg
+                              aria-hidden="true"
+                              aria-label="Grid"
+                              className="bx--btn__icon"
+                              fill="currentColor"
+                              focusable="false"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M12 4H6A2 2 0 004 6v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0012 4zm0 8H6V6h6zM26 4H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0026 4zm0 8H20V6h6zM12 18H6a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0012 18zm0 8H6V20h6zM26 18H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0026 18zm0 8H20V20h6z"
+                              />
+                            </svg>
+                          </button>
+                          <button
+                            className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                            disabled={false}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            tabIndex={0}
+                            type="button"
+                          >
+                            <span
+                              className="bx--assistive-text"
+                            >
+                              List
+                            </span>
+                            <svg
+                              aria-hidden="true"
+                              aria-label="List"
+                              className="bx--btn__icon"
+                              fill="currentColor"
+                              focusable="false"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M10 6H28V8H10zM10 24H28V26H10zM10 15H28V17H10zM4 15H6V17H4zM4 6H6V8H4zM4 24H6V26H4z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="iot--image-gallery-modal__flex-wrapper"
+                    >
+                      <div
+                        className="iot--image-gallery-modal__scroll-panel iot--image-gallery-modal__scroll-panel--grid"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="bx--modal-footer iot--composed-modal-footer"
+                  >
+                    <button
+                      className="iot--btn bx--btn bx--btn--secondary"
+                      disabled={false}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                      disabled={true}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      Select
+                    </button>
+                  </div>
+                </div>
+                <span
+                  className="bx--visually-hidden"
+                  role="link"
+                  tabIndex="0"
+                >
+                  Focus sentinel
+                </span>
+              </div>
+              <div
+                style={
+                  Object {
+                    "flex": 1,
+                  }
+                }
+              >
+                <div
+                  className="react-grid-layout DashboardGrid__StyledGridLayout-vxs00g-0 ANzdO"
+                  onDragEnter={[Function]}
+                  onDragLeave={[Function]}
+                  onDragOver={[Function]}
+                  onDrop={[Function]}
+                  style={
+                    Object {
+                      "height": "304px",
+                    }
+                  }
+                >
+                  <div
+                    className="iot--card react-grid-item iot--dashboard-editor--preview__card react-draggable react-resizable-hide react-resizable iot--card--wrapper"
+                    data-testid="Card"
+                    id="Timeseries"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    role="presentation"
+                    style={
+                      Object {
+                        "--card-default-height": "304px",
+                        "height": "304px",
+                        "left": "0%",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": "100%",
+                      }
+                    }
+                    tabIndex={0}
+                    type="TIMESERIES"
+                  >
+                    <div
+                      className="iot--card--header"
+                    >
+                      <span
+                        className="iot--card--title"
+                        title="Untitled"
+                      >
+                        <div
+                          className="iot--card--title--text"
+                        >
+                          Untitled
+                        </div>
+                      </span>
+                      <div
+                        className="iot--card--toolbar"
+                      >
+                        <button
+                          aria-expanded={false}
+                          aria-haspopup={true}
+                          aria-label="Menu"
+                          className="bx--overflow-menu"
+                          onClick={[Function]}
+                          onClose={[Function]}
+                          onKeyDown={[Function]}
+                          open={false}
+                          tabIndex={0}
+                          title="Open and close list of options"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="open and close list of options"
+                            className="bx--overflow-menu__icon"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <circle
+                              cx="16"
+                              cy="8"
+                              r="2"
+                            />
+                            <circle
+                              cx="16"
+                              cy="16"
+                              r="2"
+                            />
+                            <circle
+                              cx="16"
+                              cy="24"
+                              r="2"
+                            />
+                            <title>
+                              open and close list of options
+                            </title>
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      className="iot--card--content"
+                      style={
+                        Object {
+                          "--card-content-height": "256px",
+                        }
+                      }
+                    >
+                      <div
+                        className="iot--time-series-card--wrapper iot--time-series-card--wrapper__editable"
+                      >
+                        <div
+                          id="mock-line-chart"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="iot--dashboard-editor--sidebar"
+      >
+        <div
+          className="iot--card-editor"
+          data-testid="card-editor"
+        >
+          <div
+            className="iot--card-editor--header"
+          >
+            <h2
+              className="iot--card-editor--header--title"
+            >
+              Gallery
+            </h2>
+          </div>
+          <div
+            className="iot--card-editor--content"
+          >
+            <div
+              className="iot--list iot--list__full-height"
+            >
+              <div
+                className="iot--list-header-container"
+              >
+                <div
+                  className="iot--list-header--search"
+                >
+                  <div
+                    aria-labelledby="iot--list-header--search-search"
+                    className="bx--search bx--search--sm"
+                    role="search"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="bx--search-magnifier"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                      />
+                    </svg>
+                    <label
+                      className="bx--label"
+                      htmlFor="iot--list-header--search"
+                      id="iot--list-header--search-search"
+                    >
+                      Enter a value
+                    </label>
+                    <input
+                      autoComplete="off"
+                      className="bx--search-input"
+                      id="iot--list-header--search"
+                      onChange={[Function]}
+                      placeholder="Enter a value"
+                      role="searchbox"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--list--content__full-height iot--list--content"
+              >
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
+                  <div
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <div
+                      className="iot--list-item--content"
+                    >
+                      <div
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                      >
+                        <div
+                          className="iot--card-gallery-list__icon"
+                        >
+                          <svg
+                            height={34}
+                            width={40}
+                          >
+                            <g
+                              fill="none"
+                              fillRule="nonzero"
+                              transform="translate(0 1)"
+                            >
+                              <path
+                                d="M20.556 1.233L32.28 7.368l.033.013 7.299 1.68v-.453l-7.193-1.675L20.376.63 7.546 30.883.519 28.516l-.002.483 7.23 2.436z"
+                                fill="#0062FF"
+                              />
+                              <circle
+                                cx={7.382}
+                                cy={31.154}
+                                fill="#FFF"
+                                r={1}
+                                stroke="#0062FF"
+                                strokeWidth={1.5}
+                              />
+                              <circle
+                                cx={20.455}
+                                cy={0.966}
+                                fill="#FFF"
+                                r={1}
+                                stroke="#0062FF"
+                                strokeWidth={1.5}
+                              />
+                              <circle
+                                cx={32.904}
+                                cy={7.365}
+                                fill="#FFF"
+                                r={1}
+                                stroke="#0062FF"
+                                strokeWidth={1.5}
+                              />
+                              <path
+                                d="M.13 13.592h.776v-.155H.13zM1.424 13.592H2.2v-.155h-.777zM2.718 13.592h.777v-.155h-.777zM4.013 13.592h.777v-.155h-.777zM5.307 13.592h.777v-.155h-.777zM6.602 13.592h.777v-.155h-.777zM7.896 13.592h.777v-.155h-.777zM9.19 13.592h.778v-.155H9.19zM10.485 13.592h.777v-.155h-.777zM11.78 13.592h.777v-.155h-.777zM13.074 13.592h.777v-.155h-.777zM14.369 13.592h.777v-.155h-.777zM15.663 13.592h.777v-.155h-.777zM16.958 13.592h.777v-.155h-.777zM18.252 13.592h.777v-.155h-.777zM19.547 13.592h.777v-.155h-.777zM20.841 13.592h.777v-.155h-.777zM22.136 13.592h.777v-.155h-.777zM23.43 13.592h.777v-.155h-.777zM24.725 13.592h.777v-.155h-.777zM26.02 13.592h.776v-.155h-.777zM27.314 13.592h.777v-.155h-.777zM28.608 13.592h.777v-.155h-.777zM29.903 13.592h.777v-.155h-.777zM31.197 13.592h.777v-.155h-.777zM32.492 13.592h.777v-.155h-.777zM33.786 13.592h.777v-.155h-.777zM35.08 13.592h.778v-.155h-.777zM36.375 13.592h.777v-.155h-.777zM37.67 13.592h.777v-.155h-.777zM38.964 13.592h.389v-.155h-.389z"
+                                fill="#0062FF"
+                              />
+                            </g>
+                          </svg>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
+                        <div
+                          className="iot--list-item--content--values--main"
+                        >
+                          <div
+                            className="iot--list-item--content--values--value"
+                            title="Time series line"
+                          >
+                            Time series line
+                          </div>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  className="iot--list--content__full-height iot--list--content"
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
                 >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={34}
-                              width={40}
-                            >
-                              <g
-                                fill="none"
-                                fillRule="nonzero"
-                                transform="translate(0 1)"
-                              >
-                                <path
-                                  d="M20.556 1.233L32.28 7.368l.033.013 7.299 1.68v-.453l-7.193-1.675L20.376.63 7.546 30.883.519 28.516l-.002.483 7.23 2.436z"
-                                  fill="#0062FF"
-                                />
-                                <circle
-                                  cx={7.382}
-                                  cy={31.154}
-                                  fill="#FFF"
-                                  r={1}
-                                  stroke="#0062FF"
-                                  strokeWidth={1.5}
-                                />
-                                <circle
-                                  cx={20.455}
-                                  cy={0.966}
-                                  fill="#FFF"
-                                  r={1}
-                                  stroke="#0062FF"
-                                  strokeWidth={1.5}
-                                />
-                                <circle
-                                  cx={32.904}
-                                  cy={7.365}
-                                  fill="#FFF"
-                                  r={1}
-                                  stroke="#0062FF"
-                                  strokeWidth={1.5}
-                                />
-                                <path
-                                  d="M.13 13.592h.776v-.155H.13zM1.424 13.592H2.2v-.155h-.777zM2.718 13.592h.777v-.155h-.777zM4.013 13.592h.777v-.155h-.777zM5.307 13.592h.777v-.155h-.777zM6.602 13.592h.777v-.155h-.777zM7.896 13.592h.777v-.155h-.777zM9.19 13.592h.778v-.155H9.19zM10.485 13.592h.777v-.155h-.777zM11.78 13.592h.777v-.155h-.777zM13.074 13.592h.777v-.155h-.777zM14.369 13.592h.777v-.155h-.777zM15.663 13.592h.777v-.155h-.777zM16.958 13.592h.777v-.155h-.777zM18.252 13.592h.777v-.155h-.777zM19.547 13.592h.777v-.155h-.777zM20.841 13.592h.777v-.155h-.777zM22.136 13.592h.777v-.155h-.777zM23.43 13.592h.777v-.155h-.777zM24.725 13.592h.777v-.155h-.777zM26.02 13.592h.776v-.155h-.777zM27.314 13.592h.777v-.155h-.777zM28.608 13.592h.777v-.155h-.777zM29.903 13.592h.777v-.155h-.777zM31.197 13.592h.777v-.155h-.777zM32.492 13.592h.777v-.155h-.777zM33.786 13.592h.777v-.155h-.777zM35.08 13.592h.778v-.155h-.777zM36.375 13.592h.777v-.155h-.777zM37.67 13.592h.777v-.155h-.777zM38.964 13.592h.389v-.155h-.389z"
-                                  fill="#0062FF"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                            <path
+                              d="M0 0h1.111v32H0zm31.111 2.963h1.111V32h-1.111zM7.778 19.259h1.111V32H7.778zm7.778-7.407h1.111V32h-1.111zM38.889 26.37H40V32h-1.111zM23.333 14.222h1.111V32h-1.111z"
+                              fill="#0062FF"
+                            />
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Simple bar"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Time series line"
-                            >
-                              Time series line
-                            </div>
+                            Simple bar
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
                             >
                               <path
-                                d="M0 0h1.111v32H0zm31.111 2.963h1.111V32h-1.111zM7.778 19.259h1.111V32H7.778zm7.778-7.407h1.111V32h-1.111zM38.889 26.37H40V32h-1.111zM23.333 14.222h1.111V32h-1.111z"
+                                d="M38.926 7.822H40V32h-1.074z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M37.584 17.422h1.074V32h-1.074z"
                                 fill="#0062FF"
                               />
-                            </svg>
-                          </div>
+                              <path
+                                d="M31.41 3.2h1.073V32H31.41z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M30.067 9.956h1.074V32h-1.074z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M23.893 14.578h1.073V32h-1.073z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M22.55 21.333h1.074V32H22.55z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M16.644 12.089h1.074V32h-1.074z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M15.302 25.6h1.074V32h-1.074z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M8.86 20.267h1.073V32H8.859z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M7.517 23.111h1.074V32H7.517z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M1.342 0h1.074v32H1.342z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M0 14.222h1.074V32H0z"
+                                fill="#0062FF"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Grouped bar"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Simple bar"
-                            >
-                              Simple bar
-                            </div>
+                            Grouped bar
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
                             >
-                              <g
-                                fill="none"
-                              >
-                                <path
-                                  d="M38.926 7.822H40V32h-1.074z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M37.584 17.422h1.074V32h-1.074z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M31.41 3.2h1.073V32H31.41z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M30.067 9.956h1.074V32h-1.074z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M23.893 14.578h1.073V32h-1.073z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M22.55 21.333h1.074V32H22.55z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M16.644 12.089h1.074V32h-1.074z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M15.302 25.6h1.074V32h-1.074z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M8.86 20.267h1.073V32H8.859z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M7.517 23.111h1.074V32H7.517z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M1.342 0h1.074v32H1.342z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M0 14.222h1.074V32H0z"
-                                  fill="#0062FF"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M38.108 7.467H40v24.178h-1.892z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M38.108 17.067H40v14.578h-1.892z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M38.108 16.711H40v1h-1.892z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M30.27 2.844h1.892v28.8H30.27z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M30.27 9.956h1.892V32H30.27z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M30.27 9.6h1.892v1H30.27z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M22.703 14.578h1.892V32h-1.892z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M22.703 21.333h1.892V32h-1.892z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M22.703 20.978h1.892v1h-1.892z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M15.405 12.089h1.892V32h-1.892z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M15.405 25.6h1.892V32h-1.892z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M15.405 25.244h1.892v1h-1.892z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M7.838 20.267H9.73V32H7.838z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M7.838 23.111H9.73V32H7.838z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M7.838 22.756H9.73v1H7.838z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M0 0h1.892v32H0z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M0 14.222h1.892V32H0z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M0 13.867h1.892v1H0z"
+                                fill="#FFF"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Stacked bar"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Grouped bar"
-                            >
-                              Grouped bar
-                            </div>
+                            Stacked bar
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
+                              <path
+                                d="M.5.5h38.752v31H.5z"
+                                stroke="#2160F8"
+                              />
+                              <path
+                                d="M4.969 21.714h21.863v4.571H4.969zm26.832 0l1.988 4.572h-3.975z"
+                                fill="#8EC1FF"
+                              />
+                              <text
+                                fill="#2160F8"
+                                fontFamily="IBMPlexSans, IBM Plex Sans"
+                                fontSize={10}
                               >
-                                <path
-                                  d="M38.108 7.467H40v24.178h-1.892z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M38.108 17.067H40v14.578h-1.892z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M38.108 16.711H40v1h-1.892z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M30.27 2.844h1.892v28.8H30.27z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M30.27 9.956h1.892V32H30.27z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M30.27 9.6h1.892v1H30.27z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M22.703 14.578h1.892V32h-1.892z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M22.703 21.333h1.892V32h-1.892z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M22.703 20.978h1.892v1h-1.892z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M15.405 12.089h1.892V32h-1.892z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M15.405 25.6h1.892V32h-1.892z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M15.405 25.244h1.892v1h-1.892z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M7.838 20.267H9.73V32H7.838z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M7.838 23.111H9.73V32H7.838z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M7.838 22.756H9.73v1H7.838z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M0 0h1.892v32H0z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M0 14.222h1.892V32H0z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M0 13.867h1.892v1H0z"
-                                  fill="#FFF"
-                                />
-                              </g>
-                            </svg>
-                          </div>
-                        </div>
-                        <div
-                          className="iot--list-item--content--values"
-                        >
-                          <div
-                            className="iot--list-item--content--values--main"
-                          >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Stacked bar"
-                            >
-                              Stacked bar
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
-                  >
-                    <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
-                    >
-                      <div
-                        className="iot--list-item--content"
-                      >
-                        <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
-                        >
-                          <div
-                            className="iot--card-gallery-list__icon"
-                          >
-                            <svg
-                              height={32}
-                              width={40}
-                            >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M.5.5h38.752v31H.5z"
-                                  stroke="#2160F8"
-                                />
-                                <path
-                                  d="M4.969 21.714h21.863v4.571H4.969zm26.832 0l1.988 4.572h-3.975z"
-                                  fill="#8EC1FF"
-                                />
-                                <text
-                                  fill="#2160F8"
-                                  fontFamily="IBMPlexSans, IBM Plex Sans"
-                                  fontSize={10}
+                                <tspan
+                                  x={4.969}
+                                  y={15.5}
                                 >
-                                  <tspan
-                                    x={4.969}
-                                    y={15.5}
-                                  >
-                                    25%
-                                  </tspan>
-                                </text>
-                              </g>
-                            </svg>
-                          </div>
+                                  25%
+                                </tspan>
+                              </text>
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Value / KPI"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Value / KPI"
-                            >
-                              Value / KPI
-                            </div>
+                            Value / KPI
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M1.29 21.57L13 10.477l11.2 12.347L30.5 16l8.21 9.6"
-                                  stroke="#0062FF"
-                                />
-                                <ellipse
-                                  cx={25.835}
-                                  cy={7.62}
-                                  rx={3.19}
-                                  ry={3.5}
-                                  stroke="#005BFF"
-                                />
-                                <path
-                                  d="M.5.5h39v31H.5z"
-                                  stroke="#2160F8"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M1.29 21.57L13 10.477l11.2 12.347L30.5 16l8.21 9.6"
+                                stroke="#0062FF"
+                              />
+                              <ellipse
+                                cx={25.835}
+                                cy={7.62}
+                                rx={3.19}
+                                ry={3.5}
+                                stroke="#005BFF"
+                              />
+                              <path
+                                d="M.5.5h39v31H.5z"
+                                stroke="#2160F8"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Image"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Image"
-                            >
-                              Image
-                            </div>
+                            Image
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M0 0h40v2.759H0z"
-                                  fill="#0058FF"
-                                />
-                                <path
-                                  d="M.5 3.259h39V31.5H.5z"
-                                  stroke="#005BFF"
-                                />
-                                <path
-                                  d="M3.5 6.621h19V9.38h-19zm21.5 0h11V9.38H25zM3.5 18.759h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 12.69h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 24.828h19v2.759h-19zm21.5 0h11v2.759H25z"
-                                  fill="#D8D8D8"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M0 0h40v2.759H0z"
+                                fill="#0058FF"
+                              />
+                              <path
+                                d="M.5 3.259h39V31.5H.5z"
+                                stroke="#005BFF"
+                              />
+                              <path
+                                d="M3.5 6.621h19V9.38h-19zm21.5 0h11V9.38H25zM3.5 18.759h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 12.69h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 24.828h19v2.759h-19zm21.5 0h11v2.759H25z"
+                                fill="#D8D8D8"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Data table"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Data table"
-                            >
-                              Data table
-                            </div>
+                            Data table
                           </div>
                         </div>
                       </div>
@@ -9837,2144 +9805,137 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
     }
   >
     <div
-      style={
-        Object {
-          "height": "calc(100vh - 6rem)",
-        }
-      }
+      className="iot--dashboard-editor"
     >
       <div
-        className="iot--dashboard-editor"
+        className="iot--dashboard-editor--content"
       >
         <div
-          className="iot--dashboard-editor--content"
+          className="page-title-bar"
         >
           <div
-            className="page-title-bar"
+            className="page-title-bar-header"
           >
             <div
-              className="page-title-bar-header"
+              className="page-title-bar-header-left"
             >
               <div
-                className="page-title-bar-header-left"
+                className="page-title-bar-breadcrumb"
               >
-                <div
-                  className="page-title-bar-breadcrumb"
+                <nav
+                  aria-label="Breadcrumb"
                 >
-                  <nav
-                    aria-label="Breadcrumb"
+                  <ol
+                    className="bx--breadcrumb"
                   >
-                    <ol
-                      className="bx--breadcrumb"
+                    <li
+                      className="bx--breadcrumb-item"
                     >
-                      <li
-                        className="bx--breadcrumb-item"
+                      <a
+                        className="bx--link bx--link"
+                        href="www.ibm.com"
                       >
-                        <a
-                          className="bx--link bx--link"
-                          href="www.ibm.com"
-                        >
-                          Dashboard library
-                        </a>
-                      </li>
-                      <li
-                        className="bx--breadcrumb-item"
-                      >
-                        <a
-                          className="bx--link bx--link"
-                          href="www.ibm.com"
-                        >
-                          Favorites
-                        </a>
-                      </li>
-                    </ol>
-                  </nav>
-                </div>
-                <div
-                  className="page-title-bar-title"
-                >
-                  <div
-                    className="page-title-bar-title--text"
-                  >
-                    <h2>
-                      Custom dashboard
-                    </h2>
-                    <button
-                      className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
+                        Dashboard library
+                      </a>
+                    </li>
+                    <li
+                      className="bx--breadcrumb-item"
                     >
-                      <span
-                        className="bx--assistive-text"
+                      <a
+                        className="bx--link bx--link"
+                        href="www.ibm.com"
                       >
-                        Edit title
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Edit title"
-                        className="bx--btn__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
+                        Favorites
+                      </a>
+                    </li>
+                  </ol>
+                </nav>
               </div>
               <div
-                className="page-title-bar-header-right"
+                className="page-title-bar-title"
               >
                 <div
-                  className="iot--dashboard-editor-header--right"
+                  className="page-title-bar-title--text"
                 >
-                  <div
-                    className="iot--dashboard-editor-header--top"
-                  />
-                  <div
-                    className="iot--dashboard-editor-header--bottom"
+                  <h2>
+                    Custom dashboard
+                  </h2>
+                  <button
+                    className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
                   >
-                    <button
-                      aria-describedby="icon-tooltip-2"
-                      className="bx--tooltip__trigger bx--tooltip--a11y iot--dashboard-editor-header--bottom__import bx--tooltip--bottom bx--tooltip--align-center"
-                      onFocus={[Function]}
-                      onMouseEnter={[Function]}
-                      type="button"
+                    <span
+                      className="bx--assistive-text"
                     >
-                      <span
-                        className="bx--assistive-text"
-                        id="icon-tooltip-2"
-                      >
-                        Import
-                      </span>
-                      <label
-                        accepts={
-                          Array [
-                            ".json",
-                          ]
-                        }
-                        aria-disabled={false}
-                        className="bx--btn bx--btn--ghost bx--btn--field"
-                        htmlFor="id2"
-                        onKeyDown={[Function]}
-                        tabIndex={0}
-                      >
-                        <span
-                          role="button"
-                        >
-                          <svg
-                            aria-hidden={true}
-                            fill="#161616"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M28 19L14.83 19 17.41 16.41 16 15 11 20 16 25 17.41 23.59 14.83 21 28 21 28 19z"
-                            />
-                            <path
-                              d="M24,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,16,2H6A2,2,0,0,0,4,4V28a2,2,0,0,0,2,2H22a2,2,0,0,0,2-2V26H22v2H6V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L21.59,10Z"
-                            />
-                          </svg>
-                        </span>
-                      </label>
-                      <input
-                        className="bx--visually-hidden"
-                        disabled={false}
-                        id="id2"
-                        multiple={false}
-                        onChange={[Function]}
-                        onClick={[Function]}
-                        tabIndex="-1"
-                        type="file"
+                      Edit title
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Edit title"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
                       />
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      <span
-                        className="bx--assistive-text"
-                      >
-                        Export
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Export"
-                        className="bx--btn__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M13 21L26.17 21 23.59 23.59 25 25 30 20 25 15 23.59 16.41 26.17 19 13 19 13 21z"
-                        />
-                        <path
-                          d="M22,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,14,2H4A2,2,0,0,0,2,4V28a2,2,0,0,0,2,2H20a2,2,0,0,0,2-2V26H20v2H4V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L19.59,10Z"
-                        />
-                      </svg>
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      <span
-                        className="bx--assistive-text"
-                      >
-                        Delete
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Delete"
-                        className="bx--btn__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M12 12H14V24H12zM18 12H20V24H18z"
-                        />
-                        <path
-                          d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                        />
-                      </svg>
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--secondary"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--primary"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      Save and close
-                    </button>
-                  </div>
+                    </svg>
+                  </button>
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            className="iot--dashboard-editor--preview"
-          >
             <div
-              className=""
+              className="page-title-bar-header-right"
             >
               <div
-                className="iot--dashboard-editor--preview__grid-container"
+                className="iot--dashboard-editor-header--right"
               >
                 <div
-                  className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
-                  data-floating-menu-container={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onClose={[Function]}
-                  onKeyDown={[Function]}
-                  open={false}
-                  role="presentation"
+                  className="iot--dashboard-editor-header--top"
+                />
+                <div
+                  className="iot--dashboard-editor-header--bottom"
                 >
-                  <span
-                    className="bx--visually-hidden"
-                    role="link"
-                    tabIndex="0"
+                  <button
+                    aria-describedby="icon-tooltip-2"
+                    className="bx--tooltip__trigger bx--tooltip--a11y iot--dashboard-editor-header--bottom__import bx--tooltip--bottom bx--tooltip--align-center"
+                    onFocus={[Function]}
+                    onMouseEnter={[Function]}
+                    type="button"
                   >
-                    Focus sentinel
-                  </span>
-                  <div
-                    className="bx--modal-container"
-                    role="dialog"
-                  >
-                    <div
-                      className="bx--modal-header"
+                    <span
+                      className="bx--assistive-text"
+                      id="icon-tooltip-2"
                     >
-                      <p
-                        className="bx--modal-header__label bx--type-delta"
-                      >
-                        New image card
-                      </p>
-                      <p
-                        className="bx--modal-header__heading bx--type-beta"
-                      >
-                        Image gallery
-                      </p>
-                      <button
-                        aria-label="Close"
-                        className="bx--modal-close"
-                        onClick={[Function]}
-                        title="Close"
-                        type="button"
+                      Import
+                    </span>
+                    <label
+                      accepts={
+                        Array [
+                          ".json",
+                        ]
+                      }
+                      aria-disabled={false}
+                      className="bx--btn bx--btn--ghost bx--btn--field"
+                      htmlFor="id2"
+                      onKeyDown={[Function]}
+                      tabIndex={0}
+                    >
+                      <span
+                        role="button"
                       >
                         <svg
                           aria-hidden={true}
-                          className="bx--modal-close__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      className="bx--modal-content"
-                    >
-                      <div
-                        className="iot--image-gallery-modal__top-section"
-                      >
-                        <p
-                          alt="Select the image that you want to display on this card."
-                          className="iot--image-gallery-modal__instruction-text"
-                        >
-                          Select the image that you want to display on this card.
-                        </p>
-                        <div
-                          className="iot--image-gallery-modal__search-list-view-container"
-                        >
-                          <div
-                            aria-labelledby="iot--image-gallery-modal--search-search"
-                            className="bx--search bx--search--xl bx--search--light"
-                            role="search"
-                          >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              fill="currentColor"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="iot--image-gallery-modal--search"
-                              id="iot--image-gallery-modal--search-search"
-                            >
-                              
-                            </label>
-                            <input
-                              autoComplete="off"
-                              className="bx--search-input"
-                              id="iot--image-gallery-modal--search"
-                              onChange={[Function]}
-                              placeholder="Search image by file name"
-                              role="searchbox"
-                              type="text"
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 32 32"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                                />
-                              </svg>
-                            </button>
-                          </div>
-                          <div
-                            className="bx--content-switcher iot--image-gallery-modal__content-switcher"
-                            onChange={[Function]}
-                            role="tablist"
-                          >
-                            <button
-                              className="iot--icon-switch iot--icon-switch--large bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
-                              disabled={false}
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              tabIndex={0}
-                              type="button"
-                            >
-                              <span
-                                className="bx--assistive-text"
-                              >
-                                Grid
-                              </span>
-                              <svg
-                                aria-hidden="true"
-                                aria-label="Grid"
-                                className="bx--btn__icon"
-                                fill="currentColor"
-                                focusable="false"
-                                height={20}
-                                preserveAspectRatio="xMidYMid meet"
-                                role="img"
-                                viewBox="0 0 32 32"
-                                width={20}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M12 4H6A2 2 0 004 6v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0012 4zm0 8H6V6h6zM26 4H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0026 4zm0 8H20V6h6zM12 18H6a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0012 18zm0 8H6V20h6zM26 18H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0026 18zm0 8H20V20h6z"
-                                />
-                              </svg>
-                            </button>
-                            <button
-                              className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
-                              disabled={false}
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              tabIndex={0}
-                              type="button"
-                            >
-                              <span
-                                className="bx--assistive-text"
-                              >
-                                List
-                              </span>
-                              <svg
-                                aria-hidden="true"
-                                aria-label="List"
-                                className="bx--btn__icon"
-                                fill="currentColor"
-                                focusable="false"
-                                height={20}
-                                preserveAspectRatio="xMidYMid meet"
-                                role="img"
-                                viewBox="0 0 32 32"
-                                width={20}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M10 6H28V8H10zM10 24H28V26H10zM10 15H28V17H10zM4 15H6V17H4zM4 6H6V8H4zM4 24H6V26H4z"
-                                />
-                              </svg>
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        className="iot--image-gallery-modal__flex-wrapper"
-                      >
-                        <div
-                          className="iot--image-gallery-modal__scroll-panel iot--image-gallery-modal__scroll-panel--grid"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      className="bx--modal-footer iot--composed-modal-footer"
-                    >
-                      <button
-                        className="iot--btn bx--btn bx--btn--secondary"
-                        disabled={false}
-                        onClick={[Function]}
-                        tabIndex={0}
-                        type="button"
-                      >
-                        Cancel
-                      </button>
-                      <button
-                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                        disabled={true}
-                        onClick={[Function]}
-                        tabIndex={0}
-                        type="button"
-                      >
-                        Select
-                      </button>
-                    </div>
-                  </div>
-                  <span
-                    className="bx--visually-hidden"
-                    role="link"
-                    tabIndex="0"
-                  >
-                    Focus sentinel
-                  </span>
-                </div>
-                <div
-                  style={
-                    Object {
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <div
-                    className="react-grid-layout DashboardGrid__StyledGridLayout-vxs00g-0 ANzdO"
-                    onDragEnter={[Function]}
-                    onDragLeave={[Function]}
-                    onDragOver={[Function]}
-                    onDrop={[Function]}
-                    style={
-                      Object {
-                        "height": "1264px",
-                      }
-                    }
-                  >
-                    <div
-                      className="iot--card react-grid-item iot--dashboard-editor--preview__card react-draggable react-resizable-hide react-resizable iot--card--wrapper"
-                      data-testid="Card"
-                      id="Table"
-                      onClick={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchEnd={[Function]}
-                      role="presentation"
-                      style={
-                        Object {
-                          "--card-default-height": "624px",
-                          "height": "624px",
-                          "left": "0%",
-                          "position": "absolute",
-                          "top": "0px",
-                          "width": "49.375%",
-                        }
-                      }
-                      tabIndex={0}
-                      type="TABLE"
-                    >
-                      <div
-                        className="iot--card--content"
-                        style={
-                          Object {
-                            "--card-content-height": "576px",
-                          }
-                        }
-                      >
-                        <div
-                          className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
-                        >
-                          <section
-                            aria-label="data table toolbar"
-                            className="bx--table-toolbar"
-                          >
-                            <div
-                              className="bx--batch-actions iot--table-batch-actions"
-                            >
-                              <div
-                                className="bx--batch-summary"
-                              >
-                                <p
-                                  className="bx--batch-summary__para"
-                                >
-                                  <span>
-                                    0 item selected
-                                  </span>
-                                </p>
-                              </div>
-                              <div
-                                className="bx--action-list"
-                              >
-                                <button
-                                  className="bx--batch-summary__cancel bx--btn bx--btn--primary"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={-1}
-                                  type="button"
-                                >
-                                  Cancel
-                                </button>
-                              </div>
-                            </div>
-                            <label
-                              className="iot--table-toolbar-secondary-title"
-                            >
-                              Table card
-                            </label>
-                            <div
-                              className="bx--toolbar-content iot--table-toolbar-content"
-                            >
-                              <div
-                                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onKeyDown={[Function]}
-                                tabIndex="0"
-                              >
-                                <div
-                                  aria-labelledby="table-for-card-Table-toolbar-search-search"
-                                  className="bx--search bx--search--sm table-toolbar-search"
-                                  role="search"
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="bx--search-magnifier"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                                    />
-                                  </svg>
-                                  <label
-                                    className="bx--label"
-                                    htmlFor="table-for-card-Table-toolbar-search"
-                                    id="table-for-card-Table-toolbar-search-search"
-                                  >
-                                    Search
-                                  </label>
-                                  <input
-                                    aria-hidden={true}
-                                    autoComplete="off"
-                                    className="bx--search-input"
-                                    disabled={true}
-                                    id="table-for-card-Table-toolbar-search"
-                                    onChange={[Function]}
-                                    placeholder="Search"
-                                    role="searchbox"
-                                    tabIndex="-1"
-                                    type="text"
-                                    value=""
-                                  />
-                                  <button
-                                    aria-label="Clear search input"
-                                    className="bx--search-close bx--search-close--hidden"
-                                    onClick={[Function]}
-                                    type="button"
-                                  >
-                                    <svg
-                                      aria-hidden={true}
-                                      fill="currentColor"
-                                      focusable="false"
-                                      height={16}
-                                      preserveAspectRatio="xMidYMid meet"
-                                      viewBox="0 0 32 32"
-                                      width={16}
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                                      />
-                                    </svg>
-                                  </button>
-                                </div>
-                              </div>
-                              <button
-                                className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost bx--btn--disabled"
-                                data-testid="download-button"
-                                disabled={true}
-                                onClick={[Function]}
-                                tabIndex={0}
-                                title="Download table content"
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  aria-label="Download table content"
-                                  className="bx--btn__icon"
-                                  fill="currentColor"
-                                  focusable="false"
-                                  height={20}
-                                  preserveAspectRatio="xMidYMid meet"
-                                  role="img"
-                                  viewBox="0 0 32 32"
-                                  width={20}
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
-                                  />
-                                  <path
-                                    d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
-                                  />
-                                </svg>
-                              </button>
-                              <button
-                                className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost bx--btn--disabled"
-                                data-testid="filter-button"
-                                disabled={true}
-                                onClick={[Function]}
-                                tabIndex={0}
-                                title="Filters"
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  aria-label="Filters"
-                                  className="bx--btn__icon"
-                                  fill="currentColor"
-                                  focusable="false"
-                                  height={20}
-                                  preserveAspectRatio="xMidYMid meet"
-                                  role="img"
-                                  viewBox="0 0 32 32"
-                                  width={20}
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M18,28H14a2,2,0,0,1-2-2V18.41L4.59,11A2,2,0,0,1,4,9.59V6A2,2,0,0,1,6,4H26a2,2,0,0,1,2,2V9.59A2,2,0,0,1,27.41,11L20,18.41V26A2,2,0,0,1,18,28ZM6,6V9.59l8,8V26h4V17.59l8-8V6Z"
-                                  />
-                                </svg>
-                              </button>
-                              <div
-                                className="iot--card--toolbar"
-                              >
-                                <button
-                                  aria-expanded={false}
-                                  aria-haspopup={true}
-                                  aria-label="Menu"
-                                  className="bx--overflow-menu"
-                                  onClick={[Function]}
-                                  onClose={[Function]}
-                                  onKeyDown={[Function]}
-                                  open={false}
-                                  tabIndex={0}
-                                  title="Open and close list of options"
-                                  type="button"
-                                >
-                                  <svg
-                                    aria-label="open and close list of options"
-                                    className="bx--overflow-menu__icon"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    onClick={[Function]}
-                                    onKeyDown={[Function]}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <circle
-                                      cx="16"
-                                      cy="8"
-                                      r="2"
-                                    />
-                                    <circle
-                                      cx="16"
-                                      cy="16"
-                                      r="2"
-                                    />
-                                    <circle
-                                      cx="16"
-                                      cy="24"
-                                      r="2"
-                                    />
-                                    <title>
-                                      open and close list of options
-                                    </title>
-                                  </svg>
-                                </button>
-                              </div>
-                            </div>
-                          </section>
-                          <div
-                            className="addons-iot-table-container"
-                          >
-                            <div
-                              className="bx--data-table-content"
-                            >
-                              <table
-                                className="bx--data-table bx--data-table--no-border"
-                                title={null}
-                              >
-                                <thead
-                                  onMouseMove={null}
-                                  onMouseUp={null}
-                                >
-                                  <tr>
-                                    <th
-                                      aria-sort="none"
-                                      className="table-header-label-start iot--table-head--table-header table-header-sortable"
-                                      scope="col"
-                                      style={
-                                        Object {
-                                          "width": undefined,
-                                        }
-                                      }
-                                      width=""
-                                    >
-                                      <button
-                                        align="start"
-                                        className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
-                                        data-column="undefined"
-                                        data-floating-menu-container={true}
-                                        id="column-undefined"
-                                        onClick={[Function]}
-                                        style={
-                                          Object {
-                                            "--table-header-width": "",
-                                          }
-                                        }
-                                        width=""
-                                      >
-                                        <span
-                                          className="bx--table-header-label"
-                                        >
-                                          <span
-                                            className=""
-                                            title="--"
-                                          >
-                                            --
-                                          </span>
-                                        </span>
-                                        <svg
-                                          aria-label="Sort rows by this header in ascending order"
-                                          className="bx--table-sort__icon"
-                                          fill="currentColor"
-                                          focusable="false"
-                                          height={20}
-                                          preserveAspectRatio="xMidYMid meet"
-                                          role="img"
-                                          viewBox="0 0 32 32"
-                                          width={20}
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
-                                          />
-                                        </svg>
-                                        <svg
-                                          aria-label="Sort rows by this header in ascending order"
-                                          className="bx--table-sort__icon-unsorted"
-                                          fill="currentColor"
-                                          focusable="false"
-                                          height={20}
-                                          preserveAspectRatio="xMidYMid meet"
-                                          role="img"
-                                          viewBox="0 0 32 32"
-                                          width={20}
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                                          />
-                                        </svg>
-                                      </button>
-                                    </th>
-                                    <th
-                                      aria-sort="none"
-                                      className="table-header-label-start iot--table-head--table-header table-header-sortable"
-                                      scope="col"
-                                      style={
-                                        Object {
-                                          "width": undefined,
-                                        }
-                                      }
-                                      width=""
-                                    >
-                                      <button
-                                        align="start"
-                                        className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
-                                        data-column="undefined2"
-                                        data-floating-menu-container={true}
-                                        id="column-undefined2"
-                                        onClick={[Function]}
-                                        style={
-                                          Object {
-                                            "--table-header-width": "",
-                                          }
-                                        }
-                                        width=""
-                                      >
-                                        <span
-                                          className="bx--table-header-label"
-                                        >
-                                          <span
-                                            className=""
-                                            title="--"
-                                          >
-                                            --
-                                          </span>
-                                        </span>
-                                        <svg
-                                          aria-label="Sort rows by this header in ascending order"
-                                          className="bx--table-sort__icon"
-                                          fill="currentColor"
-                                          focusable="false"
-                                          height={20}
-                                          preserveAspectRatio="xMidYMid meet"
-                                          role="img"
-                                          viewBox="0 0 32 32"
-                                          width={20}
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
-                                          />
-                                        </svg>
-                                        <svg
-                                          aria-label="Sort rows by this header in ascending order"
-                                          className="bx--table-sort__icon-unsorted"
-                                          fill="currentColor"
-                                          focusable="false"
-                                          height={20}
-                                          preserveAspectRatio="xMidYMid meet"
-                                          role="img"
-                                          viewBox="0 0 32 32"
-                                          width={20}
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                                          />
-                                        </svg>
-                                      </button>
-                                    </th>
-                                  </tr>
-                                </thead>
-                                <tbody
-                                  aria-live="polite"
-                                >
-                                  <tr
-                                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
-                                    onClick={[Function]}
-                                  >
-                                    <td
-                                      align="start"
-                                      className="data-table-start"
-                                      data-column="undefined"
-                                      data-offset={0}
-                                      id="cell-table-for-card-Table-sample-values-Table-0-undefined"
-                                      offset={0}
-                                      width=""
-                                    >
-                                      <span
-                                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                                      >
-                                        <span
-                                          className=""
-                                          title="--"
-                                        >
-                                          --
-                                        </span>
-                                      </span>
-                                    </td>
-                                    <td
-                                      align="start"
-                                      className="data-table-start"
-                                      data-column="undefined2"
-                                      data-offset={0}
-                                      id="cell-table-for-card-Table-sample-values-Table-0-undefined2"
-                                      offset={0}
-                                      width=""
-                                    >
-                                      <span
-                                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                                      >
-                                        <span
-                                          className=""
-                                          title="--"
-                                        >
-                                          --
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
-                                    onClick={[Function]}
-                                  >
-                                    <td
-                                      align="start"
-                                      className="data-table-start"
-                                      data-column="undefined"
-                                      data-offset={0}
-                                      id="cell-table-for-card-Table-sample-values-Table-1-undefined"
-                                      offset={0}
-                                      width=""
-                                    >
-                                      <span
-                                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                                      >
-                                        <span
-                                          className=""
-                                          title="--"
-                                        >
-                                          --
-                                        </span>
-                                      </span>
-                                    </td>
-                                    <td
-                                      align="start"
-                                      className="data-table-start"
-                                      data-column="undefined2"
-                                      data-offset={0}
-                                      id="cell-table-for-card-Table-sample-values-Table-1-undefined2"
-                                      offset={0}
-                                      width=""
-                                    >
-                                      <span
-                                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                                      >
-                                        <span
-                                          className=""
-                                          title="--"
-                                        >
-                                          --
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
-                                    onClick={[Function]}
-                                  >
-                                    <td
-                                      align="start"
-                                      className="data-table-start"
-                                      data-column="undefined"
-                                      data-offset={0}
-                                      id="cell-table-for-card-Table-sample-values-Table-2-undefined"
-                                      offset={0}
-                                      width=""
-                                    >
-                                      <span
-                                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                                      >
-                                        <span
-                                          className=""
-                                          title="--"
-                                        >
-                                          --
-                                        </span>
-                                      </span>
-                                    </td>
-                                    <td
-                                      align="start"
-                                      className="data-table-start"
-                                      data-column="undefined2"
-                                      data-offset={0}
-                                      id="cell-table-for-card-Table-sample-values-Table-2-undefined2"
-                                      offset={0}
-                                      width=""
-                                    >
-                                      <span
-                                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                                      >
-                                        <span
-                                          className=""
-                                          title="--"
-                                        >
-                                          --
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
-                                    onClick={[Function]}
-                                  >
-                                    <td
-                                      align="start"
-                                      className="data-table-start"
-                                      data-column="undefined"
-                                      data-offset={0}
-                                      id="cell-table-for-card-Table-sample-values-Table-3-undefined"
-                                      offset={0}
-                                      width=""
-                                    >
-                                      <span
-                                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                                      >
-                                        <span
-                                          className=""
-                                          title="--"
-                                        >
-                                          --
-                                        </span>
-                                      </span>
-                                    </td>
-                                    <td
-                                      align="start"
-                                      className="data-table-start"
-                                      data-column="undefined2"
-                                      data-offset={0}
-                                      id="cell-table-for-card-Table-sample-values-Table-3-undefined2"
-                                      offset={0}
-                                      width=""
-                                    >
-                                      <span
-                                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                                      >
-                                        <span
-                                          className=""
-                                          title="--"
-                                        >
-                                          --
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
-                                    onClick={[Function]}
-                                  >
-                                    <td
-                                      align="start"
-                                      className="data-table-start"
-                                      data-column="undefined"
-                                      data-offset={0}
-                                      id="cell-table-for-card-Table-sample-values-Table-4-undefined"
-                                      offset={0}
-                                      width=""
-                                    >
-                                      <span
-                                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                                      >
-                                        <span
-                                          className=""
-                                          title="--"
-                                        >
-                                          --
-                                        </span>
-                                      </span>
-                                    </td>
-                                    <td
-                                      align="start"
-                                      className="data-table-start"
-                                      data-column="undefined2"
-                                      data-offset={0}
-                                      id="cell-table-for-card-Table-sample-values-Table-4-undefined2"
-                                      offset={0}
-                                      width=""
-                                    >
-                                      <span
-                                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                                      >
-                                        <span
-                                          className=""
-                                          title="--"
-                                        >
-                                          --
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
-                                    onClick={[Function]}
-                                  >
-                                    <td
-                                      align="start"
-                                      className="data-table-start"
-                                      data-column="undefined"
-                                      data-offset={0}
-                                      id="cell-table-for-card-Table-sample-values-Table-5-undefined"
-                                      offset={0}
-                                      width=""
-                                    >
-                                      <span
-                                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                                      >
-                                        <span
-                                          className=""
-                                          title="--"
-                                        >
-                                          --
-                                        </span>
-                                      </span>
-                                    </td>
-                                    <td
-                                      align="start"
-                                      className="data-table-start"
-                                      data-column="undefined2"
-                                      data-offset={0}
-                                      id="cell-table-for-card-Table-sample-values-Table-5-undefined2"
-                                      offset={0}
-                                      width=""
-                                    >
-                                      <span
-                                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                                      >
-                                        <span
-                                          className=""
-                                          title="--"
-                                        >
-                                          --
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
-                                    onClick={[Function]}
-                                  >
-                                    <td
-                                      align="start"
-                                      className="data-table-start"
-                                      data-column="undefined"
-                                      data-offset={0}
-                                      id="cell-table-for-card-Table-sample-values-Table-6-undefined"
-                                      offset={0}
-                                      width=""
-                                    >
-                                      <span
-                                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                                      >
-                                        <span
-                                          className=""
-                                          title="--"
-                                        >
-                                          --
-                                        </span>
-                                      </span>
-                                    </td>
-                                    <td
-                                      align="start"
-                                      className="data-table-start"
-                                      data-column="undefined2"
-                                      data-offset={0}
-                                      id="cell-table-for-card-Table-sample-values-Table-6-undefined2"
-                                      offset={0}
-                                      width=""
-                                    >
-                                      <span
-                                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                                      >
-                                        <span
-                                          className=""
-                                          title="--"
-                                        >
-                                          --
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
-                                    onClick={[Function]}
-                                  >
-                                    <td
-                                      align="start"
-                                      className="data-table-start"
-                                      data-column="undefined"
-                                      data-offset={0}
-                                      id="cell-table-for-card-Table-sample-values-Table-7-undefined"
-                                      offset={0}
-                                      width=""
-                                    >
-                                      <span
-                                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                                      >
-                                        <span
-                                          className=""
-                                          title="--"
-                                        >
-                                          --
-                                        </span>
-                                      </span>
-                                    </td>
-                                    <td
-                                      align="start"
-                                      className="data-table-start"
-                                      data-column="undefined2"
-                                      data-offset={0}
-                                      id="cell-table-for-card-Table-sample-values-Table-7-undefined2"
-                                      offset={0}
-                                      width=""
-                                    >
-                                      <span
-                                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                                      >
-                                        <span
-                                          className=""
-                                          title="--"
-                                        >
-                                          --
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
-                                    onClick={[Function]}
-                                  >
-                                    <td
-                                      align="start"
-                                      className="data-table-start"
-                                      data-column="undefined"
-                                      data-offset={0}
-                                      id="cell-table-for-card-Table-sample-values-Table-8-undefined"
-                                      offset={0}
-                                      width=""
-                                    >
-                                      <span
-                                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                                      >
-                                        <span
-                                          className=""
-                                          title="--"
-                                        >
-                                          --
-                                        </span>
-                                      </span>
-                                    </td>
-                                    <td
-                                      align="start"
-                                      className="data-table-start"
-                                      data-column="undefined2"
-                                      data-offset={0}
-                                      id="cell-table-for-card-Table-sample-values-Table-8-undefined2"
-                                      offset={0}
-                                      width=""
-                                    >
-                                      <span
-                                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                                      >
-                                        <span
-                                          className=""
-                                          title="--"
-                                        >
-                                          --
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
-                                    onClick={[Function]}
-                                  >
-                                    <td
-                                      align="start"
-                                      className="data-table-start"
-                                      data-column="undefined"
-                                      data-offset={0}
-                                      id="cell-table-for-card-Table-sample-values-Table-9-undefined"
-                                      offset={0}
-                                      width=""
-                                    >
-                                      <span
-                                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                                      >
-                                        <span
-                                          className=""
-                                          title="--"
-                                        >
-                                          --
-                                        </span>
-                                      </span>
-                                    </td>
-                                    <td
-                                      align="start"
-                                      className="data-table-start"
-                                      data-column="undefined2"
-                                      data-offset={0}
-                                      id="cell-table-for-card-Table-sample-values-Table-9-undefined2"
-                                      offset={0}
-                                      width=""
-                                    >
-                                      <span
-                                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                                      >
-                                        <span
-                                          className=""
-                                          title="--"
-                                        >
-                                          --
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                </tbody>
-                              </table>
-                            </div>
-                          </div>
-                          <div
-                            className="bx--pagination iot--pagination iot--pagination--hide-page"
-                            style={
-                              Object {
-                                "--pagination-text-display": "flex",
-                              }
-                            }
-                          >
-                            <div
-                              className="bx--pagination__left"
-                            >
-                              <label
-                                className="bx--pagination__text"
-                                htmlFor="bx-pagination-select-4"
-                                id="bx-pagination-select-4-count-label"
-                              >
-                                Items per page:
-                              </label>
-                              <div
-                                className="bx--form-item"
-                              >
-                                <div
-                                  className="bx--select bx--select--inline bx--select__item-count"
-                                >
-                                  <div
-                                    className="bx--select-input--inline__wrapper"
-                                  >
-                                    <div
-                                      className="bx--select-input__wrapper"
-                                      data-invalid={null}
-                                    >
-                                      <select
-                                        className="bx--select-input"
-                                        id="bx-pagination-select-4"
-                                        onChange={[Function]}
-                                        value={10}
-                                      >
-                                        <option
-                                          className="bx--select-option"
-                                          disabled={false}
-                                          hidden={false}
-                                          value={10}
-                                        >
-                                          10
-                                        </option>
-                                        <option
-                                          className="bx--select-option"
-                                          disabled={false}
-                                          hidden={false}
-                                          value={25}
-                                        >
-                                          25
-                                        </option>
-                                        <option
-                                          className="bx--select-option"
-                                          disabled={false}
-                                          hidden={false}
-                                          value={100}
-                                        >
-                                          100
-                                        </option>
-                                      </select>
-                                      <svg
-                                        aria-hidden={true}
-                                        className="bx--select__arrow"
-                                        fill="currentColor"
-                                        focusable="false"
-                                        height={16}
-                                        preserveAspectRatio="xMidYMid meet"
-                                        viewBox="0 0 16 16"
-                                        width={16}
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                              <span
-                                className="bx--pagination__text bx--pagination__items-count"
-                              >
-                                1–10 of 10 items
-                              </span>
-                            </div>
-                            <div
-                              className="bx--pagination__right"
-                            >
-                              <div
-                                className="bx--form-item"
-                              >
-                                <div
-                                  className="bx--select bx--select--inline bx--select__page-number"
-                                >
-                                  <label
-                                    className="bx--label bx--visually-hidden"
-                                    htmlFor="bx-pagination-select-4-right"
-                                  >
-                                    Page number, of 1 pages
-                                  </label>
-                                  <div
-                                    className="bx--select-input--inline__wrapper"
-                                  >
-                                    <div
-                                      className="bx--select-input__wrapper"
-                                      data-invalid={null}
-                                    >
-                                      <select
-                                        className="bx--select-input"
-                                        id="bx-pagination-select-4-right"
-                                        onChange={[Function]}
-                                        value={1}
-                                      >
-                                        <option
-                                          className="bx--select-option"
-                                          disabled={false}
-                                          hidden={false}
-                                          value={1}
-                                        >
-                                          1
-                                        </option>
-                                      </select>
-                                      <svg
-                                        aria-hidden={true}
-                                        className="bx--select__arrow"
-                                        fill="currentColor"
-                                        focusable="false"
-                                        height={16}
-                                        preserveAspectRatio="xMidYMid meet"
-                                        viewBox="0 0 16 16"
-                                        width={16}
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                              <span
-                                className="bx--pagination__text"
-                              >
-                                1 of 1 pages
-                              </span>
-                              <div
-                                className="bx--pagination__control-buttons"
-                              >
-                                <button
-                                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index bx--btn bx--btn--ghost bx--btn--disabled bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
-                                  disabled={true}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
-                                >
-                                  <span
-                                    className="bx--assistive-text"
-                                  >
-                                    Previous page
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-label="Previous page"
-                                    className="bx--btn__icon"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M20 24L10 16 20 8z"
-                                    />
-                                  </svg>
-                                </button>
-                                <button
-                                  className="bx--pagination__button bx--pagination__button--forward bx--pagination__button--no-index bx--btn bx--btn--ghost bx--btn--disabled bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-end"
-                                  disabled={true}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
-                                >
-                                  <span
-                                    className="bx--assistive-text"
-                                  >
-                                    Next page
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-label="Next page"
-                                    className="bx--btn__icon"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height={16}
-                                    preserveAspectRatio="xMidYMid meet"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M12 8L22 16 12 24z"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      className="iot--card react-grid-item iot--dashboard-editor--preview__card react-draggable react-resizable-hide react-resizable iot--card--wrapper"
-                      data-testid="Card"
-                      id="Custom"
-                      onClick={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchEnd={[Function]}
-                      role="presentation"
-                      style={
-                        Object {
-                          "--card-default-height": "304px",
-                          "height": "304px",
-                          "left": "50.625%",
-                          "position": "absolute",
-                          "top": "0px",
-                          "width": "49.375%",
-                        }
-                      }
-                      tabIndex={0}
-                      type="CUSTOM"
-                      value={35}
-                    >
-                      <div
-                        className="iot--card--header"
-                      >
-                        <span
-                          className="iot--card--title"
-                          title="Custom rendered card"
-                        >
-                          <div
-                            className="iot--card--title--text"
-                          >
-                            Custom rendered card
-                          </div>
-                        </span>
-                        <div
-                          className="iot--card--toolbar"
-                        />
-                      </div>
-                      <div
-                        className="iot--card--content"
-                        style={
-                          Object {
-                            "--card-content-height": "256px",
-                          }
-                        }
-                      />
-                    </div>
-                    <div
-                      className="iot--card react-grid-item iot--dashboard-editor--preview__card react-draggable react-resizable-hide react-resizable iot--card--wrapper"
-                      data-testid="Card"
-                      id="Standard"
-                      onClick={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchEnd={[Function]}
-                      role="presentation"
-                      style={
-                        Object {
-                          "--card-default-height": "304px",
-                          "height": "304px",
-                          "left": "50.625%",
-                          "position": "absolute",
-                          "top": "320px",
-                          "width": "49.375%",
-                        }
-                      }
-                      tabIndex={0}
-                      type="VALUE"
-                    >
-                      <div
-                        className="iot--card--header"
-                      >
-                        <span
-                          className="iot--card--title"
-                          title="Default rendered card"
-                        >
-                          <div
-                            className="iot--card--title--text"
-                          >
-                            Default rendered card
-                          </div>
-                        </span>
-                        <div
-                          className="iot--card--toolbar"
-                        >
-                          <button
-                            aria-expanded={false}
-                            aria-haspopup={true}
-                            aria-label="Menu"
-                            className="bx--overflow-menu"
-                            onClick={[Function]}
-                            onClose={[Function]}
-                            onKeyDown={[Function]}
-                            open={false}
-                            tabIndex={0}
-                            title="Open and close list of options"
-                            type="button"
-                          >
-                            <svg
-                              aria-label="open and close list of options"
-                              className="bx--overflow-menu__icon"
-                              fill="currentColor"
-                              focusable="false"
-                              height={16}
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              preserveAspectRatio="xMidYMid meet"
-                              role="img"
-                              viewBox="0 0 32 32"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <circle
-                                cx="16"
-                                cy="8"
-                                r="2"
-                              />
-                              <circle
-                                cx="16"
-                                cy="16"
-                                r="2"
-                              />
-                              <circle
-                                cx="16"
-                                cy="24"
-                                r="2"
-                              />
-                              <title>
-                                open and close list of options
-                              </title>
-                            </svg>
-                          </button>
-                        </div>
-                      </div>
-                      <div
-                        className="iot--card--content"
-                        style={
-                          Object {
-                            "--card-content-height": "256px",
-                          }
-                        }
-                      >
-                        <div
-                          className="ValueCard__ContentWrapper-hyxf2q-0 jWmKBV"
-                        >
-                          <div
-                            className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUM"
-                          >
-                            <div
-                              className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
-                              label="Key 1"
-                              size="MEDIUM"
-                            >
-                              <div
-                                className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                                color={null}
-                              >
-                                <span
-                                  className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
-                                  size="MEDIUM"
-                                  title="-- %"
-                                  value="--"
-                                >
-                                  --
-                                </span>
-                              </div>
-                              <span
-                                className="iot--value-card__attribute-unit"
-                                style={
-                                  Object {
-                                    "--default-font-size": "1.5rem",
-                                  }
-                                }
-                              >
-                                %
-                              </span>
-                            </div>
-                            <div
-                              className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="MEDIUM"
-                              title="Key 1"
-                            >
-                              Key 1
-                            </div>
-                          </div>
-                          <div
-                            className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUM"
-                          >
-                            <hr
-                              className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
-                            />
-                          </div>
-                          <div
-                            className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUM"
-                          >
-                            <div
-                              className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
-                              label="Key 2"
-                              size="MEDIUM"
-                            >
-                              <div
-                                className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                                color={null}
-                              >
-                                <span
-                                  className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
-                                  size="MEDIUM"
-                                  title="-- lb"
-                                  value="--"
-                                >
-                                  --
-                                </span>
-                              </div>
-                              <span
-                                className="iot--value-card__attribute-unit"
-                                style={
-                                  Object {
-                                    "--default-font-size": "1.5rem",
-                                  }
-                                }
-                              >
-                                lb
-                              </span>
-                            </div>
-                            <div
-                              className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="MEDIUM"
-                              title="Key 2"
-                            >
-                              Key 2
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      className="iot--card react-grid-item iot--dashboard-editor--preview__card react-draggable react-resizable-hide react-resizable iot--card--wrapper"
-                      data-testid="Card"
-                      id="Timeseries"
-                      onClick={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchEnd={[Function]}
-                      role="presentation"
-                      style={
-                        Object {
-                          "--card-default-height": "304px",
-                          "height": "304px",
-                          "left": "0%",
-                          "position": "absolute",
-                          "top": "640px",
-                          "width": "100%",
-                        }
-                      }
-                      tabIndex={0}
-                      type="TIMESERIES"
-                    >
-                      <div
-                        className="iot--card--header"
-                      >
-                        <span
-                          className="iot--card--title"
-                          title="Timeseries"
-                        >
-                          <div
-                            className="iot--card--title--text"
-                          >
-                            Timeseries
-                          </div>
-                        </span>
-                        <div
-                          className="iot--card--toolbar"
-                        >
-                          <button
-                            aria-expanded={false}
-                            aria-haspopup={true}
-                            aria-label="Menu"
-                            className="bx--overflow-menu"
-                            onClick={[Function]}
-                            onClose={[Function]}
-                            onKeyDown={[Function]}
-                            open={false}
-                            tabIndex={0}
-                            title="Open and close list of options"
-                            type="button"
-                          >
-                            <svg
-                              aria-label="open and close list of options"
-                              className="bx--overflow-menu__icon"
-                              fill="currentColor"
-                              focusable="false"
-                              height={16}
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              preserveAspectRatio="xMidYMid meet"
-                              role="img"
-                              viewBox="0 0 32 32"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <circle
-                                cx="16"
-                                cy="8"
-                                r="2"
-                              />
-                              <circle
-                                cx="16"
-                                cy="16"
-                                r="2"
-                              />
-                              <circle
-                                cx="16"
-                                cy="24"
-                                r="2"
-                              />
-                              <title>
-                                open and close list of options
-                              </title>
-                            </svg>
-                          </button>
-                        </div>
-                      </div>
-                      <div
-                        className="iot--card--content"
-                        style={
-                          Object {
-                            "--card-content-height": "256px",
-                          }
-                        }
-                      >
-                        <div
-                          className="iot--time-series-card--wrapper iot--time-series-card--wrapper__editable"
-                        >
-                          <div
-                            id="mock-line-chart"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      className="iot--card react-grid-item iot--dashboard-editor--preview__card react-draggable react-resizable-hide react-resizable iot--bar-chart-card iot--card--wrapper"
-                      data-testid="Card"
-                      id="Bar"
-                      onClick={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchEnd={[Function]}
-                      role="presentation"
-                      style={
-                        Object {
-                          "--card-default-height": "304px",
-                          "height": "304px",
-                          "left": "0%",
-                          "position": "absolute",
-                          "top": "960px",
-                          "width": "49.375%",
-                        }
-                      }
-                      tabIndex={0}
-                      type="BAR"
-                    >
-                      <div
-                        className="iot--card--header"
-                      >
-                        <span
-                          className="iot--card--title"
-                          title="Bar"
-                        >
-                          <div
-                            className="iot--card--title--text"
-                          >
-                            Bar
-                          </div>
-                        </span>
-                        <div
-                          className="iot--card--toolbar"
-                        >
-                          <button
-                            aria-expanded={false}
-                            aria-haspopup={true}
-                            aria-label="Menu"
-                            className="bx--overflow-menu"
-                            onClick={[Function]}
-                            onClose={[Function]}
-                            onKeyDown={[Function]}
-                            open={false}
-                            tabIndex={0}
-                            title="Open and close list of options"
-                            type="button"
-                          >
-                            <svg
-                              aria-label="open and close list of options"
-                              className="bx--overflow-menu__icon"
-                              fill="currentColor"
-                              focusable="false"
-                              height={16}
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              preserveAspectRatio="xMidYMid meet"
-                              role="img"
-                              viewBox="0 0 32 32"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <circle
-                                cx="16"
-                                cy="8"
-                                r="2"
-                              />
-                              <circle
-                                cx="16"
-                                cy="16"
-                                r="2"
-                              />
-                              <circle
-                                cx="16"
-                                cy="24"
-                                r="2"
-                              />
-                              <title>
-                                open and close list of options
-                              </title>
-                            </svg>
-                          </button>
-                        </div>
-                      </div>
-                      <div
-                        className="iot--card--content"
-                        style={
-                          Object {
-                            "--card-content-height": "256px",
-                          }
-                        }
-                      >
-                        <div
-                          className="iot--bar-chart-container iot--bar-chart-container--editable"
-                        >
-                          <div
-                            id="mock-bar-chart-simple"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="iot--dashboard-editor--sidebar"
-        >
-          <div
-            className="iot--card-editor"
-            data-testid="card-editor"
-          >
-            <div
-              className="iot--card-editor--header"
-            >
-              <h2
-                className="iot--card-editor--header--title"
-              >
-                Gallery
-              </h2>
-            </div>
-            <div
-              className="iot--card-editor--content"
-            >
-              <div
-                className="iot--list iot--list__full-height"
-              >
-                <div
-                  className="iot--list-header-container"
-                >
-                  <div
-                    className="iot--list-header--search"
-                  >
-                    <div
-                      aria-labelledby="iot--list-header--search-search"
-                      className="bx--search bx--search--sm"
-                      role="search"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="bx--search-magnifier"
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                        />
-                      </svg>
-                      <label
-                        className="bx--label"
-                        htmlFor="iot--list-header--search"
-                        id="iot--list-header--search-search"
-                      >
-                        Enter a value
-                      </label>
-                      <input
-                        autoComplete="off"
-                        className="bx--search-input"
-                        id="iot--list-header--search"
-                        onChange={[Function]}
-                        placeholder="Enter a value"
-                        role="searchbox"
-                        type="text"
-                        value=""
-                      />
-                      <button
-                        aria-label="Clear search input"
-                        className="bx--search-close bx--search-close--hidden"
-                        onClick={[Function]}
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="currentColor"
+                          fill="#161616"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -11983,558 +9944,2557 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <path
-                            d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                            d="M28 19L14.83 19 17.41 16.41 16 15 11 20 16 25 17.41 23.59 14.83 21 28 21 28 19z"
+                          />
+                          <path
+                            d="M24,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,16,2H6A2,2,0,0,0,4,4V28a2,2,0,0,0,2,2H22a2,2,0,0,0,2-2V26H22v2H6V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L21.59,10Z"
                           />
                         </svg>
-                      </button>
+                      </span>
+                    </label>
+                    <input
+                      className="bx--visually-hidden"
+                      disabled={false}
+                      id="id2"
+                      multiple={false}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      tabIndex="-1"
+                      type="file"
+                    />
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Export
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Export"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M13 21L26.17 21 23.59 23.59 25 25 30 20 25 15 23.59 16.41 26.17 19 13 19 13 21z"
+                      />
+                      <path
+                        d="M22,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,14,2H4A2,2,0,0,0,2,4V28a2,2,0,0,0,2,2H20a2,2,0,0,0,2-2V26H20v2H4V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L19.59,10Z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Delete
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Delete"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M12 12H14V24H12zM18 12H20V24H18z"
+                      />
+                      <path
+                        d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--secondary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Save and close
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--dashboard-editor--preview"
+        >
+          <div
+            className=""
+          >
+            <div
+              className="iot--dashboard-editor--preview__grid-container"
+            >
+              <div
+                className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
+                data-floating-menu-container={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onClose={[Function]}
+                onKeyDown={[Function]}
+                open={false}
+                role="presentation"
+              >
+                <span
+                  className="bx--visually-hidden"
+                  role="link"
+                  tabIndex="0"
+                >
+                  Focus sentinel
+                </span>
+                <div
+                  className="bx--modal-container"
+                  role="dialog"
+                >
+                  <div
+                    className="bx--modal-header"
+                  >
+                    <p
+                      className="bx--modal-header__label bx--type-delta"
+                    >
+                      New image card
+                    </p>
+                    <p
+                      className="bx--modal-header__heading bx--type-beta"
+                    >
+                      Image gallery
+                    </p>
+                    <button
+                      aria-label="Close"
+                      className="bx--modal-close"
+                      onClick={[Function]}
+                      title="Close"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="bx--modal-close__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                  <div
+                    className="bx--modal-content"
+                  >
+                    <div
+                      className="iot--image-gallery-modal__top-section"
+                    >
+                      <p
+                        alt="Select the image that you want to display on this card."
+                        className="iot--image-gallery-modal__instruction-text"
+                      >
+                        Select the image that you want to display on this card.
+                      </p>
+                      <div
+                        className="iot--image-gallery-modal__search-list-view-container"
+                      >
+                        <div
+                          aria-labelledby="iot--image-gallery-modal--search-search"
+                          className="bx--search bx--search--xl bx--search--light"
+                          role="search"
+                        >
+                          <svg
+                            aria-hidden={true}
+                            className="bx--search-magnifier"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                            />
+                          </svg>
+                          <label
+                            className="bx--label"
+                            htmlFor="iot--image-gallery-modal--search"
+                            id="iot--image-gallery-modal--search-search"
+                          >
+                            
+                          </label>
+                          <input
+                            autoComplete="off"
+                            className="bx--search-input"
+                            id="iot--image-gallery-modal--search"
+                            onChange={[Function]}
+                            placeholder="Search image by file name"
+                            role="searchbox"
+                            type="text"
+                          />
+                          <button
+                            aria-label="Clear search input"
+                            className="bx--search-close bx--search-close--hidden"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <div
+                          className="bx--content-switcher iot--image-gallery-modal__content-switcher"
+                          onChange={[Function]}
+                          role="tablist"
+                        >
+                          <button
+                            className="iot--icon-switch iot--icon-switch--large bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                            disabled={false}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            tabIndex={0}
+                            type="button"
+                          >
+                            <span
+                              className="bx--assistive-text"
+                            >
+                              Grid
+                            </span>
+                            <svg
+                              aria-hidden="true"
+                              aria-label="Grid"
+                              className="bx--btn__icon"
+                              fill="currentColor"
+                              focusable="false"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M12 4H6A2 2 0 004 6v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0012 4zm0 8H6V6h6zM26 4H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0026 4zm0 8H20V6h6zM12 18H6a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0012 18zm0 8H6V20h6zM26 18H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0026 18zm0 8H20V20h6z"
+                              />
+                            </svg>
+                          </button>
+                          <button
+                            className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                            disabled={false}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            tabIndex={0}
+                            type="button"
+                          >
+                            <span
+                              className="bx--assistive-text"
+                            >
+                              List
+                            </span>
+                            <svg
+                              aria-hidden="true"
+                              aria-label="List"
+                              className="bx--btn__icon"
+                              fill="currentColor"
+                              focusable="false"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M10 6H28V8H10zM10 24H28V26H10zM10 15H28V17H10zM4 15H6V17H4zM4 6H6V8H4zM4 24H6V26H4z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="iot--image-gallery-modal__flex-wrapper"
+                    >
+                      <div
+                        className="iot--image-gallery-modal__scroll-panel iot--image-gallery-modal__scroll-panel--grid"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="bx--modal-footer iot--composed-modal-footer"
+                  >
+                    <button
+                      className="iot--btn bx--btn bx--btn--secondary"
+                      disabled={false}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                      disabled={true}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      Select
+                    </button>
+                  </div>
+                </div>
+                <span
+                  className="bx--visually-hidden"
+                  role="link"
+                  tabIndex="0"
+                >
+                  Focus sentinel
+                </span>
+              </div>
+              <div
+                style={
+                  Object {
+                    "flex": 1,
+                  }
+                }
+              >
+                <div
+                  className="react-grid-layout DashboardGrid__StyledGridLayout-vxs00g-0 ANzdO"
+                  onDragEnter={[Function]}
+                  onDragLeave={[Function]}
+                  onDragOver={[Function]}
+                  onDrop={[Function]}
+                  style={
+                    Object {
+                      "height": "1264px",
+                    }
+                  }
+                >
+                  <div
+                    className="iot--card react-grid-item iot--dashboard-editor--preview__card react-draggable react-resizable-hide react-resizable iot--card--wrapper"
+                    data-testid="Card"
+                    id="Table"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    role="presentation"
+                    style={
+                      Object {
+                        "--card-default-height": "624px",
+                        "height": "624px",
+                        "left": "0%",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": "49.375%",
+                      }
+                    }
+                    tabIndex={0}
+                    type="TABLE"
+                  >
+                    <div
+                      className="iot--card--content"
+                      style={
+                        Object {
+                          "--card-content-height": "576px",
+                        }
+                      }
+                    >
+                      <div
+                        className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
+                      >
+                        <section
+                          aria-label="data table toolbar"
+                          className="bx--table-toolbar"
+                        >
+                          <div
+                            className="bx--batch-actions iot--table-batch-actions"
+                          >
+                            <div
+                              className="bx--batch-summary"
+                            >
+                              <p
+                                className="bx--batch-summary__para"
+                              >
+                                <span>
+                                  0 item selected
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              className="bx--action-list"
+                            >
+                              <button
+                                className="bx--batch-summary__cancel bx--btn bx--btn--primary"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={-1}
+                                type="button"
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                          </div>
+                          <label
+                            className="iot--table-toolbar-secondary-title"
+                          >
+                            Table card
+                          </label>
+                          <div
+                            className="bx--toolbar-content iot--table-toolbar-content"
+                          >
+                            <div
+                              className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              tabIndex="0"
+                            >
+                              <div
+                                aria-labelledby="table-for-card-Table-toolbar-search-search"
+                                className="bx--search bx--search--sm table-toolbar-search"
+                                role="search"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="bx--search-magnifier"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                                  />
+                                </svg>
+                                <label
+                                  className="bx--label"
+                                  htmlFor="table-for-card-Table-toolbar-search"
+                                  id="table-for-card-Table-toolbar-search-search"
+                                >
+                                  Search
+                                </label>
+                                <input
+                                  aria-hidden={true}
+                                  autoComplete="off"
+                                  className="bx--search-input"
+                                  disabled={true}
+                                  id="table-for-card-Table-toolbar-search"
+                                  onChange={[Function]}
+                                  placeholder="Search"
+                                  role="searchbox"
+                                  tabIndex="-1"
+                                  type="text"
+                                  value=""
+                                />
+                                <button
+                                  aria-label="Clear search input"
+                                  className="bx--search-close bx--search-close--hidden"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={16}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                                    />
+                                  </svg>
+                                </button>
+                              </div>
+                            </div>
+                            <button
+                              className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost bx--btn--disabled"
+                              data-testid="download-button"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex={0}
+                              title="Download table content"
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                aria-label="Download table content"
+                                className="bx--btn__icon"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                                />
+                                <path
+                                  d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
+                                />
+                              </svg>
+                            </button>
+                            <button
+                              className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost bx--btn--disabled"
+                              data-testid="filter-button"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex={0}
+                              title="Filters"
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                aria-label="Filters"
+                                className="bx--btn__icon"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M18,28H14a2,2,0,0,1-2-2V18.41L4.59,11A2,2,0,0,1,4,9.59V6A2,2,0,0,1,6,4H26a2,2,0,0,1,2,2V9.59A2,2,0,0,1,27.41,11L20,18.41V26A2,2,0,0,1,18,28ZM6,6V9.59l8,8V26h4V17.59l8-8V6Z"
+                                />
+                              </svg>
+                            </button>
+                            <div
+                              className="iot--card--toolbar"
+                            >
+                              <button
+                                aria-expanded={false}
+                                aria-haspopup={true}
+                                aria-label="Menu"
+                                className="bx--overflow-menu"
+                                onClick={[Function]}
+                                onClose={[Function]}
+                                onKeyDown={[Function]}
+                                open={false}
+                                tabIndex={0}
+                                title="Open and close list of options"
+                                type="button"
+                              >
+                                <svg
+                                  aria-label="open and close list of options"
+                                  className="bx--overflow-menu__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="16"
+                                    cy="8"
+                                    r="2"
+                                  />
+                                  <circle
+                                    cx="16"
+                                    cy="16"
+                                    r="2"
+                                  />
+                                  <circle
+                                    cx="16"
+                                    cy="24"
+                                    r="2"
+                                  />
+                                  <title>
+                                    open and close list of options
+                                  </title>
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </section>
+                        <div
+                          className="addons-iot-table-container"
+                        >
+                          <div
+                            className="bx--data-table-content"
+                          >
+                            <table
+                              className="bx--data-table bx--data-table--no-border"
+                              title={null}
+                            >
+                              <thead
+                                onMouseMove={null}
+                                onMouseUp={null}
+                              >
+                                <tr>
+                                  <th
+                                    aria-sort="none"
+                                    className="table-header-label-start iot--table-head--table-header table-header-sortable"
+                                    scope="col"
+                                    style={
+                                      Object {
+                                        "width": undefined,
+                                      }
+                                    }
+                                    width=""
+                                  >
+                                    <button
+                                      align="start"
+                                      className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
+                                      data-column="undefined"
+                                      data-floating-menu-container={true}
+                                      id="column-undefined"
+                                      onClick={[Function]}
+                                      style={
+                                        Object {
+                                          "--table-header-width": "",
+                                        }
+                                      }
+                                      width=""
+                                    >
+                                      <span
+                                        className="bx--table-header-label"
+                                      >
+                                        <span
+                                          className=""
+                                          title="--"
+                                        >
+                                          --
+                                        </span>
+                                      </span>
+                                      <svg
+                                        aria-label="Sort rows by this header in ascending order"
+                                        className="bx--table-sort__icon"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        role="img"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                                        />
+                                      </svg>
+                                      <svg
+                                        aria-label="Sort rows by this header in ascending order"
+                                        className="bx--table-sort__icon-unsorted"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        role="img"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                        />
+                                      </svg>
+                                    </button>
+                                  </th>
+                                  <th
+                                    aria-sort="none"
+                                    className="table-header-label-start iot--table-head--table-header table-header-sortable"
+                                    scope="col"
+                                    style={
+                                      Object {
+                                        "width": undefined,
+                                      }
+                                    }
+                                    width=""
+                                  >
+                                    <button
+                                      align="start"
+                                      className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
+                                      data-column="undefined2"
+                                      data-floating-menu-container={true}
+                                      id="column-undefined2"
+                                      onClick={[Function]}
+                                      style={
+                                        Object {
+                                          "--table-header-width": "",
+                                        }
+                                      }
+                                      width=""
+                                    >
+                                      <span
+                                        className="bx--table-header-label"
+                                      >
+                                        <span
+                                          className=""
+                                          title="--"
+                                        >
+                                          --
+                                        </span>
+                                      </span>
+                                      <svg
+                                        aria-label="Sort rows by this header in ascending order"
+                                        className="bx--table-sort__icon"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        role="img"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                                        />
+                                      </svg>
+                                      <svg
+                                        aria-label="Sort rows by this header in ascending order"
+                                        className="bx--table-sort__icon-unsorted"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        role="img"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                        />
+                                      </svg>
+                                    </button>
+                                  </th>
+                                </tr>
+                              </thead>
+                              <tbody
+                                aria-live="polite"
+                              >
+                                <tr
+                                  className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                                  onClick={[Function]}
+                                >
+                                  <td
+                                    align="start"
+                                    className="data-table-start"
+                                    data-column="undefined"
+                                    data-offset={0}
+                                    id="cell-table-for-card-Table-sample-values-Table-0-undefined"
+                                    offset={0}
+                                    width=""
+                                  >
+                                    <span
+                                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                                    >
+                                      <span
+                                        className=""
+                                        title="--"
+                                      >
+                                        --
+                                      </span>
+                                    </span>
+                                  </td>
+                                  <td
+                                    align="start"
+                                    className="data-table-start"
+                                    data-column="undefined2"
+                                    data-offset={0}
+                                    id="cell-table-for-card-Table-sample-values-Table-0-undefined2"
+                                    offset={0}
+                                    width=""
+                                  >
+                                    <span
+                                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                                    >
+                                      <span
+                                        className=""
+                                        title="--"
+                                      >
+                                        --
+                                      </span>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr
+                                  className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                                  onClick={[Function]}
+                                >
+                                  <td
+                                    align="start"
+                                    className="data-table-start"
+                                    data-column="undefined"
+                                    data-offset={0}
+                                    id="cell-table-for-card-Table-sample-values-Table-1-undefined"
+                                    offset={0}
+                                    width=""
+                                  >
+                                    <span
+                                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                                    >
+                                      <span
+                                        className=""
+                                        title="--"
+                                      >
+                                        --
+                                      </span>
+                                    </span>
+                                  </td>
+                                  <td
+                                    align="start"
+                                    className="data-table-start"
+                                    data-column="undefined2"
+                                    data-offset={0}
+                                    id="cell-table-for-card-Table-sample-values-Table-1-undefined2"
+                                    offset={0}
+                                    width=""
+                                  >
+                                    <span
+                                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                                    >
+                                      <span
+                                        className=""
+                                        title="--"
+                                      >
+                                        --
+                                      </span>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr
+                                  className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                                  onClick={[Function]}
+                                >
+                                  <td
+                                    align="start"
+                                    className="data-table-start"
+                                    data-column="undefined"
+                                    data-offset={0}
+                                    id="cell-table-for-card-Table-sample-values-Table-2-undefined"
+                                    offset={0}
+                                    width=""
+                                  >
+                                    <span
+                                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                                    >
+                                      <span
+                                        className=""
+                                        title="--"
+                                      >
+                                        --
+                                      </span>
+                                    </span>
+                                  </td>
+                                  <td
+                                    align="start"
+                                    className="data-table-start"
+                                    data-column="undefined2"
+                                    data-offset={0}
+                                    id="cell-table-for-card-Table-sample-values-Table-2-undefined2"
+                                    offset={0}
+                                    width=""
+                                  >
+                                    <span
+                                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                                    >
+                                      <span
+                                        className=""
+                                        title="--"
+                                      >
+                                        --
+                                      </span>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr
+                                  className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                                  onClick={[Function]}
+                                >
+                                  <td
+                                    align="start"
+                                    className="data-table-start"
+                                    data-column="undefined"
+                                    data-offset={0}
+                                    id="cell-table-for-card-Table-sample-values-Table-3-undefined"
+                                    offset={0}
+                                    width=""
+                                  >
+                                    <span
+                                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                                    >
+                                      <span
+                                        className=""
+                                        title="--"
+                                      >
+                                        --
+                                      </span>
+                                    </span>
+                                  </td>
+                                  <td
+                                    align="start"
+                                    className="data-table-start"
+                                    data-column="undefined2"
+                                    data-offset={0}
+                                    id="cell-table-for-card-Table-sample-values-Table-3-undefined2"
+                                    offset={0}
+                                    width=""
+                                  >
+                                    <span
+                                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                                    >
+                                      <span
+                                        className=""
+                                        title="--"
+                                      >
+                                        --
+                                      </span>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr
+                                  className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                                  onClick={[Function]}
+                                >
+                                  <td
+                                    align="start"
+                                    className="data-table-start"
+                                    data-column="undefined"
+                                    data-offset={0}
+                                    id="cell-table-for-card-Table-sample-values-Table-4-undefined"
+                                    offset={0}
+                                    width=""
+                                  >
+                                    <span
+                                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                                    >
+                                      <span
+                                        className=""
+                                        title="--"
+                                      >
+                                        --
+                                      </span>
+                                    </span>
+                                  </td>
+                                  <td
+                                    align="start"
+                                    className="data-table-start"
+                                    data-column="undefined2"
+                                    data-offset={0}
+                                    id="cell-table-for-card-Table-sample-values-Table-4-undefined2"
+                                    offset={0}
+                                    width=""
+                                  >
+                                    <span
+                                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                                    >
+                                      <span
+                                        className=""
+                                        title="--"
+                                      >
+                                        --
+                                      </span>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr
+                                  className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                                  onClick={[Function]}
+                                >
+                                  <td
+                                    align="start"
+                                    className="data-table-start"
+                                    data-column="undefined"
+                                    data-offset={0}
+                                    id="cell-table-for-card-Table-sample-values-Table-5-undefined"
+                                    offset={0}
+                                    width=""
+                                  >
+                                    <span
+                                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                                    >
+                                      <span
+                                        className=""
+                                        title="--"
+                                      >
+                                        --
+                                      </span>
+                                    </span>
+                                  </td>
+                                  <td
+                                    align="start"
+                                    className="data-table-start"
+                                    data-column="undefined2"
+                                    data-offset={0}
+                                    id="cell-table-for-card-Table-sample-values-Table-5-undefined2"
+                                    offset={0}
+                                    width=""
+                                  >
+                                    <span
+                                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                                    >
+                                      <span
+                                        className=""
+                                        title="--"
+                                      >
+                                        --
+                                      </span>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr
+                                  className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                                  onClick={[Function]}
+                                >
+                                  <td
+                                    align="start"
+                                    className="data-table-start"
+                                    data-column="undefined"
+                                    data-offset={0}
+                                    id="cell-table-for-card-Table-sample-values-Table-6-undefined"
+                                    offset={0}
+                                    width=""
+                                  >
+                                    <span
+                                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                                    >
+                                      <span
+                                        className=""
+                                        title="--"
+                                      >
+                                        --
+                                      </span>
+                                    </span>
+                                  </td>
+                                  <td
+                                    align="start"
+                                    className="data-table-start"
+                                    data-column="undefined2"
+                                    data-offset={0}
+                                    id="cell-table-for-card-Table-sample-values-Table-6-undefined2"
+                                    offset={0}
+                                    width=""
+                                  >
+                                    <span
+                                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                                    >
+                                      <span
+                                        className=""
+                                        title="--"
+                                      >
+                                        --
+                                      </span>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr
+                                  className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                                  onClick={[Function]}
+                                >
+                                  <td
+                                    align="start"
+                                    className="data-table-start"
+                                    data-column="undefined"
+                                    data-offset={0}
+                                    id="cell-table-for-card-Table-sample-values-Table-7-undefined"
+                                    offset={0}
+                                    width=""
+                                  >
+                                    <span
+                                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                                    >
+                                      <span
+                                        className=""
+                                        title="--"
+                                      >
+                                        --
+                                      </span>
+                                    </span>
+                                  </td>
+                                  <td
+                                    align="start"
+                                    className="data-table-start"
+                                    data-column="undefined2"
+                                    data-offset={0}
+                                    id="cell-table-for-card-Table-sample-values-Table-7-undefined2"
+                                    offset={0}
+                                    width=""
+                                  >
+                                    <span
+                                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                                    >
+                                      <span
+                                        className=""
+                                        title="--"
+                                      >
+                                        --
+                                      </span>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr
+                                  className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                                  onClick={[Function]}
+                                >
+                                  <td
+                                    align="start"
+                                    className="data-table-start"
+                                    data-column="undefined"
+                                    data-offset={0}
+                                    id="cell-table-for-card-Table-sample-values-Table-8-undefined"
+                                    offset={0}
+                                    width=""
+                                  >
+                                    <span
+                                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                                    >
+                                      <span
+                                        className=""
+                                        title="--"
+                                      >
+                                        --
+                                      </span>
+                                    </span>
+                                  </td>
+                                  <td
+                                    align="start"
+                                    className="data-table-start"
+                                    data-column="undefined2"
+                                    data-offset={0}
+                                    id="cell-table-for-card-Table-sample-values-Table-8-undefined2"
+                                    offset={0}
+                                    width=""
+                                  >
+                                    <span
+                                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                                    >
+                                      <span
+                                        className=""
+                                        title="--"
+                                      >
+                                        --
+                                      </span>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr
+                                  className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                                  onClick={[Function]}
+                                >
+                                  <td
+                                    align="start"
+                                    className="data-table-start"
+                                    data-column="undefined"
+                                    data-offset={0}
+                                    id="cell-table-for-card-Table-sample-values-Table-9-undefined"
+                                    offset={0}
+                                    width=""
+                                  >
+                                    <span
+                                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                                    >
+                                      <span
+                                        className=""
+                                        title="--"
+                                      >
+                                        --
+                                      </span>
+                                    </span>
+                                  </td>
+                                  <td
+                                    align="start"
+                                    className="data-table-start"
+                                    data-column="undefined2"
+                                    data-offset={0}
+                                    id="cell-table-for-card-Table-sample-values-Table-9-undefined2"
+                                    offset={0}
+                                    width=""
+                                  >
+                                    <span
+                                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                                    >
+                                      <span
+                                        className=""
+                                        title="--"
+                                      >
+                                        --
+                                      </span>
+                                    </span>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </div>
+                        </div>
+                        <div
+                          className="bx--pagination iot--pagination iot--pagination--hide-page"
+                          style={
+                            Object {
+                              "--pagination-text-display": "flex",
+                            }
+                          }
+                        >
+                          <div
+                            className="bx--pagination__left"
+                          >
+                            <label
+                              className="bx--pagination__text"
+                              htmlFor="bx-pagination-select-4"
+                              id="bx-pagination-select-4-count-label"
+                            >
+                              Items per page:
+                            </label>
+                            <div
+                              className="bx--form-item"
+                            >
+                              <div
+                                className="bx--select bx--select--inline bx--select__item-count"
+                              >
+                                <div
+                                  className="bx--select-input--inline__wrapper"
+                                >
+                                  <div
+                                    className="bx--select-input__wrapper"
+                                    data-invalid={null}
+                                  >
+                                    <select
+                                      className="bx--select-input"
+                                      id="bx-pagination-select-4"
+                                      onChange={[Function]}
+                                      value={10}
+                                    >
+                                      <option
+                                        className="bx--select-option"
+                                        disabled={false}
+                                        hidden={false}
+                                        value={10}
+                                      >
+                                        10
+                                      </option>
+                                      <option
+                                        className="bx--select-option"
+                                        disabled={false}
+                                        hidden={false}
+                                        value={25}
+                                      >
+                                        25
+                                      </option>
+                                      <option
+                                        className="bx--select-option"
+                                        disabled={false}
+                                        hidden={false}
+                                        value={100}
+                                      >
+                                        100
+                                      </option>
+                                    </select>
+                                    <svg
+                                      aria-hidden={true}
+                                      className="bx--select__arrow"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height={16}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                                      />
+                                    </svg>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <span
+                              className="bx--pagination__text bx--pagination__items-count"
+                            >
+                              1–10 of 10 items
+                            </span>
+                          </div>
+                          <div
+                            className="bx--pagination__right"
+                          >
+                            <div
+                              className="bx--form-item"
+                            >
+                              <div
+                                className="bx--select bx--select--inline bx--select__page-number"
+                              >
+                                <label
+                                  className="bx--label bx--visually-hidden"
+                                  htmlFor="bx-pagination-select-4-right"
+                                >
+                                  Page number, of 1 pages
+                                </label>
+                                <div
+                                  className="bx--select-input--inline__wrapper"
+                                >
+                                  <div
+                                    className="bx--select-input__wrapper"
+                                    data-invalid={null}
+                                  >
+                                    <select
+                                      className="bx--select-input"
+                                      id="bx-pagination-select-4-right"
+                                      onChange={[Function]}
+                                      value={1}
+                                    >
+                                      <option
+                                        className="bx--select-option"
+                                        disabled={false}
+                                        hidden={false}
+                                        value={1}
+                                      >
+                                        1
+                                      </option>
+                                    </select>
+                                    <svg
+                                      aria-hidden={true}
+                                      className="bx--select__arrow"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height={16}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                                      />
+                                    </svg>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <span
+                              className="bx--pagination__text"
+                            >
+                              1 of 1 pages
+                            </span>
+                            <div
+                              className="bx--pagination__control-buttons"
+                            >
+                              <button
+                                className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index bx--btn bx--btn--ghost bx--btn--disabled bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                                disabled={true}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--assistive-text"
+                                >
+                                  Previous page
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Previous page"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M20 24L10 16 20 8z"
+                                  />
+                                </svg>
+                              </button>
+                              <button
+                                className="bx--pagination__button bx--pagination__button--forward bx--pagination__button--no-index bx--btn bx--btn--ghost bx--btn--disabled bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-end"
+                                disabled={true}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--assistive-text"
+                                >
+                                  Next page
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Next page"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 8L22 16 12 24z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="iot--card react-grid-item iot--dashboard-editor--preview__card react-draggable react-resizable-hide react-resizable iot--card--wrapper"
+                    data-testid="Card"
+                    id="Custom"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    role="presentation"
+                    style={
+                      Object {
+                        "--card-default-height": "304px",
+                        "height": "304px",
+                        "left": "50.625%",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": "49.375%",
+                      }
+                    }
+                    tabIndex={0}
+                    type="CUSTOM"
+                    value={35}
+                  >
+                    <div
+                      className="iot--card--header"
+                    >
+                      <span
+                        className="iot--card--title"
+                        title="Custom rendered card"
+                      >
+                        <div
+                          className="iot--card--title--text"
+                        >
+                          Custom rendered card
+                        </div>
+                      </span>
+                      <div
+                        className="iot--card--toolbar"
+                      />
+                    </div>
+                    <div
+                      className="iot--card--content"
+                      style={
+                        Object {
+                          "--card-content-height": "256px",
+                        }
+                      }
+                    />
+                  </div>
+                  <div
+                    className="iot--card react-grid-item iot--dashboard-editor--preview__card react-draggable react-resizable-hide react-resizable iot--card--wrapper"
+                    data-testid="Card"
+                    id="Standard"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    role="presentation"
+                    style={
+                      Object {
+                        "--card-default-height": "304px",
+                        "height": "304px",
+                        "left": "50.625%",
+                        "position": "absolute",
+                        "top": "320px",
+                        "width": "49.375%",
+                      }
+                    }
+                    tabIndex={0}
+                    type="VALUE"
+                  >
+                    <div
+                      className="iot--card--header"
+                    >
+                      <span
+                        className="iot--card--title"
+                        title="Default rendered card"
+                      >
+                        <div
+                          className="iot--card--title--text"
+                        >
+                          Default rendered card
+                        </div>
+                      </span>
+                      <div
+                        className="iot--card--toolbar"
+                      >
+                        <button
+                          aria-expanded={false}
+                          aria-haspopup={true}
+                          aria-label="Menu"
+                          className="bx--overflow-menu"
+                          onClick={[Function]}
+                          onClose={[Function]}
+                          onKeyDown={[Function]}
+                          open={false}
+                          tabIndex={0}
+                          title="Open and close list of options"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="open and close list of options"
+                            className="bx--overflow-menu__icon"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <circle
+                              cx="16"
+                              cy="8"
+                              r="2"
+                            />
+                            <circle
+                              cx="16"
+                              cy="16"
+                              r="2"
+                            />
+                            <circle
+                              cx="16"
+                              cy="24"
+                              r="2"
+                            />
+                            <title>
+                              open and close list of options
+                            </title>
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      className="iot--card--content"
+                      style={
+                        Object {
+                          "--card-content-height": "256px",
+                        }
+                      }
+                    >
+                      <div
+                        className="ValueCard__ContentWrapper-hyxf2q-0 jWmKBV"
+                      >
+                        <div
+                          className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                          size="MEDIUM"
+                        >
+                          <div
+                            className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
+                            label="Key 1"
+                            size="MEDIUM"
+                          >
+                            <div
+                              className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                              color={null}
+                            >
+                              <span
+                                className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
+                                size="MEDIUM"
+                                title="-- %"
+                                value="--"
+                              >
+                                --
+                              </span>
+                            </div>
+                            <span
+                              className="iot--value-card__attribute-unit"
+                              style={
+                                Object {
+                                  "--default-font-size": "1.5rem",
+                                }
+                              }
+                            >
+                              %
+                            </span>
+                          </div>
+                          <div
+                            className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
+                            size="MEDIUM"
+                            title="Key 1"
+                          >
+                            Key 1
+                          </div>
+                        </div>
+                        <div
+                          className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                          size="MEDIUM"
+                        >
+                          <hr
+                            className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
+                          />
+                        </div>
+                        <div
+                          className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                          size="MEDIUM"
+                        >
+                          <div
+                            className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
+                            label="Key 2"
+                            size="MEDIUM"
+                          >
+                            <div
+                              className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                              color={null}
+                            >
+                              <span
+                                className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
+                                size="MEDIUM"
+                                title="-- lb"
+                                value="--"
+                              >
+                                --
+                              </span>
+                            </div>
+                            <span
+                              className="iot--value-card__attribute-unit"
+                              style={
+                                Object {
+                                  "--default-font-size": "1.5rem",
+                                }
+                              }
+                            >
+                              lb
+                            </span>
+                          </div>
+                          <div
+                            className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
+                            size="MEDIUM"
+                            title="Key 2"
+                          >
+                            Key 2
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="iot--card react-grid-item iot--dashboard-editor--preview__card react-draggable react-resizable-hide react-resizable iot--card--wrapper"
+                    data-testid="Card"
+                    id="Timeseries"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    role="presentation"
+                    style={
+                      Object {
+                        "--card-default-height": "304px",
+                        "height": "304px",
+                        "left": "0%",
+                        "position": "absolute",
+                        "top": "640px",
+                        "width": "100%",
+                      }
+                    }
+                    tabIndex={0}
+                    type="TIMESERIES"
+                  >
+                    <div
+                      className="iot--card--header"
+                    >
+                      <span
+                        className="iot--card--title"
+                        title="Timeseries"
+                      >
+                        <div
+                          className="iot--card--title--text"
+                        >
+                          Timeseries
+                        </div>
+                      </span>
+                      <div
+                        className="iot--card--toolbar"
+                      >
+                        <button
+                          aria-expanded={false}
+                          aria-haspopup={true}
+                          aria-label="Menu"
+                          className="bx--overflow-menu"
+                          onClick={[Function]}
+                          onClose={[Function]}
+                          onKeyDown={[Function]}
+                          open={false}
+                          tabIndex={0}
+                          title="Open and close list of options"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="open and close list of options"
+                            className="bx--overflow-menu__icon"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <circle
+                              cx="16"
+                              cy="8"
+                              r="2"
+                            />
+                            <circle
+                              cx="16"
+                              cy="16"
+                              r="2"
+                            />
+                            <circle
+                              cx="16"
+                              cy="24"
+                              r="2"
+                            />
+                            <title>
+                              open and close list of options
+                            </title>
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      className="iot--card--content"
+                      style={
+                        Object {
+                          "--card-content-height": "256px",
+                        }
+                      }
+                    >
+                      <div
+                        className="iot--time-series-card--wrapper iot--time-series-card--wrapper__editable"
+                      >
+                        <div
+                          id="mock-line-chart"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="iot--card react-grid-item iot--dashboard-editor--preview__card react-draggable react-resizable-hide react-resizable iot--bar-chart-card iot--card--wrapper"
+                    data-testid="Card"
+                    id="Bar"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    role="presentation"
+                    style={
+                      Object {
+                        "--card-default-height": "304px",
+                        "height": "304px",
+                        "left": "0%",
+                        "position": "absolute",
+                        "top": "960px",
+                        "width": "49.375%",
+                      }
+                    }
+                    tabIndex={0}
+                    type="BAR"
+                  >
+                    <div
+                      className="iot--card--header"
+                    >
+                      <span
+                        className="iot--card--title"
+                        title="Bar"
+                      >
+                        <div
+                          className="iot--card--title--text"
+                        >
+                          Bar
+                        </div>
+                      </span>
+                      <div
+                        className="iot--card--toolbar"
+                      >
+                        <button
+                          aria-expanded={false}
+                          aria-haspopup={true}
+                          aria-label="Menu"
+                          className="bx--overflow-menu"
+                          onClick={[Function]}
+                          onClose={[Function]}
+                          onKeyDown={[Function]}
+                          open={false}
+                          tabIndex={0}
+                          title="Open and close list of options"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="open and close list of options"
+                            className="bx--overflow-menu__icon"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <circle
+                              cx="16"
+                              cy="8"
+                              r="2"
+                            />
+                            <circle
+                              cx="16"
+                              cy="16"
+                              r="2"
+                            />
+                            <circle
+                              cx="16"
+                              cy="24"
+                              r="2"
+                            />
+                            <title>
+                              open and close list of options
+                            </title>
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      className="iot--card--content"
+                      style={
+                        Object {
+                          "--card-content-height": "256px",
+                        }
+                      }
+                    >
+                      <div
+                        className="iot--bar-chart-container iot--bar-chart-container--editable"
+                      >
+                        <div
+                          id="mock-bar-chart-simple"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="iot--dashboard-editor--sidebar"
+      >
+        <div
+          className="iot--card-editor"
+          data-testid="card-editor"
+        >
+          <div
+            className="iot--card-editor--header"
+          >
+            <h2
+              className="iot--card-editor--header--title"
+            >
+              Gallery
+            </h2>
+          </div>
+          <div
+            className="iot--card-editor--content"
+          >
+            <div
+              className="iot--list iot--list__full-height"
+            >
+              <div
+                className="iot--list-header-container"
+              >
+                <div
+                  className="iot--list-header--search"
+                >
+                  <div
+                    aria-labelledby="iot--list-header--search-search"
+                    className="bx--search bx--search--sm"
+                    role="search"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="bx--search-magnifier"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                      />
+                    </svg>
+                    <label
+                      className="bx--label"
+                      htmlFor="iot--list-header--search"
+                      id="iot--list-header--search-search"
+                    >
+                      Enter a value
+                    </label>
+                    <input
+                      autoComplete="off"
+                      className="bx--search-input"
+                      id="iot--list-header--search"
+                      onChange={[Function]}
+                      placeholder="Enter a value"
+                      role="searchbox"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--list--content__full-height iot--list--content"
+              >
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
+                  <div
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <div
+                      className="iot--list-item--content"
+                    >
+                      <div
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                      >
+                        <div
+                          className="iot--card-gallery-list__icon"
+                        >
+                          <svg
+                            height={34}
+                            width={40}
+                          >
+                            <g
+                              fill="none"
+                              fillRule="nonzero"
+                              transform="translate(0 1)"
+                            >
+                              <path
+                                d="M20.556 1.233L32.28 7.368l.033.013 7.299 1.68v-.453l-7.193-1.675L20.376.63 7.546 30.883.519 28.516l-.002.483 7.23 2.436z"
+                                fill="#0062FF"
+                              />
+                              <circle
+                                cx={7.382}
+                                cy={31.154}
+                                fill="#FFF"
+                                r={1}
+                                stroke="#0062FF"
+                                strokeWidth={1.5}
+                              />
+                              <circle
+                                cx={20.455}
+                                cy={0.966}
+                                fill="#FFF"
+                                r={1}
+                                stroke="#0062FF"
+                                strokeWidth={1.5}
+                              />
+                              <circle
+                                cx={32.904}
+                                cy={7.365}
+                                fill="#FFF"
+                                r={1}
+                                stroke="#0062FF"
+                                strokeWidth={1.5}
+                              />
+                              <path
+                                d="M.13 13.592h.776v-.155H.13zM1.424 13.592H2.2v-.155h-.777zM2.718 13.592h.777v-.155h-.777zM4.013 13.592h.777v-.155h-.777zM5.307 13.592h.777v-.155h-.777zM6.602 13.592h.777v-.155h-.777zM7.896 13.592h.777v-.155h-.777zM9.19 13.592h.778v-.155H9.19zM10.485 13.592h.777v-.155h-.777zM11.78 13.592h.777v-.155h-.777zM13.074 13.592h.777v-.155h-.777zM14.369 13.592h.777v-.155h-.777zM15.663 13.592h.777v-.155h-.777zM16.958 13.592h.777v-.155h-.777zM18.252 13.592h.777v-.155h-.777zM19.547 13.592h.777v-.155h-.777zM20.841 13.592h.777v-.155h-.777zM22.136 13.592h.777v-.155h-.777zM23.43 13.592h.777v-.155h-.777zM24.725 13.592h.777v-.155h-.777zM26.02 13.592h.776v-.155h-.777zM27.314 13.592h.777v-.155h-.777zM28.608 13.592h.777v-.155h-.777zM29.903 13.592h.777v-.155h-.777zM31.197 13.592h.777v-.155h-.777zM32.492 13.592h.777v-.155h-.777zM33.786 13.592h.777v-.155h-.777zM35.08 13.592h.778v-.155h-.777zM36.375 13.592h.777v-.155h-.777zM37.67 13.592h.777v-.155h-.777zM38.964 13.592h.389v-.155h-.389z"
+                                fill="#0062FF"
+                              />
+                            </g>
+                          </svg>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
+                        <div
+                          className="iot--list-item--content--values--main"
+                        >
+                          <div
+                            className="iot--list-item--content--values--value"
+                            title="Time series line"
+                          >
+                            Time series line
+                          </div>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  className="iot--list--content__full-height iot--list--content"
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
                 >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={34}
-                              width={40}
-                            >
-                              <g
-                                fill="none"
-                                fillRule="nonzero"
-                                transform="translate(0 1)"
-                              >
-                                <path
-                                  d="M20.556 1.233L32.28 7.368l.033.013 7.299 1.68v-.453l-7.193-1.675L20.376.63 7.546 30.883.519 28.516l-.002.483 7.23 2.436z"
-                                  fill="#0062FF"
-                                />
-                                <circle
-                                  cx={7.382}
-                                  cy={31.154}
-                                  fill="#FFF"
-                                  r={1}
-                                  stroke="#0062FF"
-                                  strokeWidth={1.5}
-                                />
-                                <circle
-                                  cx={20.455}
-                                  cy={0.966}
-                                  fill="#FFF"
-                                  r={1}
-                                  stroke="#0062FF"
-                                  strokeWidth={1.5}
-                                />
-                                <circle
-                                  cx={32.904}
-                                  cy={7.365}
-                                  fill="#FFF"
-                                  r={1}
-                                  stroke="#0062FF"
-                                  strokeWidth={1.5}
-                                />
-                                <path
-                                  d="M.13 13.592h.776v-.155H.13zM1.424 13.592H2.2v-.155h-.777zM2.718 13.592h.777v-.155h-.777zM4.013 13.592h.777v-.155h-.777zM5.307 13.592h.777v-.155h-.777zM6.602 13.592h.777v-.155h-.777zM7.896 13.592h.777v-.155h-.777zM9.19 13.592h.778v-.155H9.19zM10.485 13.592h.777v-.155h-.777zM11.78 13.592h.777v-.155h-.777zM13.074 13.592h.777v-.155h-.777zM14.369 13.592h.777v-.155h-.777zM15.663 13.592h.777v-.155h-.777zM16.958 13.592h.777v-.155h-.777zM18.252 13.592h.777v-.155h-.777zM19.547 13.592h.777v-.155h-.777zM20.841 13.592h.777v-.155h-.777zM22.136 13.592h.777v-.155h-.777zM23.43 13.592h.777v-.155h-.777zM24.725 13.592h.777v-.155h-.777zM26.02 13.592h.776v-.155h-.777zM27.314 13.592h.777v-.155h-.777zM28.608 13.592h.777v-.155h-.777zM29.903 13.592h.777v-.155h-.777zM31.197 13.592h.777v-.155h-.777zM32.492 13.592h.777v-.155h-.777zM33.786 13.592h.777v-.155h-.777zM35.08 13.592h.778v-.155h-.777zM36.375 13.592h.777v-.155h-.777zM37.67 13.592h.777v-.155h-.777zM38.964 13.592h.389v-.155h-.389z"
-                                  fill="#0062FF"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                            <path
+                              d="M0 0h1.111v32H0zm31.111 2.963h1.111V32h-1.111zM7.778 19.259h1.111V32H7.778zm7.778-7.407h1.111V32h-1.111zM38.889 26.37H40V32h-1.111zM23.333 14.222h1.111V32h-1.111z"
+                              fill="#0062FF"
+                            />
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Simple bar"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Time series line"
-                            >
-                              Time series line
-                            </div>
+                            Simple bar
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
                             >
                               <path
-                                d="M0 0h1.111v32H0zm31.111 2.963h1.111V32h-1.111zM7.778 19.259h1.111V32H7.778zm7.778-7.407h1.111V32h-1.111zM38.889 26.37H40V32h-1.111zM23.333 14.222h1.111V32h-1.111z"
+                                d="M38.926 7.822H40V32h-1.074z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M37.584 17.422h1.074V32h-1.074z"
                                 fill="#0062FF"
                               />
-                            </svg>
-                          </div>
+                              <path
+                                d="M31.41 3.2h1.073V32H31.41z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M30.067 9.956h1.074V32h-1.074z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M23.893 14.578h1.073V32h-1.073z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M22.55 21.333h1.074V32H22.55z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M16.644 12.089h1.074V32h-1.074z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M15.302 25.6h1.074V32h-1.074z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M8.86 20.267h1.073V32H8.859z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M7.517 23.111h1.074V32H7.517z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M1.342 0h1.074v32H1.342z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M0 14.222h1.074V32H0z"
+                                fill="#0062FF"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Grouped bar"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Simple bar"
-                            >
-                              Simple bar
-                            </div>
+                            Grouped bar
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
                             >
-                              <g
-                                fill="none"
-                              >
-                                <path
-                                  d="M38.926 7.822H40V32h-1.074z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M37.584 17.422h1.074V32h-1.074z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M31.41 3.2h1.073V32H31.41z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M30.067 9.956h1.074V32h-1.074z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M23.893 14.578h1.073V32h-1.073z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M22.55 21.333h1.074V32H22.55z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M16.644 12.089h1.074V32h-1.074z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M15.302 25.6h1.074V32h-1.074z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M8.86 20.267h1.073V32H8.859z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M7.517 23.111h1.074V32H7.517z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M1.342 0h1.074v32H1.342z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M0 14.222h1.074V32H0z"
-                                  fill="#0062FF"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M38.108 7.467H40v24.178h-1.892z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M38.108 17.067H40v14.578h-1.892z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M38.108 16.711H40v1h-1.892z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M30.27 2.844h1.892v28.8H30.27z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M30.27 9.956h1.892V32H30.27z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M30.27 9.6h1.892v1H30.27z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M22.703 14.578h1.892V32h-1.892z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M22.703 21.333h1.892V32h-1.892z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M22.703 20.978h1.892v1h-1.892z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M15.405 12.089h1.892V32h-1.892z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M15.405 25.6h1.892V32h-1.892z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M15.405 25.244h1.892v1h-1.892z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M7.838 20.267H9.73V32H7.838z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M7.838 23.111H9.73V32H7.838z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M7.838 22.756H9.73v1H7.838z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M0 0h1.892v32H0z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M0 14.222h1.892V32H0z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M0 13.867h1.892v1H0z"
+                                fill="#FFF"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Stacked bar"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Grouped bar"
-                            >
-                              Grouped bar
-                            </div>
+                            Stacked bar
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
+                              <path
+                                d="M.5.5h38.752v31H.5z"
+                                stroke="#2160F8"
+                              />
+                              <path
+                                d="M4.969 21.714h21.863v4.571H4.969zm26.832 0l1.988 4.572h-3.975z"
+                                fill="#8EC1FF"
+                              />
+                              <text
+                                fill="#2160F8"
+                                fontFamily="IBMPlexSans, IBM Plex Sans"
+                                fontSize={10}
                               >
-                                <path
-                                  d="M38.108 7.467H40v24.178h-1.892z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M38.108 17.067H40v14.578h-1.892z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M38.108 16.711H40v1h-1.892z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M30.27 2.844h1.892v28.8H30.27z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M30.27 9.956h1.892V32H30.27z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M30.27 9.6h1.892v1H30.27z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M22.703 14.578h1.892V32h-1.892z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M22.703 21.333h1.892V32h-1.892z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M22.703 20.978h1.892v1h-1.892z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M15.405 12.089h1.892V32h-1.892z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M15.405 25.6h1.892V32h-1.892z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M15.405 25.244h1.892v1h-1.892z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M7.838 20.267H9.73V32H7.838z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M7.838 23.111H9.73V32H7.838z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M7.838 22.756H9.73v1H7.838z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M0 0h1.892v32H0z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M0 14.222h1.892V32H0z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M0 13.867h1.892v1H0z"
-                                  fill="#FFF"
-                                />
-                              </g>
-                            </svg>
-                          </div>
-                        </div>
-                        <div
-                          className="iot--list-item--content--values"
-                        >
-                          <div
-                            className="iot--list-item--content--values--main"
-                          >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Stacked bar"
-                            >
-                              Stacked bar
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
-                  >
-                    <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
-                    >
-                      <div
-                        className="iot--list-item--content"
-                      >
-                        <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
-                        >
-                          <div
-                            className="iot--card-gallery-list__icon"
-                          >
-                            <svg
-                              height={32}
-                              width={40}
-                            >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M.5.5h38.752v31H.5z"
-                                  stroke="#2160F8"
-                                />
-                                <path
-                                  d="M4.969 21.714h21.863v4.571H4.969zm26.832 0l1.988 4.572h-3.975z"
-                                  fill="#8EC1FF"
-                                />
-                                <text
-                                  fill="#2160F8"
-                                  fontFamily="IBMPlexSans, IBM Plex Sans"
-                                  fontSize={10}
+                                <tspan
+                                  x={4.969}
+                                  y={15.5}
                                 >
-                                  <tspan
-                                    x={4.969}
-                                    y={15.5}
-                                  >
-                                    25%
-                                  </tspan>
-                                </text>
-                              </g>
-                            </svg>
-                          </div>
+                                  25%
+                                </tspan>
+                              </text>
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Value / KPI"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Value / KPI"
-                            >
-                              Value / KPI
-                            </div>
+                            Value / KPI
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M1.29 21.57L13 10.477l11.2 12.347L30.5 16l8.21 9.6"
-                                  stroke="#0062FF"
-                                />
-                                <ellipse
-                                  cx={25.835}
-                                  cy={7.62}
-                                  rx={3.19}
-                                  ry={3.5}
-                                  stroke="#005BFF"
-                                />
-                                <path
-                                  d="M.5.5h39v31H.5z"
-                                  stroke="#2160F8"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M1.29 21.57L13 10.477l11.2 12.347L30.5 16l8.21 9.6"
+                                stroke="#0062FF"
+                              />
+                              <ellipse
+                                cx={25.835}
+                                cy={7.62}
+                                rx={3.19}
+                                ry={3.5}
+                                stroke="#005BFF"
+                              />
+                              <path
+                                d="M.5.5h39v31H.5z"
+                                stroke="#2160F8"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Image"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Image"
-                            >
-                              Image
-                            </div>
+                            Image
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M0 0h40v2.759H0z"
-                                  fill="#0058FF"
-                                />
-                                <path
-                                  d="M.5 3.259h39V31.5H.5z"
-                                  stroke="#005BFF"
-                                />
-                                <path
-                                  d="M3.5 6.621h19V9.38h-19zm21.5 0h11V9.38H25zM3.5 18.759h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 12.69h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 24.828h19v2.759h-19zm21.5 0h11v2.759H25z"
-                                  fill="#D8D8D8"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M0 0h40v2.759H0z"
+                                fill="#0058FF"
+                              />
+                              <path
+                                d="M.5 3.259h39V31.5H.5z"
+                                stroke="#005BFF"
+                              />
+                              <path
+                                d="M3.5 6.621h19V9.38h-19zm21.5 0h11V9.38H25zM3.5 18.759h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 12.69h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 24.828h19v2.759h-19zm21.5 0h11v2.759H25z"
+                                fill="#D8D8D8"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Data table"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Data table"
-                            >
-                              Data table
-                            </div>
+                            Data table
                           </div>
                         </div>
                       </div>
@@ -12587,821 +12547,137 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
     }
   >
     <div
-      style={
-        Object {
-          "height": "calc(100vh - 6rem)",
-        }
-      }
+      className="iot--dashboard-editor"
     >
       <div
-        className="iot--dashboard-editor"
+        className="iot--dashboard-editor--content"
       >
         <div
-          className="iot--dashboard-editor--content"
+          className="page-title-bar"
         >
           <div
-            className="page-title-bar"
+            className="page-title-bar-header"
           >
             <div
-              className="page-title-bar-header"
+              className="page-title-bar-header-left"
             >
               <div
-                className="page-title-bar-header-left"
+                className="page-title-bar-breadcrumb"
               >
-                <div
-                  className="page-title-bar-breadcrumb"
+                <nav
+                  aria-label="Breadcrumb"
                 >
-                  <nav
-                    aria-label="Breadcrumb"
+                  <ol
+                    className="bx--breadcrumb"
                   >
-                    <ol
-                      className="bx--breadcrumb"
+                    <li
+                      className="bx--breadcrumb-item"
                     >
-                      <li
-                        className="bx--breadcrumb-item"
+                      <a
+                        className="bx--link bx--link"
+                        href="www.ibm.com"
                       >
-                        <a
-                          className="bx--link bx--link"
-                          href="www.ibm.com"
-                        >
-                          Dashboard library
-                        </a>
-                      </li>
-                      <li
-                        className="bx--breadcrumb-item"
-                      >
-                        <a
-                          className="bx--link bx--link"
-                          href="www.ibm.com"
-                        >
-                          Favorites
-                        </a>
-                      </li>
-                    </ol>
-                  </nav>
-                </div>
-                <div
-                  className="page-title-bar-title"
-                >
-                  <div
-                    className="page-title-bar-title--text"
-                  >
-                    <h2>
-                      My dashboard
-                    </h2>
-                    <button
-                      className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
+                        Dashboard library
+                      </a>
+                    </li>
+                    <li
+                      className="bx--breadcrumb-item"
                     >
-                      <span
-                        className="bx--assistive-text"
+                      <a
+                        className="bx--link bx--link"
+                        href="www.ibm.com"
                       >
-                        Edit title
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Edit title"
-                        className="bx--btn__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
+                        Favorites
+                      </a>
+                    </li>
+                  </ol>
+                </nav>
               </div>
               <div
-                className="page-title-bar-header-right"
+                className="page-title-bar-title"
               >
                 <div
-                  className="iot--dashboard-editor-header--right"
+                  className="page-title-bar-title--text"
                 >
-                  <div
-                    className="iot--dashboard-editor-header--top"
-                  />
-                  <div
-                    className="iot--dashboard-editor-header--bottom"
+                  <h2>
+                    My dashboard
+                  </h2>
+                  <button
+                    className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
                   >
-                    <button
-                      aria-describedby="icon-tooltip-4"
-                      className="bx--tooltip__trigger bx--tooltip--a11y iot--dashboard-editor-header--bottom__import bx--tooltip--bottom bx--tooltip--align-center"
-                      onFocus={[Function]}
-                      onMouseEnter={[Function]}
-                      type="button"
+                    <span
+                      className="bx--assistive-text"
                     >
-                      <span
-                        className="bx--assistive-text"
-                        id="icon-tooltip-4"
-                      >
-                        Import
-                      </span>
-                      <label
-                        accepts={
-                          Array [
-                            ".json",
-                          ]
-                        }
-                        aria-disabled={false}
-                        className="bx--btn bx--btn--ghost bx--btn--field"
-                        htmlFor="id4"
-                        onKeyDown={[Function]}
-                        tabIndex={0}
-                      >
-                        <span
-                          role="button"
-                        >
-                          <svg
-                            aria-hidden={true}
-                            fill="#161616"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M28 19L14.83 19 17.41 16.41 16 15 11 20 16 25 17.41 23.59 14.83 21 28 21 28 19z"
-                            />
-                            <path
-                              d="M24,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,16,2H6A2,2,0,0,0,4,4V28a2,2,0,0,0,2,2H22a2,2,0,0,0,2-2V26H22v2H6V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L21.59,10Z"
-                            />
-                          </svg>
-                        </span>
-                      </label>
-                      <input
-                        className="bx--visually-hidden"
-                        disabled={false}
-                        id="id4"
-                        multiple={false}
-                        onChange={[Function]}
-                        onClick={[Function]}
-                        tabIndex="-1"
-                        type="file"
+                      Edit title
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Edit title"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
                       />
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      <span
-                        className="bx--assistive-text"
-                      >
-                        Export
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Export"
-                        className="bx--btn__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M13 21L26.17 21 23.59 23.59 25 25 30 20 25 15 23.59 16.41 26.17 19 13 19 13 21z"
-                        />
-                        <path
-                          d="M22,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,14,2H4A2,2,0,0,0,2,4V28a2,2,0,0,0,2,2H20a2,2,0,0,0,2-2V26H20v2H4V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L19.59,10Z"
-                        />
-                      </svg>
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      <span
-                        className="bx--assistive-text"
-                      >
-                        Delete
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        aria-label="Delete"
-                        className="bx--btn__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M12 12H14V24H12zM18 12H20V24H18z"
-                        />
-                        <path
-                          d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
-                        />
-                      </svg>
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--secondary"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      className="iot--btn bx--btn bx--btn--field bx--btn--primary"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      Save and close
-                    </button>
-                  </div>
+                    </svg>
+                  </button>
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            className="bx--inline-notification bx--inline-notification--low-contrast bx--inline-notification--info"
-            kind="info"
-            role="alert"
-          >
             <div
-              className="bx--inline-notification__details"
-            >
-              <svg
-                aria-hidden={true}
-                className="bx--inline-notification__icon"
-                fill="currentColor"
-                focusable="false"
-                height={20}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Zm0,5a1.5,1.5,0,1,1-1.5,1.5A1.5,1.5,0,0,1,16,7Zm4,17.125h-8v-2.25h2.875v-6.75h-1.875v-2.25h4.125v9h2.875Z"
-                />
-                <path
-                  d="M16,7a1.5,1.5,0,1,1-1.5,1.5A1.5,1.5,0,0,1,16,7Zm4,17.125h-8v-2.25h2.875v-6.75h-1.875v-2.25h4.125v9h2.875Z"
-                  data-icon-path="inner-path"
-                  fill="none"
-                />
-                <title>
-                  info icon
-                </title>
-              </svg>
-              <div
-                className="bx--inline-notification__text-wrapper"
-              >
-                <p
-                  className="bx--inline-notification__title"
-                >
-                  This is the dashboard editor
-                </p>
-                <div
-                  className="bx--inline-notification__subtitle"
-                >
-                  Use the side panel to create or edit cards
-                </div>
-              </div>
-            </div>
-            <button
-              aria-label="closes notification"
-              className="bx--inline-notification__close-button"
-              onClick={[Function]}
-              title="closes notification"
-              type="button"
-            >
-              <svg
-                aria-label="close notification"
-                className="bx--inline-notification__close-icon"
-                fill="currentColor"
-                focusable="false"
-                height={20}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 32 32"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            className="bx--inline-notification bx--inline-notification--low-contrast bx--inline-notification--success"
-            kind="success"
-            role="alert"
-          >
-            <div
-              className="bx--inline-notification__details"
-            >
-              <svg
-                aria-hidden={true}
-                className="bx--inline-notification__icon"
-                fill="currentColor"
-                focusable="false"
-                height={20}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 20 20"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10,1c-4.9,0-9,4.1-9,9s4.1,9,9,9s9-4,9-9S15,1,10,1z M8.7,13.5l-3.2-3.2l1-1l2.2,2.2l4.8-4.8l1,1L8.7,13.5z"
-                />
-                <path
-                  d="M8.7,13.5l-3.2-3.2l1-1l2.2,2.2l4.8-4.8l1,1L8.7,13.5z"
-                  data-icon-path="inner-path"
-                  fill="none"
-                  opacity="0"
-                />
-                <title>
-                  success icon
-                </title>
-              </svg>
-              <div
-                className="bx--inline-notification__text-wrapper"
-              >
-                <p
-                  className="bx--inline-notification__title"
-                >
-                  Import successful
-                </p>
-                <div
-                  className="bx--inline-notification__subtitle"
-                >
-                  The JSON import was successful
-                </div>
-              </div>
-            </div>
-            <button
-              aria-label="closes notification"
-              className="bx--inline-notification__close-button"
-              onClick={[Function]}
-              title="closes notification"
-              type="button"
-            >
-              <svg
-                aria-label="close notification"
-                className="bx--inline-notification__close-icon"
-                fill="currentColor"
-                focusable="false"
-                height={20}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 32 32"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            className="bx--inline-notification bx--inline-notification--low-contrast bx--inline-notification--error"
-            kind="error"
-            role="alert"
-          >
-            <div
-              className="bx--inline-notification__details"
-            >
-              <svg
-                aria-hidden={true}
-                className="bx--inline-notification__icon"
-                fill="currentColor"
-                focusable="false"
-                height={20}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 20 20"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10,1c-5,0-9,4-9,9s4,9,9,9s9-4,9-9S15,1,10,1z M13.5,14.5l-8-8l1-1l8,8L13.5,14.5z"
-                />
-                <path
-                  d="M13.5,14.5l-8-8l1-1l8,8L13.5,14.5z"
-                  data-icon-path="inner-path"
-                  opacity="0"
-                />
-                <title>
-                  error icon
-                </title>
-              </svg>
-              <div
-                className="bx--inline-notification__text-wrapper"
-              >
-                <p
-                  className="bx--inline-notification__title"
-                >
-                  Data error
-                </p>
-                <div
-                  className="bx--inline-notification__subtitle"
-                >
-                  The image provided was not able to be fetched
-                </div>
-              </div>
-            </div>
-            <button
-              aria-label="closes notification"
-              className="bx--inline-notification__close-button"
-              onClick={[Function]}
-              title="closes notification"
-              type="button"
-            >
-              <svg
-                aria-label="close notification"
-                className="bx--inline-notification__close-icon"
-                fill="currentColor"
-                focusable="false"
-                height={20}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 32 32"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            className="iot--dashboard-editor--preview"
-          >
-            <div
-              className=""
+              className="page-title-bar-header-right"
             >
               <div
-                className="iot--dashboard-editor--preview__grid-container"
+                className="iot--dashboard-editor-header--right"
               >
                 <div
-                  className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
-                  data-floating-menu-container={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onClose={[Function]}
-                  onKeyDown={[Function]}
-                  open={false}
-                  role="presentation"
+                  className="iot--dashboard-editor-header--top"
+                />
+                <div
+                  className="iot--dashboard-editor-header--bottom"
                 >
-                  <span
-                    className="bx--visually-hidden"
-                    role="link"
-                    tabIndex="0"
+                  <button
+                    aria-describedby="icon-tooltip-4"
+                    className="bx--tooltip__trigger bx--tooltip--a11y iot--dashboard-editor-header--bottom__import bx--tooltip--bottom bx--tooltip--align-center"
+                    onFocus={[Function]}
+                    onMouseEnter={[Function]}
+                    type="button"
                   >
-                    Focus sentinel
-                  </span>
-                  <div
-                    className="bx--modal-container"
-                    role="dialog"
-                  >
-                    <div
-                      className="bx--modal-header"
+                    <span
+                      className="bx--assistive-text"
+                      id="icon-tooltip-4"
                     >
-                      <p
-                        className="bx--modal-header__label bx--type-delta"
-                      >
-                        New image card
-                      </p>
-                      <p
-                        className="bx--modal-header__heading bx--type-beta"
-                      >
-                        Image gallery
-                      </p>
-                      <button
-                        aria-label="Close"
-                        className="bx--modal-close"
-                        onClick={[Function]}
-                        title="Close"
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="bx--modal-close__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      className="bx--modal-content"
-                    >
-                      <div
-                        className="iot--image-gallery-modal__top-section"
-                      >
-                        <p
-                          alt="Select the image that you want to display on this card."
-                          className="iot--image-gallery-modal__instruction-text"
-                        >
-                          Select the image that you want to display on this card.
-                        </p>
-                        <div
-                          className="iot--image-gallery-modal__search-list-view-container"
-                        >
-                          <div
-                            aria-labelledby="iot--image-gallery-modal--search-search"
-                            className="bx--search bx--search--xl bx--search--light"
-                            role="search"
-                          >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              fill="currentColor"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="iot--image-gallery-modal--search"
-                              id="iot--image-gallery-modal--search-search"
-                            >
-                              
-                            </label>
-                            <input
-                              autoComplete="off"
-                              className="bx--search-input"
-                              id="iot--image-gallery-modal--search"
-                              onChange={[Function]}
-                              placeholder="Search image by file name"
-                              role="searchbox"
-                              type="text"
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                fill="currentColor"
-                                focusable="false"
-                                height={16}
-                                preserveAspectRatio="xMidYMid meet"
-                                viewBox="0 0 32 32"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                                />
-                              </svg>
-                            </button>
-                          </div>
-                          <div
-                            className="bx--content-switcher iot--image-gallery-modal__content-switcher"
-                            onChange={[Function]}
-                            role="tablist"
-                          >
-                            <button
-                              className="iot--icon-switch iot--icon-switch--large bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
-                              disabled={false}
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              tabIndex={0}
-                              type="button"
-                            >
-                              <span
-                                className="bx--assistive-text"
-                              >
-                                Grid
-                              </span>
-                              <svg
-                                aria-hidden="true"
-                                aria-label="Grid"
-                                className="bx--btn__icon"
-                                fill="currentColor"
-                                focusable="false"
-                                height={20}
-                                preserveAspectRatio="xMidYMid meet"
-                                role="img"
-                                viewBox="0 0 32 32"
-                                width={20}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M12 4H6A2 2 0 004 6v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0012 4zm0 8H6V6h6zM26 4H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0026 4zm0 8H20V6h6zM12 18H6a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0012 18zm0 8H6V20h6zM26 18H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0026 18zm0 8H20V20h6z"
-                                />
-                              </svg>
-                            </button>
-                            <button
-                              className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
-                              disabled={false}
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              tabIndex={0}
-                              type="button"
-                            >
-                              <span
-                                className="bx--assistive-text"
-                              >
-                                List
-                              </span>
-                              <svg
-                                aria-hidden="true"
-                                aria-label="List"
-                                className="bx--btn__icon"
-                                fill="currentColor"
-                                focusable="false"
-                                height={20}
-                                preserveAspectRatio="xMidYMid meet"
-                                role="img"
-                                viewBox="0 0 32 32"
-                                width={20}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M10 6H28V8H10zM10 24H28V26H10zM10 15H28V17H10zM4 15H6V17H4zM4 6H6V8H4zM4 24H6V26H4z"
-                                />
-                              </svg>
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        className="iot--image-gallery-modal__flex-wrapper"
-                      >
-                        <div
-                          className="iot--image-gallery-modal__scroll-panel iot--image-gallery-modal__scroll-panel--grid"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      className="bx--modal-footer iot--composed-modal-footer"
-                    >
-                      <button
-                        className="iot--btn bx--btn bx--btn--secondary"
-                        disabled={false}
-                        onClick={[Function]}
-                        tabIndex={0}
-                        type="button"
-                      >
-                        Cancel
-                      </button>
-                      <button
-                        className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                        disabled={true}
-                        onClick={[Function]}
-                        tabIndex={0}
-                        type="button"
-                      >
-                        Select
-                      </button>
-                    </div>
-                  </div>
-                  <span
-                    className="bx--visually-hidden"
-                    role="link"
-                    tabIndex="0"
-                  >
-                    Focus sentinel
-                  </span>
-                </div>
-                <div
-                  style={
-                    Object {
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <div
-                    className="react-grid-layout DashboardGrid__StyledGridLayout-vxs00g-0 ANzdO"
-                    onDragEnter={[Function]}
-                    onDragLeave={[Function]}
-                    onDragOver={[Function]}
-                    onDrop={[Function]}
-                    style={
-                      Object {
-                        "height": "-16px",
+                      Import
+                    </span>
+                    <label
+                      accepts={
+                        Array [
+                          ".json",
+                        ]
                       }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="iot--dashboard-editor--sidebar"
-        >
-          <div
-            className="iot--card-editor"
-            data-testid="card-editor"
-          >
-            <div
-              className="iot--card-editor--header"
-            >
-              <h2
-                className="iot--card-editor--header--title"
-              >
-                Gallery
-              </h2>
-            </div>
-            <div
-              className="iot--card-editor--content"
-            >
-              <div
-                className="iot--list iot--list__full-height"
-              >
-                <div
-                  className="iot--list-header-container"
-                >
-                  <div
-                    className="iot--list-header--search"
-                  >
-                    <div
-                      aria-labelledby="iot--list-header--search-search"
-                      className="bx--search bx--search--sm"
-                      role="search"
+                      aria-disabled={false}
+                      className="bx--btn bx--btn--ghost bx--btn--field"
+                      htmlFor="id4"
+                      onKeyDown={[Function]}
+                      tabIndex={0}
                     >
-                      <svg
-                        aria-hidden={true}
-                        className="bx--search-magnifier"
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                        />
-                      </svg>
-                      <label
-                        className="bx--label"
-                        htmlFor="iot--list-header--search"
-                        id="iot--list-header--search-search"
-                      >
-                        Enter a value
-                      </label>
-                      <input
-                        autoComplete="off"
-                        className="bx--search-input"
-                        id="iot--list-header--search"
-                        onChange={[Function]}
-                        placeholder="Enter a value"
-                        role="searchbox"
-                        type="text"
-                        value=""
-                      />
-                      <button
-                        aria-label="Clear search input"
-                        className="bx--search-close bx--search-close--hidden"
-                        onClick={[Function]}
-                        type="button"
+                      <span
+                        role="button"
                       >
                         <svg
                           aria-hidden={true}
-                          fill="currentColor"
+                          fill="#161616"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -13410,620 +12686,1296 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <path
-                            d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                            d="M28 19L14.83 19 17.41 16.41 16 15 11 20 16 25 17.41 23.59 14.83 21 28 21 28 19z"
+                          />
+                          <path
+                            d="M24,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,16,2H6A2,2,0,0,0,4,4V28a2,2,0,0,0,2,2H22a2,2,0,0,0,2-2V26H22v2H6V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L21.59,10Z"
                           />
                         </svg>
-                      </button>
+                      </span>
+                    </label>
+                    <input
+                      className="bx--visually-hidden"
+                      disabled={false}
+                      id="id4"
+                      multiple={false}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      tabIndex="-1"
+                      type="file"
+                    />
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Export
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Export"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M13 21L26.17 21 23.59 23.59 25 25 30 20 25 15 23.59 16.41 26.17 19 13 19 13 21z"
+                      />
+                      <path
+                        d="M22,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,14,2H4A2,2,0,0,0,2,4V28a2,2,0,0,0,2,2H20a2,2,0,0,0,2-2V26H20v2H4V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L19.59,10Z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Delete
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Delete"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M12 12H14V24H12zM18 12H20V24H18z"
+                      />
+                      <path
+                        d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--secondary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Save and close
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="bx--inline-notification bx--inline-notification--low-contrast bx--inline-notification--info"
+          kind="info"
+          role="alert"
+        >
+          <div
+            className="bx--inline-notification__details"
+          >
+            <svg
+              aria-hidden={true}
+              className="bx--inline-notification__icon"
+              fill="currentColor"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Zm0,5a1.5,1.5,0,1,1-1.5,1.5A1.5,1.5,0,0,1,16,7Zm4,17.125h-8v-2.25h2.875v-6.75h-1.875v-2.25h4.125v9h2.875Z"
+              />
+              <path
+                d="M16,7a1.5,1.5,0,1,1-1.5,1.5A1.5,1.5,0,0,1,16,7Zm4,17.125h-8v-2.25h2.875v-6.75h-1.875v-2.25h4.125v9h2.875Z"
+                data-icon-path="inner-path"
+                fill="none"
+              />
+              <title>
+                info icon
+              </title>
+            </svg>
+            <div
+              className="bx--inline-notification__text-wrapper"
+            >
+              <p
+                className="bx--inline-notification__title"
+              >
+                This is the dashboard editor
+              </p>
+              <div
+                className="bx--inline-notification__subtitle"
+              >
+                Use the side panel to create or edit cards
+              </div>
+            </div>
+          </div>
+          <button
+            aria-label="closes notification"
+            className="bx--inline-notification__close-button"
+            onClick={[Function]}
+            title="closes notification"
+            type="button"
+          >
+            <svg
+              aria-label="close notification"
+              className="bx--inline-notification__close-icon"
+              fill="currentColor"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className="bx--inline-notification bx--inline-notification--low-contrast bx--inline-notification--success"
+          kind="success"
+          role="alert"
+        >
+          <div
+            className="bx--inline-notification__details"
+          >
+            <svg
+              aria-hidden={true}
+              className="bx--inline-notification__icon"
+              fill="currentColor"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 20 20"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10,1c-4.9,0-9,4.1-9,9s4.1,9,9,9s9-4,9-9S15,1,10,1z M8.7,13.5l-3.2-3.2l1-1l2.2,2.2l4.8-4.8l1,1L8.7,13.5z"
+              />
+              <path
+                d="M8.7,13.5l-3.2-3.2l1-1l2.2,2.2l4.8-4.8l1,1L8.7,13.5z"
+                data-icon-path="inner-path"
+                fill="none"
+                opacity="0"
+              />
+              <title>
+                success icon
+              </title>
+            </svg>
+            <div
+              className="bx--inline-notification__text-wrapper"
+            >
+              <p
+                className="bx--inline-notification__title"
+              >
+                Import successful
+              </p>
+              <div
+                className="bx--inline-notification__subtitle"
+              >
+                The JSON import was successful
+              </div>
+            </div>
+          </div>
+          <button
+            aria-label="closes notification"
+            className="bx--inline-notification__close-button"
+            onClick={[Function]}
+            title="closes notification"
+            type="button"
+          >
+            <svg
+              aria-label="close notification"
+              className="bx--inline-notification__close-icon"
+              fill="currentColor"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className="bx--inline-notification bx--inline-notification--low-contrast bx--inline-notification--error"
+          kind="error"
+          role="alert"
+        >
+          <div
+            className="bx--inline-notification__details"
+          >
+            <svg
+              aria-hidden={true}
+              className="bx--inline-notification__icon"
+              fill="currentColor"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 20 20"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10,1c-5,0-9,4-9,9s4,9,9,9s9-4,9-9S15,1,10,1z M13.5,14.5l-8-8l1-1l8,8L13.5,14.5z"
+              />
+              <path
+                d="M13.5,14.5l-8-8l1-1l8,8L13.5,14.5z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                error icon
+              </title>
+            </svg>
+            <div
+              className="bx--inline-notification__text-wrapper"
+            >
+              <p
+                className="bx--inline-notification__title"
+              >
+                Data error
+              </p>
+              <div
+                className="bx--inline-notification__subtitle"
+              >
+                The image provided was not able to be fetched
+              </div>
+            </div>
+          </div>
+          <button
+            aria-label="closes notification"
+            className="bx--inline-notification__close-button"
+            onClick={[Function]}
+            title="closes notification"
+            type="button"
+          >
+            <svg
+              aria-label="close notification"
+              className="bx--inline-notification__close-icon"
+              fill="currentColor"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className="iot--dashboard-editor--preview"
+        >
+          <div
+            className=""
+          >
+            <div
+              className="iot--dashboard-editor--preview__grid-container"
+            >
+              <div
+                className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
+                data-floating-menu-container={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onClose={[Function]}
+                onKeyDown={[Function]}
+                open={false}
+                role="presentation"
+              >
+                <span
+                  className="bx--visually-hidden"
+                  role="link"
+                  tabIndex="0"
+                >
+                  Focus sentinel
+                </span>
+                <div
+                  className="bx--modal-container"
+                  role="dialog"
+                >
+                  <div
+                    className="bx--modal-header"
+                  >
+                    <p
+                      className="bx--modal-header__label bx--type-delta"
+                    >
+                      New image card
+                    </p>
+                    <p
+                      className="bx--modal-header__heading bx--type-beta"
+                    >
+                      Image gallery
+                    </p>
+                    <button
+                      aria-label="Close"
+                      className="bx--modal-close"
+                      onClick={[Function]}
+                      title="Close"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="bx--modal-close__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                  <div
+                    className="bx--modal-content"
+                  >
+                    <div
+                      className="iot--image-gallery-modal__top-section"
+                    >
+                      <p
+                        alt="Select the image that you want to display on this card."
+                        className="iot--image-gallery-modal__instruction-text"
+                      >
+                        Select the image that you want to display on this card.
+                      </p>
+                      <div
+                        className="iot--image-gallery-modal__search-list-view-container"
+                      >
+                        <div
+                          aria-labelledby="iot--image-gallery-modal--search-search"
+                          className="bx--search bx--search--xl bx--search--light"
+                          role="search"
+                        >
+                          <svg
+                            aria-hidden={true}
+                            className="bx--search-magnifier"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                            />
+                          </svg>
+                          <label
+                            className="bx--label"
+                            htmlFor="iot--image-gallery-modal--search"
+                            id="iot--image-gallery-modal--search-search"
+                          >
+                            
+                          </label>
+                          <input
+                            autoComplete="off"
+                            className="bx--search-input"
+                            id="iot--image-gallery-modal--search"
+                            onChange={[Function]}
+                            placeholder="Search image by file name"
+                            role="searchbox"
+                            type="text"
+                          />
+                          <button
+                            aria-label="Clear search input"
+                            className="bx--search-close bx--search-close--hidden"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <div
+                          className="bx--content-switcher iot--image-gallery-modal__content-switcher"
+                          onChange={[Function]}
+                          role="tablist"
+                        >
+                          <button
+                            className="iot--icon-switch iot--icon-switch--large bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                            disabled={false}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            tabIndex={0}
+                            type="button"
+                          >
+                            <span
+                              className="bx--assistive-text"
+                            >
+                              Grid
+                            </span>
+                            <svg
+                              aria-hidden="true"
+                              aria-label="Grid"
+                              className="bx--btn__icon"
+                              fill="currentColor"
+                              focusable="false"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M12 4H6A2 2 0 004 6v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0012 4zm0 8H6V6h6zM26 4H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0026 4zm0 8H20V6h6zM12 18H6a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0012 18zm0 8H6V20h6zM26 18H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0026 18zm0 8H20V20h6z"
+                              />
+                            </svg>
+                          </button>
+                          <button
+                            className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top"
+                            disabled={false}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            tabIndex={0}
+                            type="button"
+                          >
+                            <span
+                              className="bx--assistive-text"
+                            >
+                              List
+                            </span>
+                            <svg
+                              aria-hidden="true"
+                              aria-label="List"
+                              className="bx--btn__icon"
+                              fill="currentColor"
+                              focusable="false"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M10 6H28V8H10zM10 24H28V26H10zM10 15H28V17H10zM4 15H6V17H4zM4 6H6V8H4zM4 24H6V26H4z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="iot--image-gallery-modal__flex-wrapper"
+                    >
+                      <div
+                        className="iot--image-gallery-modal__scroll-panel iot--image-gallery-modal__scroll-panel--grid"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="bx--modal-footer iot--composed-modal-footer"
+                  >
+                    <button
+                      className="iot--btn bx--btn bx--btn--secondary"
+                      disabled={false}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                      disabled={true}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      Select
+                    </button>
+                  </div>
+                </div>
+                <span
+                  className="bx--visually-hidden"
+                  role="link"
+                  tabIndex="0"
+                >
+                  Focus sentinel
+                </span>
+              </div>
+              <div
+                style={
+                  Object {
+                    "flex": 1,
+                  }
+                }
+              >
+                <div
+                  className="react-grid-layout DashboardGrid__StyledGridLayout-vxs00g-0 ANzdO"
+                  onDragEnter={[Function]}
+                  onDragLeave={[Function]}
+                  onDragOver={[Function]}
+                  onDrop={[Function]}
+                  style={
+                    Object {
+                      "height": "-16px",
+                    }
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="iot--dashboard-editor--sidebar"
+      >
+        <div
+          className="iot--card-editor"
+          data-testid="card-editor"
+        >
+          <div
+            className="iot--card-editor--header"
+          >
+            <h2
+              className="iot--card-editor--header--title"
+            >
+              Gallery
+            </h2>
+          </div>
+          <div
+            className="iot--card-editor--content"
+          >
+            <div
+              className="iot--list iot--list__full-height"
+            >
+              <div
+                className="iot--list-header-container"
+              >
+                <div
+                  className="iot--list-header--search"
+                >
+                  <div
+                    aria-labelledby="iot--list-header--search-search"
+                    className="bx--search bx--search--sm"
+                    role="search"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="bx--search-magnifier"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                      />
+                    </svg>
+                    <label
+                      className="bx--label"
+                      htmlFor="iot--list-header--search"
+                      id="iot--list-header--search-search"
+                    >
+                      Enter a value
+                    </label>
+                    <input
+                      autoComplete="off"
+                      className="bx--search-input"
+                      id="iot--list-header--search"
+                      onChange={[Function]}
+                      placeholder="Enter a value"
+                      role="searchbox"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--list--content__full-height iot--list--content"
+              >
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
+                  <div
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <div
+                      className="iot--list-item--content"
+                    >
+                      <div
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                      >
+                        <div
+                          className="iot--card-gallery-list__icon"
+                        >
+                          <svg
+                            height={34}
+                            width={40}
+                          >
+                            <g
+                              fill="none"
+                              fillRule="nonzero"
+                              transform="translate(0 1)"
+                            >
+                              <path
+                                d="M20.556 1.233L32.28 7.368l.033.013 7.299 1.68v-.453l-7.193-1.675L20.376.63 7.546 30.883.519 28.516l-.002.483 7.23 2.436z"
+                                fill="#0062FF"
+                              />
+                              <circle
+                                cx={7.382}
+                                cy={31.154}
+                                fill="#FFF"
+                                r={1}
+                                stroke="#0062FF"
+                                strokeWidth={1.5}
+                              />
+                              <circle
+                                cx={20.455}
+                                cy={0.966}
+                                fill="#FFF"
+                                r={1}
+                                stroke="#0062FF"
+                                strokeWidth={1.5}
+                              />
+                              <circle
+                                cx={32.904}
+                                cy={7.365}
+                                fill="#FFF"
+                                r={1}
+                                stroke="#0062FF"
+                                strokeWidth={1.5}
+                              />
+                              <path
+                                d="M.13 13.592h.776v-.155H.13zM1.424 13.592H2.2v-.155h-.777zM2.718 13.592h.777v-.155h-.777zM4.013 13.592h.777v-.155h-.777zM5.307 13.592h.777v-.155h-.777zM6.602 13.592h.777v-.155h-.777zM7.896 13.592h.777v-.155h-.777zM9.19 13.592h.778v-.155H9.19zM10.485 13.592h.777v-.155h-.777zM11.78 13.592h.777v-.155h-.777zM13.074 13.592h.777v-.155h-.777zM14.369 13.592h.777v-.155h-.777zM15.663 13.592h.777v-.155h-.777zM16.958 13.592h.777v-.155h-.777zM18.252 13.592h.777v-.155h-.777zM19.547 13.592h.777v-.155h-.777zM20.841 13.592h.777v-.155h-.777zM22.136 13.592h.777v-.155h-.777zM23.43 13.592h.777v-.155h-.777zM24.725 13.592h.777v-.155h-.777zM26.02 13.592h.776v-.155h-.777zM27.314 13.592h.777v-.155h-.777zM28.608 13.592h.777v-.155h-.777zM29.903 13.592h.777v-.155h-.777zM31.197 13.592h.777v-.155h-.777zM32.492 13.592h.777v-.155h-.777zM33.786 13.592h.777v-.155h-.777zM35.08 13.592h.778v-.155h-.777zM36.375 13.592h.777v-.155h-.777zM37.67 13.592h.777v-.155h-.777zM38.964 13.592h.389v-.155h-.389z"
+                                fill="#0062FF"
+                              />
+                            </g>
+                          </svg>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
+                        <div
+                          className="iot--list-item--content--values--main"
+                        >
+                          <div
+                            className="iot--list-item--content--values--value"
+                            title="Time series line"
+                          >
+                            Time series line
+                          </div>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  className="iot--list--content__full-height iot--list--content"
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
                 >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={34}
-                              width={40}
-                            >
-                              <g
-                                fill="none"
-                                fillRule="nonzero"
-                                transform="translate(0 1)"
-                              >
-                                <path
-                                  d="M20.556 1.233L32.28 7.368l.033.013 7.299 1.68v-.453l-7.193-1.675L20.376.63 7.546 30.883.519 28.516l-.002.483 7.23 2.436z"
-                                  fill="#0062FF"
-                                />
-                                <circle
-                                  cx={7.382}
-                                  cy={31.154}
-                                  fill="#FFF"
-                                  r={1}
-                                  stroke="#0062FF"
-                                  strokeWidth={1.5}
-                                />
-                                <circle
-                                  cx={20.455}
-                                  cy={0.966}
-                                  fill="#FFF"
-                                  r={1}
-                                  stroke="#0062FF"
-                                  strokeWidth={1.5}
-                                />
-                                <circle
-                                  cx={32.904}
-                                  cy={7.365}
-                                  fill="#FFF"
-                                  r={1}
-                                  stroke="#0062FF"
-                                  strokeWidth={1.5}
-                                />
-                                <path
-                                  d="M.13 13.592h.776v-.155H.13zM1.424 13.592H2.2v-.155h-.777zM2.718 13.592h.777v-.155h-.777zM4.013 13.592h.777v-.155h-.777zM5.307 13.592h.777v-.155h-.777zM6.602 13.592h.777v-.155h-.777zM7.896 13.592h.777v-.155h-.777zM9.19 13.592h.778v-.155H9.19zM10.485 13.592h.777v-.155h-.777zM11.78 13.592h.777v-.155h-.777zM13.074 13.592h.777v-.155h-.777zM14.369 13.592h.777v-.155h-.777zM15.663 13.592h.777v-.155h-.777zM16.958 13.592h.777v-.155h-.777zM18.252 13.592h.777v-.155h-.777zM19.547 13.592h.777v-.155h-.777zM20.841 13.592h.777v-.155h-.777zM22.136 13.592h.777v-.155h-.777zM23.43 13.592h.777v-.155h-.777zM24.725 13.592h.777v-.155h-.777zM26.02 13.592h.776v-.155h-.777zM27.314 13.592h.777v-.155h-.777zM28.608 13.592h.777v-.155h-.777zM29.903 13.592h.777v-.155h-.777zM31.197 13.592h.777v-.155h-.777zM32.492 13.592h.777v-.155h-.777zM33.786 13.592h.777v-.155h-.777zM35.08 13.592h.778v-.155h-.777zM36.375 13.592h.777v-.155h-.777zM37.67 13.592h.777v-.155h-.777zM38.964 13.592h.389v-.155h-.389z"
-                                  fill="#0062FF"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                            <path
+                              d="M0 0h1.111v32H0zm31.111 2.963h1.111V32h-1.111zM7.778 19.259h1.111V32H7.778zm7.778-7.407h1.111V32h-1.111zM38.889 26.37H40V32h-1.111zM23.333 14.222h1.111V32h-1.111z"
+                              fill="#0062FF"
+                            />
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Simple bar"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Time series line"
-                            >
-                              Time series line
-                            </div>
+                            Simple bar
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
                             >
                               <path
-                                d="M0 0h1.111v32H0zm31.111 2.963h1.111V32h-1.111zM7.778 19.259h1.111V32H7.778zm7.778-7.407h1.111V32h-1.111zM38.889 26.37H40V32h-1.111zM23.333 14.222h1.111V32h-1.111z"
+                                d="M38.926 7.822H40V32h-1.074z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M37.584 17.422h1.074V32h-1.074z"
                                 fill="#0062FF"
                               />
-                            </svg>
-                          </div>
+                              <path
+                                d="M31.41 3.2h1.073V32H31.41z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M30.067 9.956h1.074V32h-1.074z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M23.893 14.578h1.073V32h-1.073z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M22.55 21.333h1.074V32H22.55z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M16.644 12.089h1.074V32h-1.074z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M15.302 25.6h1.074V32h-1.074z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M8.86 20.267h1.073V32H8.859z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M7.517 23.111h1.074V32H7.517z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M1.342 0h1.074v32H1.342z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M0 14.222h1.074V32H0z"
+                                fill="#0062FF"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Grouped bar"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Simple bar"
-                            >
-                              Simple bar
-                            </div>
+                            Grouped bar
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
                             >
-                              <g
-                                fill="none"
-                              >
-                                <path
-                                  d="M38.926 7.822H40V32h-1.074z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M37.584 17.422h1.074V32h-1.074z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M31.41 3.2h1.073V32H31.41z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M30.067 9.956h1.074V32h-1.074z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M23.893 14.578h1.073V32h-1.073z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M22.55 21.333h1.074V32H22.55z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M16.644 12.089h1.074V32h-1.074z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M15.302 25.6h1.074V32h-1.074z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M8.86 20.267h1.073V32H8.859z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M7.517 23.111h1.074V32H7.517z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M1.342 0h1.074v32H1.342z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M0 14.222h1.074V32H0z"
-                                  fill="#0062FF"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M38.108 7.467H40v24.178h-1.892z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M38.108 17.067H40v14.578h-1.892z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M38.108 16.711H40v1h-1.892z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M30.27 2.844h1.892v28.8H30.27z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M30.27 9.956h1.892V32H30.27z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M30.27 9.6h1.892v1H30.27z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M22.703 14.578h1.892V32h-1.892z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M22.703 21.333h1.892V32h-1.892z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M22.703 20.978h1.892v1h-1.892z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M15.405 12.089h1.892V32h-1.892z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M15.405 25.6h1.892V32h-1.892z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M15.405 25.244h1.892v1h-1.892z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M7.838 20.267H9.73V32H7.838z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M7.838 23.111H9.73V32H7.838z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M7.838 22.756H9.73v1H7.838z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M0 0h1.892v32H0z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M0 14.222h1.892V32H0z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M0 13.867h1.892v1H0z"
+                                fill="#FFF"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Stacked bar"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Grouped bar"
-                            >
-                              Grouped bar
-                            </div>
+                            Stacked bar
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
+                              <path
+                                d="M.5.5h38.752v31H.5z"
+                                stroke="#2160F8"
+                              />
+                              <path
+                                d="M4.969 21.714h21.863v4.571H4.969zm26.832 0l1.988 4.572h-3.975z"
+                                fill="#8EC1FF"
+                              />
+                              <text
+                                fill="#2160F8"
+                                fontFamily="IBMPlexSans, IBM Plex Sans"
+                                fontSize={10}
                               >
-                                <path
-                                  d="M38.108 7.467H40v24.178h-1.892z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M38.108 17.067H40v14.578h-1.892z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M38.108 16.711H40v1h-1.892z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M30.27 2.844h1.892v28.8H30.27z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M30.27 9.956h1.892V32H30.27z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M30.27 9.6h1.892v1H30.27z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M22.703 14.578h1.892V32h-1.892z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M22.703 21.333h1.892V32h-1.892z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M22.703 20.978h1.892v1h-1.892z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M15.405 12.089h1.892V32h-1.892z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M15.405 25.6h1.892V32h-1.892z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M15.405 25.244h1.892v1h-1.892z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M7.838 20.267H9.73V32H7.838z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M7.838 23.111H9.73V32H7.838z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M7.838 22.756H9.73v1H7.838z"
-                                  fill="#FFF"
-                                />
-                                <path
-                                  d="M0 0h1.892v32H0z"
-                                  fill="#97C1FF"
-                                />
-                                <path
-                                  d="M0 14.222h1.892V32H0z"
-                                  fill="#0062FF"
-                                />
-                                <path
-                                  d="M0 13.867h1.892v1H0z"
-                                  fill="#FFF"
-                                />
-                              </g>
-                            </svg>
-                          </div>
-                        </div>
-                        <div
-                          className="iot--list-item--content--values"
-                        >
-                          <div
-                            className="iot--list-item--content--values--main"
-                          >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Stacked bar"
-                            >
-                              Stacked bar
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
-                  >
-                    <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
-                    >
-                      <div
-                        className="iot--list-item--content"
-                      >
-                        <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
-                        >
-                          <div
-                            className="iot--card-gallery-list__icon"
-                          >
-                            <svg
-                              height={32}
-                              width={40}
-                            >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M.5.5h38.752v31H.5z"
-                                  stroke="#2160F8"
-                                />
-                                <path
-                                  d="M4.969 21.714h21.863v4.571H4.969zm26.832 0l1.988 4.572h-3.975z"
-                                  fill="#8EC1FF"
-                                />
-                                <text
-                                  fill="#2160F8"
-                                  fontFamily="IBMPlexSans, IBM Plex Sans"
-                                  fontSize={10}
+                                <tspan
+                                  x={4.969}
+                                  y={15.5}
                                 >
-                                  <tspan
-                                    x={4.969}
-                                    y={15.5}
-                                  >
-                                    25%
-                                  </tspan>
-                                </text>
-                              </g>
-                            </svg>
-                          </div>
+                                  25%
+                                </tspan>
+                              </text>
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Value / KPI"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Value / KPI"
-                            >
-                              Value / KPI
-                            </div>
+                            Value / KPI
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M1.29 21.57L13 10.477l11.2 12.347L30.5 16l8.21 9.6"
-                                  stroke="#0062FF"
-                                />
-                                <ellipse
-                                  cx={25.835}
-                                  cy={7.62}
-                                  rx={3.19}
-                                  ry={3.5}
-                                  stroke="#005BFF"
-                                />
-                                <path
-                                  d="M.5.5h39v31H.5z"
-                                  stroke="#2160F8"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M1.29 21.57L13 10.477l11.2 12.347L30.5 16l8.21 9.6"
+                                stroke="#0062FF"
+                              />
+                              <ellipse
+                                cx={25.835}
+                                cy={7.62}
+                                rx={3.19}
+                                ry={3.5}
+                                stroke="#005BFF"
+                              />
+                              <path
+                                d="M.5.5h39v31H.5z"
+                                stroke="#2160F8"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Image"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Image"
-                            >
-                              Image
-                            </div>
+                            Image
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M0 0h40v2.759H0z"
-                                  fill="#0058FF"
-                                />
-                                <path
-                                  d="M.5 3.259h39V31.5H.5z"
-                                  stroke="#005BFF"
-                                />
-                                <path
-                                  d="M3.5 6.621h19V9.38h-19zm21.5 0h11V9.38H25zM3.5 18.759h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 12.69h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 24.828h19v2.759h-19zm21.5 0h11v2.759H25z"
-                                  fill="#D8D8D8"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M0 0h40v2.759H0z"
+                                fill="#0058FF"
+                              />
+                              <path
+                                d="M.5 3.259h39V31.5H.5z"
+                                stroke="#005BFF"
+                              />
+                              <path
+                                d="M3.5 6.621h19V9.38h-19zm21.5 0h11V9.38H25zM3.5 18.759h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 12.69h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 24.828h19v2.759h-19zm21.5 0h11v2.759H25z"
+                                fill="#D8D8D8"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Data table"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Data table"
-                            >
-                              Data table
-                            </div>
+                            Data table
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
                   <div
-                    className="iot--list-item-parent"
-                    data-floating-menu-container={true}
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <div
-                      className="iot--list-item iot--list-item__selectable"
-                      data_testid={null}
-                      onClick={[Function]}
-                      onKeyPress={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      className="iot--list-item--content"
                     >
                       <div
-                        className="iot--list-item--content"
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
                       >
                         <div
-                          className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                          className="iot--card-gallery-list__icon"
                         >
-                          <div
-                            className="iot--card-gallery-list__icon"
+                          <svg
+                            height={32}
+                            width={40}
                           >
-                            <svg
-                              height={32}
-                              width={40}
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
                             >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <path
-                                  d="M.5.5h39v31H.5z"
-                                  stroke="#2160F8"
-                                />
-                                <path
-                                  d="M25 5h11v3H25zm0 6h11v3H25zm0 12h11v3H25zm0-6h11v3H25z"
-                                  fill="#D8D8D8"
-                                />
-                                <path
-                                  d="M18.415 19.585l-2.915-2.92V14.5a.5.5 0 00-.145-.355l-5-5a.5.5 0 00-.71 0l-4.5 4.5a.5.5 0 000 .71l5 5a.5.5 0 00.355.145h2.17l2.915 2.92a2.001 2.001 0 002.83-2.83v-.005zM7 13.205l1.145 1.15.71-.71-1.15-1.145.795-.795 2.145 2.15.71-.71L9.205 11l.795-.795 3.295 3.295L9.5 17.295 6.205 14 7 13.205zm10.705 8.5a1 1 0 01-1.41 0l-3.065-3.06a.9.9 0 00-.355-.145h-2.17l-.5-.5L14 14.205l.5.5v2.17a.5.5 0 00.145.35l3.06 3.07a1 1 0 010 1.41z"
-                                  fill="#0F62FE"
-                                />
-                              </g>
-                            </svg>
-                          </div>
+                              <path
+                                d="M.5.5h39v31H.5z"
+                                stroke="#2160F8"
+                              />
+                              <path
+                                d="M25 5h11v3H25zm0 6h11v3H25zm0 12h11v3H25zm0-6h11v3H25z"
+                                fill="#D8D8D8"
+                              />
+                              <path
+                                d="M18.415 19.585l-2.915-2.92V14.5a.5.5 0 00-.145-.355l-5-5a.5.5 0 00-.71 0l-4.5 4.5a.5.5 0 000 .71l5 5a.5.5 0 00.355.145h2.17l2.915 2.92a2.001 2.001 0 002.83-2.83v-.005zM7 13.205l1.145 1.15.71-.71-1.15-1.145.795-.795 2.145 2.15.71-.71L9.205 11l.795-.795 3.295 3.295L9.5 17.295 6.205 14 7 13.205zm10.705 8.5a1 1 0 01-1.41 0l-3.065-3.06a.9.9 0 00-.355-.145h-2.17l-.5-.5L14 14.205l.5.5v2.17a.5.5 0 00.145.35l3.06 3.07a1 1 0 010 1.41z"
+                                fill="#0F62FE"
+                              />
+                            </g>
+                          </svg>
                         </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
                         <div
-                          className="iot--list-item--content--values"
+                          className="iot--list-item--content--values--main"
                         >
                           <div
-                            className="iot--list-item--content--values--main"
+                            className="iot--list-item--content--values--value"
+                            title="Custom"
                           >
-                            <div
-                              className="iot--list-item--content--values--value"
-                              title="Custom"
-                            >
-                              Custom
-                            </div>
+                            Custom
                           </div>
                         </div>
                       </div>

--- a/src/components/DashboardEditor/_dashboard-editor.scss
+++ b/src/components/DashboardEditor/_dashboard-editor.scss
@@ -1,6 +1,7 @@
 .#{$iot-prefix}--dashboard-editor {
   display: flex;
-  height: 100%;
+  // need to reserve space for the suite header
+  height: calc(100vh - 3rem);
   > .#{$prefix}--skeleton__text {
     margin-top: 1rem;
     margin-left: 1rem;


### PR DESCRIPTION
Closes #1840

**Summary**
The editor inside of Monitor required the user to scroll because it wasn't taking the suite header into account.

**Change List (commits, features, bugs, etc)**
 - Calculate height for editor
 - Remove the styled `div` that wrapped each story

**Acceptance Test (how to verify the PR)**
Go to any editor story and verify that the height is correct and the edit JSON button is responsive.
