### PR TITLE
feat(repo): had to do a manual bump as version got out of whack

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -274,5 +274,5 @@
   "resolutions": {
     "chokidar": "3.3.1"
   },
-  "version": "2.143.0-next.31"
+  "version": "2.143.0-next.32"
 }


### PR DESCRIPTION
Manual bump needed to fix our publishing. Somehow our version numbers got out of sync with package

- bumped up version in package.json
