### PR TITLE
fix(datetimepicker): cant use multiple datetimepicker on same page #2085

### DIFF
--- a/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
@@ -18,6 +18,7 @@ import {
 import moment from 'moment';
 import { Calendar16 } from '@carbon/icons-react';
 import classnames from 'classnames';
+import uuid from 'uuid';
 
 import TimePickerSpinner from '../TimePickerSpinner/TimePickerSpinner';
 import { settings } from '../../constants/Settings';
@@ -172,7 +173,7 @@ const propTypes = {
   /** The language locale used to format the days of the week, months, and numbers. */
   locale: PropTypes.string,
   /** Unique id of the component */
-  id: PropTypes.string.isRequired,
+  id: PropTypes.string,
 };
 
 const defaultProps = {
@@ -256,6 +257,7 @@ const defaultProps = {
   },
   light: false,
   locale: 'en',
+  id: undefined,
 };
 
 const DateTimePicker = ({
@@ -275,7 +277,7 @@ const DateTimePicker = ({
   i18n,
   light,
   locale,
-  id,
+  id = uuid.v4(),
   ...others
 }) => {
   const strings = {

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
@@ -171,6 +171,8 @@ const propTypes = {
   light: PropTypes.bool,
   /** The language locale used to format the days of the week, months, and numbers. */
   locale: PropTypes.string,
+  /** Unique id of the component */
+  id: PropTypes.string.isRequired,
 };
 
 const defaultProps = {
@@ -273,6 +275,7 @@ const DateTimePicker = ({
   i18n,
   light,
   locale,
+  id,
   ...others
 }) => {
   const strings = {
@@ -325,10 +328,10 @@ const DateTimePicker = ({
         datePickerRef.current.cal.open();
         // while waiting for https://github.com/carbon-design-system/carbon/issues/5713
         // the only way to display the calendar inline is to reparent its DOM to our component
-        const wrapper = document.getElementById(`${iotPrefix}--date-time-picker__wrapper`);
+        const wrapper = document.getElementById(`${id}-${iotPrefix}--date-time-picker__wrapper`);
         if (typeof wrapper !== 'undefined' && wrapper !== null) {
           const dp = document
-            .getElementById(`${iotPrefix}--date-time-picker__wrapper`)
+            .getElementById(`${id}-${iotPrefix}--date-time-picker__wrapper`)
             .getElementsByClassName(`${iotPrefix}--date-time-picker__datepicker`)[0];
           dp.appendChild(datePickerRef.current.cal.calendarContainer);
         }
@@ -337,7 +340,7 @@ const DateTimePicker = ({
     return () => {
       clearTimeout(timeout);
     };
-  }, [datePickerRef]);
+  }, [datePickerRef, id]);
 
   /**
    * Parses a value object into a human readable value
@@ -695,7 +698,7 @@ const DateTimePicker = ({
   return (
     <div
       data-testid={testId}
-      id={`${iotPrefix}--date-time-picker__wrapper`}
+      id={`${id}-${iotPrefix}--date-time-picker__wrapper`}
       className={`${iotPrefix}--date-time-picker__wrapper`}
     >
       <div
@@ -778,16 +781,16 @@ const DateTimePicker = ({
                     <RadioButtonGroup
                       valueSelected={customRangeKind}
                       onChange={onCustomRangeChange}
-                      name="radiogroup"
+                      name={`${id}-radiogroup`}
                     >
                       <RadioButton
                         value={PICKER_KINDS.RELATIVE}
-                        id="relative"
+                        id={`${id}-relative`}
                         labelText={strings.relativeLabel}
                       />
                       <RadioButton
                         value={PICKER_KINDS.ABSOLUTE}
-                        id="absolute"
+                        id={`${id}-absolute`}
                         labelText={strings.absoluteLabel}
                       />
                     </RadioButtonGroup>
@@ -801,23 +804,23 @@ const DateTimePicker = ({
                     >
                       <div className={`${iotPrefix}--date-time-picker__fields-wrapper`}>
                         <NumberInput
-                          id="last-number"
+                          id={`${id}-last-number`}
                           invalidText={strings.invalidNumberLabel}
                           step={1}
                           min={0}
                           value={relativeValue ? relativeValue.lastNumber : 0}
                           onChange={onRelativeLastNumberChange}
-                          translateWithId={(id) =>
-                            id === 'increment.number'
+                          translateWithId={(messageId) =>
+                            messageId === 'increment.number'
                               ? `${i18n.increment} ${i18n.number}`
-                              : id === 'decrement.number'
+                              : messageId === 'decrement.number'
                               ? `${i18n.decrement} ${i18n.number}`
                               : null
                           }
                         />
                         <Select
                           {...others}
-                          id="last-interval"
+                          id={`${id}-last-interval`}
                           defaultValue={
                             relativeValue ? relativeValue.lastInterval : INTERVAL_VALUES.MINUTES
                           }
@@ -844,7 +847,7 @@ const DateTimePicker = ({
                         <Select
                           {...others}
                           ref={relativeSelect}
-                          id="relative-to-when"
+                          id={`${id}-relative-to-when`}
                           defaultValue={relativeValue ? relativeValue.relativeToWhen : ''}
                           onChange={onRelativeToWhenChange}
                           hideLabel
@@ -864,7 +867,7 @@ const DateTimePicker = ({
                         </Select>
                         {hasTimeInput ? (
                           <TimePickerSpinner
-                            id="relative-to-time"
+                            id={`${id}-relative-to-time`}
                             value={relativeValue ? relativeValue.relativeToTime : ''}
                             i18n={i18n}
                             onChange={onRelativeToTimeChange}
@@ -889,8 +892,16 @@ const DateTimePicker = ({
                         }
                         locale={locale}
                       >
-                        <DatePickerInput labelText="" id="date-picker-input-start" hideLabel />
-                        <DatePickerInput labelText="" id="date-picker-input-end" hideLabel />
+                        <DatePickerInput
+                          labelText=""
+                          id={`${id}-date-picker-input-start`}
+                          hideLabel
+                        />
+                        <DatePickerInput
+                          labelText=""
+                          id={`${id}-date-picker-input-end`}
+                          hideLabel
+                        />
                       </DatePicker>
                     </div>
                     {hasTimeInput ? (
@@ -900,7 +911,7 @@ const DateTimePicker = ({
                       >
                         <div className={`${iotPrefix}--date-time-picker__fields-wrapper`}>
                           <TimePickerSpinner
-                            id="start-time"
+                            id={`${id}-start-time`}
                             labelText={strings.startTimeLabel}
                             value={absoluteValue ? absoluteValue.startTime : '00:00'}
                             i18n={i18n}
@@ -909,7 +920,7 @@ const DateTimePicker = ({
                             autoComplete="off"
                           />
                           <TimePickerSpinner
-                            id="end-time"
+                            id={`${id}-end-time`}
                             labelText={strings.endTimeLabel}
                             value={absoluteValue ? absoluteValue.endTime : '00:00'}
                             i18n={i18n}

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.story.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.story.jsx
@@ -50,6 +50,7 @@ export const Default = () => {
       }}
     >
       <DateTimePicker
+        id="datetimepicker"
         dateTimeMask={text('dateTimeMask', 'YYYY-MM-DD HH:mm')}
         relatives={[
           {
@@ -73,6 +74,7 @@ export const SelectedPreset = () => {
       }}
     >
       <DateTimePicker
+        id="datetimepicker"
         defaultValue={{
           timeRangeKind: PICKER_KINDS.PRESET,
           timeRangeValue: PRESET_VALUES[3],
@@ -99,6 +101,7 @@ export const SelectedRelative = () => {
       }}
     >
       <DateTimePicker
+        id="datetimepicker"
         defaultValue={defaultRelativeValue}
         hasTimeInput={boolean('hasTimeInput', true)}
         onApply={action('onApply')}
@@ -122,6 +125,7 @@ export const SelectedAbsolute = () => {
       }}
     >
       <DateTimePicker
+        id="datetimepicker"
         defaultValue={defaultAbsoluteValue}
         hasTimeInput={boolean('hasTimeInput', true)}
         onApply={action('onApply')}
@@ -145,6 +149,7 @@ export const WithoutARelativeOption = () => {
       }}
     >
       <DateTimePicker
+        id="datetimepicker"
         defaultValue={{
           timeRangeKind: PICKER_KINDS.PRESET,
           timeRangeValue: PRESET_VALUES[3],
@@ -172,6 +177,7 @@ export const LightVersion = () => {
       }}
     >
       <DateTimePicker
+        id="datetimepicker"
         dateTimeMask={text('dateTimeMask', 'YYYY-MM-DD HH:mm')}
         relatives={[
           {

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
@@ -432,7 +432,9 @@ describe('DateTimePicker', () => {
       },
     ];
 
-    render(<DateTimePicker presets={presets} i18n={i18nTest} relatives={relatives} />);
+    render(
+      <DateTimePicker id="datetimepicker" presets={presets} i18n={i18nTest} relatives={relatives} />
+    );
     i18nTest.presetLabels.forEach((label) => {
       expect(screen.getAllByText(label)[0]).toBeInTheDocument();
     });

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
@@ -22,7 +22,6 @@ const defaultPresets = [
 ];
 
 const dateTimePickerProps = {
-  id: 'datetimepicker',
   onCancel: jest.fn(),
   onApply: jest.fn(),
 };

--- a/packages/react/src/components/DateTimePicker/__snapshots__/DateTimePicker.story.storyshot
+++ b/packages/react/src/components/DateTimePicker/__snapshots__/DateTimePicker.story.storyshot
@@ -23,7 +23,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
       <div
         className="iot--date-time-picker__wrapper"
         data-testid="date-time-picker"
-        id="iot--date-time-picker__wrapper"
+        id="datetimepicker-iot--date-time-picker__wrapper"
       >
         <div
           className="iot--date-time-picker__box "
@@ -203,7 +203,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
       <div
         className="iot--date-time-picker__wrapper"
         data-testid="date-time-picker"
-        id="iot--date-time-picker__wrapper"
+        id="datetimepicker-iot--date-time-picker__wrapper"
       >
         <div
           className="iot--date-time-picker__box iot--date-time-picker__box--light"
@@ -383,7 +383,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
       <div
         className="iot--date-time-picker__wrapper"
         data-testid="date-time-picker"
-        id="iot--date-time-picker__wrapper"
+        id="datetimepicker-iot--date-time-picker__wrapper"
       >
         <div
           className="iot--date-time-picker__box "
@@ -446,15 +446,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
                         <input
                           checked={false}
                           className="bx--radio-button"
-                          id="relative"
-                          name="radiogroup"
+                          id="datetimepicker-relative"
+                          name="datetimepicker-radiogroup"
                           onChange={[Function]}
                           type="radio"
                           value="RELATIVE"
                         />
                         <label
                           className="bx--radio-button__label"
-                          htmlFor="relative"
+                          htmlFor="datetimepicker-relative"
                         >
                           <span
                             className="bx--radio-button__appearance"
@@ -472,15 +472,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
                         <input
                           checked={true}
                           className="bx--radio-button"
-                          id="absolute"
-                          name="radiogroup"
+                          id="datetimepicker-absolute"
+                          name="datetimepicker-radiogroup"
                           onChange={[Function]}
                           type="radio"
                           value="ABSOLUTE"
                         />
                         <label
                           className="bx--radio-button__label"
-                          htmlFor="absolute"
+                          htmlFor="datetimepicker-absolute"
                         >
                           <span
                             className="bx--radio-button__appearance"
@@ -517,7 +517,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
                             <input
                               className="bx--date-picker__input"
                               disabled={false}
-                              id="date-picker-input-start"
+                              id="datetimepicker-date-picker-input-start"
                               onChange={[Function]}
                               onClick={[Function]}
                               pattern="\\\\d{1,2}\\\\/\\\\d{1,2}\\\\/\\\\d{4}"
@@ -551,7 +551,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
                             <input
                               className="bx--date-picker__input"
                               disabled={false}
-                              id="date-picker-input-end"
+                              id="datetimepicker-date-picker-input-end"
                               onChange={[Function]}
                               onClick={[Function]}
                               pattern="\\\\d{1,2}\\\\/\\\\d{1,2}\\\\/\\\\d{4}"
@@ -598,7 +598,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
                         >
                           <label
                             className="bx--label"
-                            htmlFor="start-time"
+                            htmlFor="datetimepicker-start-time"
                           >
                             Start time
                           </label>
@@ -612,7 +612,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
                                 autoComplete="off"
                                 className="bx--time-picker__input-field bx--text-input"
                                 disabled={false}
-                                id="start-time"
+                                id="datetimepicker-start-time"
                                 maxLength={5}
                                 onBlur={[Function]}
                                 onChange={[Function]}
@@ -700,7 +700,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
                         >
                           <label
                             className="bx--label"
-                            htmlFor="end-time"
+                            htmlFor="datetimepicker-end-time"
                           >
                             End time
                           </label>
@@ -714,7 +714,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
                                 autoComplete="off"
                                 className="bx--time-picker__input-field bx--text-input"
                                 disabled={false}
-                                id="end-time"
+                                id="datetimepicker-end-time"
                                 maxLength={5}
                                 onBlur={[Function]}
                                 onChange={[Function]}
@@ -875,7 +875,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
       <div
         className="iot--date-time-picker__wrapper"
         data-testid="date-time-picker"
-        id="iot--date-time-picker__wrapper"
+        id="datetimepicker-iot--date-time-picker__wrapper"
       >
         <div
           className="iot--date-time-picker__box "
@@ -1055,7 +1055,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
       <div
         className="iot--date-time-picker__wrapper"
         data-testid="date-time-picker"
-        id="iot--date-time-picker__wrapper"
+        id="datetimepicker-iot--date-time-picker__wrapper"
       >
         <div
           className="iot--date-time-picker__box "
@@ -1118,15 +1118,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
                         <input
                           checked={true}
                           className="bx--radio-button"
-                          id="relative"
-                          name="radiogroup"
+                          id="datetimepicker-relative"
+                          name="datetimepicker-radiogroup"
                           onChange={[Function]}
                           type="radio"
                           value="RELATIVE"
                         />
                         <label
                           className="bx--radio-button__label"
-                          htmlFor="relative"
+                          htmlFor="datetimepicker-relative"
                         >
                           <span
                             className="bx--radio-button__appearance"
@@ -1144,15 +1144,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
                         <input
                           checked={false}
                           className="bx--radio-button"
-                          id="absolute"
-                          name="radiogroup"
+                          id="datetimepicker-absolute"
+                          name="datetimepicker-radiogroup"
                           onChange={[Function]}
                           type="radio"
                           value="ABSOLUTE"
                         />
                         <label
                           className="bx--radio-button__label"
-                          htmlFor="absolute"
+                          htmlFor="datetimepicker-absolute"
                         >
                           <span
                             className="bx--radio-button__appearance"
@@ -1192,7 +1192,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
                               aria-describedby={null}
                               aria-label="Numeric input field with increment and decrement buttons"
                               disabled={false}
-                              id="last-number"
+                              id="datetimepicker-last-number"
                               min={0}
                               onChange={[Function]}
                               pattern="[0-9]*"
@@ -1267,7 +1267,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
                         >
                           <label
                             className="bx--label bx--visually-hidden"
-                            htmlFor="last-interval"
+                            htmlFor="datetimepicker-last-interval"
                           >
                             Select
                           </label>
@@ -1278,7 +1278,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
                             <select
                               className="bx--select-input"
                               defaultValue="MINUTES"
-                              id="last-interval"
+                              id="datetimepicker-last-interval"
                               onChange={[Function]}
                             >
                               <option
@@ -1369,7 +1369,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
                         >
                           <label
                             className="bx--label bx--visually-hidden"
-                            htmlFor="relative-to-when"
+                            htmlFor="datetimepicker-relative-to-when"
                           >
                             Select
                           </label>
@@ -1380,7 +1380,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
                             <select
                               className="bx--select-input"
                               defaultValue="TODAY"
-                              id="relative-to-when"
+                              id="datetimepicker-relative-to-when"
                               onChange={[Function]}
                             >
                               <option
@@ -1434,7 +1434,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
                                 autoComplete="off"
                                 className="bx--time-picker__input-field bx--text-input"
                                 disabled={false}
-                                id="relative-to-time"
+                                id="datetimepicker-relative-to-time"
                                 maxLength={5}
                                 onBlur={[Function]}
                                 onChange={[Function]}
@@ -1595,7 +1595,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/DateT
       <div
         className="iot--date-time-picker__wrapper"
         data-testid="date-time-picker"
-        id="iot--date-time-picker__wrapper"
+        id="datetimepicker-iot--date-time-picker__wrapper"
       >
         <div
           className="iot--date-time-picker__box "

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -5938,6 +5938,10 @@ Map {
         ],
         "type": "shape",
       },
+      "id": Object {
+        "isRequired": true,
+        "type": "string",
+      },
       "intervals": Object {
         "args": Array [
           Object {

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -5641,6 +5641,7 @@ Map {
         "toLabel": "to",
         "toNowLabel": "to Now",
       },
+      "id": undefined,
       "intervals": Array [
         Object {
           "label": "minutes",
@@ -5939,7 +5940,6 @@ Map {
         "type": "shape",
       },
       "id": Object {
-        "isRequired": true,
         "type": "string",
       },
       "intervals": Object {


### PR DESCRIPTION
Closes #2085 

**Summary**

- Fixes issues with using multiple DateTimePicker component on same page.

**Change List (commits, features, bugs, etc)**

- Added a new required prop "id". It is appended to all the hard coded ids to make them unique. This ensures that there are no duplicate ids if there's more than one DateTimePicker component on the same page.

**Acceptance Test (how to verify the PR)**

- Tested the fix in Health application
