### PR TITLE
fix(DashboardEditor): check min and max before applying the number input value

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ValueCardFormItems/ValueCardFormSettings.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ValueCardFormItems/ValueCardFormSettings.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { settings } from '../../../../../constants/Settings';
 import { NumberInput, ToggleSmall, Tooltip } from '../../../../../index';
 import { DEFAULT_FONT_SIZE } from '../../../../ValueCard/valueCardUtils';
+import { isNumberValidForMinMax } from '../../../../../utils/componentUtilityFunctions';
 
 const { iotPrefix } = settings;
 
@@ -47,6 +48,9 @@ const defaultProps = {
   },
 };
 
+const MIN_FONT_SIZE = 16;
+const MAX_FONT_SIZE = 54;
+
 const ValueCardFormSettings = ({ cardConfig, onChange, i18n }) => {
   const mergedI18n = { ...defaultProps.i18n, ...i18n };
   const { id, fontSize, isNumberValueCompact } = cardConfig;
@@ -59,17 +63,20 @@ const ValueCardFormSettings = ({ cardConfig, onChange, i18n }) => {
         <NumberInput
           id={`${id}_value-card-font-size`}
           step={1}
-          min={16}
-          max={54}
+          min={MIN_FONT_SIZE}
+          max={MAX_FONT_SIZE}
           light
           label={mergedI18n.fontSize}
           value={fontSize || DEFAULT_FONT_SIZE}
-          onChange={({ imaginaryTarget }) =>
-            onChange({
-              ...cardConfig,
-              fontSize: Number(imaginaryTarget.value) || imaginaryTarget.value,
-            })
-          }
+          onChange={(event) => {
+            const parsedValue = Number(event.imaginaryTarget.value);
+            if (isNumberValidForMinMax(parsedValue, MIN_FONT_SIZE, MAX_FONT_SIZE)) {
+              onChange({
+                ...cardConfig,
+                fontSize: parsedValue,
+              });
+            }
+          }}
         />
       </div>
       <div className={`${baseClassName}--input`}>

--- a/packages/react/src/components/HotspotEditorModal/HotspotTextStyleTab/HotspotTextStyleTab.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotTextStyleTab/HotspotTextStyleTab.jsx
@@ -14,6 +14,7 @@ import { settings } from '../../../constants/Settings';
 import IconSwitch from '../../IconSwitch/IconSwitch';
 import ColorDropdown from '../../ColorDropdown/ColorDropdown';
 import Button from '../../Button/Button';
+import { isNumberValidForMinMax } from '../../../utils/componentUtilityFunctions';
 
 const { iotPrefix } = settings;
 
@@ -124,10 +125,6 @@ const getSelectedColorItem = (color, colorCollection) => {
   return typeof color === 'string' && Array.isArray(colorCollection)
     ? colorCollection.find((colorObj) => colorObj.carbonColor === color)
     : color;
-};
-
-const getIntOrUndefined = (value) => {
-  return value === '' ? undefined : parseInt(value, 10);
 };
 
 const preventFormSubmission = (e) => e.preventDefault();
@@ -260,9 +257,12 @@ const HotspotTextStyleTab = ({
                 label={fontSizeLabelText}
                 invalidText={fontSizeInvalidText}
                 onChange={(event) => {
-                  onChange({
-                    fontSize: getIntOrUndefined(event.imaginaryTarget.value),
-                  });
+                  const parsedValue = Number(event.imaginaryTarget.value);
+                  if (isNumberValidForMinMax(parsedValue, minFontSize, maxFontSize)) {
+                    onChange({
+                      fontSize: parsedValue,
+                    });
+                  }
                 }}
               />
             </div>
@@ -294,9 +294,12 @@ const HotspotTextStyleTab = ({
                 light={light}
                 invalidText={fillOpacityInvalidText}
                 onChange={(event) => {
-                  onChange({
-                    backgroundOpacity: getIntOrUndefined(event.imaginaryTarget.value),
-                  });
+                  const parsedValue = Number(event.imaginaryTarget.value);
+                  if (isNumberValidForMinMax(parsedValue, minOpacity, maxOpacity)) {
+                    onChange({
+                      backgroundOpacity: parsedValue,
+                    });
+                  }
                 }}
               />
             </div>
@@ -326,9 +329,12 @@ const HotspotTextStyleTab = ({
                 light={light}
                 invalidText={borderWidthInvalidText}
                 onChange={(event) => {
-                  onChange({
-                    borderWidth: getIntOrUndefined(event.imaginaryTarget.value),
-                  });
+                  const parsedValue = Number(event.imaginaryTarget.value);
+                  if (isNumberValidForMinMax(parsedValue, minBorderWidth, maxBorderWidth)) {
+                    onChange({
+                      borderWidth: parsedValue,
+                    });
+                  }
                 }}
               />
             </div>

--- a/packages/react/src/utils/componentUtilityFunctions.js
+++ b/packages/react/src/utils/componentUtilityFunctions.js
@@ -367,3 +367,27 @@ export const hexToRgb = (hexColor) => {
   }
   return rgbColors ?? { r: 200, g: 200, b: 200 };
 };
+
+/**
+ * If min and max are provided, this function checks to see if the integer value is within the range
+ * @param {Number} value integer value
+ * @param {Number} min optional
+ * @param {Number} max optional
+ */
+export const isNumberValidForMinMax = (value, min, max) => {
+  let valid = false;
+  if (Number.isInteger(value)) {
+    valid = true;
+    if (min) {
+      if (value < min) {
+        valid = false;
+      }
+    }
+    if (max) {
+      if (value > max) {
+        valid = false;
+      }
+    }
+  }
+  return valid;
+};


### PR DESCRIPTION
Closes #

**Summary**

- When NumberInput has a min or max, the input value needs to be checked before applying the `onChange`

**Change List (commits, features, bugs, etc)**

- Added a function to check if a number value is valid when optionally given a min or max
- Used the function to check if the number value is valid before applying the onChange

**Acceptance Test (how to verify the PR)**

- Go to any DashboardEditor story, add a ValueCard, go to the settings tab in the CardEditForm, and type in valid and invalid numbers to see the input respond correctly. It should only save numbers that are valid (between 16 and 54). If an invalid number / string is given, it will show the invalid text indication and will not save the number
