### PR TITLE
fix(valuecard): fix positioning of icons and color of trending secondary values

### DIFF
--- a/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -123,7 +123,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        Comfort Level
+                        <span>
+                          Comfort Level
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -167,7 +169,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        Utilization
+                        <span>
+                          Utilization
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -211,7 +215,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        Pressure
+                        <span>
+                          Pressure
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -389,7 +395,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -482,7 +490,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -615,7 +625,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        Average
+                        <span>
+                          Average
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -710,7 +722,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        weekly
+                        <span>
+                          weekly
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -830,7 +844,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <svg
+                          aria-label="= Bad"
+                          fill="red"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          title="= Bad"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
+                          />
+                        </svg>
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -860,24 +892,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         >
                           
                         </span>
-                      </div>
-                      <div>
-                        <svg
-                          aria-label="= Bad"
-                          fill="red"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          title="= Bad"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
-                          />
-                        </svg>
                       </div>
                     </div>
                   </div>
@@ -941,7 +955,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -1211,7 +1227,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <svg
+                          aria-label="= Healthy"
+                          fill="green"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          title="= Healthy"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                          />
+                          <path
+                            d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                            data-icon-path="inner-path"
+                            opacity="0"
+                          />
+                        </svg>
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -1241,29 +1280,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         >
                           
                         </span>
-                      </div>
-                      <div>
-                        <svg
-                          aria-label="= Healthy"
-                          fill="green"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          title="= Healthy"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                          />
-                          <path
-                            d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                            data-icon-path="inner-path"
-                            opacity="0"
-                          />
-                        </svg>
                       </div>
                     </div>
                   </div>
@@ -2599,7 +2615,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        Comfort Level
+                        <span>
+                          Comfort Level
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -2643,7 +2661,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        Utilization
+                        <span>
+                          Utilization
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -2687,7 +2707,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        Pressure
+                        <span>
+                          Pressure
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -2865,7 +2887,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -2958,7 +2982,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -3091,7 +3117,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        Average
+                        <span>
+                          Average
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -3186,7 +3214,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        weekly
+                        <span>
+                          weekly
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -3306,7 +3336,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <svg
+                          aria-label="= Bad"
+                          fill="red"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          title="= Bad"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
+                          />
+                        </svg>
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -3336,24 +3384,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         >
                           
                         </span>
-                      </div>
-                      <div>
-                        <svg
-                          aria-label="= Bad"
-                          fill="red"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          title="= Bad"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
-                          />
-                        </svg>
                       </div>
                     </div>
                   </div>
@@ -3417,7 +3447,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -3687,7 +3719,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <svg
+                          aria-label="= Healthy"
+                          fill="green"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          title="= Healthy"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                          />
+                          <path
+                            d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                            data-icon-path="inner-path"
+                            opacity="0"
+                          />
+                        </svg>
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -3717,29 +3772,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         >
                           
                         </span>
-                      </div>
-                      <div>
-                        <svg
-                          aria-label="= Healthy"
-                          fill="green"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          title="= Healthy"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                          />
-                          <path
-                            d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                            data-icon-path="inner-path"
-                            opacity="0"
-                          />
-                        </svg>
                       </div>
                     </div>
                   </div>
@@ -5103,7 +5135,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        Comfort Level
+                        <span>
+                          Comfort Level
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -5147,7 +5181,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        Utilization
+                        <span>
+                          Utilization
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -5191,7 +5227,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        Pressure
+                        <span>
+                          Pressure
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -5369,7 +5407,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -5462,7 +5502,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -5595,7 +5637,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        Average
+                        <span>
+                          Average
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -5690,7 +5734,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        weekly
+                        <span>
+                          weekly
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -5810,7 +5856,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <svg
+                          aria-label="= Bad"
+                          fill="red"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          title="= Bad"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
+                          />
+                        </svg>
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -5840,24 +5904,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         >
                           
                         </span>
-                      </div>
-                      <div>
-                        <svg
-                          aria-label="= Bad"
-                          fill="red"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          title="= Bad"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
-                          />
-                        </svg>
                       </div>
                     </div>
                   </div>
@@ -5921,7 +5967,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -6191,7 +6239,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <svg
+                          aria-label="= Healthy"
+                          fill="green"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          title="= Healthy"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                          />
+                          <path
+                            d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                            data-icon-path="inner-path"
+                            opacity="0"
+                          />
+                        </svg>
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -6221,29 +6292,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         >
                           
                         </span>
-                      </div>
-                      <div>
-                        <svg
-                          aria-label="= Healthy"
-                          fill="green"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          title="= Healthy"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                          />
-                          <path
-                            d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                            data-icon-path="inner-path"
-                            opacity="0"
-                          />
-                        </svg>
                       </div>
                     </div>
                   </div>
@@ -10184,7 +10232,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        Comfort Level
+                        <span>
+                          Comfort Level
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -10228,7 +10278,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        Utilization
+                        <span>
+                          Utilization
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -10272,7 +10324,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        Pressure
+                        <span>
+                          Pressure
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -10450,7 +10504,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -10543,7 +10599,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -10676,7 +10734,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        Average
+                        <span>
+                          Average
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -10771,7 +10831,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        weekly
+                        <span>
+                          weekly
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -10891,7 +10953,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <svg
+                          aria-label="= Bad"
+                          fill="red"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          title="= Bad"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
+                          />
+                        </svg>
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -10921,24 +11001,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         >
                           
                         </span>
-                      </div>
-                      <div>
-                        <svg
-                          aria-label="= Bad"
-                          fill="red"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          title="= Bad"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
-                          />
-                        </svg>
                       </div>
                     </div>
                   </div>
@@ -11002,7 +11064,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -11272,7 +11336,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <svg
+                          aria-label="= Healthy"
+                          fill="green"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          title="= Healthy"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                          />
+                          <path
+                            d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                            data-icon-path="inner-path"
+                            opacity="0"
+                          />
+                        </svg>
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -11302,29 +11389,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         >
                           
                         </span>
-                      </div>
-                      <div>
-                        <svg
-                          aria-label="= Healthy"
-                          fill="green"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          title="= Healthy"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                          />
-                          <path
-                            d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                            data-icon-path="inner-path"
-                            opacity="0"
-                          />
-                        </svg>
                       </div>
                     </div>
                   </div>
