### PR TITLE
fix(dataseriesformcontent): it should not change existing elements

### DIFF
--- a/packages/react/src/components/BarChartCard/barChartUtils.js
+++ b/packages/react/src/components/BarChartCard/barChartUtils.js
@@ -525,7 +525,7 @@ export const formatTableData = (
   chartData
 ) => {
   const tableData = [];
-  if (!isNil(values)) {
+  if (!isNil(values) && !isNil(chartData)) {
     if (timeDataSourceId) {
       // First get all of the unique timestamps
       const uniqueTimestamps = [...new Set(values.map((val) => val[timeDataSourceId]))];

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
@@ -38,6 +38,8 @@ const propTypes = {
         src: PropTypes.string,
         zoomMax: PropTypes.number,
       }),
+      // custom card content is a function
+      PropTypes.func,
     ]),
   }),
   /** Callback function when form data changes */

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
@@ -27,22 +27,25 @@ const propTypes = {
     title: PropTypes.string,
     size: PropTypes.string,
     type: PropTypes.string,
-    content: PropTypes.shape({
-      series: PropTypes.arrayOf(
-        PropTypes.shape({
-          label: PropTypes.string,
-          dataSourceId: PropTypes.string,
-          color: PropTypes.string,
-        })
-      ),
-      xLabel: PropTypes.string,
-      yLabel: PropTypes.string,
-      unit: PropTypes.string,
-      includeZeroOnXaxis: PropTypes.bool,
-      includeZeroOnYaxis: PropTypes.bool,
-      timeDataSourceId: PropTypes.string,
-      showLegend: PropTypes.bool,
-    }),
+    content: PropTypes.oneOfType([
+      PropTypes.shape({
+        series: PropTypes.arrayOf(
+          PropTypes.shape({
+            label: PropTypes.string,
+            dataSourceId: PropTypes.string,
+            color: PropTypes.string,
+          })
+        ),
+        xLabel: PropTypes.string,
+        yLabel: PropTypes.string,
+        unit: PropTypes.string,
+        includeZeroOnXaxis: PropTypes.bool,
+        includeZeroOnYaxis: PropTypes.bool,
+        timeDataSourceId: PropTypes.string,
+        showLegend: PropTypes.bool,
+      }), // custom card content is a function
+      PropTypes.func,
+    ]),
     interval: PropTypes.string,
   }),
   /* callback when data item input value changes */

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
@@ -253,21 +253,10 @@ const DataSeriesFormItem = ({
   const canMultiSelectDataItems = cardConfig.content?.type !== BAR_CHART_TYPES.SIMPLE;
 
   // determine which content section to look at
-  const data =
+  const dataSection =
     cardConfig.type === CARD_TYPES.TIMESERIES || cardConfig.type === CARD_TYPES.BAR
       ? cardConfig?.content?.series
       : cardConfig?.content?.attributes;
-
-  // initialize items with a unique dataSourceId if not present
-  const dataSection = useMemo(
-    () =>
-      data?.map((item) =>
-        item.dataSourceId !== item.dataItemId
-          ? item
-          : { ...item, dataSourceId: `${item.dataSourceId}_${uuid.v4()}` }
-      ),
-    [data]
-  );
 
   const validDataItems = useMemo(
     () => (getValidDataItems ? getValidDataItems(cardConfig, selectedTimeRange) : dataItems),

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.test.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.test.jsx
@@ -178,7 +178,7 @@ describe('DataSeriesFormItem', () => {
             {
               dataItemId: 'temperature',
               aggregationMethod: undefined,
-              color: '#6929c4',
+              color: 'red',
               dataSourceId: expect.anything(), // this is the dataSourceId followed by a uuid
               label: 'Temperature',
             },

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
@@ -61,6 +61,7 @@ describe('TableCardFormContent', () => {
           {
             label: 'Timestamp',
             sort: 'DESC',
+            dataItemId: 'timestamp',
             dataSourceId: 'timestamp',
             type: 'TIMESTAMP',
           },
@@ -110,6 +111,7 @@ describe('TableCardFormContent', () => {
       content: {
         columns: [
           {
+            dataItemId: 'timestamp',
             dataSourceId: 'timestamp',
             label: 'Timestamp',
             type: 'TIMESTAMP',

--- a/packages/react/src/components/CardEditor/CardEditor.jsx
+++ b/packages/react/src/components/CardEditor/CardEditor.jsx
@@ -19,22 +19,26 @@ const propTypes = {
     title: PropTypes.string,
     size: PropTypes.string,
     type: PropTypes.string,
-    content: PropTypes.shape({
-      series: PropTypes.arrayOf(
-        PropTypes.shape({
-          label: PropTypes.string,
-          dataSourceId: PropTypes.string,
-          color: PropTypes.string,
-        })
-      ),
-      xLabel: PropTypes.string,
-      yLabel: PropTypes.string,
-      unit: PropTypes.string,
-      includeZeroOnXaxis: PropTypes.bool,
-      includeZeroOnYaxis: PropTypes.bool,
-      timeDataSourceId: PropTypes.string,
-      showLegend: PropTypes.bool,
-    }),
+    content: PropTypes.oneOfType([
+      PropTypes.shape({
+        series: PropTypes.arrayOf(
+          PropTypes.shape({
+            label: PropTypes.string,
+            dataSourceId: PropTypes.string,
+            color: PropTypes.string,
+          })
+        ),
+        xLabel: PropTypes.string,
+        yLabel: PropTypes.string,
+        unit: PropTypes.string,
+        includeZeroOnXaxis: PropTypes.bool,
+        includeZeroOnYaxis: PropTypes.bool,
+        timeDataSourceId: PropTypes.string,
+        showLegend: PropTypes.bool,
+      }),
+      // custom card content is a function
+      PropTypes.func,
+    ]),
     interval: PropTypes.string,
   }),
   /** Callback function when user clicks Show Gallery */

--- a/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
@@ -464,6 +464,7 @@ const DashboardEditor = ({
           (image) => image.id === cardConfig.content.id
         )?.src;
       } else if (
+        cardConfig.type === CARD_TYPES.IMAGE &&
         cardConfig.content.imgState === 'new' &&
         !imagesToUpload.some((image) => image.id === cardConfig.content.id)
       ) {

--- a/packages/react/src/components/DashboardEditor/editorUtils.jsx
+++ b/packages/react/src/components/DashboardEditor/editorUtils.jsx
@@ -494,6 +494,7 @@ export const handleDataSeriesChange = (
           ? content.columns.filter((col) => col.dataSourceId === 'timestamp')[0]
           : {
               dataSourceId: 'timestamp',
+              dataItemId: 'timestamp',
               label: 'Timestamp',
               type: 'TIMESTAMP',
               sort: 'DESC',

--- a/packages/react/src/components/DashboardEditor/editorUtils.test.jsx
+++ b/packages/react/src/components/DashboardEditor/editorUtils.test.jsx
@@ -358,6 +358,7 @@ describe('editorUtils', () => {
         content: {
           columns: [
             {
+              dataItemId: 'timestamp',
               dataSourceId: 'timestamp',
               label: 'Timestamp',
               type: 'TIMESTAMP',
@@ -489,6 +490,7 @@ describe('editorUtils', () => {
         content: {
           columns: [
             {
+              dataItemId: 'timestamp',
               dataSourceId: 'timestamp',
               label: 'Timestamp',
               type: 'TIMESTAMP',

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -9400,52 +9400,62 @@ Map {
           Object {
             "content": Object {
               "args": Array [
-                Object {
-                  "includeZeroOnXaxis": Object {
-                    "type": "bool",
-                  },
-                  "includeZeroOnYaxis": Object {
-                    "type": "bool",
-                  },
-                  "series": Object {
+                Array [
+                  Object {
                     "args": Array [
                       Object {
-                        "args": Array [
-                          Object {
-                            "color": Object {
-                              "type": "string",
+                        "includeZeroOnXaxis": Object {
+                          "type": "bool",
+                        },
+                        "includeZeroOnYaxis": Object {
+                          "type": "bool",
+                        },
+                        "series": Object {
+                          "args": Array [
+                            Object {
+                              "args": Array [
+                                Object {
+                                  "color": Object {
+                                    "type": "string",
+                                  },
+                                  "dataSourceId": Object {
+                                    "type": "string",
+                                  },
+                                  "label": Object {
+                                    "type": "string",
+                                  },
+                                },
+                              ],
+                              "type": "shape",
                             },
-                            "dataSourceId": Object {
-                              "type": "string",
-                            },
-                            "label": Object {
-                              "type": "string",
-                            },
-                          },
-                        ],
-                        "type": "shape",
+                          ],
+                          "type": "arrayOf",
+                        },
+                        "showLegend": Object {
+                          "type": "bool",
+                        },
+                        "timeDataSourceId": Object {
+                          "type": "string",
+                        },
+                        "unit": Object {
+                          "type": "string",
+                        },
+                        "xLabel": Object {
+                          "type": "string",
+                        },
+                        "yLabel": Object {
+                          "type": "string",
+                        },
                       },
                     ],
-                    "type": "arrayOf",
+                    "type": "shape",
                   },
-                  "showLegend": Object {
-                    "type": "bool",
+                  Object {
+                    "type": "func",
                   },
-                  "timeDataSourceId": Object {
-                    "type": "string",
-                  },
-                  "unit": Object {
-                    "type": "string",
-                  },
-                  "xLabel": Object {
-                    "type": "string",
-                  },
-                  "yLabel": Object {
-                    "type": "string",
-                  },
-                },
+                ],
               ],
-              "type": "shape",
+              "type": "oneOfType",
             },
             "id": Object {
               "type": "string",


### PR DESCRIPTION
Closes #

**Summary**

- Changing the existing elements of a legacy dashboard causes errors downstream

**Change List (commits, features, bugs, etc)**

- fix(dataseriesformcontent): do not change the daataSourceId of existing elements, only when new ones aare generated


