### PR TITLE
fix(cardeditform): custom cards do not yet support Settings panels in our DashboardEditor

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditForm.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditForm.jsx
@@ -298,19 +298,17 @@ const CardEditForm = ({
               onFetchDynamicDemoHotspots={onFetchDynamicDemoHotspots}
             />
           </Tab>
-          <Tab label={mergedI18n.settingsTabLabel}>
-            <CardEditFormSettings
-              availableDimensions={availableDimensions}
-              cardConfig={
-                cardConfig.type === CARD_TYPES.CUSTOM
-                  ? { ...omit(cardConfig, 'content') }
-                  : cardConfig
-              }
-              onChange={onChange}
-              i18n={mergedI18n}
-              getValidDataItems={getValidDataItems}
-            />
-          </Tab>
+          {cardConfig.type !== CARD_TYPES.CUSTOM ? ( // we don't yet support settings for custom cards
+            <Tab label={mergedI18n.settingsTabLabel}>
+              <CardEditFormSettings
+                availableDimensions={availableDimensions}
+                cardConfig={cardConfig}
+                onChange={onChange}
+                i18n={mergedI18n}
+                getValidDataItems={getValidDataItems}
+              />
+            </Tab>
+          ) : null}
         </Tabs>
         <div className={`${baseClassName}--footer`}>
           <Button

--- a/packages/react/src/components/Table/StatefulTable.test.jsx
+++ b/packages/react/src/components/Table/StatefulTable.test.jsx
@@ -160,7 +160,7 @@ describe('stateful table with real reducer', () => {
 
     // next add an additional filter with option-A
     // open the multiselect
-    userEvent.click(screen.getByText('pick an option'));
+    userEvent.click(screen.getByPlaceholderText('pick an option'));
     userEvent.click(screen.getByRole('option', { name: 'option-A' })); // fire click on option-A in our multiselect
 
     const secondFilteredRowsOptionA = screen.queryAllByTitle('option-A');
@@ -174,7 +174,7 @@ describe('stateful table with real reducer', () => {
 
     // next remove filter for option-B
     // open the multiselect
-    userEvent.click(screen.getByText('pick an option'));
+    userEvent.click(screen.getAllByPlaceholderText('pick an option')[0]);
     userEvent.click(screen.getByRole('option', { name: 'option-B' })); // fire click on option-B in our multiselect
 
     const thirdFilteredRowsOptionA = screen.queryAllByTitle('option-A');
@@ -253,7 +253,7 @@ describe('stateful table with real reducer', () => {
 
     // next add an a filter with option-A
     // open the multiselect
-    userEvent.click(screen.getByText('pick an option'));
+    userEvent.click(screen.getAllByPlaceholderText('pick an option')[0]);
     userEvent.click(screen.getByRole('option', { name: 'option-A' })); // fire click on option-A in our multiselect
 
     const secondFilteredRowsOptionA = screen.queryAllByTitle('option-A');

--- a/packages/react/src/components/Table/Table.story.jsx
+++ b/packages/react/src/components/Table/Table.story.jsx
@@ -53,6 +53,18 @@ const selectData = [
     id: 'option-C',
     text: 'option-C',
   },
+  {
+    id: 'option-D',
+    text: 'option-D',
+  },
+  {
+    id: 'option-E',
+    text: 'option-E',
+  },
+  {
+    id: 'option-F',
+    text: 'option-F',
+  },
 ];
 
 const STATUS = {

--- a/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
+++ b/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
@@ -204,11 +204,12 @@ class FilterHeaderRow extends Component {
                 <div />
               ) : column.options ? (
                 column.isMultiselect ? (
-                  <MultiSelect
+                  <MultiSelect.Filterable
                     key={columnStateValue}
                     className={`${iotPrefix}--filterheader-multiselect`}
                     id={`column-${i}`}
                     aria-label={filterText}
+                    placeholder={column.placeholderText || 'Choose an option'}
                     translateWithId={this.handleTranslation}
                     items={memoizeColumnOptions(column.options)}
                     label={column.placeholderText || 'Choose an option'}

--- a/packages/react/src/components/Table/TableHead/_table-head.scss
+++ b/packages/react/src/components/Table/TableHead/_table-head.scss
@@ -20,6 +20,10 @@
     display: flex;
     user-select: none;
     overflow: hidden;
+    // allow the multiselect filter to expand to full height and the table to scroll
+    .#{$prefix}--multi-select .#{$prefix}--list-box__menu {
+      max-height: unset;
+    }
 
     & > span {
       margin: auto 0;


### PR DESCRIPTION
Closes #https://github.ibm.com/wiotp/monitoring-dashboard/issues/1906

**Summary**

- we haven't yet built a way for Custom Card types to send along the Setting form they support, until we do, we should hide the Settings tab from CardEditForm

**Change List (commits, features, bugs, etc)**

- fix(CardEditForm): hide the Settings tab for the Custom card type

**Acceptance Test (how to verify the PR)**

- Verify in the DashboardEditor story that if you add a custom card there is no Setting tab showing in the Form