@@ -12817,7 +12881,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -12905,7 +12971,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -12995,7 +13063,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -13085,7 +13155,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -13175,7 +13247,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -13367,7 +13441,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -13528,7 +13604,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -13616,7 +13694,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -13706,7 +13786,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -13796,7 +13878,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -13886,7 +13970,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -14078,7 +14164,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -14239,7 +14327,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -14330,7 +14420,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Weekly Avg
+                          <span>
+                            Weekly Avg
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -14421,7 +14513,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -14538,7 +14632,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Long label that might not fit
+                          <span>
+                            Long label that might not fit
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -14724,7 +14820,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -14815,7 +14913,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Weekly Avg
+                          <span>
+                            Weekly Avg
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -14906,7 +15006,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -15023,7 +15125,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Long label that might not fit
+                          <span>
+                            Long label that might not fit
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -15209,7 +15313,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <svg
+                            aria-label="< 40"
+                            fill="red"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="< 40"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
+                            />
+                          </svg>
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -15239,24 +15361,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                           >
                             %
                           </span>
-                        </div>
-                        <div>
-                          <svg
-                            aria-label="< 40"
-                            fill="red"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="< 40"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -15317,7 +15421,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <svg
+                            aria-label="< 70"
+                            fill="green"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="< 70"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                            />
+                            <path
+                              d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              data-icon-path="inner-path"
+                              opacity="0"
+                            />
+                          </svg>
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -15347,29 +15474,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                           >
                             %
                           </span>
-                        </div>
-                        <div>
-                          <svg
-                            aria-label="< 70"
-                            fill="green"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="< 70"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                            />
-                            <path
-                              d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                              data-icon-path="inner-path"
-                              opacity="0"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -15430,7 +15534,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <svg
+                            aria-label="< 80"
+                            fill="orange"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="< 80"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                            />
+                            <path
+                              d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                              data-icon-path="inner-path"
+                              fill="none"
+                            />
+                          </svg>
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -15460,29 +15587,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                           >
                             %
                           </span>
-                        </div>
-                        <div>
-                          <svg
-                            aria-label="< 80"
-                            fill="orange"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="< 80"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
-                            />
-                            <path
-                              d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
-                              data-icon-path="inner-path"
-                              fill="none"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -15543,7 +15647,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <svg
+                            aria-label=">= 90"
+                            fill="red"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title=">= 90"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
+                            />
+                          </svg>
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -15573,24 +15695,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                           >
                             %
                           </span>
-                        </div>
-                        <div>
-                          <svg
-                            aria-label=">= 90"
-                            fill="red"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title=">= 90"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -15720,7 +15824,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <svg
+                            aria-label="< 40"
+                            fill="red"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="< 40"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
+                            />
+                          </svg>
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -15750,24 +15872,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                           >
                             %
                           </span>
-                        </div>
-                        <div>
-                          <svg
-                            aria-label="< 40"
-                            fill="red"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="< 40"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -15828,7 +15932,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <svg
+                            aria-label="< 70"
+                            fill="green"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="< 70"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                            />
+                            <path
+                              d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              data-icon-path="inner-path"
+                              opacity="0"
+                            />
+                          </svg>
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -15858,29 +15985,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                           >
                             %
                           </span>
-                        </div>
-                        <div>
-                          <svg
-                            aria-label="< 70"
-                            fill="green"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="< 70"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                            />
-                            <path
-                              d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                              data-icon-path="inner-path"
-                              opacity="0"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -15941,7 +16045,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <svg
+                            aria-label="< 80"
+                            fill="orange"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="< 80"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                            />
+                            <path
+                              d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                              data-icon-path="inner-path"
+                              fill="none"
+                            />
+                          </svg>
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -15971,29 +16098,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                           >
                             %
                           </span>
-                        </div>
-                        <div>
-                          <svg
-                            aria-label="< 80"
-                            fill="orange"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="< 80"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
-                            />
-                            <path
-                              d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
-                              data-icon-path="inner-path"
-                              fill="none"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -16054,7 +16158,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <svg
+                            aria-label=">= 90"
+                            fill="red"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title=">= 90"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
+                            />
+                          </svg>
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -16084,24 +16206,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                           >
                             %
                           </span>
-                        </div>
-                        <div>
-                          <svg
-                            aria-label=">= 90"
-                            fill="red"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title=">= 90"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -16231,7 +16335,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -16321,7 +16427,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -16411,7 +16519,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -16501,7 +16611,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -16591,7 +16703,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -16750,7 +16864,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -16840,7 +16956,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -16930,7 +17048,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -17020,7 +17140,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -17110,7 +17232,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -17269,7 +17393,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -17357,7 +17483,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -17447,7 +17575,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -17537,7 +17667,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -17627,7 +17759,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -17717,7 +17851,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -17809,7 +17945,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -17901,7 +18039,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -17992,7 +18132,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Weekly Avg
+                          <span>
+                            Weekly Avg
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -18083,7 +18225,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -18200,7 +18344,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Long label that might not fit
+                          <span>
+                            Long label that might not fit
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -18317,7 +18463,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <svg
+                            aria-label="< 40"
+                            fill="red"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="< 40"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
+                            />
+                          </svg>
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -18347,24 +18511,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                           >
                             %
                           </span>
-                        </div>
-                        <div>
-                          <svg
-                            aria-label="< 40"
-                            fill="red"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="< 40"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -18425,7 +18571,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <svg
+                            aria-label="< 70"
+                            fill="green"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="< 70"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                            />
+                            <path
+                              d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              data-icon-path="inner-path"
+                              opacity="0"
+                            />
+                          </svg>
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -18455,29 +18624,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                           >
                             %
                           </span>
-                        </div>
-                        <div>
-                          <svg
-                            aria-label="< 70"
-                            fill="green"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="< 70"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                            />
-                            <path
-                              d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                              data-icon-path="inner-path"
-                              opacity="0"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -18538,7 +18684,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <svg
+                            aria-label="< 80"
+                            fill="orange"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="< 80"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                            />
+                            <path
+                              d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                              data-icon-path="inner-path"
+                              fill="none"
+                            />
+                          </svg>
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -18568,29 +18737,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                           >
                             %
                           </span>
-                        </div>
-                        <div>
-                          <svg
-                            aria-label="< 80"
-                            fill="orange"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="< 80"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
-                            />
-                            <path
-                              d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
-                              data-icon-path="inner-path"
-                              fill="none"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -18651,7 +18797,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <svg
+                            aria-label=">= 90"
+                            fill="red"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title=">= 90"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
+                            />
+                          </svg>
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -18681,24 +18845,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                           >
                             %
                           </span>
-                        </div>
-                        <div>
-                          <svg
-                            aria-label=">= 90"
-                            fill="red"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title=">= 90"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -18759,7 +18905,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -18849,7 +18997,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -18939,7 +19089,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -19029,7 +19181,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -19119,7 +19273,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -19278,7 +19434,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -19366,7 +19524,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -19456,7 +19616,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -19546,7 +19708,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -19636,7 +19800,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -19726,7 +19892,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -19818,7 +19986,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -19910,7 +20080,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -20001,7 +20173,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Weekly Avg
+                          <span>
+                            Weekly Avg
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -20092,7 +20266,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -20209,7 +20385,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Long label that might not fit
+                          <span>
+                            Long label that might not fit
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -20326,7 +20504,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <svg
+                            aria-label="< 40"
+                            fill="red"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="< 40"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
+                            />
+                          </svg>
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -20356,24 +20552,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                           >
                             %
                           </span>
