### PR TITLE
fix(hierarchylist): fire onSelect for defaultSelectedId

### DIFF
--- a/packages/react/src/components/List/HierarchyList/HierarchyList.jsx
+++ b/packages/react/src/components/List/HierarchyList/HierarchyList.jsx
@@ -258,6 +258,10 @@ const HierarchyList = ({
         if (!isEqual(selectedIds, [defaultSelectedId])) {
           // If the defaultSelectedId prop is updated from the outside, we need to use it
           setSelected(defaultSelectedId);
+
+          if (onSelect) {
+            onSelect(defaultSelectedId);
+          }
         }
       }
     },

--- a/packages/react/src/components/List/HierarchyList/HierarchyList.story.jsx
+++ b/packages/react/src/components/List/HierarchyList/HierarchyList.story.jsx
@@ -17,7 +17,7 @@ const addButton = (
     size="small"
     iconDescription="Add"
     key="hierarchy-list-button-add"
-    onClick={() => action('header button clicked')}
+    onClick={() => action('header button onClick')}
   />
 );
 
@@ -34,7 +34,7 @@ export const StatefulListWithNestedSearching = () => (
     <HierarchyList
       title={text('Title', 'MLB Expanded List')}
       buttons={[addButton]}
-      isFullHeight
+      isFullHeight={boolean('isFullHeight', true)}
       items={[
         ...Object.keys(sampleHierarchy.MLB['American League']).map((team) => ({
           id: team,
@@ -67,9 +67,10 @@ export const StatefulListWithNestedSearching = () => (
           })),
         })),
       ]}
-      hasSearch
+      hasSearch={boolean('hasSearch', true)}
       pageSize={select('Page Size', ['sm', 'lg', 'xl'], 'sm')}
       isLoading={boolean('isLoading', false)}
+      onSelect={action('onSelect')}
     />
   </div>
 );
@@ -113,9 +114,10 @@ export const WithDefaultSelectedId = () => (
           })),
         })),
       ]}
-      hasSearch
+      hasSearch={boolean('hasSearch', true)}
       pageSize={select('Page Size', ['sm', 'lg', 'xl'], 'lg')}
       isLoading={boolean('isLoading', false)}
+      onSelect={action('onSelect')}
     />
   </div>
 );
@@ -180,9 +182,10 @@ export const WithOverflowMenu = () => (
           })),
         })),
       ]}
-      hasSearch
+      hasSearch={boolean('hasSearch', true)}
       pageSize={select('Page Size', ['sm', 'lg', 'xl'], 'lg')}
       isLoading={boolean('isLoading', false)}
+      onSelect={action('onSelect')}
     />
   </div>
 );
@@ -245,6 +248,8 @@ export const WithNestedReorder = () => {
           itemWillMove={() => {
             return allowsEdit;
           }}
+          hasSearch={boolean('hasSearch', true)}
+          onSelect={action('onSelect')}
         />
       </div>
     );
@@ -287,10 +292,11 @@ export const WithDefaultExpandedIds = () => (
           })),
         })),
       ]}
-      hasSearch
+      hasSearch={boolean('hasSearch', true)}
       pageSize={select('Page Size', ['sm', 'lg', 'xl'], 'xl')}
       isLoading={boolean('isLoading', false)}
       defaultExpandedIds={['Chicago White Sox', 'New York Yankees']}
+      onSelect={action('onSelect')}
     />
   </div>
 );
@@ -366,9 +372,10 @@ export const WithMixedHierarchies = () => (
           ],
         },
       ]}
-      hasSearch
+      hasSearch={boolean('hasSearch', true)}
       pageSize={select('Page Size', ['sm', 'lg', 'xl'], 'xl')}
       isLoading={boolean('isLoading', false)}
+      onSelect={action('onSelect')}
     />
   </div>
 );

--- a/packages/react/src/components/List/HierarchyList/HierarchyList.test.jsx
+++ b/packages/react/src/components/List/HierarchyList/HierarchyList.test.jsx
@@ -284,55 +284,73 @@ describe('HierarchyList', () => {
     expect(screen.getByTitle('New York Yankees')).toBeInTheDocument();
   });
 
