### PR TITLE
fix(sidebar): add some rules for handling RTL layouts

### DIFF
--- a/src/components/SideNav/_side-nav.scss
+++ b/src/components/SideNav/_side-nav.scss
@@ -61,3 +61,15 @@ $hoverBgColor: #2c2c2c;
     color: $textColor;
   }
 }
+
+html[dir='rtl'] {
+  .#{$iot-prefix}--side-nav {
+    left: unset;
+    right: 0;
+  }
+
+  .#{$prefix}--side-nav__icon:not(.#{$prefix}--side-nav__submenu-chevron) {
+    margin-left: mini-units(3);
+    margin-right: unset;
+  }
+}


### PR DESCRIPTION
Closes #1909 

**Summary**
Resolve layout issues with sidebar when using [dir="rtl"]

**Change List (commits, features, bugs, etc)**
Add some rules for RTL layouts that weren't handled in the base library. 

**Acceptance Test (how to verify the PR)**
Enable RTL mode in storybook and check that menu is on the right side and spacing looks consistent with how it is on the left.