-                        </div>
-                        <div>
-                          <svg
-                            aria-label="< 40"
-                            fill="red"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="< 40"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -20434,7 +20612,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <svg
+                            aria-label="< 70"
+                            fill="green"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="< 70"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                            />
+                            <path
+                              d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              data-icon-path="inner-path"
+                              opacity="0"
+                            />
+                          </svg>
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -20464,29 +20665,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                           >
                             %
                           </span>
-                        </div>
-                        <div>
-                          <svg
-                            aria-label="< 70"
-                            fill="green"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="< 70"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                            />
-                            <path
-                              d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                              data-icon-path="inner-path"
-                              opacity="0"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -20547,7 +20725,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <svg
+                            aria-label="< 80"
+                            fill="orange"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="< 80"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                            />
+                            <path
+                              d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                              data-icon-path="inner-path"
+                              fill="none"
+                            />
+                          </svg>
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -20577,29 +20778,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                           >
                             %
                           </span>
-                        </div>
-                        <div>
-                          <svg
-                            aria-label="< 80"
-                            fill="orange"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="< 80"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
-                            />
-                            <path
-                              d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
-                              data-icon-path="inner-path"
-                              fill="none"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -20660,7 +20838,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <svg
+                            aria-label=">= 90"
+                            fill="red"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title=">= 90"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
+                            />
+                          </svg>
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -20690,24 +20886,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                           >
                             %
                           </span>
-                        </div>
-                        <div>
-                          <svg
-                            aria-label=">= 90"
-                            fill="red"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title=">= 90"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -20768,7 +20946,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -20858,7 +21038,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -20948,7 +21130,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -21038,7 +21222,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -21128,7 +21314,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       >
                         <div
                           className="iot--value-card__attribute-label"
-                        />
+                        >
+                          <span />
+                        </div>
                         <div
                           className="iot--value-card__attribute"
                         >
@@ -21288,7 +21476,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Comfort Level
+                          <span>
+                            Comfort Level
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -21332,7 +21522,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Pressure
+                          <span>
+                            Pressure
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -21424,7 +21616,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Temperature
+                          <span>
+                            Temperature
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -21468,7 +21662,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Danger Level
+                          <span>
+                            Danger Level
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -21558,7 +21754,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Temperature
+                          <span>
+                            Temperature
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -21602,7 +21800,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Foot Traffic
+                          <span>
+                            Foot Traffic
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -21763,7 +21963,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Comfort Level
+                          <span>
+                            Comfort Level
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -21807,7 +22009,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Pressure
+                          <span>
+                            Pressure
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -21899,7 +22103,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Temperature
+                          <span>
+                            Temperature
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -21943,7 +22149,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Danger Level
+                          <span>
+                            Danger Level
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -22033,7 +22241,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Temperature
+                          <span>
+                            Temperature
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -22077,7 +22287,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Foot Traffic
+                          <span>
+                            Foot Traffic
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -22238,7 +22450,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Comfort Level
+                          <span>
+                            Comfort Level
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -22308,7 +22522,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Pressure
+                          <span>
+                            Pressure
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -22426,7 +22642,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Temperature
+                          <span>
+                            Temperature
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -22496,7 +22714,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Danger Level
+                          <span>
+                            Danger Level
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -22586,7 +22806,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Temperature
+                          <span>
+                            Temperature
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -22655,7 +22877,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Foot Traffic
+                          <span>
+                            Foot Traffic
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -22842,7 +23066,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Comfort Level
+                          <span>
+                            Comfort Level
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -22912,7 +23138,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Pressure
+                          <span>
+                            Pressure
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -23030,7 +23258,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Temperature
+                          <span>
+                            Temperature
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -23100,7 +23330,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Danger Level
+                          <span>
+                            Danger Level
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -23190,7 +23422,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Temperature
+                          <span>
+                            Temperature
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -23259,7 +23493,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Foot Traffic
+                          <span>
+                            Foot Traffic
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -23446,7 +23682,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Average
+                          <svg
+                            aria-label="< 40"
+                            fill="red"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="< 40"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
+                            />
+                          </svg>
+                          <span>
+                            Average
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -23478,24 +23732,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                             %
                           </span>
                         </div>
-                        <div>
-                          <svg
-                            aria-label="< 40"
-                            fill="red"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="< 40"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
-                            />
-                          </svg>
-                        </div>
                       </div>
                       <div
                         className="iot--value-card__attribute-wrapper iot--value-card__attribute-wrapper--horizontal"
@@ -23508,7 +23744,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Max
+                          <svg
+                            aria-label="< 70"
+                            fill="green"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="< 70"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                            />
+                            <path
+                              d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              data-icon-path="inner-path"
+                              opacity="0"
+                            />
+                          </svg>
+                          <span>
+                            Max
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -23539,29 +23798,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                           >
                             %
                           </span>
-                        </div>
-                        <div>
-                          <svg
-                            aria-label="< 70"
-                            fill="green"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="< 70"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                            />
-                            <path
-                              d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                              data-icon-path="inner-path"
-                              opacity="0"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -23623,7 +23859,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Average
+                          <svg
+                            aria-label="< 80"
+                            fill="orange"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="< 80"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                            />
+                            <path
+                              d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                              data-icon-path="inner-path"
+                              fill="none"
+                            />
+                          </svg>
+                          <span>
+                            Average
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -23655,29 +23914,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                             ˚F
                           </span>
                         </div>
-                        <div>
-                          <svg
-                            aria-label="< 80"
-                            fill="orange"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="< 80"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
-                            />
-                            <path
-                              d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
-                              data-icon-path="inner-path"
-                              fill="none"
-                            />
-                          </svg>
-                        </div>
                       </div>
                       <div
                         className="iot--value-card__attribute-wrapper iot--value-card__attribute-wrapper--horizontal"
@@ -23690,7 +23926,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Max
+                          <svg
+                            aria-label=">= 90"
+                            fill="red"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title=">= 90"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
+                            />
+                          </svg>
+                          <span>
+                            Max
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -23721,24 +23975,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                           >
                             ˚F
                           </span>
