### PR TITLE
feat(suiteheader): Support for loading states and extensibility for Help, Profile and Applications menu items

### DIFF
--- a/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
@@ -356,9 +356,21 @@ const SuiteHeader = ({
                           },
                           content: mergedI18N.about,
                         })
-                    : Array.from({ length: 6 }, (x, i) => ({
-                        content: <SkeletonText key={`$help-skeleton-${i}`} />,
-                      })),
+                    : [
+                        {
+                          metaData: {
+                            element: 'div',
+                          },
+                          content: (
+                            <div
+                              className={`${settings.iotPrefix}--suite-header-help--loading`}
+                              data-testid="suite-header-help--loading"
+                            >
+                              <SkeletonText paragraph lineCount={6} />
+                            </div>
+                          ),
+                        },
+                      ],
                 },
                 {
                   label: 'user',

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
@@ -31,7 +31,7 @@ const ROUTE_TYPES = {
   SURVEY: 'SURVEY',
 };
 
-export const SuiteHeaderRoutePropTypes = PropTypes.shape({
+export const SuiteHeaderRoutePropTypes = {
   profile: PropTypes.string,
   navigator: PropTypes.string,
   admin: PropTypes.string,
@@ -45,21 +45,21 @@ export const SuiteHeaderRoutePropTypes = PropTypes.shape({
   // properties rendered as data attributes
   workspaceId: PropTypes.string,
   domain: PropTypes.string,
-});
+};
 
-export const SuiteHeaderApplicationPropTypes = PropTypes.shape({
+export const SuiteHeaderApplicationPropTypes = {
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   href: PropTypes.string.isRequired,
   isExternal: PropTypes.bool,
-});
+};
 
-export const SuiteHeaderSurveyDataPropTypes = PropTypes.shape({
+export const SuiteHeaderSurveyDataPropTypes = {
   surveyLink: PropTypes.string.isRequired,
   privacyLink: PropTypes.string.isRequired,
-});
+};
 
-export const SuiteHeaderI18NPropTypes = PropTypes.shape({
+export const SuiteHeaderI18NPropTypes = {
   help: PropTypes.string,
   profileTitle: PropTypes.string,
   profileManageButton: PropTypes.string,
@@ -83,7 +83,7 @@ export const SuiteHeaderI18NPropTypes = PropTypes.shape({
   surveyTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   surveyText: PropTypes.string,
   surveyPrivacyPolicy: PropTypes.string,
-});
+};
 
 const defaultProps = {
   className: null,
@@ -117,17 +117,17 @@ const propTypes = {
   /** If true, renders the admin button in Header as selected */
   isAdminView: PropTypes.bool,
   /** URLs for various routes on Header buttons and submenus */
-  routes: SuiteHeaderRoutePropTypes,
+  routes: PropTypes.shape(SuiteHeaderRoutePropTypes),
   /** Applications to render in AppSwitcher */
-  applications: PropTypes.arrayOf(SuiteHeaderApplicationPropTypes),
+  applications: PropTypes.arrayOf(PropTypes.shape(SuiteHeaderApplicationPropTypes)),
   /** side navigation component */
   sideNavProps: PropTypes.shape(SideNavPropTypes),
   /** If surveyData is present, show a ToastNotification */
-  surveyData: SuiteHeaderSurveyDataPropTypes,
+  surveyData: PropTypes.shape(SuiteHeaderSurveyDataPropTypes),
   /** Function called before any route change. Returns a Promise<Boolean>. False means the redirect will not happen. This function should never throw an error. */
   onRouteChange: PropTypes.func,
   /** I18N strings */
-  i18n: SuiteHeaderI18NPropTypes,
+  i18n: PropTypes.shape(SuiteHeaderI18NPropTypes),
   /** Array of custom header action items */
   customActionItems: PropTypes.arrayOf(PropTypes.shape(HeaderActionItemPropTypes)),
   /** Array of custom help menu links */
@@ -135,7 +135,7 @@ const propTypes = {
   /** Array of custom profile menu links */
   customProfileLinks: PropTypes.arrayOf(PropTypes.shape(ChildContentPropTypes)),
   /** Array of custom applications */
-  customApplications: PropTypes.arrayOf(SuiteHeaderApplicationPropTypes),
+  customApplications: PropTypes.arrayOf(PropTypes.shape(SuiteHeaderApplicationPropTypes)),
 };
 
 const SuiteHeader = ({

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
@@ -135,7 +135,7 @@ const propTypes = {
   /** Array of custom profile menu links */
   customProfileLinks: PropTypes.arrayOf(PropTypes.shape(ChildContentPropTypes)),
   /** Array of custom applications */
-  customApplications: PropTypes.arrayOf(PropTypes.shape(ChildContentPropTypes)),
+  customApplications: PropTypes.arrayOf(SuiteHeaderApplicationPropTypes),
 };
 
 const SuiteHeader = ({

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable no-script-url */
 
-import React, { Fragment, useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { UserAvatar20, Settings20, Help20 } from '@carbon/icons-react';
 import { ButtonSkeleton } from 'carbon-components-react';
@@ -308,13 +308,13 @@ const SuiteHeader = ({
                         .filter((i) => i)
                         .join(' '),
                       btnContent: (
-                        <>
+                        <span id="suite-header-action-item-admin">
                           <Settings20
                             fill="white"
                             data-testid="admin-icon"
                             description={mergedI18N.settingsIcon}
                           />
-                        </>
+                        </span>
                       ),
                       onClick: async () => {
                         let href = routes.admin;
@@ -340,9 +340,9 @@ const SuiteHeader = ({
                   label: mergedI18N.help,
                   onClick: () => {},
                   btnContent: (
-                    <Fragment>
+                    <span id="suite-header-action-item-help">
                       <Help20 fill="white" description={mergedI18N.help} />
-                    </Fragment>
+                    </span>
                   ),
                   childContent: routes
                     ? [
@@ -369,7 +369,9 @@ const SuiteHeader = ({
                               }
                             },
                           },
-                          content: mergedI18N[item],
+                          content: (
+                            <span id={`suite-header-help-menu-${item}`}>{mergedI18N[item]}</span>
+                          ),
                         })),
                         {
                           metaData: {
@@ -384,7 +386,9 @@ const SuiteHeader = ({
                               }
                             },
                           },
-                          content: mergedI18N.about,
+                          content: (
+                            <span id="suite-header-help-menu-about">{mergedI18N.about}</span>
+                          ),
                         },
                       ]
                     : [
@@ -406,13 +410,13 @@ const SuiteHeader = ({
                 {
                   label: 'user',
                   btnContent: (
-                    <Fragment>
+                    <span id="suite-header-action-item-profile">
                       <UserAvatar20
                         data-testid="user-icon"
                         fill="white"
                         description={mergedI18N.userIcon}
                       />
-                    </Fragment>
+                    </span>
                   ),
                   childContent: [
                     {
@@ -420,20 +424,25 @@ const SuiteHeader = ({
                         element: 'div',
                       },
                       content: (
-                        <SuiteHeaderProfile
-                          displayName={userDisplayName}
-                          username={username}
-                          onProfileClick={async () => {
-                            const result = await onRouteChange(ROUTE_TYPES.PROFILE, routes.profile);
-                            if (result) {
-                              window.location.href = routes.profile;
-                            }
-                          }}
-                          i18n={{
-                            profileTitle: mergedI18N.profileTitle,
-                            profileButton: mergedI18N.profileManageButton,
-                          }}
-                        />
+                        <span id="suite-header-profile-menu-profile" style={{ width: '100%' }}>
+                          <SuiteHeaderProfile
+                            displayName={userDisplayName}
+                            username={username}
+                            onProfileClick={async () => {
+                              const result = await onRouteChange(
+                                ROUTE_TYPES.PROFILE,
+                                routes.profile
+                              );
+                              if (result) {
+                                window.location.href = routes.profile;
+                              }
+                            }}
+                            i18n={{
+                              profileTitle: mergedI18N.profileTitle,
+                              profileButton: mergedI18N.profileManageButton,
+                            }}
+                          />
+                        </span>
                       ),
                     },
                     ...customProfileLinks,
@@ -447,7 +456,9 @@ const SuiteHeader = ({
                             title: mergedI18N.logout,
                             onClick: () => setShowLogoutModal(true),
                           },
-                          content: mergedI18N.logout,
+                          content: (
+                            <span id="suite-header-profile-menu-logout">{mergedI18N.logout}</span>
+                          ),
                         }
                       : {
                           metaData: {

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.story.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.story.jsx
@@ -373,7 +373,7 @@ export const HeaderWithCustomActionItems = () => (
 );
 
 HeaderWithCustomActionItems.story = {
-  name: 'Header with custom action items and child content',
+  name: 'Header with custom action items',
 };
 
 export const HeaderWithSurveyNotification = () => {

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.story.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.story.jsx
@@ -1,3 +1,6 @@
+/* eslint-disable no-script-url */
+/* eslint-disable-next-line no-alert */
+
 import React from 'react';
 import { text, object, boolean, select } from '@storybook/addon-knobs';
 import { Switcher24 } from '@carbon/icons-react';
@@ -11,8 +14,6 @@ import Chat from '@carbon/icons-react/lib/chat/24';
 
 import SuiteHeader from './SuiteHeader';
 import SuiteHeaderI18N from './i18n';
-// import getSuiteHeaderData from './util/suiteHeaderData';
-// import useSuiteHeaderData from './hooks/useSuiteHeaderData';
 
 const sideNavLinks = [
   {
@@ -167,6 +168,78 @@ const customActionItems = [
   },
 ];
 
+const customHelpLinks = [
+  {
+    metaData: {
+      href: 'http://www.ibm.com',
+      target: '_blank',
+      rel: 'noopener noreferrer',
+      element: 'a',
+    },
+    content: '{A custom help link}',
+  },
+  {
+    metaData: {
+      href: 'http://google.com',
+      target: '_blank',
+      rel: 'noopener noreferrer',
+      element: 'a',
+    },
+    content: '{Another custom help link}',
+  },
+  {
+    metaData: {
+      element: 'a',
+      href: 'javascript:void(0)',
+      onClick: () => alert('custom help menu action'),
+    },
+    content: '{Yet another custom help link}',
+  },
+];
+
+const customProfileLinks = [
+  {
+    metaData: {
+      href: 'http://www.ibm.com',
+      target: '_blank',
+      rel: 'noopener noreferrer',
+      element: 'a',
+    },
+    content: '{A custom profile link}',
+  },
+  {
+    metaData: {
+      href: 'http://google.com',
+      target: '_blank',
+      rel: 'noopener noreferrer',
+      element: 'a',
+    },
+    content: '{Another custom profile link}',
+  },
+  {
+    metaData: {
+      element: 'a',
+      href: 'javascript:void(0)',
+      onClick: () => alert('custom profile menu action'),
+    },
+    content: '{Yet another custom profile link}',
+  },
+];
+
+const customApplications = [
+  {
+    id: 'customapp1',
+    name: 'Custom Application',
+    href: 'https://www.ibm.com',
+  },
+  {
+    id: 'customapp2',
+    name: 'Another Custom Application',
+    href: 'https://google.com',
+    isExternal: true,
+  },
+];
+
 export default {
   title: 'Watson IoT/SuiteHeader',
 
@@ -288,16 +361,19 @@ export const HeaderWithCustomActionItems = () => (
       {
         id: 'health',
         name: 'Health',
-        href: 'https://www.ibm.com',
+        href: 'https://google.com',
         isExternal: true,
       },
     ]}
     customActionItems={customActionItems}
+    customHelpLinks={customHelpLinks}
+    customProfileLinks={customProfileLinks}
+    customApplications={customApplications}
   />
 );
 
 HeaderWithCustomActionItems.story = {
-  name: 'Header with custom action items',
+  name: 'Header with custom action items and child content',
 };
 
 export const HeaderWithSurveyNotification = () => {
@@ -351,53 +427,15 @@ export const HeaderWithSurveyNotification = () => {
   );
 };
 
-export const LoadingStates = () => {
+export const LoadingState = () => {
   return <SuiteHeader suiteName="Application Suite" appName="Application Name" />;
 };
 
-LoadingStates.story = {
+LoadingState.story = {
   name: 'Loading state',
 };
 
-/* Sample of SuiteHeader usage with data hook
-export const HeaderWithHook = () => {
-  const StatefulExample = () => {
-    const [data] = useSuiteHeaderData({
-      // baseApiUrl: 'http://localhost:3001/internal',
-      domain: 'mydomain.com',
-      isTest: true,
-      surveyConfig: {
-        id: 'suite',
-        delayIntervalDays: 30,
-        frequencyDays: 90,
-      },
-      lang: 'en',
-    });
-    const surveyData = data.showSurvey
-      ? {
-          surveyLink: 'https://www.ibm.com',
-          privacyLink: 'https://www.ibm.com',
-        }
-      : null;
-    return data.username ? (
-      <SuiteHeader
-        suiteName="Application Suite"
-        appName="Application Name"
-        userDisplayName={data.userDisplayName}
-        username={data.username}
-        routes={data.routes}
-        applications={data.applications}
-        i18n={data.i18n}
-        surveyData={surveyData}
-      />
-    ) : null;
-  };
-  return <StatefulExample />;
-};
-
-HeaderWithHook.story = {
-  name: 'Header with hook',
-};
+/* Sample of SuiteHeader usage with data fetching
 
 export const HeaderWithDataFetching = () => {
   const StatefulExample = () => {
@@ -405,42 +443,27 @@ export const HeaderWithDataFetching = () => {
       username: null,
       userDisplayName: null,
       email: null,
-      routes: {
-        profile: null,
-        navigator: null,
-        admin: null,
-        logout: null,
-        about: null,
-        documentation: null,
-        whatsNew: null,
-        requestEnhancement: null,
-        support: null,
-        gettingStarted: null,
-      },
-      applications: [],
+      routes: null,
+      applications: null,
       showSurvey: false,
     });
     useEffect(() => {
-      getSuiteHeaderData({
-        // baseApiUrl: 'http://localhost:3001/internal',
-        domain: 'mydomain.com',
-        isTest: true,
-        surveyConfig: {
-          id: 'suite',
-          delayIntervalDays: 30,
-          frequencyDays: 90,
+      fetch('http://localhost:3001/internal/uiresources?id=masthead&lang=en&surveyId=test', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
         },
-        lang: 'en',
-      }).then((suiteHeaderData) => setData(suiteHeaderData));
+      })
+        .then((res) => res.json())
+        .then((resJson) => {
+          if (resJson.error || resJson.exception) {
+            return null;
+          }
+          return setData(resJson);
+        });
     }, []);
 
-    const surveyData = data.showSurvey
-      ? {
-          surveyLink: 'https://www.ibm.com',
-          privacyLink: 'https://www.ibm.com',
-        }
-      : null;
-    return data.username ? (
+    return (
       <SuiteHeader
         suiteName="Application Suite"
         appName="Application Name"
@@ -449,9 +472,9 @@ export const HeaderWithDataFetching = () => {
         routes={data.routes}
         applications={data.applications}
         i18n={data.i18n}
-        surveyData={surveyData}
+        surveyData={data.surveyData}
       />
-    ) : null;
+    );
   };
   return <StatefulExample />;
 };

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.story.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.story.jsx
@@ -100,18 +100,24 @@ const sideNavLinks = [
 
 const customActionItems = [
   {
-    label: 'alerts',
-    btnContent: <NotificationOn fill="white" description="Icon" />,
+    label: 'bell',
+    btnContent: (
+      <span id="bell-icon">
+        <NotificationOn id="notification-button" fill="white" description="Icon" />
+      </span>
+    ),
   },
   {
-    label: 'help',
+    label: 'bee',
     hasHeaderPanel: true,
     btnContent: (
-      <Bee
-        fill="white"
-        description="Icon"
-        className="bx--header__menu-item bx--header__menu-title"
-      />
+      <span id="bee-icon">
+        <Bee
+          fill="white"
+          description="Icon"
+          className="bx--header__menu-item bx--header__menu-title"
+        />
+      </span>
     ),
     childContent: [
       {
@@ -122,15 +128,14 @@ const customActionItems = [
           rel: 'noopener noreferrer',
           element: 'a',
         },
-        content: 'this is my message to you',
+        content: <span id="a-message">this is my message to you</span>,
       },
       {
         metaData: {
-          className: 'this',
           element: 'button',
         },
         content: (
-          <span>
+          <span id="an-email">
             JohnDoe@ibm.com
             <Chat fill="white" description="Icon" />
           </span>
@@ -139,8 +144,12 @@ const customActionItems = [
     ],
   },
   {
-    label: 'user',
-    btnContent: <Car fill="white" description="Icon" />,
+    label: 'car',
+    btnContent: (
+      <span id="car-icon">
+        <Car fill="white" description="Icon" />
+      </span>
+    ),
     childContent: [
       {
         metaData: {
@@ -150,15 +159,14 @@ const customActionItems = [
           rel: 'noopener noreferrer',
           element: 'a',
         },
-        content: 'this is my message to you',
+        content: <span id="another-message">this is my message to you</span>,
       },
       {
         metaData: {
-          className: 'this',
           element: 'button',
         },
         content: (
-          <span>
+          <span id="another-email">
             JohnDoe@ibm.com
             <Chat fill="white" description="Icon" />
           </span>
@@ -176,7 +184,7 @@ const customHelpLinks = [
       rel: 'noopener noreferrer',
       element: 'a',
     },
-    content: '{A custom help link}',
+    content: <span id="custom-help-link">{'{A custom help link}'}</span>,
   },
   {
     metaData: {
@@ -185,7 +193,7 @@ const customHelpLinks = [
       rel: 'noopener noreferrer',
       element: 'a',
     },
-    content: '{Another custom help link}',
+    content: <span id="another-custom-help-link">{'{Another custom help link}'}</span>,
   },
   {
     metaData: {
@@ -193,7 +201,7 @@ const customHelpLinks = [
       href: 'javascript:void(0)',
       onClick: () => alert('custom help menu action'),
     },
-    content: '{Yet another custom help link}',
+    content: <span id="yet-another-custom-help-link">{'{Yet another custom help link}'}</span>,
   },
 ];
 
@@ -205,7 +213,7 @@ const customProfileLinks = [
       rel: 'noopener noreferrer',
       element: 'a',
     },
-    content: '{A custom profile link}',
+    content: <span id="custom-profile-link">{'{A custom profile link}'}</span>,
   },
   {
     metaData: {
@@ -214,7 +222,7 @@ const customProfileLinks = [
       rel: 'noopener noreferrer',
       element: 'a',
     },
-    content: '{Another custom profile link}',
+    content: <span id="another-custom-profile-link">{'{Another custom profile link}'}</span>,
   },
   {
     metaData: {
@@ -222,7 +230,9 @@ const customProfileLinks = [
       href: 'javascript:void(0)',
       onClick: () => alert('custom profile menu action'),
     },
-    content: '{Yet another custom profile link}',
+    content: (
+      <span id="yet-another-custom-profile-link">{'{Yet another custom profile link}'}</span>
+    ),
   },
 ];
 

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.story.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.story.jsx
@@ -351,6 +351,14 @@ export const HeaderWithSurveyNotification = () => {
   );
 };
 
+export const LoadingStates = () => {
+  return <SuiteHeader suiteName="Application Suite" appName="Application Name" />;
+};
+
+LoadingStates.story = {
+  name: 'Loading state',
+};
+
 /* Sample of SuiteHeader usage with data hook
 export const HeaderWithHook = () => {
   const StatefulExample = () => {

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
@@ -3,15 +3,18 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ArrowLeft16, Bee32 } from '@carbon/icons-react';
+import { ArrowLeft16, ArrowRight16, Bee32 } from '@carbon/icons-react';
 
 import { settings } from '../../../constants/Settings';
+import Button from '../../Button';
+import { SkeletonText } from '../../SkeletonText';
 import SuiteHeader from '../SuiteHeader';
 
 const defaultProps = {
-  applications: [],
+  applications: null,
   onRouteChange: async () => true,
   i18n: {
+    myApplications: 'My applications',
     allApplicationsLink: 'All applications',
     requestAccess: 'Contact your administrator to request application access.',
     learnMoreLink: 'Learn more',
@@ -49,8 +52,9 @@ const SuiteHeaderAppSwitcher = ({
   return (
     <ul className={baseClassName}>
       <li className={`${baseClassName}--nav-link`}>
-        <a
-          href="javascript:void(0)"
+        <p>{mergedI18n.myApplications}</p>
+        <Button
+          kind="tertiary"
           data-testid="suite-header-app-switcher--all-applications"
           onClick={async () => {
             const result = await onRouteChange(
@@ -61,34 +65,45 @@ const SuiteHeaderAppSwitcher = ({
               window.location.href = allApplicationsLink;
             }
           }}
+          renderIcon={ArrowRight16}
         >
-          <ArrowLeft16 />
           {mergedI18n.allApplicationsLink}
-        </a>
+        </Button>
       </li>
-      {applications.map(({ id, name, href, isExternal = false }) => (
-        <li key={`key-${id}`} className={`${baseClassName}--app-link`}>
-          <a
-            href="javascript:void(0)"
-            data-testid={`suite-header-app-switcher--${id}`}
-            onClick={async () => {
-              const result = await onRouteChange(SuiteHeader.ROUTE_TYPES.APPLICATION, href, {
-                appId: id,
-              });
-              if (result) {
-                if (isExternal) {
-                  window.open(href, 'blank');
-                } else {
-                  window.location.href = href;
+      {applications === null ? (
+        <div
+          className={`${baseClassName}--app-skeleton`}
+          data-testid="suite-header-app-switcher--loading"
+        >
+          {Array.from({ length: 3 }, (x, i) => (
+            <SkeletonText key={`$app-switcher-skeleton-${i}`} />
+          ))}
+        </div>
+      ) : (
+        applications.map(({ id, name, href, isExternal = false }) => (
+          <li key={`key-${id}`} className={`${baseClassName}--app-link`}>
+            <a
+              href="javascript:void(0)"
+              data-testid={`suite-header-app-switcher--${id}`}
+              onClick={async () => {
+                const result = await onRouteChange(SuiteHeader.ROUTE_TYPES.APPLICATION, href, {
+                  appId: id,
+                });
+                if (result) {
+                  if (isExternal) {
+                    window.open(href, 'blank');
+                  } else {
+                    window.location.href = href;
+                  }
                 }
-              }
-            }}
-          >
-            {name}
-          </a>
-        </li>
-      ))}
-      {applications.length === 0 ? (
+              }}
+            >
+              {name}
+            </a>
+          </li>
+        ))
+      )}
+      {applications?.length === 0 ? (
         <div className={`${baseClassName}--no-app`}>
           <div className="bee-icon-container">
             <Bee32 />

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
@@ -79,6 +79,7 @@ const SuiteHeaderAppSwitcher = ({
           </Button>
         )}
       </li>
+      <div className={`${baseClassName}--nav-link--separator`} />
       {mergedApplications === null ? (
         <li>
           <div

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
@@ -9,7 +9,19 @@ import { ButtonSkeleton } from 'carbon-components-react';
 import { settings } from '../../../constants/Settings';
 import Button from '../../Button';
 import { SkeletonText } from '../../SkeletonText';
-import SuiteHeader from '../SuiteHeader';
+
+// For some reason ROUTE_TYPES imported from SuiteHeader does not work, probably because of cyclic dependency
+const ROUTE_TYPES = {
+  ADMIN: 'ADMIN',
+  NAVIGATOR: 'NAVIGATOR',
+  REFERRER: 'REFERRER',
+  APPLICATION: 'APPLICATION',
+  PROFILE: 'PROFILE',
+  ABOUT: 'ABOUT',
+  LOGOUT: 'LOGOUT',
+  DOCUMENTATION: 'DOCUMENTATION',
+  SURVEY: 'SURVEY',
+};
 
 const defaultProps = {
   applications: null,
@@ -24,7 +36,7 @@ const defaultProps = {
   },
 };
 
-const applicationPropTypes = PropTypes.shape({
+export const SuiteHeaderApplicationPropTypes = PropTypes.shape({
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   href: PropTypes.string.isRequired,
@@ -32,8 +44,8 @@ const applicationPropTypes = PropTypes.shape({
 });
 
 const propTypes = {
-  applications: PropTypes.arrayOf(applicationPropTypes),
-  customApplications: PropTypes.arrayOf(applicationPropTypes),
+  applications: PropTypes.arrayOf(SuiteHeaderApplicationPropTypes),
+  customApplications: PropTypes.arrayOf(SuiteHeaderApplicationPropTypes),
   allApplicationsLink: PropTypes.string,
   noAccessLink: PropTypes.string.isRequired,
   onRouteChange: PropTypes.func,
@@ -72,10 +84,7 @@ const SuiteHeaderAppSwitcher = ({
             kind="tertiary"
             data-testid="suite-header-app-switcher--all-applications"
             onClick={async () => {
-              const result = await onRouteChange(
-                SuiteHeader.ROUTE_TYPES.NAVIGATOR,
-                allApplicationsLink
-              );
+              const result = await onRouteChange(ROUTE_TYPES.NAVIGATOR, allApplicationsLink);
               if (result) {
                 window.location.href = allApplicationsLink;
               }
@@ -102,7 +111,7 @@ const SuiteHeaderAppSwitcher = ({
               href="javascript:void(0)"
               data-testid={`suite-header-app-switcher--${id}`}
               onClick={async () => {
-                const result = await onRouteChange(SuiteHeader.ROUTE_TYPES.APPLICATION, href, {
+                const result = await onRouteChange(ROUTE_TYPES.APPLICATION, href, {
                   appId: id,
                 });
                 if (result) {
@@ -130,10 +139,7 @@ const SuiteHeaderAppSwitcher = ({
             href="javascript:void(0)"
             data-testid="suite-header-app-switcher--no-access"
             onClick={async () => {
-              const result = await onRouteChange(
-                SuiteHeader.ROUTE_TYPES.DOCUMENTATION,
-                noAccessLink
-              );
+              const result = await onRouteChange(ROUTE_TYPES.DOCUMENTATION, noAccessLink);
               if (result) {
                 window.location.href = noAccessLink;
               }

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
@@ -91,7 +91,11 @@ const SuiteHeaderAppSwitcher = ({
         </li>
       ) : (
         mergedApplications.map(({ id, name, href, isExternal = false }) => (
-          <li key={`key-${id}`} className={`${baseClassName}--app-link`}>
+          <li
+            id={`suite-header-application-${id}`}
+            key={`key-${id}`}
+            className={`${baseClassName}--app-link`}
+          >
             <a
               href="javascript:void(0)"
               data-testid={`suite-header-app-switcher--${id}`}

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
@@ -9,19 +9,7 @@ import { ButtonSkeleton } from 'carbon-components-react';
 import { settings } from '../../../constants/Settings';
 import Button from '../../Button';
 import { SkeletonText } from '../../SkeletonText';
-
-// For some reason ROUTE_TYPES imported from SuiteHeader does not work, probably because of cyclic dependency
-const ROUTE_TYPES = {
-  ADMIN: 'ADMIN',
-  NAVIGATOR: 'NAVIGATOR',
-  REFERRER: 'REFERRER',
-  APPLICATION: 'APPLICATION',
-  PROFILE: 'PROFILE',
-  ABOUT: 'ABOUT',
-  LOGOUT: 'LOGOUT',
-  DOCUMENTATION: 'DOCUMENTATION',
-  SURVEY: 'SURVEY',
-};
+import SuiteHeader, { SuiteHeaderApplicationPropTypes } from '../SuiteHeader';
 
 const defaultProps = {
   applications: null,
@@ -36,16 +24,9 @@ const defaultProps = {
   },
 };
 
-export const SuiteHeaderApplicationPropTypes = PropTypes.shape({
-  id: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
-  href: PropTypes.string.isRequired,
-  isExternal: PropTypes.bool,
-});
-
 const propTypes = {
-  applications: PropTypes.arrayOf(SuiteHeaderApplicationPropTypes),
-  customApplications: PropTypes.arrayOf(SuiteHeaderApplicationPropTypes),
+  applications: PropTypes.arrayOf(PropTypes.shape(SuiteHeaderApplicationPropTypes)),
+  customApplications: PropTypes.arrayOf(PropTypes.shape(SuiteHeaderApplicationPropTypes)),
   allApplicationsLink: PropTypes.string,
   noAccessLink: PropTypes.string.isRequired,
   onRouteChange: PropTypes.func,
@@ -84,7 +65,10 @@ const SuiteHeaderAppSwitcher = ({
             kind="tertiary"
             data-testid="suite-header-app-switcher--all-applications"
             onClick={async () => {
-              const result = await onRouteChange(ROUTE_TYPES.NAVIGATOR, allApplicationsLink);
+              const result = await onRouteChange(
+                SuiteHeader.ROUTE_TYPES.NAVIGATOR,
+                allApplicationsLink
+              );
               if (result) {
                 window.location.href = allApplicationsLink;
               }
@@ -111,7 +95,7 @@ const SuiteHeaderAppSwitcher = ({
               href="javascript:void(0)"
               data-testid={`suite-header-app-switcher--${id}`}
               onClick={async () => {
-                const result = await onRouteChange(ROUTE_TYPES.APPLICATION, href, {
+                const result = await onRouteChange(SuiteHeader.ROUTE_TYPES.APPLICATION, href, {
                   appId: id,
                 });
                 if (result) {
@@ -139,7 +123,10 @@ const SuiteHeaderAppSwitcher = ({
             href="javascript:void(0)"
             data-testid="suite-header-app-switcher--no-access"
             onClick={async () => {
-              const result = await onRouteChange(ROUTE_TYPES.DOCUMENTATION, noAccessLink);
+              const result = await onRouteChange(
+                SuiteHeader.ROUTE_TYPES.DOCUMENTATION,
+                noAccessLink
+              );
               if (result) {
                 window.location.href = noAccessLink;
               }

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
@@ -72,12 +72,10 @@ const SuiteHeaderAppSwitcher = ({
       </li>
       {applications === null ? (
         <div
-          className={`${baseClassName}--app-skeleton`}
+          className={`${baseClassName}--loading`}
           data-testid="suite-header-app-switcher--loading"
         >
-          {Array.from({ length: 3 }, (x, i) => (
-            <SkeletonText key={`$app-switcher-skeleton-${i}`} />
-          ))}
+          <SkeletonText paragraph lineCount={3} />
         </div>
       ) : (
         applications.map(({ id, name, href, isExternal = false }) => (

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ArrowLeft16, ArrowRight16, Bee32 } from '@carbon/icons-react';
+import { ArrowRight16, Bee32 } from '@carbon/icons-react';
 
 import { settings } from '../../../constants/Settings';
 import Button from '../../Button';

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.story.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.story.jsx
@@ -51,7 +51,7 @@ NoApplications.story = {
   name: 'No applications',
 };
 
-export const Loading = () => (
+export const LoadingState = () => (
   <div style={{ width: '15rem', background: 'white' }}>
     <SuiteHeaderAppSwitcher
       allApplicationsLink="https://www.ibm.com"
@@ -60,6 +60,6 @@ export const Loading = () => (
   </div>
 );
 
-Loading.story = {
-  name: 'Loading',
+LoadingState.story = {
+  name: 'Loading state',
 };

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.story.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.story.jsx
@@ -50,3 +50,16 @@ export const NoApplications = () => (
 NoApplications.story = {
   name: 'No applications',
 };
+
+export const Loading = () => (
+  <div style={{ width: '15rem', background: 'white' }}>
+    <SuiteHeaderAppSwitcher
+      allApplicationsLink="https://www.ibm.com"
+      noAccessLink="https://www.ibm.com"
+    />
+  </div>
+);
+
+Loading.story = {
+  name: 'Loading',
+};

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.test.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { mount } from 'enzyme';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -94,5 +95,17 @@ describe('SuiteHeaderAppSwitcher', () => {
     );
     await userEvent.click(screen.getByTestId('suite-header-app-switcher--no-access'));
     expect(window.location.href).not.toBe(commonProps.noAccessLink);
+  });
+  it('shows loading state', async () => {
+    delete window.location;
+    window.location = { href: '' };
+    const wrapper = mount(
+      <SuiteHeaderAppSwitcher
+        allApplicationsLink="https://www.ibm.com"
+        noAccessLink="https://www.ibm.com"
+      />
+    );
+    // Expect skeletons
+    expect(wrapper.find('[data-testid="suite-header-app-switcher--loading"]')).toHaveLength(1);
   });
 });

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/__snapshots__/SuiteHeaderAppSwitcher.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/__snapshots__/SuiteHeaderAppSwitcher.story.storyshot
@@ -55,6 +55,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
             </svg>
           </button>
         </li>
+        <div
+          className="iot--suite-header-app-switcher--nav-link--separator"
+        />
         <li>
           <div
             className="iot--suite-header-app-switcher--nav-link--loading"
@@ -172,6 +175,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
             </svg>
           </button>
         </li>
+        <div
+          className="iot--suite-header-app-switcher--nav-link--separator"
+        />
         <div
           className="iot--suite-header-app-switcher--no-app"
         >
@@ -291,6 +297,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
             </svg>
           </button>
         </li>
+        <div
+          className="iot--suite-header-app-switcher--nav-link--separator"
+        />
         <li
           className="iot--suite-header-app-switcher--app-link"
         >

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/__snapshots__/SuiteHeaderAppSwitcher.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/__snapshots__/SuiteHeaderAppSwitcher.story.storyshot
@@ -302,6 +302,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
         />
         <li
           className="iot--suite-header-app-switcher--app-link"
+          id="suite-header-application-monitor"
         >
           <a
             data-testid="suite-header-app-switcher--monitor"
@@ -313,6 +314,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
         </li>
         <li
           className="iot--suite-header-app-switcher--app-link"
+          id="suite-header-application-health"
         >
           <a
             data-testid="suite-header-app-switcher--health"

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/__snapshots__/SuiteHeaderAppSwitcher.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/__snapshots__/SuiteHeaderAppSwitcher.story.storyshot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/SuiteHeader/SuiteHeaderAppSwitcher Loading 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/SuiteHeader/SuiteHeaderAppSwitcher Loading state 1`] = `
 <div
   className="storybook-container"
 >
@@ -55,37 +55,39 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
             </svg>
           </button>
         </li>
-        <div
-          className="iot--suite-header-app-switcher--loading"
-          data-testid="suite-header-app-switcher--loading"
-        >
-          <div>
-            <p
-              className="bx--skeleton__text"
-              style={
-                Object {
-                  "width": "calc(100% - 73px)",
+        <li>
+          <div
+            className="iot--suite-header-app-switcher--nav-link--loading"
+            data-testid="suite-header-app-switcher--loading"
+          >
+            <div>
+              <p
+                className="bx--skeleton__text"
+                style={
+                  Object {
+                    "width": "calc(100% - 73px)",
+                  }
                 }
-              }
-            />
-            <p
-              className="bx--skeleton__text"
-              style={
-                Object {
-                  "width": "calc(100% - 11px)",
+              />
+              <p
+                className="bx--skeleton__text"
+                style={
+                  Object {
+                    "width": "calc(100% - 11px)",
+                  }
                 }
-              }
-            />
-            <p
-              className="bx--skeleton__text"
-              style={
-                Object {
-                  "width": "calc(100% - 43px)",
+              />
+              <p
+                className="bx--skeleton__text"
+                style={
+                  Object {
+                    "width": "calc(100% - 43px)",
+                  }
                 }
-              }
-            />
+              />
+            </div>
           </div>
-        </div>
+        </li>
       </ul>
     </div>
   </div>

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/__snapshots__/SuiteHeaderAppSwitcher.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/__snapshots__/SuiteHeaderAppSwitcher.story.storyshot
@@ -1,5 +1,118 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/SuiteHeader/SuiteHeaderAppSwitcher Loading 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "background": "white",
+          "width": "15rem",
+        }
+      }
+    >
+      <ul
+        className="iot--suite-header-app-switcher"
+      >
+        <li
+          className="iot--suite-header-app-switcher--nav-link"
+        >
+          <p>
+            My applications
+          </p>
+          <button
+            className="iot--btn bx--btn bx--btn--tertiary"
+            data-testid="suite-header-app-switcher--all-applications"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            All applications
+            <svg
+              aria-hidden={true}
+              className="bx--btn__icon"
+              fill="currentColor"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M9.3 3.7L13.1 7.5 1 7.5 1 8.5 13.1 8.5 9.3 12.3 10 13 15 8 10 3z"
+              />
+            </svg>
+          </button>
+        </li>
+        <div
+          className="iot--suite-header-app-switcher--app-skeleton"
+          data-testid="suite-header-app-switcher--loading"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+      </ul>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/SuiteHeader/SuiteHeaderAppSwitcher No applications 1`] = `
 <div
   className="storybook-container"
@@ -26,13 +139,21 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
         <li
           className="iot--suite-header-app-switcher--nav-link"
         >
-          <a
+          <p>
+            My applications
+          </p>
+          <button
+            className="iot--btn bx--btn bx--btn--tertiary"
             data-testid="suite-header-app-switcher--all-applications"
-            href="javascript:void(0)"
+            disabled={false}
             onClick={[Function]}
+            tabIndex={0}
+            type="button"
           >
+            All applications
             <svg
               aria-hidden={true}
+              className="bx--btn__icon"
               fill="currentColor"
               focusable="false"
               height={16}
@@ -42,11 +163,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M6.7 12.3L2.9 8.5 15 8.5 15 7.5 2.9 7.5 6.7 3.7 6 3 1 8 6 13z"
+                d="M9.3 3.7L13.1 7.5 1 7.5 1 8.5 13.1 8.5 9.3 12.3 10 13 15 8 10 3z"
               />
             </svg>
-            All applications
-          </a>
+          </button>
         </li>
         <div
           className="iot--suite-header-app-switcher--no-app"
@@ -138,13 +258,21 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
         <li
           className="iot--suite-header-app-switcher--nav-link"
         >
-          <a
+          <p>
+            My applications
+          </p>
+          <button
+            className="iot--btn bx--btn bx--btn--tertiary"
             data-testid="suite-header-app-switcher--all-applications"
-            href="javascript:void(0)"
+            disabled={false}
             onClick={[Function]}
+            tabIndex={0}
+            type="button"
           >
+            All applications
             <svg
               aria-hidden={true}
+              className="bx--btn__icon"
               fill="currentColor"
               focusable="false"
               height={16}
@@ -154,11 +282,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M6.7 12.3L2.9 8.5 15 8.5 15 7.5 2.9 7.5 6.7 3.7 6 3 1 8 6 13z"
+                d="M9.3 3.7L13.1 7.5 1 7.5 1 8.5 13.1 8.5 9.3 12.3 10 13 15 8 10 3z"
               />
             </svg>
-            All applications
-          </a>
+          </button>
         </li>
         <li
           className="iot--suite-header-app-switcher--app-link"

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/__snapshots__/SuiteHeaderAppSwitcher.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/__snapshots__/SuiteHeaderAppSwitcher.story.storyshot
@@ -56,33 +56,35 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
           </button>
         </li>
         <div
-          className="iot--suite-header-app-switcher--app-skeleton"
+          className="iot--suite-header-app-switcher--loading"
           data-testid="suite-header-app-switcher--loading"
         >
-          <p
-            className="bx--skeleton__text"
-            style={
-              Object {
-                "width": "100%",
+          <div>
+            <p
+              className="bx--skeleton__text"
+              style={
+                Object {
+                  "width": "calc(100% - 73px)",
+                }
               }
-            }
-          />
-          <p
-            className="bx--skeleton__text"
-            style={
-              Object {
-                "width": "100%",
+            />
+            <p
+              className="bx--skeleton__text"
+              style={
+                Object {
+                  "width": "calc(100% - 11px)",
+                }
               }
-            }
-          />
-          <p
-            className="bx--skeleton__text"
-            style={
-              Object {
-                "width": "100%",
+            />
+            <p
+              className="bx--skeleton__text"
+              style={
+                Object {
+                  "width": "calc(100% - 43px)",
+                }
               }
-            }
-          />
+            />
+          </div>
         </div>
       </ul>
     </div>

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderLogoutModal/__snapshots__/SuiteHeaderLogoutModal.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderLogoutModal/__snapshots__/SuiteHeaderLogoutModal.story.storyshot
@@ -40,7 +40,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
           
           <h3
             className="bx--modal-header__heading"
-            id="bx--modal-header__heading--modal-5"
+            id="bx--modal-header__heading--modal-6"
           >
             Do you wish to log out?
           </h3>
@@ -70,9 +70,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
           </button>
         </div>
         <div
-          aria-labelledby="bx--modal-header__heading--modal-5"
+          aria-labelledby="bx--modal-header__heading--modal-6"
           className="bx--modal-content"
-          id="bx--modal-body--modal-5"
+          id="bx--modal-body--modal-6"
         >
           Logging out also logs you out of each application that is open in the same browser.  To ensure a secure log out, close all open browser windows.
         </div>

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/SuiteHeaderProfile.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/SuiteHeaderProfile.jsx
@@ -71,11 +71,9 @@ const SuiteHeaderProfile = ({ displayName, username, onProfileClick, onRequestLo
       ) : (
         <>
           <div className={`${baseClassName}--loading`} data-testid="suite-header-profile--loading">
-            {Array.from({ length: 3 }, (x, i) => (
-              <SkeletonText key={`$profile-skeleton-${i}`} />
-            ))}
+            <SkeletonText paragraph lineCount={3} width="80%" />
           </div>
-          <div className={`${baseClassName}--logout`}>
+          <div className={`${baseClassName}--logout ${baseClassName}--logout--loading`}>
             <ButtonSkeleton />
           </div>
         </>

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/SuiteHeaderProfile.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/SuiteHeaderProfile.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { ButtonSkeleton, SkeletonText } from 'carbon-components-react';
 
 import { Button } from '../../../index';
 import { settings } from '../../../constants/Settings';
-import { ButtonSkeleton, SkeletonText } from 'carbon-components-react';
 
 const defaultProps = {
   username: '',

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/SuiteHeaderProfile.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/SuiteHeaderProfile.jsx
@@ -3,8 +3,10 @@ import PropTypes from 'prop-types';
 
 import { Button } from '../../../index';
 import { settings } from '../../../constants/Settings';
+import { ButtonSkeleton, SkeletonText } from 'carbon-components-react';
 
 const defaultProps = {
+  username: '',
   displayName: '',
   i18n: {
     profileTitle: 'Profile',
@@ -15,7 +17,7 @@ const defaultProps = {
 
 const propTypes = {
   displayName: PropTypes.string,
-  username: PropTypes.string.isRequired,
+  username: PropTypes.string,
   onProfileClick: PropTypes.func.isRequired,
   onRequestLogout: PropTypes.func.isRequired,
   i18n: PropTypes.shape({
@@ -35,34 +37,49 @@ const SuiteHeaderProfile = ({ displayName, username, onProfileClick, onRequestLo
   return (
     <div className={baseClassName}>
       <h5>{mergedI18N.profileTitle}</h5>
-      <div className={`${baseClassName}--user`}>
-        <div className={`${baseClassName}--user--chip`}>{chipText}</div>
-        <div className={`${baseClassName}--user--detail`}>
-          <div>
-            <strong>{displayName}</strong>
+      {username ? (
+        <>
+          <div className={`${baseClassName}--user`}>
+            <div className={`${baseClassName}--user--chip`}>{chipText}</div>
+            <div className={`${baseClassName}--user--detail`}>
+              <div>
+                <strong>{displayName}</strong>
+              </div>
+              <div>{username}</div>
+            </div>
           </div>
-          <div>{username}</div>
-        </div>
-      </div>
-      <div className={`${baseClassName}--manage-button`}>
-        <Button
-          kind="secondary"
-          size="small"
-          data-testid="suite-header-profile--profile"
-          onClick={onProfileClick}
-        >
-          {mergedI18N.profileButton}
-        </Button>
-      </div>
-      <div className={`${baseClassName}--logout`}>
-        <Button
-          kind="secondary"
-          data-testid="suite-header-profile--logout"
-          onClick={onRequestLogout}
-        >
-          {mergedI18N.logoutButton}
-        </Button>
-      </div>
+          <div className={`${baseClassName}--manage-button`}>
+            <Button
+              kind="secondary"
+              size="small"
+              data-testid="suite-header-profile--profile"
+              onClick={onProfileClick}
+            >
+              {mergedI18N.profileButton}
+            </Button>
+          </div>
+          <div className={`${baseClassName}--logout`}>
+            <Button
+              kind="secondary"
+              data-testid="suite-header-profile--logout"
+              onClick={onRequestLogout}
+            >
+              {mergedI18N.logoutButton}
+            </Button>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className={`${baseClassName}--loading`} data-testid="suite-header-profile--loading">
+            {Array.from({ length: 3 }, (x, i) => (
+              <SkeletonText key={`$profile-skeleton-${i}`} />
+            ))}
+          </div>
+          <div className={`${baseClassName}--logout`}>
+            <ButtonSkeleton />
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/SuiteHeaderProfile.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/SuiteHeaderProfile.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ButtonSkeleton, SkeletonText } from 'carbon-components-react';
+import { ButtonSkeleton } from 'carbon-components-react';
 
 import { Button } from '../../../index';
+import { SkeletonText } from '../../SkeletonText';
 import { settings } from '../../../constants/Settings';
 
 const defaultProps = {
   username: '',
   displayName: '',
+  onRequestLogout: null,
   i18n: {
     profileTitle: 'Profile',
     profileButton: 'Manage profile',
@@ -19,7 +21,7 @@ const propTypes = {
   displayName: PropTypes.string,
   username: PropTypes.string,
   onProfileClick: PropTypes.func.isRequired,
-  onRequestLogout: PropTypes.func.isRequired,
+  onRequestLogout: PropTypes.func,
   i18n: PropTypes.shape({
     profileTitle: PropTypes.string,
     profileButton: PropTypes.string,
@@ -48,7 +50,11 @@ const SuiteHeaderProfile = ({ displayName, username, onProfileClick, onRequestLo
               <div>{username}</div>
             </div>
           </div>
-          <div className={`${baseClassName}--manage-button`}>
+          <div
+            className={`${baseClassName}--manage-button${
+              onRequestLogout ? '' : ` ${baseClassName}--manage-button--no-logout`
+            }`}
+          >
             <Button
               kind="secondary"
               size="small"
@@ -58,24 +64,33 @@ const SuiteHeaderProfile = ({ displayName, username, onProfileClick, onRequestLo
               {mergedI18N.profileButton}
             </Button>
           </div>
-          <div className={`${baseClassName}--logout`}>
-            <Button
-              kind="secondary"
-              data-testid="suite-header-profile--logout"
-              onClick={onRequestLogout}
-            >
-              {mergedI18N.logoutButton}
-            </Button>
-          </div>
+          {onRequestLogout && (
+            <div className={`${baseClassName}--logout`}>
+              <Button
+                kind="secondary"
+                data-testid="suite-header-profile--logout"
+                onClick={onRequestLogout}
+              >
+                {mergedI18N.logoutButton}
+              </Button>
+            </div>
+          )}
         </>
       ) : (
         <>
-          <div className={`${baseClassName}--loading`} data-testid="suite-header-profile--loading">
+          <div
+            className={`${baseClassName}--loading${
+              onRequestLogout ? '' : ` ${baseClassName}--loading--no-logout`
+            }`}
+            data-testid="suite-header-profile--loading"
+          >
             <SkeletonText paragraph lineCount={3} width="80%" />
           </div>
-          <div className={`${baseClassName}--logout ${baseClassName}--logout--loading`}>
-            <ButtonSkeleton />
-          </div>
+          {onRequestLogout && (
+            <div className={`${baseClassName}--logout ${baseClassName}--logout--loading`}>
+              <ButtonSkeleton />
+            </div>
+          )}
         </>
       )}
     </div>

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/SuiteHeaderProfile.story.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/SuiteHeaderProfile.story.jsx
@@ -28,3 +28,18 @@ export const Default = () => (
 Default.story = {
   name: 'default',
 };
+
+export const LoadingState = () => (
+  <div style={{ width: '15rem' }}>
+    <SuiteHeaderProfile
+      onProfileClick={() => {
+        window.location.href = 'https://www.ibm.com';
+      }}
+      onRequestLogout={() => {}}
+    />
+  </div>
+);
+
+LoadingState.story = {
+  name: 'Loading state',
+};

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/SuiteHeaderProfile.story.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/SuiteHeaderProfile.story.jsx
@@ -43,3 +43,33 @@ export const LoadingState = () => (
 LoadingState.story = {
   name: 'Loading state',
 };
+
+export const NoLogoutButton = () => (
+  <div style={{ width: '15rem' }}>
+    <SuiteHeaderProfile
+      displayName={text('displayName', 'Test User')}
+      username={text('username', 'myuser')}
+      onProfileClick={() => {
+        window.location.href = 'https://www.ibm.com';
+      }}
+    />
+  </div>
+);
+
+NoLogoutButton.story = {
+  name: 'No log out button',
+};
+
+export const NoLogoutButtonLoadingState = () => (
+  <div style={{ width: '15rem' }}>
+    <SuiteHeaderProfile
+      onProfileClick={() => {
+        window.location.href = 'https://www.ibm.com';
+      }}
+    />
+  </div>
+);
+
+NoLogoutButtonLoadingState.story = {
+  name: 'Loading state (no log out button)',
+};

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/SuiteHeaderProfile.test.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/SuiteHeaderProfile.test.jsx
@@ -35,4 +35,18 @@ describe('SuiteHeaderProfile', () => {
     profileButton.simulate('click');
     expect(mockOnProfileClick).toHaveBeenCalled();
   });
+  it('renders in loading state', () => {
+    const mockOnRequestLogout = jest.fn();
+    const wrapper = mount(
+      <SuiteHeaderProfile
+        {...commonProps}
+        username={undefined}
+        displayName={undefined}
+        onRequestLogout={mockOnRequestLogout}
+      />
+    );
+    // Expect skeletons and no logout button
+    expect(wrapper.find('[data-testid="suite-header-profile--loading"]')).toHaveLength(1);
+    expect(wrapper.find('[data-testid="suite-header-profile--logout"]')).toHaveLength(0);
+  });
 });

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/SuiteHeaderProfile.test.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/SuiteHeaderProfile.test.jsx
@@ -49,4 +49,8 @@ describe('SuiteHeaderProfile', () => {
     expect(wrapper.find('[data-testid="suite-header-profile--loading"]')).toHaveLength(1);
     expect(wrapper.find('[data-testid="suite-header-profile--logout"]')).toHaveLength(0);
   });
+  it('renders with no logout button', () => {
+    const wrapper = mount(<SuiteHeaderProfile {...commonProps} onRequestLogout={undefined} />);
+    expect(wrapper.find('[data-testid="suite-header-profile--logout"]')).toHaveLength(0);
+  });
 });

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/__snapshots__/SuiteHeaderProfile.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/__snapshots__/SuiteHeaderProfile.story.storyshot
@@ -1,5 +1,95 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/SuiteHeader/SuiteHeaderProfile Loading state 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "15rem",
+        }
+      }
+    >
+      <div
+        className="iot--suite-header-profile"
+      >
+        <h5>
+          Profile
+        </h5>
+        <div
+          className="iot--suite-header-profile--loading"
+          data-testid="suite-header-profile--loading"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="iot--suite-header-profile--logout"
+        >
+          <div
+            className="bx--skeleton bx--btn"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/SuiteHeader/SuiteHeaderProfile default 1`] = `
 <div
   className="storybook-container"

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/__snapshots__/SuiteHeaderProfile.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/__snapshots__/SuiteHeaderProfile.story.storyshot
@@ -29,33 +29,35 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
           className="iot--suite-header-profile--loading"
           data-testid="suite-header-profile--loading"
         >
-          <p
-            className="bx--skeleton__text"
-            style={
-              Object {
-                "width": "100%",
+          <div>
+            <p
+              className="bx--skeleton__text"
+              style={
+                Object {
+                  "width": "calc(80% - 73px)",
+                }
               }
-            }
-          />
-          <p
-            className="bx--skeleton__text"
-            style={
-              Object {
-                "width": "100%",
+            />
+            <p
+              className="bx--skeleton__text"
+              style={
+                Object {
+                  "width": "calc(80% - 11px)",
+                }
               }
-            }
-          />
-          <p
-            className="bx--skeleton__text"
-            style={
-              Object {
-                "width": "100%",
+            />
+            <p
+              className="bx--skeleton__text"
+              style={
+                Object {
+                  "width": "calc(80% - 43px)",
+                }
               }
-            }
-          />
+            />
+          </div>
         </div>
         <div
-          className="iot--suite-header-profile--logout"
+          className="iot--suite-header-profile--logout iot--suite-header-profile--logout--loading"
         >
           <div
             className="bx--skeleton bx--btn"

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/__snapshots__/SuiteHeaderProfile.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderProfile/__snapshots__/SuiteHeaderProfile.story.storyshot
@@ -1,5 +1,90 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/SuiteHeader/SuiteHeaderProfile Loading state (no log out button) 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "15rem",
+        }
+      }
+    >
+      <div
+        className="iot--suite-header-profile"
+      >
+        <h5>
+          Profile
+        </h5>
+        <div
+          className="iot--suite-header-profile--loading iot--suite-header-profile--loading--no-logout"
+          data-testid="suite-header-profile--loading"
+        >
+          <div>
+            <p
+              className="bx--skeleton__text"
+              style={
+                Object {
+                  "width": "calc(80% - 73px)",
+                }
+              }
+            />
+            <p
+              className="bx--skeleton__text"
+              style={
+                Object {
+                  "width": "calc(80% - 11px)",
+                }
+              }
+            />
+            <p
+              className="bx--skeleton__text"
+              style={
+                Object {
+                  "width": "calc(80% - 43px)",
+                }
+              }
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/SuiteHeader/SuiteHeaderProfile Loading state 1`] = `
 <div
   className="storybook-container"
@@ -62,6 +147,95 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
           <div
             className="bx--skeleton bx--btn"
           />
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/SuiteHeader/SuiteHeaderProfile No log out button 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "15rem",
+        }
+      }
+    >
+      <div
+        className="iot--suite-header-profile"
+      >
+        <h5>
+          Profile
+        </h5>
+        <div
+          className="iot--suite-header-profile--user"
+        >
+          <div
+            className="iot--suite-header-profile--user--chip"
+          >
+            TU
+          </div>
+          <div
+            className="iot--suite-header-profile--user--detail"
+          >
+            <div>
+              <strong>
+                Test User
+              </strong>
+            </div>
+            <div>
+              myuser
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--suite-header-profile--manage-button iot--suite-header-profile--manage-button--no-logout"
+        >
+          <button
+            className="iot--btn bx--btn bx--btn--sm bx--btn--secondary"
+            data-testid="suite-header-profile--profile"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            Manage profile
+          </button>
         </div>
       </div>
     </div>

--- a/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/SuiteHeader Header with custom action items 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/SuiteHeader Header with custom action items and child content 1`] = `
 <div
   className="storybook-container"
 >
@@ -428,6 +428,64 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
               <li>
                 <a
                   className="bx--header__menu-item"
+                  href="http://www.ibm.com"
+                  rel="noopener noreferrer"
+                  tabIndex={0}
+                  target="_blank"
+                >
+                  <span
+                    className="bx--text-truncate--end"
+                  >
+                    {A custom help link}
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="bx--header__menu-item"
+                  href="http://google.com"
+                  rel="noopener noreferrer"
+                  tabIndex={0}
+                  target="_blank"
+                >
+                  <span
+                    className="bx--text-truncate--end"
+                  >
+                    {Another custom help link}
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="bx--header__menu-item"
+                  href="javascript:void(0)"
+                  onClick={[Function]}
+                  tabIndex={0}
+                >
+                  <span
+                    className="bx--text-truncate--end"
+                  >
+                    {Yet another custom help link}
+                  </span>
+                </a>
+              </li>
+              <li
+                className="iot--suite-header-help--separator"
+              >
+                <div
+                  className="bx--header__menu-item"
+                  tabIndex={0}
+                >
+                  <span
+                    className="bx--text-truncate--end"
+                  >
+                    
+                  </span>
+                </div>
+              </li>
+              <li>
+                <a
+                  className="bx--header__menu-item"
                   data-testid="suite-header-help--whatsNew"
                   href="javascript:void(0)"
                   onClick={[Function]}
@@ -605,7 +663,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                         </div>
                       </div>
                       <div
-                        className="iot--suite-header-profile--manage-button"
+                        className="iot--suite-header-profile--manage-button iot--suite-header-profile--manage-button--no-logout"
                       >
                         <button
                           className="iot--btn bx--btn bx--btn--sm bx--btn--secondary"
@@ -618,23 +676,71 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                           Manage profile
                         </button>
                       </div>
-                      <div
-                        className="iot--suite-header-profile--logout"
-                      >
-                        <button
-                          className="iot--btn bx--btn bx--btn--secondary"
-                          data-testid="suite-header-profile--logout"
-                          disabled={false}
-                          onClick={[Function]}
-                          tabIndex={0}
-                          type="button"
-                        >
-                          Log out
-                        </button>
-                      </div>
                     </div>
                   </span>
                 </div>
+              </li>
+              <li>
+                <a
+                  className="bx--header__menu-item"
+                  href="http://www.ibm.com"
+                  rel="noopener noreferrer"
+                  tabIndex={0}
+                  target="_blank"
+                >
+                  <span
+                    className="bx--text-truncate--end"
+                  >
+                    {A custom profile link}
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="bx--header__menu-item"
+                  href="http://google.com"
+                  rel="noopener noreferrer"
+                  tabIndex={0}
+                  target="_blank"
+                >
+                  <span
+                    className="bx--text-truncate--end"
+                  >
+                    {Another custom profile link}
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="bx--header__menu-item"
+                  href="javascript:void(0)"
+                  onClick={[Function]}
+                  tabIndex={0}
+                >
+                  <span
+                    className="bx--text-truncate--end"
+                  >
+                    {Yet another custom profile link}
+                  </span>
+                </a>
+              </li>
+              <li
+                className="iot--suite-header--logout"
+              >
+                <a
+                  className="bx--header__menu-item"
+                  data-testid="suite-header-profile--logout"
+                  href="javascript:void(0)"
+                  onClick={[Function]}
+                  tabIndex={0}
+                  title="Logout"
+                >
+                  <span
+                    className="bx--text-truncate--end"
+                  >
+                    Logout
+                  </span>
+                </a>
               </li>
             </ul>
           </div>
@@ -720,6 +826,28 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                           />
                         </svg>
                       </button>
+                    </li>
+                    <li
+                      className="iot--suite-header-app-switcher--app-link"
+                    >
+                      <a
+                        data-testid="suite-header-app-switcher--customapp1"
+                        href="javascript:void(0)"
+                        onClick={[Function]}
+                      >
+                        Custom Application
+                      </a>
+                    </li>
+                    <li
+                      className="iot--suite-header-app-switcher--app-link"
+                    >
+                      <a
+                        data-testid="suite-header-app-switcher--customapp2"
+                        href="javascript:void(0)"
+                        onClick={[Function]}
+                      >
+                        Another Custom Application
+                      </a>
                     </li>
                     <li
                       className="iot--suite-header-app-switcher--app-link"
@@ -1201,7 +1329,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                         </div>
                       </div>
                       <div
-                        className="iot--suite-header-profile--manage-button"
+                        className="iot--suite-header-profile--manage-button iot--suite-header-profile--manage-button--no-logout"
                       >
                         <button
                           className="iot--btn bx--btn bx--btn--sm bx--btn--secondary"
@@ -1214,23 +1342,27 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                           Manage profile
                         </button>
                       </div>
-                      <div
-                        className="iot--suite-header-profile--logout"
-                      >
-                        <button
-                          className="iot--btn bx--btn bx--btn--secondary"
-                          data-testid="suite-header-profile--logout"
-                          disabled={false}
-                          onClick={[Function]}
-                          tabIndex={0}
-                          type="button"
-                        >
-                          Log out
-                        </button>
-                      </div>
                     </div>
                   </span>
                 </div>
+              </li>
+              <li
+                className="iot--suite-header--logout"
+              >
+                <a
+                  className="bx--header__menu-item"
+                  data-testid="suite-header-profile--logout"
+                  href="javascript:void(0)"
+                  onClick={[Function]}
+                  tabIndex={0}
+                  title="Logout"
+                >
+                  <span
+                    className="bx--text-truncate--end"
+                  >
+                    Logout
+                  </span>
+                </a>
               </li>
             </ul>
           </div>
@@ -2152,7 +2284,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                         </div>
                       </div>
                       <div
-                        className="iot--suite-header-profile--manage-button"
+                        className="iot--suite-header-profile--manage-button iot--suite-header-profile--manage-button--no-logout"
                       >
                         <button
                           className="iot--btn bx--btn bx--btn--sm bx--btn--secondary"
@@ -2165,23 +2297,27 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                           Manage profile
                         </button>
                       </div>
-                      <div
-                        className="iot--suite-header-profile--logout"
-                      >
-                        <button
-                          className="iot--btn bx--btn bx--btn--secondary"
-                          data-testid="suite-header-profile--logout"
-                          disabled={false}
-                          onClick={[Function]}
-                          tabIndex={0}
-                          type="button"
-                        >
-                          Log out
-                        </button>
-                      </div>
                     </div>
                   </span>
                 </div>
+              </li>
+              <li
+                className="iot--suite-header--logout"
+              >
+                <a
+                  className="bx--header__menu-item"
+                  data-testid="suite-header-profile--logout"
+                  href="javascript:void(0)"
+                  onClick={[Function]}
+                  tabIndex={0}
+                  title="Logout"
+                >
+                  <span
+                    className="bx--text-truncate--end"
+                  >
+                    Logout
+                  </span>
+                </a>
               </li>
             </ul>
           </div>
@@ -2640,7 +2776,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                         Profile
                       </h5>
                       <div
-                        className="iot--suite-header-profile--loading"
+                        className="iot--suite-header-profile--loading iot--suite-header-profile--loading--no-logout"
                         data-testid="suite-header-profile--loading"
                       >
                         <div>
@@ -2670,13 +2806,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                           />
                         </div>
                       </div>
+                    </div>
+                  </span>
+                </div>
+              </li>
+              <li>
+                <div
+                  className="bx--header__menu-item"
+                  tabIndex={0}
+                >
+                  <span
+                    className="bx--text-truncate--end"
+                  >
+                    <div
+                      className="iot--suite-header--logout--loading"
+                      data-testid="suite-header--logout--loading"
+                    >
                       <div
-                        className="iot--suite-header-profile--logout iot--suite-header-profile--logout--loading"
-                      >
-                        <div
-                          className="bx--skeleton bx--btn"
-                        />
-                      </div>
+                        className="bx--skeleton bx--btn"
+                      />
                     </div>
                   </span>
                 </div>
@@ -2740,63 +2888,47 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                       <p>
                         My applications
                       </p>
-                      <button
-                        className="iot--btn bx--btn bx--btn--tertiary"
-                        data-testid="suite-header-app-switcher--all-applications"
-                        disabled={false}
-                        onClick={[Function]}
-                        tabIndex={0}
-                        type="button"
+                      <div
+                        className="iot--suite-header-app-switcher--nav-link--button--loading"
                       >
-                        All applications
-                        <svg
-                          aria-hidden={true}
-                          className="bx--btn__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M9.3 3.7L13.1 7.5 1 7.5 1 8.5 13.1 8.5 9.3 12.3 10 13 15 8 10 3z"
-                          />
-                        </svg>
-                      </button>
-                    </li>
-                    <div
-                      className="iot--suite-header-app-switcher--loading"
-                      data-testid="suite-header-app-switcher--loading"
-                    >
-                      <div>
-                        <p
-                          className="bx--skeleton__text"
-                          style={
-                            Object {
-                              "width": "calc(100% - 73px)",
-                            }
-                          }
-                        />
-                        <p
-                          className="bx--skeleton__text"
-                          style={
-                            Object {
-                              "width": "calc(100% - 11px)",
-                            }
-                          }
-                        />
-                        <p
-                          className="bx--skeleton__text"
-                          style={
-                            Object {
-                              "width": "calc(100% - 43px)",
-                            }
-                          }
+                        <div
+                          className="bx--skeleton bx--btn"
                         />
                       </div>
-                    </div>
+                    </li>
+                    <li>
+                      <div
+                        className="iot--suite-header-app-switcher--nav-link--loading"
+                        data-testid="suite-header-app-switcher--loading"
+                      >
+                        <div>
+                          <p
+                            className="bx--skeleton__text"
+                            style={
+                              Object {
+                                "width": "calc(100% - 73px)",
+                              }
+                            }
+                          />
+                          <p
+                            className="bx--skeleton__text"
+                            style={
+                              Object {
+                                "width": "calc(100% - 11px)",
+                              }
+                            }
+                          />
+                          <p
+                            className="bx--skeleton__text"
+                            style={
+                              Object {
+                                "width": "calc(100% - 43px)",
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </li>
                   </ul>
                 </a>
               </li>
@@ -3237,7 +3369,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                         </div>
                       </div>
                       <div
-                        className="iot--suite-header-profile--manage-button"
+                        className="iot--suite-header-profile--manage-button iot--suite-header-profile--manage-button--no-logout"
                       >
                         <button
                           className="iot--btn bx--btn bx--btn--sm bx--btn--secondary"
@@ -3250,23 +3382,27 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                           Manage profile
                         </button>
                       </div>
-                      <div
-                        className="iot--suite-header-profile--logout"
-                      >
-                        <button
-                          className="iot--btn bx--btn bx--btn--secondary"
-                          data-testid="suite-header-profile--logout"
-                          disabled={false}
-                          onClick={[Function]}
-                          tabIndex={0}
-                          type="button"
-                        >
-                          Log out
-                        </button>
-                      </div>
                     </div>
                   </span>
                 </div>
+              </li>
+              <li
+                className="iot--suite-header--logout"
+              >
+                <a
+                  className="bx--header__menu-item"
+                  data-testid="suite-header-profile--logout"
+                  href="javascript:void(0)"
+                  onClick={[Function]}
+                  tabIndex={0}
+                  title="Logout"
+                >
+                  <span
+                    className="bx--text-truncate--end"
+                  >
+                    Logout
+                  </span>
+                </a>
               </li>
             </ul>
           </div>

--- a/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
@@ -692,13 +692,21 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                     <li
                       className="iot--suite-header-app-switcher--nav-link"
                     >
-                      <a
+                      <p>
+                        My applications
+                      </p>
+                      <button
+                        className="iot--btn bx--btn bx--btn--tertiary"
                         data-testid="suite-header-app-switcher--all-applications"
-                        href="javascript:void(0)"
+                        disabled={false}
                         onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
                       >
+                        All applications
                         <svg
                           aria-hidden={true}
+                          className="bx--btn__icon"
                           fill="currentColor"
                           focusable="false"
                           height={16}
@@ -708,11 +716,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <path
-                            d="M6.7 12.3L2.9 8.5 15 8.5 15 7.5 2.9 7.5 6.7 3.7 6 3 1 8 6 13z"
+                            d="M9.3 3.7L13.1 7.5 1 7.5 1 8.5 13.1 8.5 9.3 12.3 10 13 15 8 10 3z"
                           />
                         </svg>
-                        All applications
-                      </a>
+                      </button>
                     </li>
                     <li
                       className="iot--suite-header-app-switcher--app-link"
@@ -1281,13 +1288,21 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                     <li
                       className="iot--suite-header-app-switcher--nav-link"
                     >
-                      <a
+                      <p>
+                        My applications
+                      </p>
+                      <button
+                        className="iot--btn bx--btn bx--btn--tertiary"
                         data-testid="suite-header-app-switcher--all-applications"
-                        href="javascript:void(0)"
+                        disabled={false}
                         onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
                       >
+                        All applications
                         <svg
                           aria-hidden={true}
+                          className="bx--btn__icon"
                           fill="currentColor"
                           focusable="false"
                           height={16}
@@ -1297,11 +1312,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <path
-                            d="M6.7 12.3L2.9 8.5 15 8.5 15 7.5 2.9 7.5 6.7 3.7 6 3 1 8 6 13z"
+                            d="M9.3 3.7L13.1 7.5 1 7.5 1 8.5 13.1 8.5 9.3 12.3 10 13 15 8 10 3z"
                           />
                         </svg>
-                        All applications
-                      </a>
+                      </button>
                     </li>
                     <li
                       className="iot--suite-header-app-switcher--app-link"
@@ -2225,13 +2239,21 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                     <li
                       className="iot--suite-header-app-switcher--nav-link"
                     >
-                      <a
+                      <p>
+                        My applications
+                      </p>
+                      <button
+                        className="iot--btn bx--btn bx--btn--tertiary"
                         data-testid="suite-header-app-switcher--all-applications"
-                        href="javascript:void(0)"
+                        disabled={false}
                         onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
                       >
+                        All applications
                         <svg
                           aria-hidden={true}
+                          className="bx--btn__icon"
                           fill="currentColor"
                           focusable="false"
                           height={16}
@@ -2241,11 +2263,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <path
-                            d="M6.7 12.3L2.9 8.5 15 8.5 15 7.5 2.9 7.5 6.7 3.7 6 3 1 8 6 13z"
+                            d="M9.3 3.7L13.1 7.5 1 7.5 1 8.5 13.1 8.5 9.3 12.3 10 13 15 8 10 3z"
                           />
                         </svg>
-                        All applications
-                      </a>
+                      </button>
                     </li>
                     <li
                       className="iot--suite-header-app-switcher--app-link"
@@ -2269,6 +2290,557 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                         Health
                       </a>
                     </li>
+                  </ul>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </header>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/SuiteHeader Loading state 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--modal bx--modal-tall"
+      onBlur={[Function]}
+      onKeyDown={[Function]}
+      onMouseDown={[Function]}
+      role="presentation"
+    >
+      <span
+        className="bx--visually-hidden"
+        role="link"
+        tabIndex="0"
+      >
+        Focus sentinel
+      </span>
+      <div
+        aria-label="Do you wish to log out?"
+        aria-modal="true"
+        className="bx--modal-container"
+        role="dialog"
+        tabIndex="-1"
+      >
+        <div
+          className="bx--modal-header"
+        >
+          
+          <h3
+            className="bx--modal-header__heading"
+            id="bx--modal-header__heading--modal-5"
+          >
+            Do you wish to log out?
+          </h3>
+          <button
+            aria-label="Close"
+            className="bx--modal-close"
+            onClick={[Function]}
+            title="Close"
+            type="button"
+          >
+            <svg
+              aria-label="Close"
+              className="bx--modal-close__icon"
+              fill="currentColor"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          aria-labelledby="bx--modal-header__heading--modal-5"
+          className="bx--modal-content"
+          id="bx--modal-body--modal-5"
+        >
+          You are logged in to Application Name as null.  Logging out also logs you out of each application that is open in the same browser.  To ensure a secure log out, close all open browser windows.
+        </div>
+        <div
+          className="bx--modal-footer"
+        >
+          <button
+            className="bx--btn bx--btn--secondary"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            className="bx--btn bx--btn--primary"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            Log out
+          </button>
+        </div>
+      </div>
+      <span
+        className="bx--visually-hidden"
+        role="link"
+        tabIndex="0"
+      >
+        Focus sentinel
+      </span>
+    </div>
+    <header
+      aria-label="main header"
+      className="bx--header iot--suite-header"
+    >
+      <a
+        className="bx--skip-to-content"
+        href="#main-content"
+        tabIndex="0"
+      >
+        Skip to main content
+      </a>
+      <a
+        className="bx--header__name"
+        href="javascript:void(0)"
+      >
+        <span
+          className="bx--header__name--prefix"
+        >
+          IBM
+        </span>
+         
+        Application Suite
+        <div
+          className="iot--header__subtitle"
+        >
+          Application Name
+        </div>
+      </a>
+      <div
+        className="bx--header__global"
+      >
+        <div
+          className="bx--header__submenu bx--header-action-btn action-btn__group"
+          data-testid="action-btn__group"
+          onBlur={[Function]}
+          onKeyDown={[Function]}
+        >
+          <div
+            className="bx--header__submenu bx--header-action-btn"
+          >
+            <a
+              aria-expanded={false}
+              aria-haspopup="menu"
+              aria-label="Help"
+              className="bx--header__menu-item bx--header__menu-title"
+              data-testid="menuitem"
+              href=""
+              onClick={[Function]}
+              role="menuitem"
+              tabIndex={0}
+            >
+              <svg
+                aria-hidden={true}
+                description="Help"
+                fill="white"
+                focusable="false"
+                height={20}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Zm0,26A12,12,0,1,1,28,16,12,12,0,0,1,16,28Z"
+                />
+                <circle
+                  cx="16"
+                  cy="23.5"
+                  r="1.5"
+                />
+                <path
+                  d="M17,8H15.5A4.49,4.49,0,0,0,11,12.5V13h2v-.5A2.5,2.5,0,0,1,15.5,10H17a2.5,2.5,0,0,1,0,5H15v4.5h2V17a4.5,4.5,0,0,0,0-9Z"
+                />
+              </svg>
+            </a>
+            <ul
+              aria-label="Help"
+              className="bx--header__menu"
+              role="menu"
+            >
+              <li>
+                <a
+                  className="bx--header__menu-item"
+                  tabIndex={0}
+                >
+                  <span
+                    className="bx--text-truncate--end"
+                  >
+                    <p
+                      className="bx--skeleton__text"
+                      style={
+                        Object {
+                          "width": "100%",
+                        }
+                      }
+                    />
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="bx--header__menu-item"
+                  tabIndex={0}
+                >
+                  <span
+                    className="bx--text-truncate--end"
+                  >
+                    <p
+                      className="bx--skeleton__text"
+                      style={
+                        Object {
+                          "width": "100%",
+                        }
+                      }
+                    />
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="bx--header__menu-item"
+                  tabIndex={0}
+                >
+                  <span
+                    className="bx--text-truncate--end"
+                  >
+                    <p
+                      className="bx--skeleton__text"
+                      style={
+                        Object {
+                          "width": "100%",
+                        }
+                      }
+                    />
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="bx--header__menu-item"
+                  tabIndex={0}
+                >
+                  <span
+                    className="bx--text-truncate--end"
+                  >
+                    <p
+                      className="bx--skeleton__text"
+                      style={
+                        Object {
+                          "width": "100%",
+                        }
+                      }
+                    />
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="bx--header__menu-item"
+                  tabIndex={0}
+                >
+                  <span
+                    className="bx--text-truncate--end"
+                  >
+                    <p
+                      className="bx--skeleton__text"
+                      style={
+                        Object {
+                          "width": "100%",
+                        }
+                      }
+                    />
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="bx--header__menu-item"
+                  tabIndex={0}
+                >
+                  <span
+                    className="bx--text-truncate--end"
+                  >
+                    <p
+                      className="bx--skeleton__text"
+                      style={
+                        Object {
+                          "width": "100%",
+                        }
+                      }
+                    />
+                  </span>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div
+          className="bx--header__submenu bx--header-action-btn action-btn__group"
+          data-testid="action-btn__group"
+          onBlur={[Function]}
+          onKeyDown={[Function]}
+        >
+          <div
+            className="bx--header__submenu bx--header-action-btn"
+          >
+            <a
+              aria-expanded={false}
+              aria-haspopup="menu"
+              aria-label="user"
+              className="bx--header__menu-item bx--header__menu-title"
+              data-testid="menuitem"
+              href=""
+              onClick={[Function]}
+              role="menuitem"
+              tabIndex={0}
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="user-icon"
+                description="User"
+                fill="white"
+                focusable="false"
+                height={20}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2ZM10,26.38v-2A3.22,3.22,0,0,1,13,21h6a3.22,3.22,0,0,1,3,3.39v2a11.92,11.92,0,0,1-12,0Zm14-1.46v-.61A5.21,5.21,0,0,0,19,19H13a5.2,5.2,0,0,0-5,5.31s0,0,0,0v.59a12,12,0,1,1,16,0Z"
+                />
+                <path
+                  d="M16,7a5,5,0,1,0,5,5A5,5,0,0,0,16,7Zm0,8a3,3,0,1,1,3-3A3,3,0,0,1,16,15Z"
+                />
+              </svg>
+            </a>
+            <ul
+              aria-label="user"
+              className="bx--header__menu"
+              role="menu"
+            >
+              <li>
+                <div
+                  className="bx--header__menu-item"
+                  tabIndex={0}
+                >
+                  <span
+                    className="bx--text-truncate--end"
+                  >
+                    <div
+                      className="iot--suite-header-profile"
+                    >
+                      <h5>
+                        Profile
+                      </h5>
+                      <div
+                        className="iot--suite-header-profile--loading"
+                        data-testid="suite-header-profile--loading"
+                      >
+                        <p
+                          className="bx--skeleton__text"
+                          style={
+                            Object {
+                              "width": "100%",
+                            }
+                          }
+                        />
+                        <p
+                          className="bx--skeleton__text"
+                          style={
+                            Object {
+                              "width": "100%",
+                            }
+                          }
+                        />
+                        <p
+                          className="bx--skeleton__text"
+                          style={
+                            Object {
+                              "width": "100%",
+                            }
+                          }
+                        />
+                      </div>
+                      <div
+                        className="iot--suite-header-profile--logout"
+                      >
+                        <div
+                          className="bx--skeleton bx--btn"
+                        />
+                      </div>
+                    </div>
+                  </span>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div
+          className="bx--header__submenu bx--header-action-btn action-btn__group"
+          data-testid="action-btn__group"
+          onBlur={[Function]}
+          onKeyDown={[Function]}
+        >
+          <button
+            aria-expanded={false}
+            aria-haspopup="menu"
+            aria-label="AppSwitcher"
+            className="bx--header-action-btn action-btn__trigger bx--header__action"
+            onClick={[Function]}
+            title="AppSwitcher"
+            type="button"
+          >
+            <svg
+              aria-hidden={true}
+              className="bx--header__menu-item bx--header__menu-title"
+              fill="white"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M14 4H18V8H14zM4 4H8V8H4zM24 4H28V8H24zM14 14H18V18H14zM4 14H8V18H4zM24 14H28V18H24zM14 24H18V28H14zM4 24H8V28H4zM24 24H28V28H24z"
+              />
+            </svg>
+          </button>
+          <div
+            aria-label="Header Panel"
+            className="bx--header-panel bx--app-switcher"
+            data-testid="action-btn__panel"
+            tabIndex="-1"
+          >
+            <ul
+              aria-label="AppSwitcher"
+            >
+              <li
+                className="action-btn__headerpanel-li"
+              >
+                <a
+                  className="bx--app-switcher undefined"
+                  element="a"
+                >
+                  <ul
+                    className="iot--suite-header-app-switcher"
+                  >
+                    <li
+                      className="iot--suite-header-app-switcher--nav-link"
+                    >
+                      <p>
+                        My applications
+                      </p>
+                      <button
+                        className="iot--btn bx--btn bx--btn--tertiary"
+                        data-testid="suite-header-app-switcher--all-applications"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        All applications
+                        <svg
+                          aria-hidden={true}
+                          className="bx--btn__icon"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M9.3 3.7L13.1 7.5 1 7.5 1 8.5 13.1 8.5 9.3 12.3 10 13 15 8 10 3z"
+                          />
+                        </svg>
+                      </button>
+                    </li>
+                    <div
+                      className="iot--suite-header-app-switcher--app-skeleton"
+                      data-testid="suite-header-app-switcher--loading"
+                    >
+                      <p
+                        className="bx--skeleton__text"
+                        style={
+                          Object {
+                            "width": "100%",
+                          }
+                        }
+                      />
+                      <p
+                        className="bx--skeleton__text"
+                        style={
+                          Object {
+                            "width": "100%",
+                          }
+                        }
+                      />
+                      <p
+                        className="bx--skeleton__text"
+                        style={
+                          Object {
+                            "width": "100%",
+                          }
+                        }
+                      />
+                    </div>
                   </ul>
                 </a>
               </li>
@@ -2796,13 +3368,21 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                     <li
                       className="iot--suite-header-app-switcher--nav-link"
                     >
-                      <a
+                      <p>
+                        My applications
+                      </p>
+                      <button
+                        className="iot--btn bx--btn bx--btn--tertiary"
                         data-testid="suite-header-app-switcher--all-applications"
-                        href="javascript:void(0)"
+                        disabled={false}
                         onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
                       >
+                        All applications
                         <svg
                           aria-hidden={true}
+                          className="bx--btn__icon"
                           fill="currentColor"
                           focusable="false"
                           height={16}
@@ -2812,11 +3392,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <path
-                            d="M6.7 12.3L2.9 8.5 15 8.5 15 7.5 2.9 7.5 6.7 3.7 6 3 1 8 6 13z"
+                            d="M9.3 3.7L13.1 7.5 1 7.5 1 8.5 13.1 8.5 9.3 12.3 10 13 15 8 10 3z"
                           />
                         </svg>
-                        All applications
-                      </a>
+                      </button>
                     </li>
                     <li
                       className="iot--suite-header-app-switcher--app-link"

--- a/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
@@ -827,6 +827,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                         </svg>
                       </button>
                     </li>
+                    <div
+                      className="iot--suite-header-app-switcher--nav-link--separator"
+                    />
                     <li
                       className="iot--suite-header-app-switcher--app-link"
                     >
@@ -1449,6 +1452,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                         </svg>
                       </button>
                     </li>
+                    <div
+                      className="iot--suite-header-app-switcher--nav-link--separator"
+                    />
                     <li
                       className="iot--suite-header-app-switcher--app-link"
                     >
@@ -2404,6 +2410,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                         </svg>
                       </button>
                     </li>
+                    <div
+                      className="iot--suite-header-app-switcher--nav-link--separator"
+                    />
                     <li
                       className="iot--suite-header-app-switcher--app-link"
                     >
@@ -2896,6 +2905,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                         />
                       </div>
                     </li>
+                    <div
+                      className="iot--suite-header-app-switcher--nav-link--separator"
+                    />
                     <li>
                       <div
                         className="iot--suite-header-app-switcher--nav-link--loading"
@@ -3489,6 +3501,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                         </svg>
                       </button>
                     </li>
+                    <div
+                      className="iot--suite-header-app-switcher--nav-link--separator"
+                    />
                     <li
                       className="iot--suite-header-app-switcher--app-link"
                     >

--- a/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
@@ -2512,118 +2512,70 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
               role="menu"
             >
               <li>
-                <a
+                <div
                   className="bx--header__menu-item"
                   tabIndex={0}
                 >
                   <span
                     className="bx--text-truncate--end"
                   >
-                    <p
-                      className="bx--skeleton__text"
-                      style={
-                        Object {
-                          "width": "100%",
-                        }
-                      }
-                    />
+                    <div
+                      className="iot--suite-header-help--loading"
+                      data-testid="suite-header-help--loading"
+                    >
+                      <div>
+                        <p
+                          className="bx--skeleton__text"
+                          style={
+                            Object {
+                              "width": "calc(100% - 73px)",
+                            }
+                          }
+                        />
+                        <p
+                          className="bx--skeleton__text"
+                          style={
+                            Object {
+                              "width": "calc(100% - 11px)",
+                            }
+                          }
+                        />
+                        <p
+                          className="bx--skeleton__text"
+                          style={
+                            Object {
+                              "width": "calc(100% - 43px)",
+                            }
+                          }
+                        />
+                        <p
+                          className="bx--skeleton__text"
+                          style={
+                            Object {
+                              "width": "calc(100% - 73px)",
+                            }
+                          }
+                        />
+                        <p
+                          className="bx--skeleton__text"
+                          style={
+                            Object {
+                              "width": "calc(100% - 11px)",
+                            }
+                          }
+                        />
+                        <p
+                          className="bx--skeleton__text"
+                          style={
+                            Object {
+                              "width": "calc(100% - 43px)",
+                            }
+                          }
+                        />
+                      </div>
+                    </div>
                   </span>
-                </a>
-              </li>
-              <li>
-                <a
-                  className="bx--header__menu-item"
-                  tabIndex={0}
-                >
-                  <span
-                    className="bx--text-truncate--end"
-                  >
-                    <p
-                      className="bx--skeleton__text"
-                      style={
-                        Object {
-                          "width": "100%",
-                        }
-                      }
-                    />
-                  </span>
-                </a>
-              </li>
-              <li>
-                <a
-                  className="bx--header__menu-item"
-                  tabIndex={0}
-                >
-                  <span
-                    className="bx--text-truncate--end"
-                  >
-                    <p
-                      className="bx--skeleton__text"
-                      style={
-                        Object {
-                          "width": "100%",
-                        }
-                      }
-                    />
-                  </span>
-                </a>
-              </li>
-              <li>
-                <a
-                  className="bx--header__menu-item"
-                  tabIndex={0}
-                >
-                  <span
-                    className="bx--text-truncate--end"
-                  >
-                    <p
-                      className="bx--skeleton__text"
-                      style={
-                        Object {
-                          "width": "100%",
-                        }
-                      }
-                    />
-                  </span>
-                </a>
-              </li>
-              <li>
-                <a
-                  className="bx--header__menu-item"
-                  tabIndex={0}
-                >
-                  <span
-                    className="bx--text-truncate--end"
-                  >
-                    <p
-                      className="bx--skeleton__text"
-                      style={
-                        Object {
-                          "width": "100%",
-                        }
-                      }
-                    />
-                  </span>
-                </a>
-              </li>
-              <li>
-                <a
-                  className="bx--header__menu-item"
-                  tabIndex={0}
-                >
-                  <span
-                    className="bx--text-truncate--end"
-                  >
-                    <p
-                      className="bx--skeleton__text"
-                      style={
-                        Object {
-                          "width": "100%",
-                        }
-                      }
-                    />
-                  </span>
-                </a>
+                </div>
               </li>
             </ul>
           </div>
@@ -2691,33 +2643,35 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                         className="iot--suite-header-profile--loading"
                         data-testid="suite-header-profile--loading"
                       >
-                        <p
-                          className="bx--skeleton__text"
-                          style={
-                            Object {
-                              "width": "100%",
+                        <div>
+                          <p
+                            className="bx--skeleton__text"
+                            style={
+                              Object {
+                                "width": "calc(80% - 73px)",
+                              }
                             }
-                          }
-                        />
-                        <p
-                          className="bx--skeleton__text"
-                          style={
-                            Object {
-                              "width": "100%",
+                          />
+                          <p
+                            className="bx--skeleton__text"
+                            style={
+                              Object {
+                                "width": "calc(80% - 11px)",
+                              }
                             }
-                          }
-                        />
-                        <p
-                          className="bx--skeleton__text"
-                          style={
-                            Object {
-                              "width": "100%",
+                          />
+                          <p
+                            className="bx--skeleton__text"
+                            style={
+                              Object {
+                                "width": "calc(80% - 43px)",
+                              }
                             }
-                          }
-                        />
+                          />
+                        </div>
                       </div>
                       <div
-                        className="iot--suite-header-profile--logout"
+                        className="iot--suite-header-profile--logout iot--suite-header-profile--logout--loading"
                       >
                         <div
                           className="bx--skeleton bx--btn"
@@ -2813,33 +2767,35 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                       </button>
                     </li>
                     <div
-                      className="iot--suite-header-app-switcher--app-skeleton"
+                      className="iot--suite-header-app-switcher--loading"
                       data-testid="suite-header-app-switcher--loading"
                     >
-                      <p
-                        className="bx--skeleton__text"
-                        style={
-                          Object {
-                            "width": "100%",
+                      <div>
+                        <p
+                          className="bx--skeleton__text"
+                          style={
+                            Object {
+                              "width": "calc(100% - 73px)",
+                            }
                           }
-                        }
-                      />
-                      <p
-                        className="bx--skeleton__text"
-                        style={
-                          Object {
-                            "width": "100%",
+                        />
+                        <p
+                          className="bx--skeleton__text"
+                          style={
+                            Object {
+                              "width": "calc(100% - 11px)",
+                            }
                           }
-                        }
-                      />
-                      <p
-                        className="bx--skeleton__text"
-                        style={
-                          Object {
-                            "width": "100%",
+                        />
+                        <p
+                          className="bx--skeleton__text"
+                          style={
+                            Object {
+                              "width": "calc(100% - 43px)",
+                            }
                           }
-                        }
-                      />
+                        />
+                      </div>
                     </div>
                   </ul>
                 </a>

--- a/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
@@ -146,27 +146,32 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
         className="bx--header__global"
       >
         <button
-          aria-label="alerts"
+          aria-label="bell"
           className="bx--header-action-btn bx--header__action"
-          data-testid="menu-item-alerts-global"
+          data-testid="menu-item-bell-global"
           onClick={[Function]}
           type="button"
         >
-          <svg
-            aria-hidden={true}
-            description="Icon"
-            fill="white"
-            focusable="false"
-            height={24}
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 32 32"
-            width={24}
-            xmlns="http://www.w3.org/2000/svg"
+          <span
+            id="bell-icon"
           >
-            <path
-              d="M28.7,20.3,26,17.6V13A10.07,10.07,0,0,0,17,3V1H15V3A10.15,10.15,0,0,0,6,13v4.6L3.3,20.3A.91.91,0,0,0,3,21v3a.94.94,0,0,0,1,1h7a5,5,0,0,0,10,0h7a.94.94,0,0,0,1-1V21A.91.91,0,0,0,28.7,20.3ZM16,28a3,3,0,0,1-3-3h6A3,3,0,0,1,16,28Zm11-5H5V21.4l2.7-2.7A.91.91,0,0,0,8,18V13a8,8,0,0,1,16,0v5a.91.91,0,0,0,.3.7L27,21.4Z"
-            />
-          </svg>
+            <svg
+              aria-hidden={true}
+              description="Icon"
+              fill="white"
+              focusable="false"
+              height={24}
+              id="notification-button"
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width={24}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M28.7,20.3,26,17.6V13A10.07,10.07,0,0,0,17,3V1H15V3A10.15,10.15,0,0,0,6,13v4.6L3.3,20.3A.91.91,0,0,0,3,21v3a.94.94,0,0,0,1,1h7a5,5,0,0,0,10,0h7a.94.94,0,0,0,1-1V21A.91.91,0,0,0,28.7,20.3ZM16,28a3,3,0,0,1-3-3h6A3,3,0,0,1,16,28Zm11-5H5V21.4l2.7-2.7A.91.91,0,0,0,8,18V13a8,8,0,0,1,16,0v5a.91.91,0,0,0,.3.7L27,21.4Z"
+              />
+            </svg>
+          </span>
         </button>
         <div
           className="bx--header__submenu bx--header-action-btn action-btn__group"
@@ -177,28 +182,32 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
           <button
             aria-expanded={false}
             aria-haspopup="menu"
-            aria-label="help"
+            aria-label="bee"
             className="bx--header-action-btn action-btn__trigger bx--header__action"
             onClick={[Function]}
-            title="help"
+            title="bee"
             type="button"
           >
-            <svg
-              aria-hidden={true}
-              className="bx--header__menu-item bx--header__menu-title"
-              description="Icon"
-              fill="white"
-              focusable="false"
-              height={24}
-              preserveAspectRatio="xMidYMid meet"
-              viewBox="0 0 32 32"
-              width={24}
-              xmlns="http://www.w3.org/2000/svg"
+            <span
+              id="bee-icon"
             >
-              <path
-                d="M16 10a6 6 0 00-6 6v8a6 6 0 0012 0V16A6 6 0 0016 10zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0111.75 24v-.13h8.5V24A4.27 4.27 0 0116 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 018.5 0zM30.66 19.21L24 13v9.1a4 4 0 008 0A3.83 3.83 0 0030.66 19.21zM28 24.35a2.25 2.25 0 01-2.25-2.25V17l3.72 3.47h0A2.05 2.05 0 0130.2 22 2.25 2.25 0 0128 24.35zM0 22.1a4 4 0 008 0V13L1.34 19.21A3.88 3.88 0 000 22.1zm2.48-1.56h0L6.25 17v5.1a2.25 2.25 0 01-4.5 0A2.05 2.05 0 012.48 20.54zM15 5.5A3.5 3.5 0 1011.5 9 3.5 3.5 0 0015 5.5zm-5.25 0A1.75 1.75 0 1111.5 7.25 1.77 1.77 0 019.75 5.5zM20.5 2A3.5 3.5 0 1024 5.5 3.5 3.5 0 0020.5 2zm0 5.25A1.75 1.75 0 1122.25 5.5 1.77 1.77 0 0120.5 7.25z"
-              />
-            </svg>
+              <svg
+                aria-hidden={true}
+                className="bx--header__menu-item bx--header__menu-title"
+                description="Icon"
+                fill="white"
+                focusable="false"
+                height={24}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={24}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16 10a6 6 0 00-6 6v8a6 6 0 0012 0V16A6 6 0 0016 10zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0111.75 24v-.13h8.5V24A4.27 4.27 0 0116 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 018.5 0zM30.66 19.21L24 13v9.1a4 4 0 008 0A3.83 3.83 0 0030.66 19.21zM28 24.35a2.25 2.25 0 01-2.25-2.25V17l3.72 3.47h0A2.05 2.05 0 0130.2 22 2.25 2.25 0 0128 24.35zM0 22.1a4 4 0 008 0V13L1.34 19.21A3.88 3.88 0 000 22.1zm2.48-1.56h0L6.25 17v5.1a2.25 2.25 0 01-4.5 0A2.05 2.05 0 012.48 20.54zM15 5.5A3.5 3.5 0 1011.5 9 3.5 3.5 0 0015 5.5zm-5.25 0A1.75 1.75 0 1111.5 7.25 1.77 1.77 0 019.75 5.5zM20.5 2A3.5 3.5 0 1024 5.5 3.5 3.5 0 0020.5 2zm0 5.25A1.75 1.75 0 1122.25 5.5 1.77 1.77 0 0120.5 7.25z"
+                />
+              </svg>
+            </span>
           </button>
           <div
             aria-label="Header Panel"
@@ -207,7 +216,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
             tabIndex="-1"
           >
             <ul
-              aria-label="help"
+              aria-label="bee"
             >
               <li
                 className="action-btn__headerpanel-li"
@@ -219,17 +228,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   target="_blank"
                   title="this is a title"
                 >
-                  this is my message to you
+                  <span
+                    id="a-message"
+                  >
+                    this is my message to you
+                  </span>
                 </a>
               </li>
               <li
                 className="action-btn__headerpanel-li"
               >
                 <button
-                  className="this"
                   element="button"
                 >
-                  <span>
+                  <span
+                    id="an-email"
+                  >
                     JohnDoe@ibm.com
                     <svg
                       aria-hidden={true}
@@ -267,7 +281,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
             <a
               aria-expanded={false}
               aria-haspopup="menu"
-              aria-label="user"
+              aria-label="car"
               className="bx--header__menu-item bx--header__menu-title"
               data-testid="menuitem"
               href=""
@@ -275,24 +289,28 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
               role="menuitem"
               tabIndex={0}
             >
-              <svg
-                aria-hidden={true}
-                description="Icon"
-                fill="white"
-                focusable="false"
-                height={24}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={24}
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                id="car-icon"
               >
-                <path
-                  d="M29.34,15.94l-7.73-2.78L18.37,9.1A3,3,0,0,0,16.05,8h-8A3,3,0,0,0,5.58,9.32l-2.71,4A5,5,0,0,0,2,16.11V24a1,1,0,0,0,1,1H5.14a4,4,0,0,0,7.72,0h6.28a4,4,0,0,0,7.72,0H29a1,1,0,0,0,1-1V16.88A1,1,0,0,0,29.34,15.94ZM9,26a2,2,0,1,1,2-2A2,2,0,0,1,9,26Zm14,0a2,2,0,1,1,2-2A2,2,0,0,1,23,26Zm5-3H26.86a4,4,0,0,0-7.72,0H12.86a4,4,0,0,0-7.72,0H4V16.11a3,3,0,0,1,.52-1.69l2.71-4A1,1,0,0,1,8.06,10h8a1,1,0,0,1,.77.36l3.4,4.27a1.09,1.09,0,0,0,.44.32L28,17.58Z"
-                />
-              </svg>
+                <svg
+                  aria-hidden={true}
+                  description="Icon"
+                  fill="white"
+                  focusable="false"
+                  height={24}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={24}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M29.34,15.94l-7.73-2.78L18.37,9.1A3,3,0,0,0,16.05,8h-8A3,3,0,0,0,5.58,9.32l-2.71,4A5,5,0,0,0,2,16.11V24a1,1,0,0,0,1,1H5.14a4,4,0,0,0,7.72,0h6.28a4,4,0,0,0,7.72,0H29a1,1,0,0,0,1-1V16.88A1,1,0,0,0,29.34,15.94ZM9,26a2,2,0,1,1,2-2A2,2,0,0,1,9,26Zm14,0a2,2,0,1,1,2-2A2,2,0,0,1,23,26Zm5-3H26.86a4,4,0,0,0-7.72,0H12.86a4,4,0,0,0-7.72,0H4V16.11a3,3,0,0,1,.52-1.69l2.71-4A1,1,0,0,1,8.06,10h8a1,1,0,0,1,.77.36l3.4,4.27a1.09,1.09,0,0,0,.44.32L28,17.58Z"
+                  />
+                </svg>
+              </span>
             </a>
             <ul
-              aria-label="user"
+              aria-label="car"
               className="bx--header__menu"
               role="menu"
             >
@@ -308,13 +326,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    this is my message to you
+                    <span
+                      id="another-message"
+                    >
+                      this is my message to you
+                    </span>
                   </span>
                 </a>
               </li>
-              <li
-                className="this"
-              >
+              <li>
                 <button
                   className="bx--header__menu-item"
                   tabIndex={0}
@@ -322,7 +342,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    <span>
+                    <span
+                      id="another-email"
+                    >
                       JohnDoe@ibm.com
                       <svg
                         aria-hidden={true}
@@ -356,25 +378,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
           onClick={[Function]}
           type="button"
         >
-          <svg
-            aria-hidden={true}
-            data-testid="admin-icon"
-            description="Settings"
-            fill="white"
-            focusable="false"
-            height={20}
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 32 32"
-            width={20}
-            xmlns="http://www.w3.org/2000/svg"
+          <span
+            id="suite-header-action-item-admin"
           >
-            <path
-              d="M27,16.76c0-.25,0-.5,0-.76s0-.51,0-.77l1.92-1.68A2,2,0,0,0,29.3,11L26.94,7a2,2,0,0,0-1.73-1,2,2,0,0,0-.64.1l-2.43.82a11.35,11.35,0,0,0-1.31-.75l-.51-2.52a2,2,0,0,0-2-1.61H13.64a2,2,0,0,0-2,1.61l-.51,2.52a11.48,11.48,0,0,0-1.32.75L7.43,6.06A2,2,0,0,0,6.79,6,2,2,0,0,0,5.06,7L2.7,11a2,2,0,0,0,.41,2.51L5,15.24c0,.25,0,.5,0,.76s0,.51,0,.77L3.11,18.45A2,2,0,0,0,2.7,21L5.06,25a2,2,0,0,0,1.73,1,2,2,0,0,0,.64-.1l2.43-.82a11.35,11.35,0,0,0,1.31.75l.51,2.52a2,2,0,0,0,2,1.61h4.72a2,2,0,0,0,2-1.61l.51-2.52a11.48,11.48,0,0,0,1.32-.75l2.42.82a2,2,0,0,0,.64.1,2,2,0,0,0,1.73-1L29.3,21a2,2,0,0,0-.41-2.51ZM25.21,24l-3.43-1.16a8.86,8.86,0,0,1-2.71,1.57L18.36,28H13.64l-.71-3.55a9.36,9.36,0,0,1-2.7-1.57L6.79,24,4.43,20l2.72-2.4a8.9,8.9,0,0,1,0-3.13L4.43,12,6.79,8l3.43,1.16a8.86,8.86,0,0,1,2.71-1.57L13.64,4h4.72l.71,3.55a9.36,9.36,0,0,1,2.7,1.57L25.21,8,27.57,12l-2.72,2.4a8.9,8.9,0,0,1,0,3.13L27.57,20Z"
-            />
-            <path
-              d="M16,22a6,6,0,1,1,6-6A5.94,5.94,0,0,1,16,22Zm0-10a3.91,3.91,0,0,0-4,4,3.91,3.91,0,0,0,4,4,3.91,3.91,0,0,0,4-4A3.91,3.91,0,0,0,16,12Z"
-            />
-          </svg>
+            <svg
+              aria-hidden={true}
+              data-testid="admin-icon"
+              description="Settings"
+              fill="white"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M27,16.76c0-.25,0-.5,0-.76s0-.51,0-.77l1.92-1.68A2,2,0,0,0,29.3,11L26.94,7a2,2,0,0,0-1.73-1,2,2,0,0,0-.64.1l-2.43.82a11.35,11.35,0,0,0-1.31-.75l-.51-2.52a2,2,0,0,0-2-1.61H13.64a2,2,0,0,0-2,1.61l-.51,2.52a11.48,11.48,0,0,0-1.32.75L7.43,6.06A2,2,0,0,0,6.79,6,2,2,0,0,0,5.06,7L2.7,11a2,2,0,0,0,.41,2.51L5,15.24c0,.25,0,.5,0,.76s0,.51,0,.77L3.11,18.45A2,2,0,0,0,2.7,21L5.06,25a2,2,0,0,0,1.73,1,2,2,0,0,0,.64-.1l2.43-.82a11.35,11.35,0,0,0,1.31.75l.51,2.52a2,2,0,0,0,2,1.61h4.72a2,2,0,0,0,2-1.61l.51-2.52a11.48,11.48,0,0,0,1.32-.75l2.42.82a2,2,0,0,0,.64.1,2,2,0,0,0,1.73-1L29.3,21a2,2,0,0,0-.41-2.51ZM25.21,24l-3.43-1.16a8.86,8.86,0,0,1-2.71,1.57L18.36,28H13.64l-.71-3.55a9.36,9.36,0,0,1-2.7-1.57L6.79,24,4.43,20l2.72-2.4a8.9,8.9,0,0,1,0-3.13L4.43,12,6.79,8l3.43,1.16a8.86,8.86,0,0,1,2.71-1.57L13.64,4h4.72l.71,3.55a9.36,9.36,0,0,1,2.7,1.57L25.21,8,27.57,12l-2.72,2.4a8.9,8.9,0,0,1,0,3.13L27.57,20Z"
+              />
+              <path
+                d="M16,22a6,6,0,1,1,6-6A5.94,5.94,0,0,1,16,22Zm0-10a3.91,3.91,0,0,0-4,4,3.91,3.91,0,0,0,4,4,3.91,3.91,0,0,0,4-4A3.91,3.91,0,0,0,16,12Z"
+              />
+            </svg>
+          </span>
         </button>
         <div
           className="bx--header__submenu bx--header-action-btn action-btn__group"
@@ -396,29 +422,33 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
               role="menuitem"
               tabIndex={0}
             >
-              <svg
-                aria-hidden={true}
-                description="Help"
-                fill="white"
-                focusable="false"
-                height={20}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                id="suite-header-action-item-help"
               >
-                <path
-                  d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Zm0,26A12,12,0,1,1,28,16,12,12,0,0,1,16,28Z"
-                />
-                <circle
-                  cx="16"
-                  cy="23.5"
-                  r="1.5"
-                />
-                <path
-                  d="M17,8H15.5A4.49,4.49,0,0,0,11,12.5V13h2v-.5A2.5,2.5,0,0,1,15.5,10H17a2.5,2.5,0,0,1,0,5H15v4.5h2V17a4.5,4.5,0,0,0,0-9Z"
-                />
-              </svg>
+                <svg
+                  aria-hidden={true}
+                  description="Help"
+                  fill="white"
+                  focusable="false"
+                  height={20}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={20}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Zm0,26A12,12,0,1,1,28,16,12,12,0,0,1,16,28Z"
+                  />
+                  <circle
+                    cx="16"
+                    cy="23.5"
+                    r="1.5"
+                  />
+                  <path
+                    d="M17,8H15.5A4.49,4.49,0,0,0,11,12.5V13h2v-.5A2.5,2.5,0,0,1,15.5,10H17a2.5,2.5,0,0,1,0,5H15v4.5h2V17a4.5,4.5,0,0,0,0-9Z"
+                  />
+                </svg>
+              </span>
             </a>
             <ul
               aria-label="Help"
@@ -436,7 +466,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    {A custom help link}
+                    <span
+                      id="custom-help-link"
+                    >
+                      {A custom help link}
+                    </span>
                   </span>
                 </a>
               </li>
@@ -451,7 +485,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    {Another custom help link}
+                    <span
+                      id="another-custom-help-link"
+                    >
+                      {Another custom help link}
+                    </span>
                   </span>
                 </a>
               </li>
@@ -465,7 +503,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    {Yet another custom help link}
+                    <span
+                      id="yet-another-custom-help-link"
+                    >
+                      {Yet another custom help link}
+                    </span>
                   </span>
                 </a>
               </li>
@@ -495,7 +537,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    What's new
+                    <span
+                      id="suite-header-help-menu-whatsNew"
+                    >
+                      What's new
+                    </span>
                   </span>
                 </a>
               </li>
@@ -511,7 +557,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    Getting started
+                    <span
+                      id="suite-header-help-menu-gettingStarted"
+                    >
+                      Getting started
+                    </span>
                   </span>
                 </a>
               </li>
@@ -527,7 +577,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    Documentation
+                    <span
+                      id="suite-header-help-menu-documentation"
+                    >
+                      Documentation
+                    </span>
                   </span>
                 </a>
               </li>
@@ -543,7 +597,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    Request enhancement
+                    <span
+                      id="suite-header-help-menu-requestEnhancement"
+                    >
+                      Request enhancement
+                    </span>
                   </span>
                 </a>
               </li>
@@ -559,7 +617,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    Support
+                    <span
+                      id="suite-header-help-menu-support"
+                    >
+                      Support
+                    </span>
                   </span>
                 </a>
               </li>
@@ -575,7 +637,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    About
+                    <span
+                      id="suite-header-help-menu-about"
+                    >
+                      About
+                    </span>
                   </span>
                 </a>
               </li>
@@ -602,25 +668,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
               role="menuitem"
               tabIndex={0}
             >
-              <svg
-                aria-hidden={true}
-                data-testid="user-icon"
-                description="User"
-                fill="white"
-                focusable="false"
-                height={20}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                id="suite-header-action-item-profile"
               >
-                <path
-                  d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2ZM10,26.38v-2A3.22,3.22,0,0,1,13,21h6a3.22,3.22,0,0,1,3,3.39v2a11.92,11.92,0,0,1-12,0Zm14-1.46v-.61A5.21,5.21,0,0,0,19,19H13a5.2,5.2,0,0,0-5,5.31s0,0,0,0v.59a12,12,0,1,1,16,0Z"
-                />
-                <path
-                  d="M16,7a5,5,0,1,0,5,5A5,5,0,0,0,16,7Zm0,8a3,3,0,1,1,3-3A3,3,0,0,1,16,15Z"
-                />
-              </svg>
+                <svg
+                  aria-hidden={true}
+                  data-testid="user-icon"
+                  description="User"
+                  fill="white"
+                  focusable="false"
+                  height={20}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={20}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2ZM10,26.38v-2A3.22,3.22,0,0,1,13,21h6a3.22,3.22,0,0,1,3,3.39v2a11.92,11.92,0,0,1-12,0Zm14-1.46v-.61A5.21,5.21,0,0,0,19,19H13a5.2,5.2,0,0,0-5,5.31s0,0,0,0v.59a12,12,0,1,1,16,0Z"
+                  />
+                  <path
+                    d="M16,7a5,5,0,1,0,5,5A5,5,0,0,0,16,7Zm0,8a3,3,0,1,1,3-3A3,3,0,0,1,16,15Z"
+                  />
+                </svg>
+              </span>
             </a>
             <ul
               aria-label="user"
@@ -635,48 +705,57 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    <div
-                      className="iot--suite-header-profile"
+                    <span
+                      id="suite-header-profile-menu-profile"
+                      style={
+                        Object {
+                          "width": "100%",
+                        }
+                      }
                     >
-                      <h5>
-                        Profile
-                      </h5>
                       <div
-                        className="iot--suite-header-profile--user"
+                        className="iot--suite-header-profile"
                       >
+                        <h5>
+                          Profile
+                        </h5>
                         <div
-                          className="iot--suite-header-profile--user--chip"
+                          className="iot--suite-header-profile--user"
                         >
-                          AU
+                          <div
+                            className="iot--suite-header-profile--user--chip"
+                          >
+                            AU
+                          </div>
+                          <div
+                            className="iot--suite-header-profile--user--detail"
+                          >
+                            <div>
+                              <strong>
+                                Admin User
+                              </strong>
+                            </div>
+                            <div>
+                              adminuser
+                            </div>
+                          </div>
                         </div>
                         <div
-                          className="iot--suite-header-profile--user--detail"
+                          className="iot--suite-header-profile--manage-button iot--suite-header-profile--manage-button--no-logout"
                         >
-                          <div>
-                            <strong>
-                              Admin User
-                            </strong>
-                          </div>
-                          <div>
-                            adminuser
-                          </div>
+                          <button
+                            className="iot--btn bx--btn bx--btn--sm bx--btn--secondary"
+                            data-testid="suite-header-profile--profile"
+                            disabled={false}
+                            onClick={[Function]}
+                            tabIndex={0}
+                            type="button"
+                          >
+                            Manage profile
+                          </button>
                         </div>
                       </div>
-                      <div
-                        className="iot--suite-header-profile--manage-button iot--suite-header-profile--manage-button--no-logout"
-                      >
-                        <button
-                          className="iot--btn bx--btn bx--btn--sm bx--btn--secondary"
-                          data-testid="suite-header-profile--profile"
-                          disabled={false}
-                          onClick={[Function]}
-                          tabIndex={0}
-                          type="button"
-                        >
-                          Manage profile
-                        </button>
-                      </div>
-                    </div>
+                    </span>
                   </span>
                 </div>
               </li>
@@ -691,7 +770,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    {A custom profile link}
+                    <span
+                      id="custom-profile-link"
+                    >
+                      {A custom profile link}
+                    </span>
                   </span>
                 </a>
               </li>
@@ -706,7 +789,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    {Another custom profile link}
+                    <span
+                      id="another-custom-profile-link"
+                    >
+                      {Another custom profile link}
+                    </span>
                   </span>
                 </a>
               </li>
@@ -720,7 +807,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    {Yet another custom profile link}
+                    <span
+                      id="yet-another-custom-profile-link"
+                    >
+                      {Yet another custom profile link}
+                    </span>
                   </span>
                 </a>
               </li>
@@ -738,7 +829,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    Logout
+                    <span
+                      id="suite-header-profile-menu-logout"
+                    >
+                      Logout
+                    </span>
                   </span>
                 </a>
               </li>
@@ -832,6 +927,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                     />
                     <li
                       className="iot--suite-header-app-switcher--app-link"
+                      id="suite-header-application-customapp1"
                     >
                       <a
                         data-testid="suite-header-app-switcher--customapp1"
@@ -843,6 +939,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                     </li>
                     <li
                       className="iot--suite-header-app-switcher--app-link"
+                      id="suite-header-application-customapp2"
                     >
                       <a
                         data-testid="suite-header-app-switcher--customapp2"
@@ -854,6 +951,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                     </li>
                     <li
                       className="iot--suite-header-app-switcher--app-link"
+                      id="suite-header-application-monitor"
                     >
                       <a
                         data-testid="suite-header-app-switcher--monitor"
@@ -865,6 +963,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                     </li>
                     <li
                       className="iot--suite-header-app-switcher--app-link"
+                      id="suite-header-application-health"
                     >
                       <a
                         data-testid="suite-header-app-switcher--health"
@@ -1083,25 +1182,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
           onClick={[Function]}
           type="button"
         >
-          <svg
-            aria-hidden={true}
-            data-testid="admin-icon"
-            description="Settings"
-            fill="white"
-            focusable="false"
-            height={20}
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 32 32"
-            width={20}
-            xmlns="http://www.w3.org/2000/svg"
+          <span
+            id="suite-header-action-item-admin"
           >
-            <path
-              d="M27,16.76c0-.25,0-.5,0-.76s0-.51,0-.77l1.92-1.68A2,2,0,0,0,29.3,11L26.94,7a2,2,0,0,0-1.73-1,2,2,0,0,0-.64.1l-2.43.82a11.35,11.35,0,0,0-1.31-.75l-.51-2.52a2,2,0,0,0-2-1.61H13.64a2,2,0,0,0-2,1.61l-.51,2.52a11.48,11.48,0,0,0-1.32.75L7.43,6.06A2,2,0,0,0,6.79,6,2,2,0,0,0,5.06,7L2.7,11a2,2,0,0,0,.41,2.51L5,15.24c0,.25,0,.5,0,.76s0,.51,0,.77L3.11,18.45A2,2,0,0,0,2.7,21L5.06,25a2,2,0,0,0,1.73,1,2,2,0,0,0,.64-.1l2.43-.82a11.35,11.35,0,0,0,1.31.75l.51,2.52a2,2,0,0,0,2,1.61h4.72a2,2,0,0,0,2-1.61l.51-2.52a11.48,11.48,0,0,0,1.32-.75l2.42.82a2,2,0,0,0,.64.1,2,2,0,0,0,1.73-1L29.3,21a2,2,0,0,0-.41-2.51ZM25.21,24l-3.43-1.16a8.86,8.86,0,0,1-2.71,1.57L18.36,28H13.64l-.71-3.55a9.36,9.36,0,0,1-2.7-1.57L6.79,24,4.43,20l2.72-2.4a8.9,8.9,0,0,1,0-3.13L4.43,12,6.79,8l3.43,1.16a8.86,8.86,0,0,1,2.71-1.57L13.64,4h4.72l.71,3.55a9.36,9.36,0,0,1,2.7,1.57L25.21,8,27.57,12l-2.72,2.4a8.9,8.9,0,0,1,0,3.13L27.57,20Z"
-            />
-            <path
-              d="M16,22a6,6,0,1,1,6-6A5.94,5.94,0,0,1,16,22Zm0-10a3.91,3.91,0,0,0-4,4,3.91,3.91,0,0,0,4,4,3.91,3.91,0,0,0,4-4A3.91,3.91,0,0,0,16,12Z"
-            />
-          </svg>
+            <svg
+              aria-hidden={true}
+              data-testid="admin-icon"
+              description="Settings"
+              fill="white"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M27,16.76c0-.25,0-.5,0-.76s0-.51,0-.77l1.92-1.68A2,2,0,0,0,29.3,11L26.94,7a2,2,0,0,0-1.73-1,2,2,0,0,0-.64.1l-2.43.82a11.35,11.35,0,0,0-1.31-.75l-.51-2.52a2,2,0,0,0-2-1.61H13.64a2,2,0,0,0-2,1.61l-.51,2.52a11.48,11.48,0,0,0-1.32.75L7.43,6.06A2,2,0,0,0,6.79,6,2,2,0,0,0,5.06,7L2.7,11a2,2,0,0,0,.41,2.51L5,15.24c0,.25,0,.5,0,.76s0,.51,0,.77L3.11,18.45A2,2,0,0,0,2.7,21L5.06,25a2,2,0,0,0,1.73,1,2,2,0,0,0,.64-.1l2.43-.82a11.35,11.35,0,0,0,1.31.75l.51,2.52a2,2,0,0,0,2,1.61h4.72a2,2,0,0,0,2-1.61l.51-2.52a11.48,11.48,0,0,0,1.32-.75l2.42.82a2,2,0,0,0,.64.1,2,2,0,0,0,1.73-1L29.3,21a2,2,0,0,0-.41-2.51ZM25.21,24l-3.43-1.16a8.86,8.86,0,0,1-2.71,1.57L18.36,28H13.64l-.71-3.55a9.36,9.36,0,0,1-2.7-1.57L6.79,24,4.43,20l2.72-2.4a8.9,8.9,0,0,1,0-3.13L4.43,12,6.79,8l3.43,1.16a8.86,8.86,0,0,1,2.71-1.57L13.64,4h4.72l.71,3.55a9.36,9.36,0,0,1,2.7,1.57L25.21,8,27.57,12l-2.72,2.4a8.9,8.9,0,0,1,0,3.13L27.57,20Z"
+              />
+              <path
+                d="M16,22a6,6,0,1,1,6-6A5.94,5.94,0,0,1,16,22Zm0-10a3.91,3.91,0,0,0-4,4,3.91,3.91,0,0,0,4,4,3.91,3.91,0,0,0,4-4A3.91,3.91,0,0,0,16,12Z"
+              />
+            </svg>
+          </span>
         </button>
         <div
           className="bx--header__submenu bx--header-action-btn action-btn__group"
@@ -1123,29 +1226,33 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
               role="menuitem"
               tabIndex={0}
             >
-              <svg
-                aria-hidden={true}
-                description="Help"
-                fill="white"
-                focusable="false"
-                height={20}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                id="suite-header-action-item-help"
               >
-                <path
-                  d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Zm0,26A12,12,0,1,1,28,16,12,12,0,0,1,16,28Z"
-                />
-                <circle
-                  cx="16"
-                  cy="23.5"
-                  r="1.5"
-                />
-                <path
-                  d="M17,8H15.5A4.49,4.49,0,0,0,11,12.5V13h2v-.5A2.5,2.5,0,0,1,15.5,10H17a2.5,2.5,0,0,1,0,5H15v4.5h2V17a4.5,4.5,0,0,0,0-9Z"
-                />
-              </svg>
+                <svg
+                  aria-hidden={true}
+                  description="Help"
+                  fill="white"
+                  focusable="false"
+                  height={20}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={20}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Zm0,26A12,12,0,1,1,28,16,12,12,0,0,1,16,28Z"
+                  />
+                  <circle
+                    cx="16"
+                    cy="23.5"
+                    r="1.5"
+                  />
+                  <path
+                    d="M17,8H15.5A4.49,4.49,0,0,0,11,12.5V13h2v-.5A2.5,2.5,0,0,1,15.5,10H17a2.5,2.5,0,0,1,0,5H15v4.5h2V17a4.5,4.5,0,0,0,0-9Z"
+                  />
+                </svg>
+              </span>
             </a>
             <ul
               aria-label="Help"
@@ -1164,7 +1271,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    What's new
+                    <span
+                      id="suite-header-help-menu-whatsNew"
+                    >
+                      What's new
+                    </span>
                   </span>
                 </a>
               </li>
@@ -1180,7 +1291,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    Getting started
+                    <span
+                      id="suite-header-help-menu-gettingStarted"
+                    >
+                      Getting started
+                    </span>
                   </span>
                 </a>
               </li>
@@ -1196,7 +1311,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    Documentation
+                    <span
+                      id="suite-header-help-menu-documentation"
+                    >
+                      Documentation
+                    </span>
                   </span>
                 </a>
               </li>
@@ -1212,7 +1331,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    Request enhancement
+                    <span
+                      id="suite-header-help-menu-requestEnhancement"
+                    >
+                      Request enhancement
+                    </span>
                   </span>
                 </a>
               </li>
@@ -1228,7 +1351,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    Support
+                    <span
+                      id="suite-header-help-menu-support"
+                    >
+                      Support
+                    </span>
                   </span>
                 </a>
               </li>
@@ -1244,7 +1371,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    About
+                    <span
+                      id="suite-header-help-menu-about"
+                    >
+                      About
+                    </span>
                   </span>
                 </a>
               </li>
@@ -1271,25 +1402,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
               role="menuitem"
               tabIndex={0}
             >
-              <svg
-                aria-hidden={true}
-                data-testid="user-icon"
-                description="User"
-                fill="white"
-                focusable="false"
-                height={20}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                id="suite-header-action-item-profile"
               >
-                <path
-                  d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2ZM10,26.38v-2A3.22,3.22,0,0,1,13,21h6a3.22,3.22,0,0,1,3,3.39v2a11.92,11.92,0,0,1-12,0Zm14-1.46v-.61A5.21,5.21,0,0,0,19,19H13a5.2,5.2,0,0,0-5,5.31s0,0,0,0v.59a12,12,0,1,1,16,0Z"
-                />
-                <path
-                  d="M16,7a5,5,0,1,0,5,5A5,5,0,0,0,16,7Zm0,8a3,3,0,1,1,3-3A3,3,0,0,1,16,15Z"
-                />
-              </svg>
+                <svg
+                  aria-hidden={true}
+                  data-testid="user-icon"
+                  description="User"
+                  fill="white"
+                  focusable="false"
+                  height={20}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={20}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2ZM10,26.38v-2A3.22,3.22,0,0,1,13,21h6a3.22,3.22,0,0,1,3,3.39v2a11.92,11.92,0,0,1-12,0Zm14-1.46v-.61A5.21,5.21,0,0,0,19,19H13a5.2,5.2,0,0,0-5,5.31s0,0,0,0v.59a12,12,0,1,1,16,0Z"
+                  />
+                  <path
+                    d="M16,7a5,5,0,1,0,5,5A5,5,0,0,0,16,7Zm0,8a3,3,0,1,1,3-3A3,3,0,0,1,16,15Z"
+                  />
+                </svg>
+              </span>
             </a>
             <ul
               aria-label="user"
@@ -1304,48 +1439,57 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    <div
-                      className="iot--suite-header-profile"
+                    <span
+                      id="suite-header-profile-menu-profile"
+                      style={
+                        Object {
+                          "width": "100%",
+                        }
+                      }
                     >
-                      <h5>
-                        Profile
-                      </h5>
                       <div
-                        className="iot--suite-header-profile--user"
+                        className="iot--suite-header-profile"
                       >
+                        <h5>
+                          Profile
+                        </h5>
                         <div
-                          className="iot--suite-header-profile--user--chip"
+                          className="iot--suite-header-profile--user"
                         >
-                          AU
+                          <div
+                            className="iot--suite-header-profile--user--chip"
+                          >
+                            AU
+                          </div>
+                          <div
+                            className="iot--suite-header-profile--user--detail"
+                          >
+                            <div>
+                              <strong>
+                                Admin User
+                              </strong>
+                            </div>
+                            <div>
+                              adminuser
+                            </div>
+                          </div>
                         </div>
                         <div
-                          className="iot--suite-header-profile--user--detail"
+                          className="iot--suite-header-profile--manage-button iot--suite-header-profile--manage-button--no-logout"
                         >
-                          <div>
-                            <strong>
-                              Admin User
-                            </strong>
-                          </div>
-                          <div>
-                            adminuser
-                          </div>
+                          <button
+                            className="iot--btn bx--btn bx--btn--sm bx--btn--secondary"
+                            data-testid="suite-header-profile--profile"
+                            disabled={false}
+                            onClick={[Function]}
+                            tabIndex={0}
+                            type="button"
+                          >
+                            Manage profile
+                          </button>
                         </div>
                       </div>
-                      <div
-                        className="iot--suite-header-profile--manage-button iot--suite-header-profile--manage-button--no-logout"
-                      >
-                        <button
-                          className="iot--btn bx--btn bx--btn--sm bx--btn--secondary"
-                          data-testid="suite-header-profile--profile"
-                          disabled={false}
-                          onClick={[Function]}
-                          tabIndex={0}
-                          type="button"
-                        >
-                          Manage profile
-                        </button>
-                      </div>
-                    </div>
+                    </span>
                   </span>
                 </div>
               </li>
@@ -1363,7 +1507,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    Logout
+                    <span
+                      id="suite-header-profile-menu-logout"
+                    >
+                      Logout
+                    </span>
                   </span>
                 </a>
               </li>
@@ -1457,6 +1605,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                     />
                     <li
                       className="iot--suite-header-app-switcher--app-link"
+                      id="suite-header-application-monitor"
                     >
                       <a
                         data-testid="suite-header-app-switcher--monitor"
@@ -1468,6 +1617,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                     </li>
                     <li
                       className="iot--suite-header-app-switcher--app-link"
+                      id="suite-header-application-health"
                     >
                       <a
                         data-testid="suite-header-app-switcher--health"
@@ -2041,25 +2191,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
           onClick={[Function]}
           type="button"
         >
-          <svg
-            aria-hidden={true}
-            data-testid="admin-icon"
-            description="Settings"
-            fill="white"
-            focusable="false"
-            height={20}
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 32 32"
-            width={20}
-            xmlns="http://www.w3.org/2000/svg"
+          <span
+            id="suite-header-action-item-admin"
           >
-            <path
-              d="M27,16.76c0-.25,0-.5,0-.76s0-.51,0-.77l1.92-1.68A2,2,0,0,0,29.3,11L26.94,7a2,2,0,0,0-1.73-1,2,2,0,0,0-.64.1l-2.43.82a11.35,11.35,0,0,0-1.31-.75l-.51-2.52a2,2,0,0,0-2-1.61H13.64a2,2,0,0,0-2,1.61l-.51,2.52a11.48,11.48,0,0,0-1.32.75L7.43,6.06A2,2,0,0,0,6.79,6,2,2,0,0,0,5.06,7L2.7,11a2,2,0,0,0,.41,2.51L5,15.24c0,.25,0,.5,0,.76s0,.51,0,.77L3.11,18.45A2,2,0,0,0,2.7,21L5.06,25a2,2,0,0,0,1.73,1,2,2,0,0,0,.64-.1l2.43-.82a11.35,11.35,0,0,0,1.31.75l.51,2.52a2,2,0,0,0,2,1.61h4.72a2,2,0,0,0,2-1.61l.51-2.52a11.48,11.48,0,0,0,1.32-.75l2.42.82a2,2,0,0,0,.64.1,2,2,0,0,0,1.73-1L29.3,21a2,2,0,0,0-.41-2.51ZM25.21,24l-3.43-1.16a8.86,8.86,0,0,1-2.71,1.57L18.36,28H13.64l-.71-3.55a9.36,9.36,0,0,1-2.7-1.57L6.79,24,4.43,20l2.72-2.4a8.9,8.9,0,0,1,0-3.13L4.43,12,6.79,8l3.43,1.16a8.86,8.86,0,0,1,2.71-1.57L13.64,4h4.72l.71,3.55a9.36,9.36,0,0,1,2.7,1.57L25.21,8,27.57,12l-2.72,2.4a8.9,8.9,0,0,1,0,3.13L27.57,20Z"
-            />
-            <path
-              d="M16,22a6,6,0,1,1,6-6A5.94,5.94,0,0,1,16,22Zm0-10a3.91,3.91,0,0,0-4,4,3.91,3.91,0,0,0,4,4,3.91,3.91,0,0,0,4-4A3.91,3.91,0,0,0,16,12Z"
-            />
-          </svg>
+            <svg
+              aria-hidden={true}
+              data-testid="admin-icon"
+              description="Settings"
+              fill="white"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M27,16.76c0-.25,0-.5,0-.76s0-.51,0-.77l1.92-1.68A2,2,0,0,0,29.3,11L26.94,7a2,2,0,0,0-1.73-1,2,2,0,0,0-.64.1l-2.43.82a11.35,11.35,0,0,0-1.31-.75l-.51-2.52a2,2,0,0,0-2-1.61H13.64a2,2,0,0,0-2,1.61l-.51,2.52a11.48,11.48,0,0,0-1.32.75L7.43,6.06A2,2,0,0,0,6.79,6,2,2,0,0,0,5.06,7L2.7,11a2,2,0,0,0,.41,2.51L5,15.24c0,.25,0,.5,0,.76s0,.51,0,.77L3.11,18.45A2,2,0,0,0,2.7,21L5.06,25a2,2,0,0,0,1.73,1,2,2,0,0,0,.64-.1l2.43-.82a11.35,11.35,0,0,0,1.31.75l.51,2.52a2,2,0,0,0,2,1.61h4.72a2,2,0,0,0,2-1.61l.51-2.52a11.48,11.48,0,0,0,1.32-.75l2.42.82a2,2,0,0,0,.64.1,2,2,0,0,0,1.73-1L29.3,21a2,2,0,0,0-.41-2.51ZM25.21,24l-3.43-1.16a8.86,8.86,0,0,1-2.71,1.57L18.36,28H13.64l-.71-3.55a9.36,9.36,0,0,1-2.7-1.57L6.79,24,4.43,20l2.72-2.4a8.9,8.9,0,0,1,0-3.13L4.43,12,6.79,8l3.43,1.16a8.86,8.86,0,0,1,2.71-1.57L13.64,4h4.72l.71,3.55a9.36,9.36,0,0,1,2.7,1.57L25.21,8,27.57,12l-2.72,2.4a8.9,8.9,0,0,1,0,3.13L27.57,20Z"
+              />
+              <path
+                d="M16,22a6,6,0,1,1,6-6A5.94,5.94,0,0,1,16,22Zm0-10a3.91,3.91,0,0,0-4,4,3.91,3.91,0,0,0,4,4,3.91,3.91,0,0,0,4-4A3.91,3.91,0,0,0,16,12Z"
+              />
+            </svg>
+          </span>
         </button>
         <div
           className="bx--header__submenu bx--header-action-btn action-btn__group"
@@ -2081,29 +2235,33 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
               role="menuitem"
               tabIndex={0}
             >
-              <svg
-                aria-hidden={true}
-                description="Help"
-                fill="white"
-                focusable="false"
-                height={20}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                id="suite-header-action-item-help"
               >
-                <path
-                  d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Zm0,26A12,12,0,1,1,28,16,12,12,0,0,1,16,28Z"
-                />
-                <circle
-                  cx="16"
-                  cy="23.5"
-                  r="1.5"
-                />
-                <path
-                  d="M17,8H15.5A4.49,4.49,0,0,0,11,12.5V13h2v-.5A2.5,2.5,0,0,1,15.5,10H17a2.5,2.5,0,0,1,0,5H15v4.5h2V17a4.5,4.5,0,0,0,0-9Z"
-                />
-              </svg>
+                <svg
+                  aria-hidden={true}
+                  description="Help"
+                  fill="white"
+                  focusable="false"
+                  height={20}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={20}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Zm0,26A12,12,0,1,1,28,16,12,12,0,0,1,16,28Z"
+                  />
+                  <circle
+                    cx="16"
+                    cy="23.5"
+                    r="1.5"
+                  />
+                  <path
+                    d="M17,8H15.5A4.49,4.49,0,0,0,11,12.5V13h2v-.5A2.5,2.5,0,0,1,15.5,10H17a2.5,2.5,0,0,1,0,5H15v4.5h2V17a4.5,4.5,0,0,0,0-9Z"
+                  />
+                </svg>
+              </span>
             </a>
             <ul
               aria-label="Help"
@@ -2122,7 +2280,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    What's new
+                    <span
+                      id="suite-header-help-menu-whatsNew"
+                    >
+                      What's new
+                    </span>
                   </span>
                 </a>
               </li>
@@ -2138,7 +2300,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    Getting started
+                    <span
+                      id="suite-header-help-menu-gettingStarted"
+                    >
+                      Getting started
+                    </span>
                   </span>
                 </a>
               </li>
@@ -2154,7 +2320,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    Documentation
+                    <span
+                      id="suite-header-help-menu-documentation"
+                    >
+                      Documentation
+                    </span>
                   </span>
                 </a>
               </li>
@@ -2170,7 +2340,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    Request enhancement
+                    <span
+                      id="suite-header-help-menu-requestEnhancement"
+                    >
+                      Request enhancement
+                    </span>
                   </span>
                 </a>
               </li>
@@ -2186,7 +2360,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    Support
+                    <span
+                      id="suite-header-help-menu-support"
+                    >
+                      Support
+                    </span>
                   </span>
                 </a>
               </li>
@@ -2202,7 +2380,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    About
+                    <span
+                      id="suite-header-help-menu-about"
+                    >
+                      About
+                    </span>
                   </span>
                 </a>
               </li>
@@ -2229,25 +2411,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
               role="menuitem"
               tabIndex={0}
             >
-              <svg
-                aria-hidden={true}
-                data-testid="user-icon"
-                description="User"
-                fill="white"
-                focusable="false"
-                height={20}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                id="suite-header-action-item-profile"
               >
-                <path
-                  d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2ZM10,26.38v-2A3.22,3.22,0,0,1,13,21h6a3.22,3.22,0,0,1,3,3.39v2a11.92,11.92,0,0,1-12,0Zm14-1.46v-.61A5.21,5.21,0,0,0,19,19H13a5.2,5.2,0,0,0-5,5.31s0,0,0,0v.59a12,12,0,1,1,16,0Z"
-                />
-                <path
-                  d="M16,7a5,5,0,1,0,5,5A5,5,0,0,0,16,7Zm0,8a3,3,0,1,1,3-3A3,3,0,0,1,16,15Z"
-                />
-              </svg>
+                <svg
+                  aria-hidden={true}
+                  data-testid="user-icon"
+                  description="User"
+                  fill="white"
+                  focusable="false"
+                  height={20}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={20}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2ZM10,26.38v-2A3.22,3.22,0,0,1,13,21h6a3.22,3.22,0,0,1,3,3.39v2a11.92,11.92,0,0,1-12,0Zm14-1.46v-.61A5.21,5.21,0,0,0,19,19H13a5.2,5.2,0,0,0-5,5.31s0,0,0,0v.59a12,12,0,1,1,16,0Z"
+                  />
+                  <path
+                    d="M16,7a5,5,0,1,0,5,5A5,5,0,0,0,16,7Zm0,8a3,3,0,1,1,3-3A3,3,0,0,1,16,15Z"
+                  />
+                </svg>
+              </span>
             </a>
             <ul
               aria-label="user"
@@ -2262,48 +2448,57 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    <div
-                      className="iot--suite-header-profile"
+                    <span
+                      id="suite-header-profile-menu-profile"
+                      style={
+                        Object {
+                          "width": "100%",
+                        }
+                      }
                     >
-                      <h5>
-                        Profile
-                      </h5>
                       <div
-                        className="iot--suite-header-profile--user"
+                        className="iot--suite-header-profile"
                       >
+                        <h5>
+                          Profile
+                        </h5>
                         <div
-                          className="iot--suite-header-profile--user--chip"
+                          className="iot--suite-header-profile--user"
                         >
-                          AU
+                          <div
+                            className="iot--suite-header-profile--user--chip"
+                          >
+                            AU
+                          </div>
+                          <div
+                            className="iot--suite-header-profile--user--detail"
+                          >
+                            <div>
+                              <strong>
+                                Admin User
+                              </strong>
+                            </div>
+                            <div>
+                              adminuser
+                            </div>
+                          </div>
                         </div>
                         <div
-                          className="iot--suite-header-profile--user--detail"
+                          className="iot--suite-header-profile--manage-button iot--suite-header-profile--manage-button--no-logout"
                         >
-                          <div>
-                            <strong>
-                              Admin User
-                            </strong>
-                          </div>
-                          <div>
-                            adminuser
-                          </div>
+                          <button
+                            className="iot--btn bx--btn bx--btn--sm bx--btn--secondary"
+                            data-testid="suite-header-profile--profile"
+                            disabled={false}
+                            onClick={[Function]}
+                            tabIndex={0}
+                            type="button"
+                          >
+                            Manage profile
+                          </button>
                         </div>
                       </div>
-                      <div
-                        className="iot--suite-header-profile--manage-button iot--suite-header-profile--manage-button--no-logout"
-                      >
-                        <button
-                          className="iot--btn bx--btn bx--btn--sm bx--btn--secondary"
-                          data-testid="suite-header-profile--profile"
-                          disabled={false}
-                          onClick={[Function]}
-                          tabIndex={0}
-                          type="button"
-                        >
-                          Manage profile
-                        </button>
-                      </div>
-                    </div>
+                    </span>
                   </span>
                 </div>
               </li>
@@ -2321,7 +2516,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    Logout
+                    <span
+                      id="suite-header-profile-menu-logout"
+                    >
+                      Logout
+                    </span>
                   </span>
                 </a>
               </li>
@@ -2415,6 +2614,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                     />
                     <li
                       className="iot--suite-header-app-switcher--app-link"
+                      id="suite-header-application-monitor"
                     >
                       <a
                         data-testid="suite-header-app-switcher--monitor"
@@ -2426,6 +2626,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                     </li>
                     <li
                       className="iot--suite-header-app-switcher--app-link"
+                      id="suite-header-application-health"
                     >
                       <a
                         data-testid="suite-header-app-switcher--health"
@@ -2627,29 +2828,33 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
               role="menuitem"
               tabIndex={0}
             >
-              <svg
-                aria-hidden={true}
-                description="Help"
-                fill="white"
-                focusable="false"
-                height={20}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                id="suite-header-action-item-help"
               >
-                <path
-                  d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Zm0,26A12,12,0,1,1,28,16,12,12,0,0,1,16,28Z"
-                />
-                <circle
-                  cx="16"
-                  cy="23.5"
-                  r="1.5"
-                />
-                <path
-                  d="M17,8H15.5A4.49,4.49,0,0,0,11,12.5V13h2v-.5A2.5,2.5,0,0,1,15.5,10H17a2.5,2.5,0,0,1,0,5H15v4.5h2V17a4.5,4.5,0,0,0,0-9Z"
-                />
-              </svg>
+                <svg
+                  aria-hidden={true}
+                  description="Help"
+                  fill="white"
+                  focusable="false"
+                  height={20}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={20}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Zm0,26A12,12,0,1,1,28,16,12,12,0,0,1,16,28Z"
+                  />
+                  <circle
+                    cx="16"
+                    cy="23.5"
+                    r="1.5"
+                  />
+                  <path
+                    d="M17,8H15.5A4.49,4.49,0,0,0,11,12.5V13h2v-.5A2.5,2.5,0,0,1,15.5,10H17a2.5,2.5,0,0,1,0,5H15v4.5h2V17a4.5,4.5,0,0,0,0-9Z"
+                  />
+                </svg>
+              </span>
             </a>
             <ul
               aria-label="Help"
@@ -2745,25 +2950,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
               role="menuitem"
               tabIndex={0}
             >
-              <svg
-                aria-hidden={true}
-                data-testid="user-icon"
-                description="User"
-                fill="white"
-                focusable="false"
-                height={20}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                id="suite-header-action-item-profile"
               >
-                <path
-                  d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2ZM10,26.38v-2A3.22,3.22,0,0,1,13,21h6a3.22,3.22,0,0,1,3,3.39v2a11.92,11.92,0,0,1-12,0Zm14-1.46v-.61A5.21,5.21,0,0,0,19,19H13a5.2,5.2,0,0,0-5,5.31s0,0,0,0v.59a12,12,0,1,1,16,0Z"
-                />
-                <path
-                  d="M16,7a5,5,0,1,0,5,5A5,5,0,0,0,16,7Zm0,8a3,3,0,1,1,3-3A3,3,0,0,1,16,15Z"
-                />
-              </svg>
+                <svg
+                  aria-hidden={true}
+                  data-testid="user-icon"
+                  description="User"
+                  fill="white"
+                  focusable="false"
+                  height={20}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={20}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2ZM10,26.38v-2A3.22,3.22,0,0,1,13,21h6a3.22,3.22,0,0,1,3,3.39v2a11.92,11.92,0,0,1-12,0Zm14-1.46v-.61A5.21,5.21,0,0,0,19,19H13a5.2,5.2,0,0,0-5,5.31s0,0,0,0v.59a12,12,0,1,1,16,0Z"
+                  />
+                  <path
+                    d="M16,7a5,5,0,1,0,5,5A5,5,0,0,0,16,7Zm0,8a3,3,0,1,1,3-3A3,3,0,0,1,16,15Z"
+                  />
+                </svg>
+              </span>
             </a>
             <ul
               aria-label="user"
@@ -2778,44 +2987,53 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    <div
-                      className="iot--suite-header-profile"
+                    <span
+                      id="suite-header-profile-menu-profile"
+                      style={
+                        Object {
+                          "width": "100%",
+                        }
+                      }
                     >
-                      <h5>
-                        Profile
-                      </h5>
                       <div
-                        className="iot--suite-header-profile--loading iot--suite-header-profile--loading--no-logout"
-                        data-testid="suite-header-profile--loading"
+                        className="iot--suite-header-profile"
                       >
-                        <div>
-                          <p
-                            className="bx--skeleton__text"
-                            style={
-                              Object {
-                                "width": "calc(80% - 73px)",
+                        <h5>
+                          Profile
+                        </h5>
+                        <div
+                          className="iot--suite-header-profile--loading iot--suite-header-profile--loading--no-logout"
+                          data-testid="suite-header-profile--loading"
+                        >
+                          <div>
+                            <p
+                              className="bx--skeleton__text"
+                              style={
+                                Object {
+                                  "width": "calc(80% - 73px)",
+                                }
                               }
-                            }
-                          />
-                          <p
-                            className="bx--skeleton__text"
-                            style={
-                              Object {
-                                "width": "calc(80% - 11px)",
+                            />
+                            <p
+                              className="bx--skeleton__text"
+                              style={
+                                Object {
+                                  "width": "calc(80% - 11px)",
+                                }
                               }
-                            }
-                          />
-                          <p
-                            className="bx--skeleton__text"
-                            style={
-                              Object {
-                                "width": "calc(80% - 43px)",
+                            />
+                            <p
+                              className="bx--skeleton__text"
+                              style={
+                                Object {
+                                  "width": "calc(80% - 43px)",
+                                }
                               }
-                            }
-                          />
+                            />
+                          </div>
                         </div>
                       </div>
-                    </div>
+                    </span>
                   </span>
                 </div>
               </li>
@@ -3132,25 +3350,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
           onClick={[Function]}
           type="button"
         >
-          <svg
-            aria-hidden={true}
-            data-testid="admin-icon"
-            description="Settings"
-            fill="white"
-            focusable="false"
-            height={20}
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 32 32"
-            width={20}
-            xmlns="http://www.w3.org/2000/svg"
+          <span
+            id="suite-header-action-item-admin"
           >
-            <path
-              d="M27,16.76c0-.25,0-.5,0-.76s0-.51,0-.77l1.92-1.68A2,2,0,0,0,29.3,11L26.94,7a2,2,0,0,0-1.73-1,2,2,0,0,0-.64.1l-2.43.82a11.35,11.35,0,0,0-1.31-.75l-.51-2.52a2,2,0,0,0-2-1.61H13.64a2,2,0,0,0-2,1.61l-.51,2.52a11.48,11.48,0,0,0-1.32.75L7.43,6.06A2,2,0,0,0,6.79,6,2,2,0,0,0,5.06,7L2.7,11a2,2,0,0,0,.41,2.51L5,15.24c0,.25,0,.5,0,.76s0,.51,0,.77L3.11,18.45A2,2,0,0,0,2.7,21L5.06,25a2,2,0,0,0,1.73,1,2,2,0,0,0,.64-.1l2.43-.82a11.35,11.35,0,0,0,1.31.75l.51,2.52a2,2,0,0,0,2,1.61h4.72a2,2,0,0,0,2-1.61l.51-2.52a11.48,11.48,0,0,0,1.32-.75l2.42.82a2,2,0,0,0,.64.1,2,2,0,0,0,1.73-1L29.3,21a2,2,0,0,0-.41-2.51ZM25.21,24l-3.43-1.16a8.86,8.86,0,0,1-2.71,1.57L18.36,28H13.64l-.71-3.55a9.36,9.36,0,0,1-2.7-1.57L6.79,24,4.43,20l2.72-2.4a8.9,8.9,0,0,1,0-3.13L4.43,12,6.79,8l3.43,1.16a8.86,8.86,0,0,1,2.71-1.57L13.64,4h4.72l.71,3.55a9.36,9.36,0,0,1,2.7,1.57L25.21,8,27.57,12l-2.72,2.4a8.9,8.9,0,0,1,0,3.13L27.57,20Z"
-            />
-            <path
-              d="M16,22a6,6,0,1,1,6-6A5.94,5.94,0,0,1,16,22Zm0-10a3.91,3.91,0,0,0-4,4,3.91,3.91,0,0,0,4,4,3.91,3.91,0,0,0,4-4A3.91,3.91,0,0,0,16,12Z"
-            />
-          </svg>
+            <svg
+              aria-hidden={true}
+              data-testid="admin-icon"
+              description="Settings"
+              fill="white"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M27,16.76c0-.25,0-.5,0-.76s0-.51,0-.77l1.92-1.68A2,2,0,0,0,29.3,11L26.94,7a2,2,0,0,0-1.73-1,2,2,0,0,0-.64.1l-2.43.82a11.35,11.35,0,0,0-1.31-.75l-.51-2.52a2,2,0,0,0-2-1.61H13.64a2,2,0,0,0-2,1.61l-.51,2.52a11.48,11.48,0,0,0-1.32.75L7.43,6.06A2,2,0,0,0,6.79,6,2,2,0,0,0,5.06,7L2.7,11a2,2,0,0,0,.41,2.51L5,15.24c0,.25,0,.5,0,.76s0,.51,0,.77L3.11,18.45A2,2,0,0,0,2.7,21L5.06,25a2,2,0,0,0,1.73,1,2,2,0,0,0,.64-.1l2.43-.82a11.35,11.35,0,0,0,1.31.75l.51,2.52a2,2,0,0,0,2,1.61h4.72a2,2,0,0,0,2-1.61l.51-2.52a11.48,11.48,0,0,0,1.32-.75l2.42.82a2,2,0,0,0,.64.1,2,2,0,0,0,1.73-1L29.3,21a2,2,0,0,0-.41-2.51ZM25.21,24l-3.43-1.16a8.86,8.86,0,0,1-2.71,1.57L18.36,28H13.64l-.71-3.55a9.36,9.36,0,0,1-2.7-1.57L6.79,24,4.43,20l2.72-2.4a8.9,8.9,0,0,1,0-3.13L4.43,12,6.79,8l3.43,1.16a8.86,8.86,0,0,1,2.71-1.57L13.64,4h4.72l.71,3.55a9.36,9.36,0,0,1,2.7,1.57L25.21,8,27.57,12l-2.72,2.4a8.9,8.9,0,0,1,0,3.13L27.57,20Z"
+              />
+              <path
+                d="M16,22a6,6,0,1,1,6-6A5.94,5.94,0,0,1,16,22Zm0-10a3.91,3.91,0,0,0-4,4,3.91,3.91,0,0,0,4,4,3.91,3.91,0,0,0,4-4A3.91,3.91,0,0,0,16,12Z"
+              />
+            </svg>
+          </span>
         </button>
         <div
           className="bx--header__submenu bx--header-action-btn action-btn__group"
@@ -3172,29 +3394,33 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
               role="menuitem"
               tabIndex={0}
             >
-              <svg
-                aria-hidden={true}
-                description="Help"
-                fill="white"
-                focusable="false"
-                height={20}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                id="suite-header-action-item-help"
               >
-                <path
-                  d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Zm0,26A12,12,0,1,1,28,16,12,12,0,0,1,16,28Z"
-                />
-                <circle
-                  cx="16"
-                  cy="23.5"
-                  r="1.5"
-                />
-                <path
-                  d="M17,8H15.5A4.49,4.49,0,0,0,11,12.5V13h2v-.5A2.5,2.5,0,0,1,15.5,10H17a2.5,2.5,0,0,1,0,5H15v4.5h2V17a4.5,4.5,0,0,0,0-9Z"
-                />
-              </svg>
+                <svg
+                  aria-hidden={true}
+                  description="Help"
+                  fill="white"
+                  focusable="false"
+                  height={20}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={20}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Zm0,26A12,12,0,1,1,28,16,12,12,0,0,1,16,28Z"
+                  />
+                  <circle
+                    cx="16"
+                    cy="23.5"
+                    r="1.5"
+                  />
+                  <path
+                    d="M17,8H15.5A4.49,4.49,0,0,0,11,12.5V13h2v-.5A2.5,2.5,0,0,1,15.5,10H17a2.5,2.5,0,0,1,0,5H15v4.5h2V17a4.5,4.5,0,0,0,0-9Z"
+                  />
+                </svg>
+              </span>
             </a>
             <ul
               aria-label="Help"
@@ -3213,7 +3439,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    What's new
+                    <span
+                      id="suite-header-help-menu-whatsNew"
+                    >
+                      What's new
+                    </span>
                   </span>
                 </a>
               </li>
@@ -3229,7 +3459,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    Getting started
+                    <span
+                      id="suite-header-help-menu-gettingStarted"
+                    >
+                      Getting started
+                    </span>
                   </span>
                 </a>
               </li>
@@ -3245,7 +3479,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    Documentation
+                    <span
+                      id="suite-header-help-menu-documentation"
+                    >
+                      Documentation
+                    </span>
                   </span>
                 </a>
               </li>
@@ -3261,7 +3499,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    Request enhancement
+                    <span
+                      id="suite-header-help-menu-requestEnhancement"
+                    >
+                      Request enhancement
+                    </span>
                   </span>
                 </a>
               </li>
@@ -3277,7 +3519,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    Support
+                    <span
+                      id="suite-header-help-menu-support"
+                    >
+                      Support
+                    </span>
                   </span>
                 </a>
               </li>
@@ -3293,7 +3539,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    About
+                    <span
+                      id="suite-header-help-menu-about"
+                    >
+                      About
+                    </span>
                   </span>
                 </a>
               </li>
@@ -3320,25 +3570,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
               role="menuitem"
               tabIndex={0}
             >
-              <svg
-                aria-hidden={true}
-                data-testid="user-icon"
-                description="User"
-                fill="white"
-                focusable="false"
-                height={20}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 32 32"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                id="suite-header-action-item-profile"
               >
-                <path
-                  d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2ZM10,26.38v-2A3.22,3.22,0,0,1,13,21h6a3.22,3.22,0,0,1,3,3.39v2a11.92,11.92,0,0,1-12,0Zm14-1.46v-.61A5.21,5.21,0,0,0,19,19H13a5.2,5.2,0,0,0-5,5.31s0,0,0,0v.59a12,12,0,1,1,16,0Z"
-                />
-                <path
-                  d="M16,7a5,5,0,1,0,5,5A5,5,0,0,0,16,7Zm0,8a3,3,0,1,1,3-3A3,3,0,0,1,16,15Z"
-                />
-              </svg>
+                <svg
+                  aria-hidden={true}
+                  data-testid="user-icon"
+                  description="User"
+                  fill="white"
+                  focusable="false"
+                  height={20}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={20}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2ZM10,26.38v-2A3.22,3.22,0,0,1,13,21h6a3.22,3.22,0,0,1,3,3.39v2a11.92,11.92,0,0,1-12,0Zm14-1.46v-.61A5.21,5.21,0,0,0,19,19H13a5.2,5.2,0,0,0-5,5.31s0,0,0,0v.59a12,12,0,1,1,16,0Z"
+                  />
+                  <path
+                    d="M16,7a5,5,0,1,0,5,5A5,5,0,0,0,16,7Zm0,8a3,3,0,1,1,3-3A3,3,0,0,1,16,15Z"
+                  />
+                </svg>
+              </span>
             </a>
             <ul
               aria-label="user"
@@ -3353,48 +3607,57 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    <div
-                      className="iot--suite-header-profile"
+                    <span
+                      id="suite-header-profile-menu-profile"
+                      style={
+                        Object {
+                          "width": "100%",
+                        }
+                      }
                     >
-                      <h5>
-                        Profile
-                      </h5>
                       <div
-                        className="iot--suite-header-profile--user"
+                        className="iot--suite-header-profile"
                       >
+                        <h5>
+                          Profile
+                        </h5>
                         <div
-                          className="iot--suite-header-profile--user--chip"
+                          className="iot--suite-header-profile--user"
                         >
-                          AU
+                          <div
+                            className="iot--suite-header-profile--user--chip"
+                          >
+                            AU
+                          </div>
+                          <div
+                            className="iot--suite-header-profile--user--detail"
+                          >
+                            <div>
+                              <strong>
+                                Admin User
+                              </strong>
+                            </div>
+                            <div>
+                              adminuser
+                            </div>
+                          </div>
                         </div>
                         <div
-                          className="iot--suite-header-profile--user--detail"
+                          className="iot--suite-header-profile--manage-button iot--suite-header-profile--manage-button--no-logout"
                         >
-                          <div>
-                            <strong>
-                              Admin User
-                            </strong>
-                          </div>
-                          <div>
-                            adminuser
-                          </div>
+                          <button
+                            className="iot--btn bx--btn bx--btn--sm bx--btn--secondary"
+                            data-testid="suite-header-profile--profile"
+                            disabled={false}
+                            onClick={[Function]}
+                            tabIndex={0}
+                            type="button"
+                          >
+                            Manage profile
+                          </button>
                         </div>
                       </div>
-                      <div
-                        className="iot--suite-header-profile--manage-button iot--suite-header-profile--manage-button--no-logout"
-                      >
-                        <button
-                          className="iot--btn bx--btn bx--btn--sm bx--btn--secondary"
-                          data-testid="suite-header-profile--profile"
-                          disabled={false}
-                          onClick={[Function]}
-                          tabIndex={0}
-                          type="button"
-                        >
-                          Manage profile
-                        </button>
-                      </div>
-                    </div>
+                    </span>
                   </span>
                 </div>
               </li>
@@ -3412,7 +3675,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                   <span
                     className="bx--text-truncate--end"
                   >
-                    Logout
+                    <span
+                      id="suite-header-profile-menu-logout"
+                    >
+                      Logout
+                    </span>
                   </span>
                 </a>
               </li>
@@ -3506,6 +3773,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                     />
                     <li
                       className="iot--suite-header-app-switcher--app-link"
+                      id="suite-header-application-monitor"
                     >
                       <a
                         data-testid="suite-header-app-switcher--monitor"
@@ -3517,6 +3785,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Suite
                     </li>
                     <li
                       className="iot--suite-header-app-switcher--app-link"
+                      id="suite-header-application-health"
                     >
                       <a
                         data-testid="suite-header-app-switcher--health"

--- a/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/SuiteHeader Header with custom action items and child content 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/SuiteHeader Header with custom action items 1`] = `
 <div
   className="storybook-container"
 >

--- a/packages/react/src/components/SuiteHeader/_suite-header.scss
+++ b/packages/react/src/components/SuiteHeader/_suite-header.scss
@@ -46,6 +46,11 @@
 
   &--loading {
     padding-bottom: $spacing-08;
+    p {
+      background-color: $inverse-hover-ui;
+      height: $spacing-04;
+      margin-bottom: $spacing-02;
+    }
   }
 
   &--logout {
@@ -53,6 +58,11 @@
 
     .#{$prefix}--btn {
       width: 100%;
+    }
+    &--loading {
+      div {
+        background-color: $inverse-hover-ui !important;
+      }
     }
   }
 }
@@ -83,6 +93,8 @@
     width: 100%;
     button {
       margin: $spacing-05;
+      width: calc(100% - 32px);
+      min-height: 40px;
     }
     p {
       @include type-style('productive-heading-01');
@@ -129,10 +141,9 @@
     }
   }
 
-  &--app-skeleton {
+  &--loading {
     display: flex;
-    align-items: center;
-    padding: 1rem;
+    padding: $spacing-05;
     flex-direction: column;
     p {
       margin-bottom: $spacing-05;
@@ -224,5 +235,16 @@
   .#{$prefix}--header__menu-title[role='menuitem'][aria-expanded='true']
     + .#{$prefix}--header__menu {
     width: 16rem;
+  }
+
+  .#{$iot-prefix}--suite-header-help--loading {
+    background-color: $ui-05;
+    color: $inverse-01;
+    width: 100%;
+    padding: $spacing-05;
+    p {
+      background-color: $inverse-hover-ui;
+      margin-bottom: $spacing-06;
+    }
   }
 }

--- a/packages/react/src/components/SuiteHeader/_suite-header.scss
+++ b/packages/react/src/components/SuiteHeader/_suite-header.scss
@@ -108,7 +108,7 @@
       align-items: center;
       padding: $spacing-05 $spacing-05 0;
       text-decoration: none;
-      color: $text-02;
+      color: $text-01;
     }
   }
 
@@ -212,7 +212,6 @@
     button {
       display: flex;
       align-items: center;
-      justify-content: center;
     }
   }
 

--- a/packages/react/src/components/SuiteHeader/_suite-header.scss
+++ b/packages/react/src/components/SuiteHeader/_suite-header.scss
@@ -42,14 +42,20 @@
         color: $ui-05;
       }
     }
+    &--no-logout {
+      padding-bottom: $spacing-03;
+    }
   }
 
   &--loading {
-    padding-bottom: $spacing-08;
+    height: 120px;
     p {
       background-color: $inverse-hover-ui;
       height: $spacing-04;
       margin-bottom: $spacing-02;
+    }
+    &--no-logout {
+      height: 88px;
     }
   }
 
@@ -127,6 +133,21 @@
         margin-right: $spacing-03;
       }
     }
+    &--loading {
+      display: flex;
+      padding: $spacing-05;
+      flex-direction: column;
+      p {
+        margin-bottom: $spacing-05;
+      }
+    }
+    &--button--loading {
+      padding: $spacing-05;
+      div {
+        min-height: 40px;
+        width: 100% !important;
+      }
+    }
   }
 
   &--app-link {
@@ -138,15 +159,6 @@
       &:hover {
         background-color: $hover-ui;
       }
-    }
-  }
-
-  &--loading {
-    display: flex;
-    padding: $spacing-05;
-    flex-direction: column;
-    p {
-      margin-bottom: $spacing-05;
     }
   }
 
@@ -245,6 +257,29 @@
     p {
       background-color: $inverse-hover-ui;
       margin-bottom: $spacing-06;
+    }
+  }
+
+  .#{$iot-prefix}--suite-header-help--separator {
+    padding: 0;
+    height: 0;
+    border-bottom: 0.5px solid $hover-secondary;
+    margin: 0 $spacing-05 0 $spacing-05;
+  }
+
+  &--logout {
+    a {
+      background-color: $interactive-02;
+      color: $inverse-01;
+      &:hover {
+        background-color: $hover-secondary !important;
+      }
+    }
+  }
+  &--logout--loading {
+    div {
+      background-color: $inverse-hover-ui !important;
+      width: 256px !important;
     }
   }
 }

--- a/packages/react/src/components/SuiteHeader/_suite-header.scss
+++ b/packages/react/src/components/SuiteHeader/_suite-header.scss
@@ -119,8 +119,6 @@
   }
 
   &--nav-link {
-    border-bottom: solid 1px $ui-03;
-
     a {
       text-decoration: none;
       color: $text-02;
@@ -147,6 +145,12 @@
         min-height: 40px;
         width: 100% !important;
       }
+    }
+    &--separator {
+      padding: 0;
+      height: 0;
+      border-bottom: 1px solid $ui-03;
+      margin: 0 $spacing-05 0 $spacing-05;
     }
   }
 
@@ -262,7 +266,7 @@
   .#{$iot-prefix}--suite-header-help--separator {
     padding: 0;
     height: 0;
-    border-bottom: 0.5px solid $hover-secondary;
+    border-bottom: 1px solid $hover-secondary;
     margin: 0 $spacing-05 0 $spacing-05;
   }
 

--- a/packages/react/src/components/SuiteHeader/_suite-header.scss
+++ b/packages/react/src/components/SuiteHeader/_suite-header.scss
@@ -44,6 +44,10 @@
     }
   }
 
+  &--loading {
+    padding-bottom: $spacing-08;
+  }
+
   &--logout {
     margin: -$spacing-05;
 
@@ -77,6 +81,17 @@
 
   li {
     width: 100%;
+    button {
+      margin: $spacing-05;
+    }
+    p {
+      @include type-style('productive-heading-01');
+      display: flex;
+      align-items: center;
+      padding: $spacing-05 $spacing-05 0;
+      text-decoration: none;
+      color: $text-02;
+    }
   }
 
   a {
@@ -111,6 +126,16 @@
       &:hover {
         background-color: $hover-ui;
       }
+    }
+  }
+
+  &--app-skeleton {
+    display: flex;
+    align-items: center;
+    padding: 1rem;
+    flex-direction: column;
+    p {
+      margin-bottom: $spacing-05;
     }
   }
 

--- a/packages/react/src/components/SuiteHeader/i18n/index.js
+++ b/packages/react/src/components/SuiteHeader/i18n/index.js
@@ -15,6 +15,7 @@ const SuiteHeaderI18N = {
       'You are logged in to {solutionName} as {userName}.  Logging out also logs you out of each application that is open in the same browser.  To ensure a secure log out, close all open browser windows.',
     // profileLogoutModalBody: (solutionName, userName) =>
     //   `You are logged in to ${solutionName} as ${userName}.  Logging out also logs you out of each application that is open in the same browser.  To ensure a secure log out, close all open browser windows.`,
+    switcherMyApplications: 'My applications',
     switcherNavigatorLink: 'All applications',
     switcherLearnMoreLink: 'Learn more',
     switcherRequestAccess: 'Contact your administrator to request application access',

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -7057,6 +7057,9 @@ Map {
       "applications": null,
       "className": null,
       "customActionItems": Array [],
+      "customApplications": Array [],
+      "customHelpLinks": Array [],
+      "customProfileLinks": Array [],
       "i18n": Object {
         "about": "About",
         "administrationIcon": "Administration",
@@ -7172,6 +7175,81 @@ Map {
                 },
                 "onClick": Object {
                   "type": "func",
+                },
+              },
+            ],
+            "type": "shape",
+          },
+        ],
+        "type": "arrayOf",
+      },
+      "customApplications": Object {
+        "args": Array [
+          Object {
+            "args": Array [
+              Object {
+                "content": Object {
+                  "type": "node",
+                },
+                "metaData": Object {
+                  "args": Array [
+                    Object {
+                      "element": Object {
+                        "type": "string",
+                      },
+                    },
+                  ],
+                  "type": "shape",
+                },
+              },
+            ],
+            "type": "shape",
+          },
+        ],
+        "type": "arrayOf",
+      },
+      "customHelpLinks": Object {
+        "args": Array [
+          Object {
+            "args": Array [
+              Object {
+                "content": Object {
+                  "type": "node",
+                },
+                "metaData": Object {
+                  "args": Array [
+                    Object {
+                      "element": Object {
+                        "type": "string",
+                      },
+                    },
+                  ],
+                  "type": "shape",
+                },
+              },
+            ],
+            "type": "shape",
+          },
+        ],
+        "type": "arrayOf",
+      },
+      "customProfileLinks": Object {
+        "args": Array [
+          Object {
+            "args": Array [
+              Object {
+                "content": Object {
+                  "type": "node",
+                },
+                "metaData": Object {
+                  "args": Array [
+                    Object {
+                      "element": Object {
+                        "type": "string",
+                      },
+                    },
+                  ],
+                  "type": "shape",
                 },
               },
             ],
@@ -7434,6 +7512,7 @@ Map {
         "profileButton": "Manage profile",
         "profileTitle": "Profile",
       },
+      "onRequestLogout": null,
       "username": "",
     },
     "propTypes": Object {
@@ -7461,7 +7540,6 @@ Map {
         "type": "func",
       },
       "onRequestLogout": Object {
-        "isRequired": true,
         "type": "func",
       },
       "username": Object {
@@ -7471,7 +7549,9 @@ Map {
   },
   "SuiteHeaderAppSwitcher" => Object {
     "defaultProps": Object {
+      "allApplicationsLink": null,
       "applications": null,
+      "customApplications": Array [],
       "i18n": Object {
         "allApplicationsLink": "All applications",
         "learnMoreLink": "Learn more",
@@ -7482,10 +7562,36 @@ Map {
     },
     "propTypes": Object {
       "allApplicationsLink": Object {
-        "isRequired": true,
         "type": "string",
       },
       "applications": Object {
+        "args": Array [
+          Object {
+            "args": Array [
+              Object {
+                "href": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+                "id": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+                "isExternal": Object {
+                  "type": "bool",
+                },
+                "name": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+              },
+            ],
+            "type": "shape",
+          },
+        ],
+        "type": "arrayOf",
+      },
+      "customApplications": Object {
         "args": Array [
           Object {
             "args": Array [

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -7051,6 +7051,7 @@ Map {
     },
     "defaultProps": Object {
       "appName": null,
+      "applications": null,
       "className": null,
       "customActionItems": Array [],
       "i18n": Object {
@@ -7074,6 +7075,7 @@ Map {
         "surveyText": "Click here to help us improve the product",
         "surveyTitle": "Enjoying {solutionName}?",
         "switcherLearnMoreLink": "Learn more",
+        "switcherMyApplications": "My applications",
         "switcherNavigatorLink": "All applications",
         "switcherRequestAccess": "Contact your administrator to request application access",
         "userIcon": "User",
@@ -7081,8 +7083,11 @@ Map {
       },
       "isAdminView": false,
       "onRouteChange": [Function],
+      "routes": null,
       "sideNavProps": null,
       "surveyData": null,
+      "userDisplayName": null,
+      "username": null,
     },
     "propTypes": Object {
       "appName": Object {
@@ -7113,7 +7118,6 @@ Map {
             "type": "shape",
           },
         ],
-        "isRequired": true,
         "type": "arrayOf",
       },
       "className": Object {
@@ -7253,6 +7257,9 @@ Map {
               ],
               "type": "oneOfType",
             },
+            "switcherMyApplications": Object {
+              "type": "string",
+            },
             "switcherNavigatorLink": Object {
               "type": "string",
             },
@@ -7313,7 +7320,6 @@ Map {
             },
           },
         ],
-        "isRequired": true,
         "type": "shape",
       },
       "sideNavProps": Object {
@@ -7410,11 +7416,9 @@ Map {
         "type": "shape",
       },
       "userDisplayName": Object {
-        "isRequired": true,
         "type": "string",
       },
       "username": Object {
-        "isRequired": true,
         "type": "string",
       },
     },
@@ -7427,6 +7431,7 @@ Map {
         "profileButton": "Manage profile",
         "profileTitle": "Profile",
       },
+      "username": "",
     },
     "propTypes": Object {
       "displayName": Object {
@@ -7457,17 +7462,17 @@ Map {
         "type": "func",
       },
       "username": Object {
-        "isRequired": true,
         "type": "string",
       },
     },
   },
   "SuiteHeaderAppSwitcher" => Object {
     "defaultProps": Object {
-      "applications": Array [],
+      "applications": null,
       "i18n": Object {
         "allApplicationsLink": "All applications",
         "learnMoreLink": "Learn more",
+        "myApplications": "My applications",
         "requestAccess": "Contact your administrator to request application access.",
       },
       "onRouteChange": [Function],
@@ -7594,6 +7599,7 @@ Map {
       "surveyText": "Click here to help us improve the product",
       "surveyTitle": "Enjoying {solutionName}?",
       "switcherLearnMoreLink": "Learn more",
+      "switcherMyApplications": "My applications",
       "switcherNavigatorLink": "All applications",
       "switcherRequestAccess": "Contact your administrator to request application access",
       "userIcon": "User",

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -7188,18 +7188,20 @@ Map {
           Object {
             "args": Array [
               Object {
-                "content": Object {
-                  "type": "node",
+                "href": Object {
+                  "isRequired": true,
+                  "type": "string",
                 },
-                "metaData": Object {
-                  "args": Array [
-                    Object {
-                      "element": Object {
-                        "type": "string",
-                      },
-                    },
-                  ],
-                  "type": "shape",
+                "id": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+                "isExternal": Object {
+                  "type": "bool",
+                },
+                "name": Object {
+                  "isRequired": true,
+                  "type": "string",
                 },
               },
             ],

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -7570,23 +7570,7 @@ Map {
         "args": Array [
           Object {
             "args": Array [
-              Object {
-                "href": Object {
-                  "isRequired": true,
-                  "type": "string",
-                },
-                "id": Object {
-                  "isRequired": true,
-                  "type": "string",
-                },
-                "isExternal": Object {
-                  "type": "bool",
-                },
-                "name": Object {
-                  "isRequired": true,
-                  "type": "string",
-                },
-              },
+              undefined,
             ],
             "type": "shape",
           },
@@ -7597,23 +7581,7 @@ Map {
         "args": Array [
           Object {
             "args": Array [
-              Object {
-                "href": Object {
-                  "isRequired": true,
-                  "type": "string",
-                },
-                "id": Object {
-                  "isRequired": true,
-                  "type": "string",
-                },
-                "isExternal": Object {
-                  "type": "bool",
-                },
-                "name": Object {
-                  "isRequired": true,
-                  "type": "string",
-                },
-              },
+              undefined,
             ],
             "type": "shape",
           },


### PR DESCRIPTION
**Summary**

- loading states for the `SuiteHeader` component - shows skeleton components when data is not available in the header menus.
- extensibility for the `SuiteHeader` component - adds supports for custom help menu items, custom profile links and custom applications in the app switcher


**Acceptance Test (how to verify the PR)**

- tests have been created to test loading states
- an existing story has been extended to include custom entries in the SuiteHeader component action items

Loading states:

![image](https://user-images.githubusercontent.com/12237934/107098963-43f66d00-67ef-11eb-8603-6474898c1e56.png)

![image](https://user-images.githubusercontent.com/12237934/107098990-54a6e300-67ef-11eb-8c02-e7f3974773b5.png)

![image](https://user-images.githubusercontent.com/12237934/107098999-5bcdf100-67ef-11eb-8dbc-13a372d8d69e.png)

Extensibility:

![image](https://user-images.githubusercontent.com/12237934/107099048-7607cf00-67ef-11eb-828d-28900deeea81.png)

![image](https://user-images.githubusercontent.com/12237934/107099069-80c26400-67ef-11eb-9edc-5282fc9a560b.png)

![image](https://user-images.githubusercontent.com/12237934/107099085-89b33580-67ef-11eb-95a7-e032f7ca456d.png)




