### PR TITLE
fix(tablecard): in dashboard editor

### DIFF
--- a/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -1422,7 +1422,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                               <span
                                 className="bx--pagination__text bx--pagination__items-count"
                               >
-                                1–10 of 10 items
+                                1–10 of 100 items
                               </span>
                             </div>
                             <div
@@ -1438,7 +1438,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                     className="bx--label bx--visually-hidden"
                                     htmlFor="bx-pagination-select-5-right"
                                   >
-                                    Page number, of 1 pages
+                                    Page number, of 10 pages
                                   </label>
                                   <div
                                     className="bx--select-input--inline__wrapper"
@@ -1460,6 +1460,78 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                           value={1}
                                         >
                                           1
+                                        </option>
+                                        <option
+                                          className="bx--select-option"
+                                          disabled={false}
+                                          hidden={false}
+                                          value={2}
+                                        >
+                                          2
+                                        </option>
+                                        <option
+                                          className="bx--select-option"
+                                          disabled={false}
+                                          hidden={false}
+                                          value={3}
+                                        >
+                                          3
+                                        </option>
+                                        <option
+                                          className="bx--select-option"
+                                          disabled={false}
+                                          hidden={false}
+                                          value={4}
+                                        >
+                                          4
+                                        </option>
+                                        <option
+                                          className="bx--select-option"
+                                          disabled={false}
+                                          hidden={false}
+                                          value={5}
+                                        >
+                                          5
+                                        </option>
+                                        <option
+                                          className="bx--select-option"
+                                          disabled={false}
+                                          hidden={false}
+                                          value={6}
+                                        >
+                                          6
+                                        </option>
+                                        <option
+                                          className="bx--select-option"
+                                          disabled={false}
+                                          hidden={false}
+                                          value={7}
+                                        >
+                                          7
+                                        </option>
+                                        <option
+                                          className="bx--select-option"
+                                          disabled={false}
+                                          hidden={false}
+                                          value={8}
+                                        >
+                                          8
+                                        </option>
+                                        <option
+                                          className="bx--select-option"
+                                          disabled={false}
+                                          hidden={false}
+                                          value={9}
+                                        >
+                                          9
+                                        </option>
+                                        <option
+                                          className="bx--select-option"
+                                          disabled={false}
+                                          hidden={false}
+                                          value={10}
+                                        >
+                                          10
                                         </option>
                                       </select>
                                       <svg
@@ -1484,7 +1556,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                               <span
                                 className="bx--pagination__text"
                               >
-                                1 of 1 pages
+                                1 of 10 pages
                               </span>
                               <div
                                 className="bx--pagination__control-buttons"
@@ -1520,8 +1592,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                   </svg>
                                 </button>
                                 <button
-                                  className="bx--pagination__button bx--pagination__button--forward bx--pagination__button--no-index bx--btn bx--btn--ghost bx--btn--disabled bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-end"
-                                  disabled={true}
+                                  className="bx--pagination__button bx--pagination__button--forward bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-end"
+                                  disabled={false}
                                   onClick={[Function]}
                                   tabIndex={0}
                                   type="button"
@@ -14099,7 +14171,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                             <span
                               className="bx--pagination__text bx--pagination__items-count"
                             >
-                              1–10 of 10 items
+                              1–10 of 100 items
                             </span>
                           </div>
                           <div
@@ -14115,7 +14187,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                   className="bx--label bx--visually-hidden"
                                   htmlFor="bx-pagination-select-4-right"
                                 >
-                                  Page number, of 1 pages
+                                  Page number, of 10 pages
                                 </label>
                                 <div
                                   className="bx--select-input--inline__wrapper"
@@ -14137,6 +14209,78 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                         value={1}
                                       >
                                         1