-  it('parent items of defaultSelectedId should be expanded', () => {
-    const { rerender } = render(
-      <HierarchyList
-        items={items}
-        title="Hierarchy List"
-        pageSize="xl"
-        defaultSelectedId="New York Mets_JD Davis"
-        hasPagination={false}
-      />
-    );
+  describe('defaultSelectedId', () => {
+    it('parent items of defaultSelectedId should be expanded', () => {
+      const { rerender } = render(
+        <HierarchyList
+          items={items}
+          title="Hierarchy List"
+          pageSize="xl"
+          defaultSelectedId="New York Mets_JD Davis"
+          hasPagination={false}
+        />
+      );
 
-    // Nested item should be visible
-    const selectedItem = screen.getByTitle('JD Davis');
-    expect(selectedItem).toBeInTheDocument();
+      // Nested item should be visible
+      const selectedItem = screen.getByTitle('JD Davis');
+      expect(selectedItem).toBeInTheDocument();
 
-    // Should be marked selected
-    expect(selectedItem?.parentElement?.parentElement?.parentElement?.className).toContain(
-      '__selected'
-    );
-    // All other categories should be visible still
-    expect(screen.getByTitle('New York Mets')).toBeInTheDocument();
-    // Yankees are unfortunately worthy too...
-    expect(screen.getByTitle('New York Yankees')).toBeInTheDocument();
-    expect(screen.getByTitle('Chicago White Sox')).toBeInTheDocument();
-    expect(screen.getByTitle('Atlanta Braves')).toBeInTheDocument();
-    expect(screen.getByTitle('Houston Astros')).toBeInTheDocument();
-    expect(screen.getByTitle('Washington Nationals')).toBeInTheDocument();
-    // But no Yankees players should be visible
-    expect(screen.queryByTitle('Gary Sanchez')).not.toBeInTheDocument();
+      // Should be marked selected
+      expect(selectedItem?.parentElement?.parentElement?.parentElement?.className).toContain(
+        '__selected'
+      );
+      // All other categories should be visible still
+      expect(screen.getByTitle('New York Mets')).toBeInTheDocument();
+      // Yankees are unfortunately worthy too...
+      expect(screen.getByTitle('New York Yankees')).toBeInTheDocument();
+      expect(screen.getByTitle('Chicago White Sox')).toBeInTheDocument();
+      expect(screen.getByTitle('Atlanta Braves')).toBeInTheDocument();
+      expect(screen.getByTitle('Houston Astros')).toBeInTheDocument();
+      expect(screen.getByTitle('Washington Nationals')).toBeInTheDocument();
+      // But no Yankees players should be visible
+      expect(screen.queryByTitle('Gary Sanchez')).not.toBeInTheDocument();
 
-    // Change the defaultSelectedId property
-    rerender(
-      <HierarchyList
-        items={items}
-        title="Hierarchy List"
-        pageSize="xl"
-        defaultSelectedId="New York Yankees_Gary Sanchez"
-        hasPagination={false}
-      />
-    );
+      // Change the defaultSelectedId property
+      rerender(
+        <HierarchyList
+          items={items}
+          title="Hierarchy List"
+          pageSize="xl"
+          defaultSelectedId="New York Yankees_Gary Sanchez"
+          hasPagination={false}
+        />
+      );
 
-    expect(screen.queryByTitle('JD Davis')).toBeInTheDocument();
+      expect(screen.queryByTitle('JD Davis')).toBeInTheDocument();
 
-    const selectedYankee = screen.getByTitle('Gary Sanchez');
-    expect(selectedYankee).toBeInTheDocument();
+      const selectedYankee = screen.getByTitle('Gary Sanchez');
+      expect(selectedYankee).toBeInTheDocument();
 
-    expect(selectedYankee?.parentElement?.parentElement?.parentElement?.className).toContain(
-      '__selected'
-    );
+      expect(selectedYankee?.parentElement?.parentElement?.parentElement?.className).toContain(
+        '__selected'
+      );
+    });
+
+    it('defaultSelectedItem should fire onSelect on initial render', () => {
+      const mockOnSelect = jest.fn();
+      render(
+        <HierarchyList
+          items={items}
+          title="Hierarchy List"
+          pageSize="xl"
+          defaultSelectedId="New York Mets_JD Davis"
+          hasPagination={false}
+          onSelect={mockOnSelect}
+        />
+      );
+
+      expect(mockOnSelect).toBeCalledWith('New York Mets_JD Davis');
+    });
   });
 
   it('defaultExpandedIds should be expanded', () => {

--- a/packages/react/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
+++ b/packages/react/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
@@ -1299,6 +1299,69 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
               className="iot--list-header--btn-container"
             />
           </div>
+          <div
+            className="iot--list-header--search"
+          >
+            <div
+              aria-labelledby="iot--list-header--search-search"
+              className="bx--search bx--search--sm"
+              role="search"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--search-magnifier"
+                fill="currentColor"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                />
+              </svg>
+              <label
+                className="bx--label"
+                htmlFor="iot--list-header--search"
+                id="iot--list-header--search-search"
+              >
+                Enter a value
+              </label>
+              <input
+                autoComplete="off"
+                className="bx--search-input"
+                id="iot--list-header--search"
+                onChange={[Function]}
+                placeholder="Enter a value"
+                role="searchbox"
+                type="text"
+                value=""
+              />
+              <button
+                aria-label="Clear search input"
+                className="bx--search-close bx--search-close--hidden"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  fill="currentColor"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
         <div
           className="iot--list--content"


### PR DESCRIPTION
Closes #2004 

**Summary**

- `onSelect` was not being called if `defaultSelectedId` was used

**Change List (commits, features, bugs, etc)**

- Add knobs to all stories for all relevant props
- Add a test to check if `onSelect` gets called when `defaultSelectedId` is set

**Acceptance Test (how to verify the PR)**

- Unfortunately the `onSelect` action knob doesn't seem to work on initial render so the best way to test is it run locally, go to HierarchyList - defaultSelectedId story, add a breakpoint or console log for `onSelect` and see that it gets fired on the initial render