### PR TITLE
fix(dashboardeditor): support passing custom icon callback

### DIFF
--- a/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
@@ -114,6 +114,10 @@ const propTypes = {
    * onValidateCardJson(cardConfig)
    * @returns Array<string> error strings. return empty array if there is no errors
    */
+  /** Callback called when a card determines what icon render based on a named string in card config
+   *    example usage: renderIconByName(name = 'my--checkmark--icon', props = { title: 'A checkmark', etc. })
+   */
+  renderIconByName: PropTypes.func,
   onValidateCardJson: PropTypes.func,
   /** callback function to validate the uploaded image */
   onValidateUploadedImage: PropTypes.func,
@@ -273,6 +277,7 @@ const defaultProps = {
   breakpointSwitcher: null,
   supportedCardTypes: Object.keys(DASHBOARD_EDITOR_CARD_TYPES),
   renderHeader: null,
+  renderIconByName: null,
   renderCardPreview: () => null,
   headerBreadcrumbs: null,
   notification: null,
@@ -337,6 +342,7 @@ const DashboardEditor = ({
   breakpointSwitcher,
   renderHeader,
   renderCardPreview,
+  renderIconByName,
   getValidDataItems,
   getValidTimeRanges,
   dataItems,
@@ -507,6 +513,7 @@ const DashboardEditor = ({
           handleOnCardChange(update(cardConfig, payload));
         }
       },
+      renderIconByName,
       tabIndex: 0,
       onKeyDown: (e) => handleKeyDown(e, setSelectedCardId, cardConfig.id),
       onClick: () => handleOnClick(setSelectedCardId, cardConfig.id),
@@ -520,7 +527,14 @@ const DashboardEditor = ({
       validateUploadedImage:
         cardConfig.type === CARD_TYPES.IMAGE ? onValidateUploadedImage : undefined,
     }),
-    [duplicateCard, handleOnCardChange, mergedI18n, onValidateUploadedImage, removeCard]
+    [
+      duplicateCard,
+      handleOnCardChange,
+      mergedI18n,
+      onValidateUploadedImage,
+      removeCard,
+      renderIconByName,
+    ]
   );
 
   const cards = useMemo(

--- a/packages/react/src/components/DashboardEditor/DashboardEditorCardRenderer.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditorCardRenderer.jsx
@@ -108,35 +108,35 @@ const renderTableCard = (props) => (
  */
 const renderImageCard = (props) => (
   <ImageCard
-    {...props}
-    isEditable // render the icon in the right color in the card preview
-    values={{
-      ...props.values,
-      hotspots: props.values?.hotspots?.filter((hotspot) => hotspot.type !== 'dynamic') || [],
-    }}
     renderIconByName={(iconName, iconProps) => {
       // first search the validHotspot Icons
       const matchingHotspotIcon = validHotspotIcons.find((icon) => icon.id === iconName);
 
       // then search the validThresholdIcons
       const matchingThresholdIcon = validThresholdIcons.find((icon) => icon.name === iconName);
-      const iconToRender = matchingHotspotIcon
-        ? React.createElement(matchingHotspotIcon.icon, {
-            ...iconProps,
-            title: matchingHotspotIcon.text,
-          })
-        : matchingThresholdIcon
-        ? React.cloneElement(matchingThresholdIcon.carbonIcon, {
-            ...iconProps,
-            title: matchingThresholdIcon.name,
-          })
-        : React.cloneElement(Warning24, {
-            ...iconProps,
-            title: 'Warning',
-          });
+      const iconToRender = matchingHotspotIcon ? (
+        React.createElement(matchingHotspotIcon.icon, {
+          ...iconProps,
+          title: matchingHotspotIcon.text,
+        })
+      ) : matchingThresholdIcon ? (
+        React.cloneElement(matchingThresholdIcon.carbonIcon, {
+          ...iconProps,
+          title: matchingThresholdIcon.name,
+        })
+      ) : (
+        <Warning24 {...iconProps} />
+      );
+
       // otherwise default to Warning24
       // eslint-disable-next-line react/prop-types
       return <div style={{ color: iconProps.fill }}>{iconToRender}</div>;
+    }}
+    {...props}
+    isEditable // render the icon in the right color in the card preview
+    values={{
+      ...props.values,
+      hotspots: props.values?.hotspots?.filter((hotspot) => hotspot.type !== 'dynamic') || [],
     }}
   />
 );

--- a/packages/react/src/components/DashboardEditor/DashboardEditorCardRenderer.test.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditorCardRenderer.test.jsx
@@ -15,10 +15,12 @@ describe('DashboardEditorCardRenderer', () => {
     expect(screen.getByText(/myid/)).toBeInTheDocument();
   });
   it('value card renders threshold icon', () => {
+    const mockRenderIconByName = jest.fn(() => <div />);
     render(
       <DashboardEditorCardRenderer
         title="Alert Count"
         id="facilitycard"
+        renderIconByName={mockRenderIconByName}
         content={{
           attributes: [
             {
@@ -28,7 +30,7 @@ describe('DashboardEditorCardRenderer', () => {
                   comparison: '>=',
                   value: 30,
                   color: 'red',
-                  icon: 'Warning alt',
+                  icon: 'Warning filled',
                 },
                 {
                   comparison: '<=',
@@ -52,7 +54,10 @@ describe('DashboardEditorCardRenderer', () => {
         values={{ alertCount: 35 }}
       />
     );
-    expect(screen.getByTitle('>= 30')).toBeInTheDocument();
+    expect(mockRenderIconByName).toHaveBeenCalledWith(
+      'Warning filled',
+      expect.objectContaining({ title: '>= 30', fill: 'red' })
+    );
   });
   it('image card renders custom hotspot icon', () => {
     render(
@@ -76,6 +81,9 @@ describe('DashboardEditorCardRenderer', () => {
               y: 65,
               icon: 'User',
               color: 'purple',
+              content: {
+                attributes: [{ dataItemId: 'mydataitem', dataSourceId: 'myDataSource' }],
+              },
             },
           ],
         }}
@@ -113,6 +121,38 @@ describe('DashboardEditorCardRenderer', () => {
     );
     // Should find the correct Warning icon and text
     expect(screen.getByTitle('Checkmark')).toBeInTheDocument();
+  });
+  it('image card uses renderIconByName', () => {
+    const mockRenderIconByName = jest.fn(() => <div />);
+    render(
+      <DashboardEditorCardRenderer
+        title="Alert Count"
+        id="facilitycard"
+        size="LARGE"
+        type="IMAGE"
+        renderIconByName={mockRenderIconByName}
+        content={{
+          src: 'landscape',
+          image: 'landscape',
+          alt: 'Sample image',
+          zoomMax: 10,
+          hasInsertFromUrl: true,
+        }}
+        breakpoint="lg"
+        values={{
+          hotspots: [
+            {
+              x: 35,
+              y: 65,
+              color: 'purple',
+              icon: 'Checkmark',
+            },
+          ],
+        }}
+      />
+    );
+    // Should find the correct Warning icon and text
+    expect(mockRenderIconByName).toHaveBeenCalledWith('Checkmark', expect.anything());
   });
   it('list card renders list', () => {
     const listCardData = [

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -8628,6 +8628,7 @@ Map {
       "onValidateUploadedImage": null,
       "renderCardPreview": [Function],
       "renderHeader": null,
+      "renderIconByName": null,
       "supportedCardTypes": Array [
         "VALUE",
         "TIMESERIES",
@@ -9185,6 +9186,9 @@ Map {
         "type": "func",
       },
       "renderHeader": Object {
+        "type": "func",
+      },
+      "renderIconByName": Object {
         "type": "func",
       },
       "supportedCardTypes": Object {


### PR DESCRIPTION
Closes #

**Summary**

- The dashboardEditor should support the renderIconByName function just like the DashboardGrid does, so that downstream consumers can add additional icons to be used for thresholds and hotspots

**Change List (commits, features, bugs, etc)**

- fix(DashboardEditor): add the renderIconByName callback
- fix(DashboardEditorCardRenderer): for the ImageCard render fix the default render function if the card can't find the matching icon, and let the passed function override the default function for the

**Acceptance Test (how to verify the PR)**

- Verify the renderIconByName function is called, verify that none of the normal ImageCard editing cases are broken
