### PR TITLE
chore(test): ignore AsyncTable from test coverage

### DIFF
--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
     '!src/**/*.story.js?(x)',
     '!src/**/hooks/*.js',
     '!src/components/SuiteHeader/util/suiteHeaderData.js',
+    '!src/components/Table/AsyncTable/*.js?(x)',
   ],
   coveragePathIgnorePatterns: ['/node_modules/', '/lib/', '/coverage/'],
   coverageReporters: ['html', 'text-summary', 'lcov'],
@@ -14,7 +15,7 @@ module.exports = {
       functions: 80,
       lines: 80,
     },
-    './src/components/**/!(ColumnHeaderSelect|WizardInline|WizardHeader|FilterHeaderRow|TableToolbar|RowActionsCell|RowActionsError|TableHead|StatefulTable|StatefulTableDetailWizard|CatalogContent|FileDrop|Dashboard|CardRenderer|ImageHotspots|PageHero|PageTitle|EditPage|AsyncTable|ImageCard|ImageUploader|TableHead|ColumnResize|ColorDropdown|TimeSeriesCard|BarChartCard|DashboardGrid|DashboardEditor).jsx': {
+    './src/components/**/!(ColumnHeaderSelect|WizardInline|WizardHeader|FilterHeaderRow|TableToolbar|RowActionsCell|RowActionsError|TableHead|StatefulTable|StatefulTableDetailWizard|CatalogContent|FileDrop|Dashboard|CardRenderer|ImageHotspots|PageHero|PageTitle|EditPage|ImageCard|ImageUploader|TableHead|ColumnResize|ColorDropdown|TimeSeriesCard|BarChartCard|DashboardGrid|DashboardEditor).jsx': {
       statements: 80,
       branches: 80,
       functions: 80,
@@ -88,12 +89,6 @@ module.exports = {
       branches: 50,
       lines: 63,
       functions: 50,
-    },
-    './src/components/Table/AsyncTable/AsyncTable.jsx': {
-      statements: 56,
-      branches: 50,
-      lines: 57,
-      functions: 13,
     },
     './src/components/Table/TableHead/ColumnHeaderSelect/ColumnHeaderSelect.jsx': {
       branches: 75,


### PR DESCRIPTION
Closes #2091

**Summary**

- AsyncTable is only used as an example in the story, so ignored it from our test coverage.

**Change List (commits, features, bugs, etc)**

- ignore AsyncTable from test coverage

**Acceptance Test (how to verify the PR)**

- tests here
