### PR TITLE
fix(dataitemmodal): need to hide the grain if no aggregator is selected

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,7 +47,7 @@
         "NODE_ICU_DATA": "node_modules/full-icu",
         "TZ": "America/Chicago"
       },
-      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}/packages/react",
       "internalConsoleOptions": "neverOpen",
       "disableOptimisticBPs": true,
       "windows": {

--- a/packages/react/src/components/DashboardEditor/DashboardEditor.story.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.story.jsx
@@ -52,6 +52,7 @@ const mockDataItems = [
       { id: 'max', text: 'Max' },
       { id: 'min', text: 'Min' },
     ],
+    grain: 'hourly',
   },
   {
     dataItemId: 'torque_min',
@@ -65,6 +66,7 @@ const mockDataItems = [
       { id: 'max', text: 'Max' },
       { id: 'min', text: 'Min' },
     ],
+    grain: 'hourly',
   },
   {
     dataItemId: 'torque_mean',
@@ -78,6 +80,7 @@ const mockDataItems = [
       { id: 'max', text: 'Max' },
       { id: 'min', text: 'Min' },
     ],
+    grain: 'hourly',
   },
   {
     dataItemId: 'torque',


### PR DESCRIPTION
Closes #

**Summary**

- Little bit of a usability problem, the grain selector doesn't make sense at 'input' if no aggregator is selected, I have removed the input grain option and hidden the grain selector if 'none' is set as the aaaggregaator

**Change List (commits, features, bugs, etc)**

- fix(launch.json): support the new monorepo structure
- fix(DataSeriesFormModal): remove the input from the grain selector, fix the TextInput prop types warnings thrown because of bad props, only show the grain if the aggregator is not none, and default and clear the grain as the aggregator is changed

**Acceptance Test (how to verify the PR)**

- Verify in this story, as you popup the DataItemEditModal and switch the aggregator, that the grain selector disappears and reappears as you change the aggregator http://127.0.0.1:3000/?path=/story/watson-iot-experimental-dashboardeditor--default