-                        </div>
-                        <div>
-                          <svg
-                            aria-label=">= 90"
-                            fill="red"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title=">= 90"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -23869,7 +24105,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Average
+                          <svg
+                            aria-label="< 40"
+                            fill="red"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="< 40"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
+                            />
+                          </svg>
+                          <span>
+                            Average
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -23901,24 +24155,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                             %
                           </span>
                         </div>
-                        <div>
-                          <svg
-                            aria-label="< 40"
-                            fill="red"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="< 40"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
-                            />
-                          </svg>
-                        </div>
                       </div>
                       <div
                         className="iot--value-card__attribute-wrapper iot--value-card__attribute-wrapper--horizontal"
@@ -23931,7 +24167,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Max
+                          <svg
+                            aria-label="< 70"
+                            fill="green"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="< 70"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                            />
+                            <path
+                              d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              data-icon-path="inner-path"
+                              opacity="0"
+                            />
+                          </svg>
+                          <span>
+                            Max
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -23962,29 +24221,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                           >
                             %
                           </span>
-                        </div>
-                        <div>
-                          <svg
-                            aria-label="< 70"
-                            fill="green"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="< 70"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                            />
-                            <path
-                              d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                              data-icon-path="inner-path"
-                              opacity="0"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -24046,7 +24282,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Average
+                          <svg
+                            aria-label="< 80"
+                            fill="orange"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="< 80"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                            />
+                            <path
+                              d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                              data-icon-path="inner-path"
+                              fill="none"
+                            />
+                          </svg>
+                          <span>
+                            Average
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -24078,29 +24337,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                             ˚F
                           </span>
                         </div>
-                        <div>
-                          <svg
-                            aria-label="< 80"
-                            fill="orange"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="< 80"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
-                            />
-                            <path
-                              d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
-                              data-icon-path="inner-path"
-                              fill="none"
-                            />
-                          </svg>
-                        </div>
                       </div>
                       <div
                         className="iot--value-card__attribute-wrapper iot--value-card__attribute-wrapper--horizontal"
@@ -24113,7 +24349,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Max
+                          <svg
+                            aria-label=">= 90"
+                            fill="red"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title=">= 90"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
+                            />
+                          </svg>
+                          <span>
+                            Max
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -24144,24 +24398,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                           >
                             ˚F
                           </span>
-                        </div>
-                        <div>
-                          <svg
-                            aria-label=">= 90"
-                            fill="red"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title=">= 90"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -24292,7 +24528,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          YTD
+                          <span>
+                            YTD
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -24336,7 +24574,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          MTD
+                          <span>
+                            MTD
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -24406,7 +24646,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Last Week
+                          <span>
+                            Last Week
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -24524,7 +24766,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Current
+                          <span>
+                            Current
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -24566,7 +24810,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Last Week
+                          <span>
+                            Last Week
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -24608,7 +24854,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Last Month
+                          <span>
+                            Last Month
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -24698,7 +24946,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Current
+                          <svg
+                            aria-label="= Low"
+                            fill="green"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="= Low"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                            />
+                            <path
+                              d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              data-icon-path="inner-path"
+                              opacity="0"
+                            />
+                          </svg>
+                          <span>
+                            Current
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -24728,29 +24999,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                             }
                           />
                         </div>
-                        <div>
-                          <svg
-                            aria-label="= Low"
-                            fill="green"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="= Low"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                            />
-                            <path
-                              d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                              data-icon-path="inner-path"
-                              opacity="0"
-                            />
-                          </svg>
-                        </div>
                       </div>
                       <div
                         className="iot--value-card__attribute-wrapper iot--value-card__attribute-wrapper--vertical"
@@ -24763,7 +25011,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Last Week
+                          <svg
+                            aria-label="= Severe"
+                            fill="red"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="= Severe"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
+                            />
+                          </svg>
+                          <span>
+                            Last Week
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -24793,24 +25059,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                             }
                           />
                         </div>
-                        <div>
-                          <svg
-                            aria-label="= Severe"
-                            fill="red"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="= Severe"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
-                            />
-                          </svg>
-                        </div>
                       </div>
                       <div
                         className="iot--value-card__attribute-wrapper iot--value-card__attribute-wrapper--vertical"
@@ -24823,7 +25071,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Last Month
+                          <svg
+                            aria-label="= Elevated"
+                            fill="gold"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="= Elevated"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                            />
+                            <path
+                              d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                              data-icon-path="inner-path"
+                              fill="none"
+                            />
+                          </svg>
+                          <span>
+                            Last Month
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -24852,29 +25123,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                               }
                             }
                           />
-                        </div>
-                        <div>
-                          <svg
-                            aria-label="= Elevated"
-                            fill="gold"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="= Elevated"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
-                            />
-                            <path
-                              d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
-                              data-icon-path="inner-path"
-                              fill="none"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -25005,7 +25253,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          YTD
+                          <span>
+                            YTD
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -25049,7 +25299,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          MTD
+                          <span>
+                            MTD
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -25119,7 +25371,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Last Week
+                          <span>
+                            Last Week
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -25237,7 +25491,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Current
+                          <span>
+                            Current
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -25279,7 +25535,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Last Week
+                          <span>
+                            Last Week
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -25321,7 +25579,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Last Month
+                          <span>
+                            Last Month
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -25411,7 +25671,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Current
+                          <svg
+                            aria-label="= Low"
+                            fill="green"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="= Low"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                            />
+                            <path
+                              d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              data-icon-path="inner-path"
+                              opacity="0"
+                            />
+                          </svg>
+                          <span>
+                            Current
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -25441,29 +25724,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                             }
                           />
                         </div>
-                        <div>
-                          <svg
-                            aria-label="= Low"
-                            fill="green"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="= Low"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                            />
-                            <path
-                              d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                              data-icon-path="inner-path"
-                              opacity="0"
-                            />
-                          </svg>
-                        </div>
                       </div>
                       <div
                         className="iot--value-card__attribute-wrapper iot--value-card__attribute-wrapper--vertical"
@@ -25476,7 +25736,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Last Week
+                          <svg
+                            aria-label="= Severe"
+                            fill="red"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="= Severe"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
+                            />
+                          </svg>
+                          <span>
+                            Last Week
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -25506,24 +25784,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                             }
                           />
                         </div>
-                        <div>
-                          <svg
-                            aria-label="= Severe"
-                            fill="red"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="= Severe"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
-                            />
-                          </svg>
-                        </div>
                       </div>
                       <div
                         className="iot--value-card__attribute-wrapper iot--value-card__attribute-wrapper--vertical"
@@ -25536,7 +25796,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         <div
                           className="iot--value-card__attribute-label"
                         >
-                          Last Month
+                          <svg
+                            aria-label="= Elevated"
+                            fill="gold"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            title="= Elevated"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                            />
+                            <path
+                              d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                              data-icon-path="inner-path"
+                              fill="none"
+                            />
+                          </svg>
+                          <span>
+                            Last Month
+                          </span>
                         </div>
                         <div
                           className="iot--value-card__attribute"
