### PR TITLE
feat(dashboardeditor): scroll to added cards

### DIFF
--- a/packages/react/src/components/Dashboard/_dashboard-grid.scss
+++ b/packages/react/src/components/Dashboard/_dashboard-grid.scss
@@ -1,0 +1,17 @@
+.#{$iot-prefix}--dashboard-grid {
+  position: relative;
+  .react-grid-item.cssTransforms {
+    transition-property: none;
+  }
+
+  .react-resizable-hide .react-resizable-handle {
+    /* workaround to hide the resize handles in react-grid-layout */
+    display: none;
+  }
+}
+
+.#{$iot-prefix}--dashboard-grid__animate {
+  .react-grid-item.cssTransforms {
+    transition-property: transform;
+  }
+}

--- a/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { InlineNotification, SkeletonText } from 'carbon-components-react';
 import isNil from 'lodash/isNil';
@@ -404,6 +404,16 @@ const DashboardEditor = ({
     window.dispatchEvent(new Event('resize'));
   }, [selectedBreakpointIndex]);
 
+  const scrollContainerRef = useRef();
+  // when a new card is added, scroll to the bottom of the page. Instead of trying to attach the ref to the card itself,
+  // check if the scrollHeight has changed in the scroll container, meaning a new card has been added
+  useEffect(() => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTo(0, scrollContainerRef.current.scrollHeight);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scrollContainerRef.current?.scrollHeight]);
+
   /**
    * Adds a default, empty card to the preview
    * @param {string} type card type
@@ -597,6 +607,7 @@ const DashboardEditor = ({
           // enables overflow: auto if a specific breakpoint is selected so the width can be managed
           [`${baseClassName}__overflow`]: selectedBreakpointIndex !== LAYOUTS.FIT_TO_SCREEN.index,
         })}
+        ref={scrollContainerRef}
       >
         {renderHeader ? (
           renderHeader()
@@ -623,7 +634,8 @@ const DashboardEditor = ({
         <div
           className={classnames(`${baseClassName}--preview`, {
             // enables overflow: auto if a specific breakpoint is selected so the width can be managed
-            [`${baseClassName}__overflow`]: selectedBreakpointIndex !== LAYOUTS.FIT_TO_SCREEN.index,
+            [`${baseClassName}--preview__selected-breakpoint`]:
+              selectedBreakpointIndex !== LAYOUTS.FIT_TO_SCREEN.index,
           })}
         >
           <div

--- a/packages/react/src/components/DashboardEditor/DashboardEditor.test.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.test.jsx
@@ -6,6 +6,14 @@ import { Link } from '../..';
 import DashboardEditor from './DashboardEditor';
 
 describe('DashboardEditor', () => {
+  const realScrollTo = window.HTMLElement.prototype.scrollTo;
+  beforeEach(() => {
+    window.HTMLElement.prototype.scrollTo = jest.fn();
+  });
+  afterEach(() => {
+    window.HTMLElement.prototype.scrollTo = realScrollTo;
+  });
+
   const mockValueCard = {
     id: 'Standard',
     title: 'value card',

--- a/packages/react/src/components/DashboardEditor/_dashboard-editor.scss
+++ b/packages/react/src/components/DashboardEditor/_dashboard-editor.scss
@@ -67,11 +67,16 @@
       display: flex;
     }
   }
+
   &--preview {
     flex: 1;
-    background-color: $text-03;
     margin-left: $spacing-05;
     margin-right: $spacing-05;
+
+    &__selected-breakpoint {
+      background-color: $text-03;
+      overflow-x: auto; // allows a larger width
+    }
 
     &__card:focus {
       outline: 2px solid $focus;
@@ -101,10 +106,12 @@
 
     &__grid-container {
       // force a larger height so the background color will stretch the full height
-      height: 100vh;
+      // 3rem for the navbar, 100px for the PageTitleBar header
+      min-height: calc(100vh - 7rem - 100px);
       background-color: $ui-background;
     }
   }
+
   &--sidebar {
     min-height: 100%;
     width: 16rem;

--- a/packages/react/src/components/StorybookSnapshots.test.js
+++ b/packages/react/src/components/StorybookSnapshots.test.js
@@ -12,6 +12,7 @@ function mockDate(isoDate) {
   };
 }
 const realScrollIntoView = window.HTMLElement.prototype.scrollIntoView;
+const realScrollTo = window.HTMLElement.prototype.scrollTo;
 
 describe(`Storybook Snapshot tests and console checks`, () => {
   const spy = {};
@@ -92,6 +93,7 @@ describe(`Storybook Snapshot tests and console checks`, () => {
     // Mock the scroll function as its not implemented in jsdom
     // https://stackoverflow.com/questions/53271193/typeerror-scrollintoview-is-not-a-function
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
+    window.HTMLElement.prototype.scrollTo = jest.fn();
   });
   initStoryshots({
     storyKindRegex: /Watson\sIoT.*$|.*Getting\sStarted/g,
@@ -156,5 +158,6 @@ describe(`Storybook Snapshot tests and console checks`, () => {
   afterEach(() => {
     global.Date = RealDate;
     window.HTMLElement.prototype.scrollIntoView = realScrollIntoView;
+    window.HTMLElement.prototype.scrollTo = realScrollTo;
   });
 });

--- a/packages/react/src/styles.scss
+++ b/packages/react/src/styles.scss
@@ -194,6 +194,7 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 @import 'components/ComposedModal/composed-modal';
 @import 'components/CardCodeEditor/card-code-editor';
 @import 'components/Dashboard/dashboard';
+@import 'components/Dashboard/dashboard-grid';
 @import 'components/DashboardEditor/dashboard-editor';
 @import 'components/DateTimePicker/date-time-picker';
 @import 'components/FilterTags/filter-tags';


### PR DESCRIPTION
Closes #1987 

**Summary**

- When a card is added, scroll to the bottom of the dashboard grid so that the card is visible. This is done by checking if the scroll height of the grid container has changed, meaning a card has been added, then scrolling to the bottom

**Change List (commits, features, bugs, etc)**

- Re-adds dashboard-grid's style file as it got lost in the monorepo merge
- Update the styling for DashboardEditor to only show the background color when breakpoints are being used
- Fix the height of the grid container in DashboardEditor to not have any scroll by default

**Acceptance Test (how to verify the PR)**

- Go to any DashboardEditor story, add cards until the visible grid is full, then continue to add cards and ensure you can always see the newly added card
- While in those stories, ensure the editor doesn't start with a scrollbar when its empty