+                                      </option>
+                                      <option
+                                        className="bx--select-option"
+                                        disabled={false}
+                                        hidden={false}
+                                        value={2}
+                                      >
+                                        2
+                                      </option>
+                                      <option
+                                        className="bx--select-option"
+                                        disabled={false}
+                                        hidden={false}
+                                        value={3}
+                                      >
+                                        3
+                                      </option>
+                                      <option
+                                        className="bx--select-option"
+                                        disabled={false}
+                                        hidden={false}
+                                        value={4}
+                                      >
+                                        4
+                                      </option>
+                                      <option
+                                        className="bx--select-option"
+                                        disabled={false}
+                                        hidden={false}
+                                        value={5}
+                                      >
+                                        5
+                                      </option>
+                                      <option
+                                        className="bx--select-option"
+                                        disabled={false}
+                                        hidden={false}
+                                        value={6}
+                                      >
+                                        6
+                                      </option>
+                                      <option
+                                        className="bx--select-option"
+                                        disabled={false}
+                                        hidden={false}
+                                        value={7}
+                                      >
+                                        7
+                                      </option>
+                                      <option
+                                        className="bx--select-option"
+                                        disabled={false}
+                                        hidden={false}
+                                        value={8}
+                                      >
+                                        8
+                                      </option>
+                                      <option
+                                        className="bx--select-option"
+                                        disabled={false}
+                                        hidden={false}
+                                        value={9}
+                                      >
+                                        9
+                                      </option>
+                                      <option
+                                        className="bx--select-option"
+                                        disabled={false}
+                                        hidden={false}
+                                        value={10}
+                                      >
+                                        10
                                       </option>
                                     </select>
                                     <svg
@@ -14161,7 +14305,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                             <span
                               className="bx--pagination__text"
                             >
-                              1 of 1 pages
+                              1 of 10 pages
                             </span>
                             <div
                               className="bx--pagination__control-buttons"
@@ -14197,8 +14341,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                                 </svg>
                               </button>
                               <button
-                                className="bx--pagination__button bx--pagination__button--forward bx--pagination__button--no-index bx--btn bx--btn--ghost bx--btn--disabled bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-end"
-                                disabled={true}
+                                className="bx--pagination__button bx--pagination__button--forward bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-end"
+                                disabled={false}
                                 onClick={[Function]}
                                 tabIndex={0}
                                 type="button"

