### PR TITLE
fix(hotspotmodaleditor): stop the image from scrolling

### DIFF
--- a/src/components/HotspotEditorModal/_hotspot-editor-modal.scss
+++ b/src/components/HotspotEditorModal/_hotspot-editor-modal.scss
@@ -14,6 +14,7 @@
     & > *:last-child {
       margin-right: $layout-03;
       min-width: $right-side-width;
+      overflow-y: auto;
     }
 
     .#{$prefix}--tabs {

--- a/src/components/ImageCard/ImageHotspots.jsx
+++ b/src/components/ImageCard/ImageHotspots.jsx
@@ -387,7 +387,13 @@ export const zoom = (
   }
 };
 
-const getAccumulatedOffset = (imageElement) => {
+/**
+ * Since the imageElement is not at the borders of the screen, we need to calculate the X and Y offsets of the Image from the parents
+ * @param {*} imageElement
+ * @return {object} top, left pixels that indicate where the image is placed on the page
+ */
+export const getAccumulatedOffset = (imageElement) => {
+  // TODO: replace with simpler approach and share as utility function: https://stackoverflow.com/questions/5601659/how-do-you-calculate-the-page-position-of-a-dom-element-when-the-body-can-be-rel
   const offset = {
     top: imageElement.offsetTop,
     left: imageElement.offsetLeft,

--- a/yarn.lock
+++ b/yarn.lock
@@ -17124,18 +17124,6 @@ react-dnd-html5-backend@11.1.3:
   dependencies:
     dnd-core "^11.1.3"
 
-react-dnd-test-backend@^11.1.3:
-  version "11.1.3"
-  resolved "https://registry.yarnpkg.com/react-dnd-test-backend/-/react-dnd-test-backend-11.1.3.tgz#7af2cfa3dc891845ef0e4b8d2e58383b066b1f67"
-  integrity sha512-5qFm+NI2GdWIUfiYun0A8Gv0xjbq0NGOPS+f6z3x/3nTuliApjmqcM1lfTgePoz1FDG47ZofF58N8y96If62+Q==
-  dependencies:
-    dnd-core "^11.1.3"
-
-react-dnd-test-utils@^11.1.3:
-  version "11.1.3"
-  resolved "https://registry.yarnpkg.com/react-dnd-test-utils/-/react-dnd-test-utils-11.1.3.tgz#edd36df5989ab6b868db5fea0dcdf25a64ac94f9"
-  integrity sha512-Yg+oTpXaCJ+NxEFt+qXJZX96dbar47EK410eXj7bDsIdYYTZzYO51BtEGlEvR/a9Kb4vEkhPZkJLxyCfqNrpjw==
-
 react-dnd@11.1.3:
   version "11.1.3"
   resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-11.1.3.tgz#f9844f5699ccc55dfc81462c2c19f726e670c1af"


### PR DESCRIPTION
Closes #1896

**Summary**

- Fixes issue where the scrolling inside the Modal also scrolled the image down

**Change List (commits, features, bugs, etc)**

- fix(hotspot): allow only the right-pane to scroll, not the image itself

**Acceptance Test (how to verify the PR)**

- Ensure that at small screen sizes where the right-pane is scrolled down, clicking to add hotspots puts them in the right place
