### PR TITLE
fix(cardeditform): if I made changes to the content section in the CardCodeEditor they were not passed along

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditForm.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditForm.jsx
@@ -219,15 +219,7 @@ export const hideCardPropertiesForEditor = (card) => {
  * @param {Function} onChange
  * @param {Function} setShowEditor
  */
-export const handleSubmit = (
-  card,
-  id,
-  content,
-  setError,
-  onValidateCardJson,
-  onChange,
-  setShowEditor
-) => {
+export const handleSubmit = (card, id, setError, onValidateCardJson, onChange, setShowEditor) => {
   // first validate basic JSON syntax
   const basicErrors = basicCardValidation(card);
   // second validate the consumer's custom function if provided
@@ -238,7 +230,7 @@ export const handleSubmit = (
   const allErrors = basicErrors.concat(customValidationErrors);
   // then submit
   if (isEmpty(allErrors)) {
-    onChange({ ...JSON.parse(card), id, content });
+    onChange({ ...JSON.parse(card), id });
     setShowEditor(false);
     return true;
   }
@@ -268,7 +260,7 @@ const CardEditForm = ({
   const [showEditor, setShowEditor] = useState(false);
   const [modalData, setModalData] = useState();
 
-  const { id, content } = cardConfig;
+  const { id } = cardConfig;
   const baseClassName = `${iotPrefix}--card-edit-form`;
 
   return (
@@ -276,7 +268,7 @@ const CardEditForm = ({
       {showEditor ? (
         <CardCodeEditor
           onSubmit={(card, setError) =>
-            handleSubmit(card, id, content, setError, onValidateCardJson, onChange, setShowEditor)
+            handleSubmit(card, id, setError, onValidateCardJson, onChange, setShowEditor)
           }
           onClose={() => setShowEditor(false)}
           initialValue={modalData}

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditForm.test.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditForm.test.jsx
@@ -93,34 +93,28 @@ describe('CardEditForm', () => {
   // meaning we can't fire user events on the form
   describe('handleSubmit', () => {
     it('should throw error if JSON is empty', () => {
-      handleSubmit(
-        '',
-        '',
-        '',
-        mockSetError,
-        mockOnValidateCardJson,
-        mockOnChange,
-        mockSetShowEditor
-      );
+      handleSubmit('', '', mockSetError, mockOnValidateCardJson, mockOnChange, mockSetShowEditor);
       expect(mockSetError).toBeCalledWith('Unexpected end of JSON input');
     });
     it('should call onChange and setShowEditor if JSON is valid', () => {
+      handleSubmit('{}', '', mockSetError, mockOnValidateCardJson, mockOnChange, mockSetShowEditor);
+      expect(mockOnChange).toBeCalled();
+      expect(mockSetShowEditor).toBeCalledWith(false);
+    });
+    it('should call onChange with content section changese', () => {
       handleSubmit(
-        '{}',
-        '',
+        '{"content":"my content"}',
         '',
         mockSetError,
         mockOnValidateCardJson,
         mockOnChange,
         mockSetShowEditor
       );
-      expect(mockOnChange).toBeCalled();
-      expect(mockSetShowEditor).toBeCalledWith(false);
+      expect(mockOnChange).toBeCalledWith(expect.objectContaining({ content: 'my content' }));
     });
     it('should throw error if JSON is not valid', () => {
       handleSubmit(
         '1234',
-        '',
         '',
         mockSetError,
         mockOnValidateCardJson,

--- a/packages/react/src/components/ValueCard/Attribute.jsx
+++ b/packages/react/src/components/ValueCard/Attribute.jsx
@@ -15,6 +15,8 @@ const propTypes = {
   attribute: PropTypes.shape({
     label: PropTypes.string,
     unit: PropTypes.string,
+    // decimal precision
+    precision: PropTypes.number,
     thresholds: PropTypes.arrayOf(
       PropTypes.shape({
         comparison: PropTypes.oneOf(['<', '>', '=', '<=', '>=']).isRequired,
@@ -28,8 +30,7 @@ const propTypes = {
   isEditable: PropTypes.bool,
   layout: PropTypes.oneOf(Object.values(CARD_LAYOUTS)),
   locale: PropTypes.string,
-  // decimal precision
-  precision: PropTypes.number,
+
   renderIconByName: PropTypes.func,
   /** Optional trend information */
   secondaryValue: PropTypes.shape({
@@ -47,7 +48,6 @@ const propTypes = {
 
 const defaultProps = {
   layout: null,
-  precision: 0,
   renderIconByName: null,
   secondaryValue: null,
   locale: 'en',
@@ -62,13 +62,12 @@ const BEM_BASE = `${BASE_CLASS_NAME}__attribute`;
  * He also determines which threshold applies to a given attribute (perhaps that should be moved)
  */
 const Attribute = ({
-  attribute: { label, unit, thresholds },
+  attribute: { label, unit, thresholds, precision },
   attributeCount,
   customFormatter,
   isEditable,
   layout,
   locale,
-  precision,
   renderIconByName,
   secondaryValue,
   value,

--- a/packages/react/src/components/ValueCard/ValueCard.jsx
+++ b/packages/react/src/components/ValueCard/ValueCard.jsx
@@ -143,7 +143,6 @@ ValueCard.defaultProps = {
   cardVariables: null,
   customFormatter: null,
   isNumberValueCompact: false,
-  precision: null,
 };
 
 export default ValueCard;

--- a/packages/react/src/components/ValueCard/ValueCard.test.jsx
+++ b/packages/react/src/components/ValueCard/ValueCard.test.jsx
@@ -75,4 +75,27 @@ describe('ValueCard', () => {
     expect(defaultFormattedValue).toBe('10,000');
     expect(screen.queryByText(testValue)).toBeTruthy();
   });
+  it('Precision value for attribute is used', () => {
+    render(
+      <ValueCard
+        id="myIdTest"
+        title="Health score"
+        content={{ attributes: [{ label: 'title', dataSourceId: 'v', precision: 2 }] }}
+        size={CARD_SIZES.SMALL}
+        values={{ v: 10000 }}
+      />
+    );
+    expect(screen.queryByText('10,000.00')).toBeTruthy();
+
+    render(
+      <ValueCard
+        id="myIdTest"
+        title="Health score"
+        content={{ attributes: [{ label: 'title', dataSourceId: 'v', precision: 1 }] }}
+        size={CARD_SIZES.SMALL}
+        values={{ v: 10000 }}
+      />
+    );
+    expect(screen.queryByText('10,000.0')).toBeTruthy();
+  });
 });

--- a/packages/react/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/packages/react/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -2434,7 +2434,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                       }
                     }
                   >
-                    456,778,234,234,234,240
+                    456,778,234,234,234,240.0
                   </span>
                 </div>
                 <span
@@ -2501,7 +2501,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                       }
                     }
                   >
-                    88,888,678,234,234,240,000
+                    88,888,678,234,234,240,000.0
                   </span>
                 </div>
                 <span

--- a/packages/react/src/constants/CardPropTypes.js
+++ b/packages/react/src/constants/CardPropTypes.js
@@ -63,6 +63,7 @@ export const AttributePropTypes = PropTypes.shape({
       icon: PropTypes.string,
     })
   ),
+  precision: PropTypes.number,
   unit: PropTypes.string,
 });
 

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -11595,7 +11595,6 @@ Map {
       "fontSize": 42,
       "isNumberValueCompact": false,
       "locale": "en",
-      "precision": null,
       "size": "MEDIUM",
       "values": null,
     },
@@ -12101,6 +12100,9 @@ Map {
                       },
                       "label": Object {
                         "type": "string",
+                      },
+                      "precision": Object {
+                        "type": "number",
                       },
                       "secondaryValue": Object {
                         "args": Array [

--- a/yarn.lock
+++ b/yarn.lock
@@ -6000,7 +6000,7 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-anymatch@^3.0.3, anymatch@~3.1.1:
+anymatch@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
   integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
@@ -6211,6 +6211,11 @@ ast-types@^0.13.2:
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
+
+async-each@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
+  integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
 async-foreach@^0.1.3:
   version "0.1.3"
@@ -6797,10 +6802,10 @@ big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
 
-binary-extensions@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
-  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+binary-extensions@^1.0.0:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
+  integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
 bl@^1.0.0:
   version "1.2.2"
@@ -6891,7 +6896,7 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
-braces@^2.3.1:
+braces@^2.3.1, braces@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
   dependencies:
@@ -6906,7 +6911,7 @@ braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@^3.0.1, braces@~3.0.2:
+braces@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -7477,20 +7482,24 @@ cheerio@^1.0.0-rc.2:
     lodash "^4.15.0"
     parse5 "^3.0.1"
 
-chokidar@3.3.1, chokidar@^2.0.2, chokidar@^2.0.4:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.1.tgz#c84e5b3d18d9a4d77558fef466b1bf16bbeb3450"
-  integrity sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==
+chokidar@^2.0.2, chokidar@^2.0.4:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
+  integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
   dependencies:
-    anymatch "~3.1.1"
-    braces "~3.0.2"
-    glob-parent "~5.1.0"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.3.0"
+    anymatch "^2.0.0"
+    async-each "^1.0.1"
+    braces "^2.3.2"
+    glob-parent "^3.1.0"
+    inherits "^2.0.3"
+    is-binary-path "^1.0.0"
+    is-glob "^4.0.0"
+    normalize-path "^3.0.0"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.2.1"
+    upath "^1.1.1"
   optionalDependencies:
-    fsevents "~2.1.2"
+    fsevents "^1.2.7"
 
 chownr@^1.0.1:
   version "1.0.1"
@@ -10941,7 +10950,7 @@ fsevents@^1.2.7:
     nan "^2.12.1"
     node-pre-gyp "^0.12.0"
 
-fsevents@^2.1.2, fsevents@~2.1.2:
+fsevents@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
@@ -11209,7 +11218,7 @@ glob-parent@^5.0.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@^5.1.0, glob-parent@~5.1.0:
+glob-parent@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
@@ -12177,12 +12186,12 @@ is-arrayish@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
 
-is-binary-path@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
-  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+is-binary-path@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
+  integrity sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=
   dependencies:
-    binary-extensions "^2.0.0"
+    binary-extensions "^1.0.0"
 
 is-boolean-object@^1.0.0:
   version "1.0.0"
@@ -12363,7 +12372,7 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
-is-glob@^4.0.1, is-glob@~4.0.1:
+is-glob@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
@@ -15196,7 +15205,7 @@ normalize-path@^2.0.1, normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
-normalize-path@^3.0.0, normalize-path@~3.0.0:
+normalize-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -15982,7 +15991,7 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
-picomatch@^2.0.4, picomatch@^2.0.7, picomatch@^2.2.1:
+picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
@@ -17664,12 +17673,14 @@ readdir-scoped-modules@^1.0.0:
     graceful-fs "^4.1.2"
     once "^1.3.0"
 
-readdirp@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.3.0.tgz#984458d13a1e42e2e9f5841b129e162f369aff17"
-  integrity sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==
+readdirp@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
+  integrity sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==
   dependencies:
-    picomatch "^2.0.7"
+    graceful-fs "^4.1.11"
+    micromatch "^3.1.10"
+    readable-stream "^2.0.2"
 
 realpath-native@^1.1.0:
   version "1.1.0"
@@ -20508,7 +20519,7 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-upath@^1.2.0:
+upath@^1.1.1, upath@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==


### PR DESCRIPTION
Prereqs #2015 

**Summary**

- There was a bug where if the user changed the `content` section of a card in the JSON Editor (for example changing the label) they were not passed along when the JSON Editor was saved and the updated card was submitted.

To see the bug, open the JSON Editor and manually set this card 
https://next.carbon-addons-iot-react.com/?path=/story/watson-iot-experimental-cardeditor--interactive

```
{
    "title": "New card",
    "size": "SMALL",
    "content": "my custom",
    "type": "VALUE"
}
```

Notice in the left pane, the content is removed (or if you open the code editor again)

**Change List (commits, features, bugs, etc)**

- fix(CardEditForm): handleSubmit we should not override the content section of the CardEditor

**Acceptance Test (how to verify the PR)**

- Verify in the deploy preview that the content section of the Card from the CardEditor is preserved in the story