--- a/packages/react/src/components/TableCard/TableCard.jsx
+++ b/packages/react/src/components/TableCard/TableCard.jsx
@@ -640,12 +640,13 @@ const TableCard = ({
       {...others}
     >
       {({ height }) => {
-        const numberOfRowsPerPage = !isNil(height) ? Math.floor((height - 48 * 3) / 48) : 10;
+        const numberOfRowsPerPage = Math.max(!isNil(height) && Math.floor((height - 48) / 48), 10);
         return (
           <StyledStatefulTable
             columns={columnsToRender}
             data={tableDataWithTimestamp}
             id={`table-for-card-${id}`}
+            key={`table-for-card-${numberOfRowsPerPage}-${columnsToRender?.length}`}
             isExpanded={isExpanded}
             secondaryTitle={title}
             tooltip={tooltip}

--- a/packages/react/src/components/TableCard/TableCard.jsx
+++ b/packages/react/src/components/TableCard/TableCard.jsx
@@ -641,7 +641,7 @@ const TableCard = ({
     >
       {({ height }) => {
         const numberOfRowsPerPage = Math.max(
-          !isNil(height) ? Math.floor((height - 48) / 48) : 10,
+          !isNil(height) && height !== 0 ? Math.floor((height - 48) / 48) : 10,
           1 // at least pass 1 row per page
         );
         return (

--- a/packages/react/src/components/TableCard/TableCard.jsx
+++ b/packages/react/src/components/TableCard/TableCard.jsx
@@ -640,7 +640,10 @@ const TableCard = ({
       {...others}
     >
       {({ height }) => {
-        const numberOfRowsPerPage = Math.max(!isNil(height) && Math.floor((height - 48) / 48), 10);
+        const numberOfRowsPerPage = Math.max(
+          !isNil(height) ? Math.floor((height - 48) / 48) : 10,
+          1 // at least pass 1 row per page
+        );
         return (
           <StyledStatefulTable
             columns={columnsToRender}

--- a/packages/react/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/packages/react/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -7661,7 +7661,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <span
                   className="bx--pagination__text bx--pagination__items-count"
                 >
-                  1–10 of 10 items
+                  1–10 of 100 items
                 </span>
               </div>
               <div
@@ -7677,7 +7677,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="bx--label bx--visually-hidden"
                       htmlFor="bx-pagination-select-46-right"
                     >
-                      Page number, of 1 pages
+                      Page number, of 10 pages
                     </label>
                     <div
                       className="bx--select-input--inline__wrapper"
@@ -7699,6 +7699,78 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             value={1}
                           >
                             1
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={2}
+                          >
+                            2
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={3}
+                          >
+                            3
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={4}
+                          >
+                            4
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={5}
+                          >
+                            5
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={6}
+                          >
+                            6
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={7}
+                          >
+                            7
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={8}
+                          >
+                            8
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={9}
+                          >
+                            9
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={10}
+                          >
+                            10
                           </option>
                         </select>
                         <svg
@@ -7723,7 +7795,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <span
                   className="bx--pagination__text"
                 >
-                  1 of 1 pages
+                  1 of 10 pages
                 </span>
                 <div
                   className="bx--pagination__control-buttons"
@@ -7759,8 +7831,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </svg>
                   </button>
                   <button
-                    className="bx--pagination__button bx--pagination__button--forward bx--pagination__button--no-index bx--btn bx--btn--ghost bx--btn--disabled bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-end"
-                    disabled={true}
+                    className="bx--pagination__button bx--pagination__button--forward bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-end"
+                    disabled={false}
                     onClick={[Function]}
                     tabIndex={0}
                     type="button"
@@ -9355,7 +9427,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <span
                   className="bx--pagination__text bx--pagination__items-count"
                 >
-                  1–10 of 10 items
+                  1–10 of 100 items
                 </span>
               </div>
               <div
@@ -9371,7 +9443,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="bx--label bx--visually-hidden"
                       htmlFor="bx-pagination-select-47-right"
                     >
-                      Page number, of 1 pages
+                      Page number, of 10 pages
                     </label>
                     <div
                       className="bx--select-input--inline__wrapper"
@@ -9393,6 +9465,78 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             value={1}
                           >
                             1
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={2}
+                          >
+                            2
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={3}
+                          >
+                            3
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={4}
+                          >
+                            4
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={5}
+                          >
+                            5
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={6}
+                          >
+                            6
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={7}
+                          >
+                            7
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={8}
+                          >
+                            8
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={9}
+                          >
+                            9
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={10}
+                          >
+                            10
                           </option>
                         </select>
                         <svg
@@ -9417,7 +9561,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <span
                   className="bx--pagination__text"
                 >
-                  1 of 1 pages
+                  1 of 10 pages
                 </span>
                 <div
                   className="bx--pagination__control-buttons"
@@ -9453,8 +9597,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </svg>
                   </button>
                   <button
-                    className="bx--pagination__button bx--pagination__button--forward bx--pagination__button--no-index bx--btn bx--btn--ghost bx--btn--disabled bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-end"
-                    disabled={true}
+                    className="bx--pagination__button bx--pagination__button--forward bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-end"
+                    disabled={false}
                     onClick={[Function]}
                     tabIndex={0}
                     type="button"

--- a/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.js
+++ b/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.js
@@ -74,7 +74,7 @@ export const generateSampleValues = (series, timeDataSourceId, timeGrain = 'day'
  * @param {*} columns
  */
 export const generateTableSampleValues = (id, columns) => {
-  const sampleValues = Array(10).fill(1);
+  const sampleValues = Array(100).fill(1);
   return sampleValues.map((item, index) => ({
     id: `sample-values-${id}-${index}`,
     values: columns.reduce((obj, column) => {

--- a/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.test.js
+++ b/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.test.js
@@ -76,7 +76,7 @@ describe('timeSeriesUtils', () => {
       { dataSourceId: 'column2' },
       { dataSourceId: 'column3', type: 'TIMESTAMP' },
     ]);
-    expect(tableSampleValues).toHaveLength(10);
+    expect(tableSampleValues).toHaveLength(100);
     expect(every(tableSampleValues, 'id')).toEqual(true); // every row should have its own id
     expect(every(tableSampleValues, 'values')).toEqual(true); // every row should have its own values
     expect(tableSampleValues[0].values).toHaveProperty('column1');


### PR DESCRIPTION
Closes #

**Summary**

- There were two problems in using the TableCards in the DashboardEditor
- The first was that in certain instances a pageSize of 0 was being passed, which causes the Pagination component from carbon to cycle indefinitely.  Also there was a small bug where the whole table rows wouldn't render and there was whitespace underneath
- The second was that if the columns in the table changed, it would render duplicate columns due to a bug with the underlying Table where if you change the order and number of columns it renders duplicates

**Change List (commits, features, bugs, etc)**

- fix(TableCard): use key to throw away the table and rerender if the pageSize or the number of columns change.
- fix(TableCard): we can fit two more rows in the editable card, fix the numberOfRowsPerPage calculation
- fix(timeSeriesUtils): increase the generated number of rows to 100 so we can handle all the possible sizes of a table card

**Acceptance Test (how to verify the PR)**

- Verify the old TableCard stories
- Verify that if you add a TableCard through the DashboardEditor, and change the columns, it renders successfully with the correct columns. Make sure if you change the size of the TableCard, the new number of rows per page renders