@@ -25565,29 +25848,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                               }
                             }
                           />
-                        </div>
-                        <div>
-                          <svg
-                            aria-label="= Elevated"
-                            fill="gold"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            title="= Elevated"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
-                            />
-                            <path
-                              d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
-                              data-icon-path="inner-path"
-                              fill="none"
-                            />
-                          </svg>
                         </div>
                       </div>
                     </div>
@@ -25781,7 +26041,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        Comfort Level
+                        <span>
+                          Comfort Level
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -25825,7 +26087,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        Utilization
+                        <span>
+                          Utilization
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -25869,7 +26133,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        Pressure
+                        <span>
+                          Pressure
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -26047,7 +26313,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -26140,7 +26408,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -26273,7 +26543,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        Average
+                        <span>
+                          Average
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -26368,7 +26640,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                       <div
                         className="iot--value-card__attribute-label"
                       >
-                        weekly
+                        <span>
+                          weekly
+                        </span>
                       </div>
                       <div
                         className="iot--value-card__attribute"
@@ -26488,7 +26762,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <svg
+                          aria-label="= Bad"
+                          fill="red"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          title="= Bad"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
+                          />
+                        </svg>
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -26518,24 +26810,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         >
                           
                         </span>
-                      </div>
-                      <div>
-                        <svg
-                          aria-label="= Bad"
-                          fill="red"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          title="= Bad"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
-                          />
-                        </svg>
                       </div>
                     </div>
                   </div>
@@ -26599,7 +26873,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -26869,7 +27145,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     >
                       <div
                         className="iot--value-card__attribute-label"
-                      />
+                      >
+                        <svg
+                          aria-label="= Healthy"
+                          fill="green"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          title="= Healthy"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                          />
+                          <path
+                            d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                            data-icon-path="inner-path"
+                            opacity="0"
+                          />
+                        </svg>
+                        <span />
+                      </div>
                       <div
                         className="iot--value-card__attribute"
                       >
@@ -26899,29 +27198,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                         >
                           
                         </span>
-                      </div>
-                      <div>
-                        <svg
-                          aria-label="= Healthy"
-                          fill="green"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          title="= Healthy"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                          />
-                          <path
-                            d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                            data-icon-path="inner-path"
-                            opacity="0"
-                          />
-                        </svg>
                       </div>
                     </div>
                   </div>

--- a/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
@@ -709,7 +709,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                 >
                   <div
                     className="iot--value-card__attribute-label"
-                  />
+                  >
+                    <span />
+                  </div>
                   <div
                     className="iot--value-card__attribute"
                   >

--- a/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -1845,7 +1845,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                             <div
                               className="iot--value-card__attribute-label"
                             >
-                              Torque Min
+                              <span>
+                                Torque Min
+                              </span>
                             </div>
                             <div
                               className="iot--value-card__attribute"
@@ -3571,7 +3573,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                           <div
                             className="iot--value-card__attribute-label"
                           >
-                            Key 1
+                            <span>
+                              Key 1
+                            </span>
                           </div>
                           <div
                             className="iot--value-card__attribute"
@@ -3615,7 +3619,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                           <div
                             className="iot--value-card__attribute-label"
                           >
-                            Key 2
+                            <span>
+                              Key 2
+                            </span>
                           </div>
                           <div
                             className="iot--value-card__attribute"
@@ -14594,7 +14600,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                           <div
                             className="iot--value-card__attribute-label"
                           >
-                            Torque
+                            <span>
+                              Torque
+                            </span>
                           </div>
                           <div
                             className="iot--value-card__attribute"
@@ -14638,7 +14646,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                           <div
                             className="iot--value-card__attribute-label"
                           >
-                            Pressure
+                            <span>
+                              Pressure
+                            </span>
                           </div>
                           <div
                             className="iot--value-card__attribute"

--- a/packages/react/src/components/RuleBuilder/RuleBuilder.story.jsx
+++ b/packages/react/src/components/RuleBuilder/RuleBuilder.story.jsx
@@ -2,11 +2,18 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { Star16, Share16, TrashCan16 } from '@carbon/icons-react';
 
+import StoryNotice, { experimentalStoryTitle } from '../../internal/StoryNotice';
+
 import RuleBuilder from './RuleBuilder';
 import { columns, TEST_TREE_DATA } from './RuleBuilderEditor.story';
 
+export const Experimental = () => <StoryNotice componentName="RuleBuilder" experimental />;
+Experimental.story = {
+  name: experimentalStoryTitle,
+};
+
 export default {
-  title: 'Watson IoT Experimental/RuleBuilder',
+  title: 'Watson IoT Experimental/☢️ RuleBuilder',
   parameters: {
     component: RuleBuilder,
   },

--- a/packages/react/src/components/RuleBuilder/RuleBuilderEditor.story.jsx
+++ b/packages/react/src/components/RuleBuilder/RuleBuilderEditor.story.jsx
@@ -3,14 +3,7 @@ import { withKnobs } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { DatePicker, DatePickerInput, NumberInput } from 'carbon-components-react';
 
-import StoryNotice, { experimentalStoryTitle } from '../../internal/StoryNotice';
-
 import RuleBuilderEditor from './RuleBuilderEditor';
-
-export const Experimental = () => <StoryNotice componentName="RuleBuilder" experimental />;
-Experimental.story = {
-  name: experimentalStoryTitle,
-};
 
 export const columns = [
   { id: 'column1', name: 'Column 1' },
@@ -194,7 +187,7 @@ RuleBuilderCustomOperandsAndFieldRenderer.story = {
 };
 
 export default {
-  title: 'Watson IoT Experimental/☢️ RuleBuilder',
+  title: 'Watson IoT Experimental/☢️ RuleBuilder/RuleBuilderEditor',
   decorators: [withKnobs],
 
   parameters: {

--- a/packages/react/src/components/RuleBuilder/__snapshots__/RuleBuilder.story.storyshot
+++ b/packages/react/src/components/RuleBuilder/__snapshots__/RuleBuilder.story.storyshot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/RuleBuilder new filter 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/☢️ RuleBuilder new filter 1`] = `
 <div
   className="storybook-container"
 >
@@ -1996,7 +1996,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/RuleBuilder with existing filter rules 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/☢️ RuleBuilder with existing filter rules 1`] = `
 <div
   className="storybook-container"
 >
@@ -6422,6 +6422,106 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           </div>
         </div>
       </section>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/☢️ RuleBuilder ️⚠️ Experimental Notice  1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--toast-notification bx--toast-notification--warning-alt"
+      kind="warning-alt"
+      role="alert"
+      style={
+        Object {
+          "marginBottom": "0.5rem",
+          "minWidth": "30rem",
+        }
+      }
+    >
+      <svg
+        aria-hidden={true}
+        className="bx--toast-notification__icon"
+        fill="currentColor"
+        focusable="false"
+        height={20}
+        preserveAspectRatio="xMidYMid meet"
+        viewBox="0 0 32 32"
+        width={20}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+        />
+        <path
+          d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+          data-icon-path="inner-path"
+          fill="none"
+        />
+        <title>
+          warning-alt icon
+        </title>
+      </svg>
+      <div
+        className="bx--toast-notification__details"
+      >
+        <h3
+          className="bx--toast-notification__title"
+        >
+          Experimental Component Notice
+        </h3>
+        <div
+          className="bx--toast-notification__subtitle"
+        >
+          <span>
+            RuleBuilder
+             is an
+            <a
+              href="https://github.com/carbon-design-system/carbon-addons-iot-react/blob/next/packages/react/docs/guides/experimental-components.md"
+            >
+              experimental component
+            </a>
+            and may have changing APIs with no major version bump and/or insufficient test coverage. Use of this component in production is discouraged.
+          </span>
+        </div>
+        <div
+          className="bx--toast-notification__caption"
+        />
+      </div>
     </div>
   </div>
   <button

--- a/packages/react/src/components/RuleBuilder/__snapshots__/RuleBuilderEditor.story.storyshot
+++ b/packages/react/src/components/RuleBuilder/__snapshots__/RuleBuilderEditor.story.storyshot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/☢️ RuleBuilder with a deeply nested rule tree 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/☢️ RuleBuilder/RuleBuilderEditor with a deeply nested rule tree 1`] = `
 <div
   className="storybook-container"
 >
@@ -2198,7 +2198,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/☢️ RuleBuilder with an empty tree 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/☢️ RuleBuilder/RuleBuilderEditor with an empty tree 1`] = `
 <div
   className="storybook-container"
 >
@@ -2629,7 +2629,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/☢️ RuleBuilder with custom column operands and field renderers 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/☢️ RuleBuilder/RuleBuilderEditor with custom column operands and field renderers 1`] = `
 <div
   className="storybook-container"
 >
@@ -3031,106 +3031,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
             </svg>
           </button>
         </div>
-      </div>
-    </div>
-  </div>
-  <button
-    className="info__show-button"
-    onClick={[Function]}
-    style={
-      Object {
-        "background": "#027ac5",
-        "border": "none",
-        "borderRadius": "0 0 0 5px",
-        "color": "#fff",
-        "cursor": "pointer",
-        "display": "block",
-        "fontFamily": "sans-serif",
-        "fontSize": 12,
-        "padding": "5px 15px",
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
-    type="button"
-  >
-    Show Info
-  </button>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/☢️ RuleBuilder ️⚠️ Experimental Notice  1`] = `
-<div
-  className="storybook-container"
->
-  <div
-    style={
-      Object {
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    <div
-      className="bx--toast-notification bx--toast-notification--warning-alt"
-      kind="warning-alt"
-      role="alert"
-      style={
-        Object {
-          "marginBottom": "0.5rem",
-          "minWidth": "30rem",
-        }
-      }
-    >
-      <svg
-        aria-hidden={true}
-        className="bx--toast-notification__icon"
-        fill="currentColor"
-        focusable="false"
-        height={20}
-        preserveAspectRatio="xMidYMid meet"
-        viewBox="0 0 32 32"
-        width={20}
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
-        />
-        <path
-          d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
-          data-icon-path="inner-path"
-          fill="none"
-        />
-        <title>
-          warning-alt icon
-        </title>
-      </svg>
-      <div
-        className="bx--toast-notification__details"
-      >
-        <h3
-          className="bx--toast-notification__title"
-        >
-          Experimental Component Notice
-        </h3>
-        <div
-          className="bx--toast-notification__subtitle"
-        >
-          <span>
-            RuleBuilder
-             is an
-            <a
-              href="https://github.com/carbon-design-system/carbon-addons-iot-react/blob/next/packages/react/docs/guides/experimental-components.md"
-            >
-              experimental component
-            </a>
-            and may have changing APIs with no major version bump and/or insufficient test coverage. Use of this component in production is discouraged.
-          </span>
-        </div>
-        <div
-          className="bx--toast-notification__caption"
-        />
       </div>
     </div>
   </div>

--- a/packages/react/src/components/ValueCard/Attribute.jsx
+++ b/packages/react/src/components/ValueCard/Attribute.jsx
@@ -117,7 +117,21 @@ const Attribute = ({
           '--value-card-attribute-width': `${attributeWidthPercentage}%`,
         }}
       >
-        <div className={`${BEM_BASE}-label`}>{label}</div>
+        <div className={`${BEM_BASE}-label`}>
+          {matchingThreshold?.icon ? (
+            <CardIcon
+              fill={matchingThreshold.color}
+              color={matchingThreshold.color}
+              width={16}
+              height={16}
+              title={`${matchingThreshold.comparison} ${matchingThreshold.value}`}
+              renderIconByName={renderIconByName}
+              icon={matchingThreshold.icon}
+            />
+          ) : null}
+          <span>{label}</span>
+        </div>
+
         <div className={`${BEM_BASE}`}>
           <ValueRenderer
             value={value}
@@ -144,19 +158,6 @@ const Attribute = ({
               <CaretDown16 className={`${BEM_BASE}_trend-icon`} aria-label="trending down" />
             ) : null}
             {secondaryValue.value}
-          </div>
-        ) : null}
-        {matchingThreshold?.icon ? (
-          <div>
-            <CardIcon
-              fill={matchingThreshold.color}
-              color={matchingThreshold.color}
-              width={16}
-              height={16}
-              title={`${matchingThreshold.comparison} ${matchingThreshold.value}`}
-              renderIconByName={renderIconByName}
-              icon={matchingThreshold.icon}
-            />
           </div>
         ) : null}
       </div>

--- a/packages/react/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/packages/react/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -993,7 +993,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Comfort Level
+                <span>
+                  Comfort Level
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -1037,7 +1039,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Average Temperature
+                <span>
+                  Average Temperature
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -1081,7 +1085,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Utilization
+                <span>
+                  Utilization
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -1125,7 +1131,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Humidity
+                <span>
+                  Humidity
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -1169,7 +1177,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Air Flow
+                <span>
+                  Air Flow
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -1300,7 +1310,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Comfort Level
+                <span>
+                  Comfort Level
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -1344,7 +1356,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Average Temperature
+                <span>
+                  Average Temperature
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -1388,7 +1402,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Utilization
+                <span>
+                  Utilization
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -1432,7 +1448,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                CPU
+                <span>
+                  CPU
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -1476,7 +1494,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Humidity
+                <span>
+                  Humidity
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -1520,7 +1540,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Location
+                <span>
+                  Location
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -1564,7 +1586,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Air quality
+                <span>
+                  Air quality
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -1694,7 +1718,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
             >
               <div
                 className="iot--value-card__attribute-label"
-              />
+              >
+                <span />
+              </div>
               <div
                 className="iot--value-card__attribute"
               >
@@ -1824,7 +1850,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Comfort Level
+                <span>
+                  Comfort Level
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -1955,7 +1983,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Comfort Level
+                <span>
+                  Comfort Level
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -1999,7 +2029,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Average Temperature
+                <span>
+                  Average Temperature
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -2130,7 +2162,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Comfort Level
+                <span>
+                  Comfort Level
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -2174,7 +2208,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Average Temperature
+                <span>
+                  Average Temperature
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -2218,7 +2254,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Utilization
+                <span>
+                  Utilization
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -2349,7 +2387,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Comfort Level
+                <svg
+                  aria-label="> 80"
+                  fill="#F00"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  title="> 80"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                  />
+                  <path
+                    d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
+                    data-icon-path="inner-path"
+                    fill="none"
+                  />
+                </svg>
+                <span>
+                  Comfort Level
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -2381,7 +2442,18 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   %
                 </span>
               </div>
-              <div>
+            </div>
+            <div
+              className="iot--value-card__attribute-wrapper iot--value-card__attribute-wrapper--vertical"
+              style={
+                Object {
+                  "--value-card-attribute-width": "100%",
+                }
+              }
+            >
+              <div
+                className="iot--value-card__attribute-label"
+              >
                 <svg
                   aria-label="> 80"
                   fill="#F00"
@@ -2403,20 +2475,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                     fill="none"
                   />
                 </svg>
-              </div>
-            </div>
-            <div
-              className="iot--value-card__attribute-wrapper iot--value-card__attribute-wrapper--vertical"
-              style={
-                Object {
-                  "--value-card-attribute-width": "100%",
-                }
-              }
-            >
-              <div
-                className="iot--value-card__attribute-label"
-              >
-                Average Temperature
+                <span>
+                  Average Temperature
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -2448,7 +2509,18 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   ˚F
                 </span>
               </div>
-              <div>
+            </div>
+            <div
+              className="iot--value-card__attribute-wrapper iot--value-card__attribute-wrapper--vertical"
+              style={
+                Object {
+                  "--value-card-attribute-width": "100%",
+                }
+              }
+            >
+              <div
+                className="iot--value-card__attribute-label"
+              >
                 <svg
                   aria-label="> 80"
                   fill="#F00"
@@ -2470,20 +2542,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                     fill="none"
                   />
                 </svg>
-              </div>
-            </div>
-            <div
-              className="iot--value-card__attribute-wrapper iot--value-card__attribute-wrapper--vertical"
-              style={
-                Object {
-                  "--value-card-attribute-width": "100%",
-                }
-              }
-            >
-              <div
-                className="iot--value-card__attribute-label"
-              >
-                Humidity
+                <span>
+                  Humidity
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -2514,29 +2575,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                 >
                   ˚F
                 </span>
-              </div>
-              <div>
-                <svg
-                  aria-label="> 80"
-                  fill="#F00"
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  role="img"
-                  title="> 80"
-                  viewBox="0 0 32 32"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M29.879,27.5212l-13-25.0363a1.04,1.04,0,0,0-1.7583,0l-13,25.0363A1.0015,1.0015,0,0,0,3,29H29a1.001,1.001,0,0,0,.8789-1.4788ZM14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
-                  />
-                  <path
-                    d="M14.8751,10.0086h2.25V20h-2.25ZM16,26a1.5,1.5,0,1,1,1.5-1.5A1.5,1.5,0,0,1,16,26Z"
-                    data-icon-path="inner-path"
-                    fill="none"
-                  />
-                </svg>
               </div>
             </div>
           </div>
@@ -2637,7 +2675,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Comfort Level
+                <span>
+                  Comfort Level
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -2681,7 +2721,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Average Temperature
+                <span>
+                  Average Temperature
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -2725,7 +2767,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Utilization
+                <span>
+                  Utilization
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -2856,7 +2900,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Tagpath
+                <span>
+                  Tagpath
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -2986,7 +3032,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
             >
               <div
                 className="iot--value-card__attribute-label"
-              />
+              >
+                <span />
+              </div>
               <div
                 className="iot--value-card__attribute"
               >
@@ -3115,7 +3163,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
             >
               <div
                 className="iot--value-card__attribute-label"
-              />
+              >
+                <span />
+              </div>
               <div
                 className="iot--value-card__attribute"
               >
@@ -3244,7 +3294,28 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
             >
               <div
                 className="iot--value-card__attribute-label"
-              />
+              >
+                <svg
+                  fill="green"
+                  focusable="true"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  tabIndex="0"
+                  title="< 5"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M16 10a6 6 0 00-6 6v8a6 6 0 0012 0V16A6 6 0 0016 10zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0111.75 24v-.13h8.5V24A4.27 4.27 0 0116 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 018.5 0zM30.66 19.21L24 13v9.1a4 4 0 008 0A3.83 3.83 0 0030.66 19.21zM28 24.35a2.25 2.25 0 01-2.25-2.25V17l3.72 3.47h0A2.05 2.05 0 0130.2 22 2.25 2.25 0 0128 24.35zM0 22.1a4 4 0 008 0V13L1.34 19.21A3.88 3.88 0 000 22.1zm2.48-1.56h0L6.25 17v5.1a2.25 2.25 0 01-4.5 0A2.05 2.05 0 012.48 20.54zM15 5.5A3.5 3.5 0 1011.5 9 3.5 3.5 0 0015 5.5zm-5.25 0A1.75 1.75 0 1111.5 7.25 1.77 1.77 0 019.75 5.5zM20.5 2A3.5 3.5 0 1024 5.5 3.5 3.5 0 0020.5 2zm0 5.25A1.75 1.75 0 1122.25 5.5 1.77 1.77 0 0120.5 7.25z"
+                  />
+                  <title>
+                    &lt; 5
+                  </title>
+                </svg>
+                <span />
+              </div>
               <div
                 className="iot--value-card__attribute"
               >
@@ -3274,27 +3345,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                 >
                   
                 </span>
-              </div>
-              <div>
-                <svg
-                  fill="green"
-                  focusable="true"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  role="img"
-                  tabIndex="0"
-                  title="< 5"
-                  viewBox="0 0 32 32"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M16 10a6 6 0 00-6 6v8a6 6 0 0012 0V16A6 6 0 0016 10zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0111.75 24v-.13h8.5V24A4.27 4.27 0 0116 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 018.5 0zM30.66 19.21L24 13v9.1a4 4 0 008 0A3.83 3.83 0 0030.66 19.21zM28 24.35a2.25 2.25 0 01-2.25-2.25V17l3.72 3.47h0A2.05 2.05 0 0130.2 22 2.25 2.25 0 0128 24.35zM0 22.1a4 4 0 008 0V13L1.34 19.21A3.88 3.88 0 000 22.1zm2.48-1.56h0L6.25 17v5.1a2.25 2.25 0 01-4.5 0A2.05 2.05 0 012.48 20.54zM15 5.5A3.5 3.5 0 1011.5 9 3.5 3.5 0 0015 5.5zm-5.25 0A1.75 1.75 0 1111.5 7.25 1.77 1.77 0 019.75 5.5zM20.5 2A3.5 3.5 0 1024 5.5 3.5 3.5 0 0020.5 2zm0 5.25A1.75 1.75 0 1122.25 5.5 1.77 1.77 0 0120.5 7.25z"
-                  />
-                  <title>
-                    &lt; 5
-                  </title>
-                </svg>
               </div>
             </div>
           </div>
@@ -3394,7 +3444,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
             >
               <div
                 className="iot--value-card__attribute-label"
-              />
+              >
+                <svg
+                  aria-label="> 5"
+                  fill="green"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  title="> 5"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                  />
+                  <path
+                    d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                    data-icon-path="inner-path"
+                    opacity="0"
+                  />
+                </svg>
+                <span />
+              </div>
               <div
                 className="iot--value-card__attribute"
               >
@@ -3424,29 +3497,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                 >
                   
                 </span>
-              </div>
-              <div>
-                <svg
-                  aria-label="> 5"
-                  fill="green"
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  role="img"
-                  title="> 5"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                  />
-                  <path
-                    d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
-                    data-icon-path="inner-path"
-                    opacity="0"
-                  />
-                </svg>
               </div>
             </div>
           </div>
@@ -3546,7 +3596,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
             >
               <div
                 className="iot--value-card__attribute-label"
-              />
+              >
+                <span />
+              </div>
               <div
                 className="iot--value-card__attribute"
               >
@@ -3675,7 +3727,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
             >
               <div
                 className="iot--value-card__attribute-label"
-              />
+              >
+                <span />
+              </div>
               <div
                 className="iot--value-card__attribute"
               >
@@ -3830,7 +3884,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
             >
               <div
                 className="iot--value-card__attribute-label"
-              />
+              >
+                <span />
+              </div>
               <div
                 className="iot--value-card__attribute"
               >
@@ -3985,7 +4041,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
             >
               <div
                 className="iot--value-card__attribute-label"
-              />
+              >
+                <span />
+              </div>
               <div
                 className="iot--value-card__attribute"
               >
@@ -4115,7 +4173,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                label variable is working
+                <span>
+                  label variable is working
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -4246,7 +4306,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Status
+                <span>
+                  Status
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -4290,7 +4352,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Comfort level
+                <span>
+                  Comfort level
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -4334,7 +4398,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Occupancy
+                <span>
+                  Occupancy
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -4378,7 +4444,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Humidity
+                <span>
+                  Humidity
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -4508,7 +4576,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
             >
               <div
                 className="iot--value-card__attribute-label"
-              />
+              >
+                <svg
+                  aria-label="= Unhealthy"
+                  fill="red"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  title="= Unhealthy"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
+                  />
+                </svg>
+                <span />
+              </div>
               <div
                 className="iot--value-card__attribute"
               >
@@ -4538,24 +4624,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                 >
                   
                 </span>
-              </div>
-              <div>
-                <svg
-                  aria-label="= Unhealthy"
-                  fill="red"
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  role="img"
-                  title="= Unhealthy"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L8,8.8l-2.7,2.7l-0.8-0.8L7.2,8L4.5,5.3l0.8-0.8L8,7.2	l2.7-2.7l0.8,0.8L8.8,8l2.7,2.7L10.7,11.5z"
-                  />
-                </svg>
               </div>
             </div>
           </div>
@@ -4656,7 +4724,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Monthly summary
+                <span>
+                  Monthly summary
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -4791,7 +4861,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Device 1 Comfort
+                <span>
+                  Device 1 Comfort
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -4835,7 +4907,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Device 2 Comfort
+                <span>
+                  Device 2 Comfort
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -4966,7 +5040,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Comfort Level
+                <span>
+                  Comfort Level
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -5010,7 +5086,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Monthly summary
+                <span>
+                  Monthly summary
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -5054,7 +5132,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Yearly summary
+                <span>
+                  Yearly summary
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -5185,7 +5265,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Monthly summary
+                <span>
+                  Monthly summary
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -5229,7 +5311,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Yearly summary
+                <span>
+                  Yearly summary
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"
@@ -5360,7 +5444,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               <div
                 className="iot--value-card__attribute-label"
               >
-                Comfort Level
+                <span>
+                  Comfort Level
+                </span>
               </div>
               <div
                 className="iot--value-card__attribute"

--- a/packages/react/src/components/ValueCard/_attribute.scss
+++ b/packages/react/src/components/ValueCard/_attribute.scss
@@ -39,14 +39,24 @@
     // set the height so the height and value will always be in the same position regardless if they exist
     height: $layout-01;
     margin-bottom: $spacing-02;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    & > span {
+      height: $layout-01;
+    }
+
+    & > svg {
+      margin-right: $spacing-02;
+    }
   }
 
-  &--secondary-value {
-    height: rem(24px);
+  &-secondary-value {
+    height: $layout-01;
     display: flex;
     align-items: center;
     font-size: 0.875rem;
-    padding-left: $spacing-02;
     margin-bottom: $spacing-02;
     color: var(--secondary-value-color);
   }


### PR DESCRIPTION
Closes #2060 

**Summary**

- Move the icon beside the label instead of below the value
- Fix the spacing and coloring of the trending values

**Change List (commits, features, bugs, etc)**

- minor fix for rulebuilder story
- bring valuecard design into alignment with designs

**Acceptance Test (how to verify the PR)**

- The https://deploy-preview-2087--carbon-addons-iot-react.netlify.app?path=/story/watson-iot-🚫-dashboard--only-value-cards story should now show the icons to the left of the label on cards with an icon, and the trending values should be vertically aligned and be green or red respectively compared with what is currently on [next](https://next.carbon-addons-iot-react.com/?path=/story/watson-iot-%F0%9F%9A%AB-dashboard--only-value-cards)
