### PR TITLE
fix(dashboardgrid): workaround to trigger resize event

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -142,7 +142,7 @@
     "prop-types": "^15.7.2",
     "react-dnd": "11.1.3",
     "react-dnd-html5-backend": "11.1.3",
-    "react-grid-layout": "^0.18.3",
+    "react-grid-layout": "^1.2.2",
     "react-sizeme": "^2.6.3",
     "react-transition-group": "^2.6.0",
     "react-visibility-sensor": "^5.0.2",

--- a/packages/react/src/components/Dashboard/DashboardGrid.story.jsx
+++ b/packages/react/src/components/Dashboard/DashboardGrid.story.jsx
@@ -67,7 +67,10 @@ export const DashboardDefaultLayouts = () => {
     <Fragment>
       Resize your window to see the callback handlers get triggered in the Actions tab.
       <FullWidthWrapper>
-        <DashboardGrid {...commonGridProps}>{Cards}</DashboardGrid>
+        <div style={{ display: 'flex' }}>
+          <div style={{ width: '200px' }}>Sample sidebar</div>
+          <DashboardGrid {...commonGridProps}>{Cards}</DashboardGrid>
+        </div>
       </FullWidthWrapper>
     </Fragment>
   );

--- a/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -65,7 +65,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
               }
             >
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard"
                 onMouseDown={[Function]}
@@ -75,11 +75,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "304px",
+                    "MozTransform": "translate(0px,0px)",
+                    "OTransform": "translate(0px,0px)",
+                    "WebkitTransform": "translate(0px,0px)",
                     "height": "304px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,0px)",
                     "position": "absolute",
-                    "top": "0px",
-                    "width": "49.375%",
+                    "transform": "translate(0px,0px)",
+                    "width": "632px",
                   }
                 }
                 type="VALUE"
@@ -254,7 +257,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--bar-chart-card iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--bar-chart-card iot--card--wrapper"
                 data-testid="Card"
                 id="barchartcard"
                 onMouseDown={[Function]}
@@ -264,11 +267,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "304px",
+                    "MozTransform": "translate(0px,320px)",
+                    "OTransform": "translate(0px,320px)",
+                    "WebkitTransform": "translate(0px,320px)",
                     "height": "304px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,320px)",
                     "position": "absolute",
-                    "top": "320px",
-                    "width": "100%",
+                    "transform": "translate(0px,320px)",
+                    "width": "1280px",
                   }
                 }
                 type="BAR"
@@ -338,7 +344,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-xs"
                 onMouseDown={[Function]}
@@ -348,11 +354,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(0px,640px)",
+                    "OTransform": "translate(0px,640px)",
+                    "WebkitTransform": "translate(0px,640px)",
                     "height": "144px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,640px)",
                     "position": "absolute",
-                    "top": "640px",
-                    "width": "24.0625%",
+                    "transform": "translate(0px,640px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -433,7 +442,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-tooltip"
                 onMouseDown={[Function]}
@@ -443,11 +452,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(324px,640px)",
+                    "OTransform": "translate(324px,640px)",
+                    "WebkitTransform": "translate(324px,640px)",
                     "height": "144px",
-                    "left": "25.3125%",
+                    "msTransform": "translate(324px,640px)",
                     "position": "absolute",
-                    "top": "640px",
-                    "width": "24.0625%",
+                    "transform": "translate(324px,640px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -528,7 +540,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="section-card"
                 onMouseDown={[Function]}
@@ -538,11 +550,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(648px,640px)",
+                    "OTransform": "translate(648px,640px)",
+                    "WebkitTransform": "translate(648px,640px)",
                     "height": "144px",
-                    "left": "50.625%",
+                    "msTransform": "translate(648px,640px)",
                     "position": "absolute",
-                    "top": "640px",
-                    "width": "49.375%",
+                    "transform": "translate(648px,640px)",
+                    "width": "632px",
                   }
                 }
                 type="CUSTOM"
@@ -567,7 +582,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-xs2"
                 onMouseDown={[Function]}
@@ -577,11 +592,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(0px,800px)",
+                    "OTransform": "translate(0px,800px)",
+                    "WebkitTransform": "translate(0px,800px)",
                     "height": "144px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,800px)",
                     "position": "absolute",
-                    "top": "800px",
-                    "width": "24.0625%",
+                    "transform": "translate(0px,800px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -664,7 +682,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-xs3"
                 onMouseDown={[Function]}
@@ -674,11 +692,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(324px,800px)",
+                    "OTransform": "translate(324px,800px)",
+                    "WebkitTransform": "translate(324px,800px)",
                     "height": "144px",
-                    "left": "25.3125%",
+                    "msTransform": "translate(324px,800px)",
                     "position": "absolute",
-                    "top": "800px",
-                    "width": "24.0625%",
+                    "transform": "translate(324px,800px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -787,7 +808,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-comfort-level"
                 onMouseDown={[Function]}
@@ -797,11 +818,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(648px,800px)",
+                    "OTransform": "translate(648px,800px)",
+                    "WebkitTransform": "translate(648px,800px)",
                     "height": "144px",
-                    "left": "50.625%",
+                    "msTransform": "translate(648px,800px)",
                     "position": "absolute",
-                    "top": "800px",
-                    "width": "24.0625%",
+                    "transform": "translate(648px,800px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -898,7 +922,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-xs4"
                 onMouseDown={[Function]}
@@ -908,11 +932,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(972px,800px)",
+                    "OTransform": "translate(972px,800px)",
+                    "WebkitTransform": "translate(972px,800px)",
                     "height": "144px",
-                    "left": "75.9375%",
+                    "msTransform": "translate(972px,800px)",
                     "position": "absolute",
-                    "top": "800px",
-                    "width": "24.0625%",
+                    "transform": "translate(972px,800px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -1029,11 +1056,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(0px,960px)",
+                    "OTransform": "translate(0px,960px)",
+                    "WebkitTransform": "translate(0px,960px)",
                     "height": "144px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,960px)",
                     "position": "absolute",
-                    "top": "960px",
-                    "width": "24.0625%",
+                    "transform": "translate(0px,960px)",
+                    "width": "308px",
                   }
                 }
                 type="GAUGE"
@@ -1099,7 +1129,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   }
                 >
                   <div
-                    className="iot--gauge-container react-grid-item react-resizable-hide react-resizable"
+                    className="iot--gauge-container react-grid-item cssTransforms react-resizable-hide react-resizable"
                     style={
                       Object {
                         "paddingBottom": 0,
@@ -1111,7 +1141,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   >
                     <svg
                       aria-labelledby="gauge-label"
-                      className="iot--gauge react-grid-item react-resizable-hide react-resizable"
+                      className="iot--gauge react-grid-item cssTransforms react-resizable-hide react-resizable"
                       percent="0"
                       style={
                         Object {
@@ -1170,7 +1200,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-health"
                 onMouseDown={[Function]}
@@ -1180,11 +1210,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(324px,960px)",
+                    "OTransform": "translate(324px,960px)",
+                    "WebkitTransform": "translate(324px,960px)",
                     "height": "144px",
-                    "left": "25.3125%",
+                    "msTransform": "translate(324px,960px)",
                     "position": "absolute",
-                    "top": "960px",
-                    "width": "49.375%",
+                    "transform": "translate(324px,960px)",
+                    "width": "632px",
                   }
                 }
                 type="VALUE"
@@ -1286,7 +1319,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facility-temperature-timeseries"
                 onMouseDown={[Function]}
@@ -1296,11 +1329,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "304px",
+                    "MozTransform": "translate(0px,1120px)",
+                    "OTransform": "translate(0px,1120px)",
+                    "WebkitTransform": "translate(0px,1120px)",
                     "height": "304px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,1120px)",
                     "position": "absolute",
-                    "top": "1120px",
-                    "width": "49.375%",
+                    "transform": "translate(0px,1120px)",
+                    "width": "632px",
                   }
                 }
                 type="TIMESERIES"
@@ -1415,7 +1451,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="alert-table1"
                 onMouseDown={[Function]}
@@ -1425,11 +1461,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "624px",
+                    "MozTransform": "translate(648px,1120px)",
+                    "OTransform": "translate(648px,1120px)",
+                    "WebkitTransform": "translate(648px,1120px)",
                     "height": "624px",
-                    "left": "50.625%",
+                    "msTransform": "translate(648px,1120px)",
                     "position": "absolute",
-                    "top": "1120px",
-                    "width": "49.375%",
+                    "transform": "translate(648px,1120px)",
+                    "width": "632px",
                   }
                 }
                 type="TABLE"
@@ -1958,7 +1997,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facility-multi-timeseries"
                 onMouseDown={[Function]}
@@ -1968,11 +2007,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "624px",
+                    "MozTransform": "translate(0px,1440px)",
+                    "OTransform": "translate(0px,1440px)",
+                    "WebkitTransform": "translate(0px,1440px)",
                     "height": "624px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,1440px)",
                     "position": "absolute",
-                    "top": "1440px",
-                    "width": "49.375%",
+                    "transform": "translate(0px,1440px)",
+                    "width": "632px",
                   }
                 }
                 type="TIMESERIES"
@@ -2088,7 +2130,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
               </div>
               <div
                 accept={null}
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="floor map picture"
                 onMouseDown={[Function]}
@@ -2098,11 +2140,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "304px",
+                    "MozTransform": "translate(648px,1760px)",
+                    "OTransform": "translate(648px,1760px)",
+                    "WebkitTransform": "translate(648px,1760px)",
                     "height": "304px",
-                    "left": "50.625%",
+                    "msTransform": "translate(648px,1760px)",
                     "position": "absolute",
-                    "top": "1760px",
-                    "width": "49.375%",
+                    "transform": "translate(648px,1760px)",
+                    "width": "632px",
                   }
                 }
                 type="IMAGE"
@@ -2557,7 +2602,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
               }
             >
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard"
                 onMouseDown={[Function]}
@@ -2567,11 +2612,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "304px",
+                    "MozTransform": "translate(0px,0px)",
+                    "OTransform": "translate(0px,0px)",
+                    "WebkitTransform": "translate(0px,0px)",
                     "height": "304px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,0px)",
                     "position": "absolute",
-                    "top": "0px",
-                    "width": "49.375%",
+                    "transform": "translate(0px,0px)",
+                    "width": "632px",
                   }
                 }
                 type="VALUE"
@@ -2746,7 +2794,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--bar-chart-card iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--bar-chart-card iot--card--wrapper"
                 data-testid="Card"
                 id="barchartcard"
                 onMouseDown={[Function]}
@@ -2756,11 +2804,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "304px",
+                    "MozTransform": "translate(0px,320px)",
+                    "OTransform": "translate(0px,320px)",
+                    "WebkitTransform": "translate(0px,320px)",
                     "height": "304px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,320px)",
                     "position": "absolute",
-                    "top": "320px",
-                    "width": "100%",
+                    "transform": "translate(0px,320px)",
+                    "width": "1280px",
                   }
                 }
                 type="BAR"
@@ -2830,7 +2881,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-xs"
                 onMouseDown={[Function]}
@@ -2840,11 +2891,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(0px,640px)",
+                    "OTransform": "translate(0px,640px)",
+                    "WebkitTransform": "translate(0px,640px)",
                     "height": "144px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,640px)",
                     "position": "absolute",
-                    "top": "640px",
-                    "width": "24.0625%",
+                    "transform": "translate(0px,640px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -2925,7 +2979,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-tooltip"
                 onMouseDown={[Function]}
@@ -2935,11 +2989,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(324px,640px)",
+                    "OTransform": "translate(324px,640px)",
+                    "WebkitTransform": "translate(324px,640px)",
                     "height": "144px",
-                    "left": "25.3125%",
+                    "msTransform": "translate(324px,640px)",
                     "position": "absolute",
-                    "top": "640px",
-                    "width": "24.0625%",
+                    "transform": "translate(324px,640px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -3020,7 +3077,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="section-card"
                 onMouseDown={[Function]}
@@ -3030,11 +3087,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(648px,640px)",
+                    "OTransform": "translate(648px,640px)",
+                    "WebkitTransform": "translate(648px,640px)",
                     "height": "144px",
-                    "left": "50.625%",
+                    "msTransform": "translate(648px,640px)",
                     "position": "absolute",
-                    "top": "640px",
-                    "width": "49.375%",
+                    "transform": "translate(648px,640px)",
+                    "width": "632px",
                   }
                 }
                 type="CUSTOM"
@@ -3059,7 +3119,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-xs2"
                 onMouseDown={[Function]}
@@ -3069,11 +3129,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(0px,800px)",
+                    "OTransform": "translate(0px,800px)",
+                    "WebkitTransform": "translate(0px,800px)",
                     "height": "144px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,800px)",
                     "position": "absolute",
-                    "top": "800px",
-                    "width": "24.0625%",
+                    "transform": "translate(0px,800px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -3156,7 +3219,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-xs3"
                 onMouseDown={[Function]}
@@ -3166,11 +3229,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(324px,800px)",
+                    "OTransform": "translate(324px,800px)",
+                    "WebkitTransform": "translate(324px,800px)",
                     "height": "144px",
-                    "left": "25.3125%",
+                    "msTransform": "translate(324px,800px)",
                     "position": "absolute",
-                    "top": "800px",
-                    "width": "24.0625%",
+                    "transform": "translate(324px,800px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -3279,7 +3345,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-comfort-level"
                 onMouseDown={[Function]}
@@ -3289,11 +3355,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(648px,800px)",
+                    "OTransform": "translate(648px,800px)",
+                    "WebkitTransform": "translate(648px,800px)",
                     "height": "144px",
-                    "left": "50.625%",
+                    "msTransform": "translate(648px,800px)",
                     "position": "absolute",
-                    "top": "800px",
-                    "width": "24.0625%",
+                    "transform": "translate(648px,800px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -3390,7 +3459,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-xs4"
                 onMouseDown={[Function]}
@@ -3400,11 +3469,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(972px,800px)",
+                    "OTransform": "translate(972px,800px)",
+                    "WebkitTransform": "translate(972px,800px)",
                     "height": "144px",
-                    "left": "75.9375%",
+                    "msTransform": "translate(972px,800px)",
                     "position": "absolute",
-                    "top": "800px",
-                    "width": "24.0625%",
+                    "transform": "translate(972px,800px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -3521,11 +3593,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(0px,960px)",
+                    "OTransform": "translate(0px,960px)",
+                    "WebkitTransform": "translate(0px,960px)",
                     "height": "144px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,960px)",
                     "position": "absolute",
-                    "top": "960px",
-                    "width": "24.0625%",
+                    "transform": "translate(0px,960px)",
+                    "width": "308px",
                   }
                 }
                 type="GAUGE"
@@ -3591,7 +3666,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   }
                 >
                   <div
-                    className="iot--gauge-container react-grid-item react-resizable-hide react-resizable"
+                    className="iot--gauge-container react-grid-item cssTransforms react-resizable-hide react-resizable"
                     style={
                       Object {
                         "paddingBottom": 0,
@@ -3603,7 +3678,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   >
                     <svg
                       aria-labelledby="gauge-label"
-                      className="iot--gauge react-grid-item react-resizable-hide react-resizable"
+                      className="iot--gauge react-grid-item cssTransforms react-resizable-hide react-resizable"
                       percent="0"
                       style={
                         Object {
@@ -3662,7 +3737,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-health"
                 onMouseDown={[Function]}
@@ -3672,11 +3747,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(324px,960px)",
+                    "OTransform": "translate(324px,960px)",
+                    "WebkitTransform": "translate(324px,960px)",
                     "height": "144px",
-                    "left": "25.3125%",
+                    "msTransform": "translate(324px,960px)",
                     "position": "absolute",
-                    "top": "960px",
-                    "width": "49.375%",
+                    "transform": "translate(324px,960px)",
+                    "width": "632px",
                   }
                 }
                 type="VALUE"
@@ -3778,7 +3856,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facility-temperature-timeseries"
                 onMouseDown={[Function]}
@@ -3788,11 +3866,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "304px",
+                    "MozTransform": "translate(0px,1120px)",
+                    "OTransform": "translate(0px,1120px)",
+                    "WebkitTransform": "translate(0px,1120px)",
                     "height": "304px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,1120px)",
                     "position": "absolute",
-                    "top": "1120px",
-                    "width": "49.375%",
+                    "transform": "translate(0px,1120px)",
+                    "width": "632px",
                   }
                 }
                 type="TIMESERIES"
@@ -3907,7 +3988,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="alert-table1"
                 onMouseDown={[Function]}
@@ -3917,11 +3998,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "624px",
+                    "MozTransform": "translate(648px,1120px)",
+                    "OTransform": "translate(648px,1120px)",
+                    "WebkitTransform": "translate(648px,1120px)",
                     "height": "624px",
-                    "left": "50.625%",
+                    "msTransform": "translate(648px,1120px)",
                     "position": "absolute",
-                    "top": "1120px",
-                    "width": "49.375%",
+                    "transform": "translate(648px,1120px)",
+                    "width": "632px",
                   }
                 }
                 type="TABLE"
@@ -4450,7 +4534,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facility-multi-timeseries"
                 onMouseDown={[Function]}
@@ -4460,11 +4544,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "624px",
+                    "MozTransform": "translate(0px,1440px)",
+                    "OTransform": "translate(0px,1440px)",
+                    "WebkitTransform": "translate(0px,1440px)",
                     "height": "624px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,1440px)",
                     "position": "absolute",
-                    "top": "1440px",
-                    "width": "49.375%",
+                    "transform": "translate(0px,1440px)",
+                    "width": "632px",
                   }
                 }
                 type="TIMESERIES"
@@ -4580,7 +4667,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
               </div>
               <div
                 accept={null}
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="floor map picture"
                 onMouseDown={[Function]}
@@ -4590,11 +4677,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "304px",
+                    "MozTransform": "translate(648px,1760px)",
+                    "OTransform": "translate(648px,1760px)",
+                    "WebkitTransform": "translate(648px,1760px)",
                     "height": "304px",
-                    "left": "50.625%",
+                    "msTransform": "translate(648px,1760px)",
                     "position": "absolute",
-                    "top": "1760px",
-                    "width": "49.375%",
+                    "transform": "translate(648px,1760px)",
+                    "width": "632px",
                   }
                 }
                 type="IMAGE"
@@ -5077,7 +5167,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
               }
             >
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard"
                 onMouseDown={[Function]}
@@ -5087,11 +5177,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "304px",
+                    "MozTransform": "translate(0px,0px)",
+                    "OTransform": "translate(0px,0px)",
+                    "WebkitTransform": "translate(0px,0px)",
                     "height": "304px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,0px)",
                     "position": "absolute",
-                    "top": "0px",
-                    "width": "49.375%",
+                    "transform": "translate(0px,0px)",
+                    "width": "632px",
                   }
                 }
                 type="VALUE"
@@ -5266,7 +5359,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--bar-chart-card iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--bar-chart-card iot--card--wrapper"
                 data-testid="Card"
                 id="barchartcard"
                 onMouseDown={[Function]}
@@ -5276,11 +5369,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "304px",
+                    "MozTransform": "translate(0px,320px)",
+                    "OTransform": "translate(0px,320px)",
+                    "WebkitTransform": "translate(0px,320px)",
                     "height": "304px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,320px)",
                     "position": "absolute",
-                    "top": "320px",
-                    "width": "100%",
+                    "transform": "translate(0px,320px)",
+                    "width": "1280px",
                   }
                 }
                 type="BAR"
@@ -5350,7 +5446,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-xs"
                 onMouseDown={[Function]}
@@ -5360,11 +5456,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(0px,640px)",
+                    "OTransform": "translate(0px,640px)",
+                    "WebkitTransform": "translate(0px,640px)",
                     "height": "144px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,640px)",
                     "position": "absolute",
-                    "top": "640px",
-                    "width": "24.0625%",
+                    "transform": "translate(0px,640px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -5445,7 +5544,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-tooltip"
                 onMouseDown={[Function]}
@@ -5455,11 +5554,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(324px,640px)",
+                    "OTransform": "translate(324px,640px)",
+                    "WebkitTransform": "translate(324px,640px)",
                     "height": "144px",
-                    "left": "25.3125%",
+                    "msTransform": "translate(324px,640px)",
                     "position": "absolute",
-                    "top": "640px",
-                    "width": "24.0625%",
+                    "transform": "translate(324px,640px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -5540,7 +5642,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="section-card"
                 onMouseDown={[Function]}
@@ -5550,11 +5652,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(648px,640px)",
+                    "OTransform": "translate(648px,640px)",
+                    "WebkitTransform": "translate(648px,640px)",
                     "height": "144px",
-                    "left": "50.625%",
+                    "msTransform": "translate(648px,640px)",
                     "position": "absolute",
-                    "top": "640px",
-                    "width": "49.375%",
+                    "transform": "translate(648px,640px)",
+                    "width": "632px",
                   }
                 }
                 type="CUSTOM"
@@ -5579,7 +5684,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-xs2"
                 onMouseDown={[Function]}
@@ -5589,11 +5694,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(0px,800px)",
+                    "OTransform": "translate(0px,800px)",
+                    "WebkitTransform": "translate(0px,800px)",
                     "height": "144px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,800px)",
                     "position": "absolute",
-                    "top": "800px",
-                    "width": "24.0625%",
+                    "transform": "translate(0px,800px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -5676,7 +5784,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-xs3"
                 onMouseDown={[Function]}
@@ -5686,11 +5794,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(324px,800px)",
+                    "OTransform": "translate(324px,800px)",
+                    "WebkitTransform": "translate(324px,800px)",
                     "height": "144px",
-                    "left": "25.3125%",
+                    "msTransform": "translate(324px,800px)",
                     "position": "absolute",
-                    "top": "800px",
-                    "width": "24.0625%",
+                    "transform": "translate(324px,800px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -5799,7 +5910,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-comfort-level"
                 onMouseDown={[Function]}
@@ -5809,11 +5920,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(648px,800px)",
+                    "OTransform": "translate(648px,800px)",
+                    "WebkitTransform": "translate(648px,800px)",
                     "height": "144px",
-                    "left": "50.625%",
+                    "msTransform": "translate(648px,800px)",
                     "position": "absolute",
-                    "top": "800px",
-                    "width": "24.0625%",
+                    "transform": "translate(648px,800px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -5910,7 +6024,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-xs4"
                 onMouseDown={[Function]}
@@ -5920,11 +6034,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(972px,800px)",
+                    "OTransform": "translate(972px,800px)",
+                    "WebkitTransform": "translate(972px,800px)",
                     "height": "144px",
-                    "left": "75.9375%",
+                    "msTransform": "translate(972px,800px)",
                     "position": "absolute",
-                    "top": "800px",
-                    "width": "24.0625%",
+                    "transform": "translate(972px,800px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -6041,11 +6158,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(0px,960px)",
+                    "OTransform": "translate(0px,960px)",
+                    "WebkitTransform": "translate(0px,960px)",
                     "height": "144px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,960px)",
                     "position": "absolute",
-                    "top": "960px",
-                    "width": "24.0625%",
+                    "transform": "translate(0px,960px)",
+                    "width": "308px",
                   }
                 }
                 type="GAUGE"
@@ -6111,7 +6231,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   }
                 >
                   <div
-                    className="iot--gauge-container react-grid-item react-resizable-hide react-resizable"
+                    className="iot--gauge-container react-grid-item cssTransforms react-resizable-hide react-resizable"
                     style={
                       Object {
                         "paddingBottom": 0,
@@ -6123,7 +6243,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   >
                     <svg
                       aria-labelledby="gauge-label"
-                      className="iot--gauge react-grid-item react-resizable-hide react-resizable"
+                      className="iot--gauge react-grid-item cssTransforms react-resizable-hide react-resizable"
                       percent="0"
                       style={
                         Object {
@@ -6182,7 +6302,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-health"
                 onMouseDown={[Function]}
@@ -6192,11 +6312,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(324px,960px)",
+                    "OTransform": "translate(324px,960px)",
+                    "WebkitTransform": "translate(324px,960px)",
                     "height": "144px",
-                    "left": "25.3125%",
+                    "msTransform": "translate(324px,960px)",
                     "position": "absolute",
-                    "top": "960px",
-                    "width": "49.375%",
+                    "transform": "translate(324px,960px)",
+                    "width": "632px",
                   }
                 }
                 type="VALUE"
@@ -6298,7 +6421,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facility-temperature-timeseries"
                 onMouseDown={[Function]}
@@ -6308,11 +6431,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "304px",
+                    "MozTransform": "translate(0px,1120px)",
+                    "OTransform": "translate(0px,1120px)",
+                    "WebkitTransform": "translate(0px,1120px)",
                     "height": "304px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,1120px)",
                     "position": "absolute",
-                    "top": "1120px",
-                    "width": "49.375%",
+                    "transform": "translate(0px,1120px)",
+                    "width": "632px",
                   }
                 }
                 type="TIMESERIES"
@@ -6427,7 +6553,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="alert-table1"
                 onMouseDown={[Function]}
@@ -6437,11 +6563,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "624px",
+                    "MozTransform": "translate(648px,1120px)",
+                    "OTransform": "translate(648px,1120px)",
+                    "WebkitTransform": "translate(648px,1120px)",
                     "height": "624px",
-                    "left": "50.625%",
+                    "msTransform": "translate(648px,1120px)",
                     "position": "absolute",
-                    "top": "1120px",
-                    "width": "49.375%",
+                    "transform": "translate(648px,1120px)",
+                    "width": "632px",
                   }
                 }
                 type="TABLE"
@@ -6970,7 +7099,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facility-multi-timeseries"
                 onMouseDown={[Function]}
@@ -6980,11 +7109,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "624px",
+                    "MozTransform": "translate(0px,1440px)",
+                    "OTransform": "translate(0px,1440px)",
+                    "WebkitTransform": "translate(0px,1440px)",
                     "height": "624px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,1440px)",
                     "position": "absolute",
-                    "top": "1440px",
-                    "width": "49.375%",
+                    "transform": "translate(0px,1440px)",
+                    "width": "632px",
                   }
                 }
                 type="TIMESERIES"
@@ -7100,7 +7232,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
               </div>
               <div
                 accept={null}
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="floor map picture"
                 onMouseDown={[Function]}
@@ -7110,11 +7242,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "304px",
+                    "MozTransform": "translate(648px,1760px)",
+                    "OTransform": "translate(648px,1760px)",
+                    "WebkitTransform": "translate(648px,1760px)",
                     "height": "304px",
-                    "left": "50.625%",
+                    "msTransform": "translate(648px,1760px)",
                     "position": "absolute",
-                    "top": "1760px",
-                    "width": "49.375%",
+                    "transform": "translate(648px,1760px)",
+                    "width": "632px",
                   }
                 }
                 type="IMAGE"
@@ -7569,7 +7704,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
             }
           >
             <div
-              className="iot--card react-grid-item react-resizable-hide react-resizable iot--bar-chart-card iot--card--wrapper"
+              className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--bar-chart-card iot--card--wrapper"
               data-testid="Card"
               id="expandedcard"
               onMouseDown={[Function]}
@@ -7579,11 +7714,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
               style={
                 Object {
                   "--card-default-height": "624px",
+                  "MozTransform": "translate(0px,0px)",
+                  "OTransform": "translate(0px,0px)",
+                  "WebkitTransform": "translate(0px,0px)",
                   "height": "624px",
-                  "left": "0%",
+                  "msTransform": "translate(0px,0px)",
                   "position": "absolute",
-                  "top": "0px",
-                  "width": "49.375%",
+                  "transform": "translate(0px,0px)",
+                  "width": "632px",
                 }
               }
               type="BAR"
@@ -7763,7 +7901,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
             >
               <div
                 accept={null}
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="expandedcard"
                 onMouseDown={[Function]}
@@ -7773,11 +7911,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "624px",
+                    "MozTransform": "translate(0px,0px)",
+                    "OTransform": "translate(0px,0px)",
+                    "WebkitTransform": "translate(0px,0px)",
                     "height": "624px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,0px)",
                     "position": "absolute",
-                    "top": "0px",
-                    "width": "49.375%",
+                    "transform": "translate(0px,0px)",
+                    "width": "632px",
                   }
                 }
                 type="IMAGE"
@@ -8039,7 +8180,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
             }
           >
             <div
-              className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+              className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
               data-testid="Card"
               id="expandedcard"
               onMouseDown={[Function]}
@@ -8049,11 +8190,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
               style={
                 Object {
                   "--card-default-height": "624px",
+                  "MozTransform": "translate(0px,0px)",
+                  "OTransform": "translate(0px,0px)",
+                  "WebkitTransform": "translate(0px,0px)",
                   "height": "624px",
-                  "left": "0%",
+                  "msTransform": "translate(0px,0px)",
                   "position": "absolute",
-                  "top": "0px",
-                  "width": "49.375%",
+                  "transform": "translate(0px,0px)",
+                  "width": "632px",
                 }
               }
               type="TIMESERIES"
@@ -8232,7 +8376,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
               }
             >
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="expandedcard"
                 onMouseDown={[Function]}
@@ -8242,11 +8386,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "624px",
+                    "MozTransform": "translate(0px,0px)",
+                    "OTransform": "translate(0px,0px)",
+                    "WebkitTransform": "translate(0px,0px)",
                     "height": "624px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,0px)",
                     "position": "absolute",
-                    "top": "0px",
-                    "width": "100%",
+                    "transform": "translate(0px,0px)",
+                    "width": "1280px",
                   }
                 }
                 type="TABLE"
@@ -10174,7 +10321,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
               }
             >
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard"
                 onMouseDown={[Function]}
@@ -10184,11 +10331,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "304px",
+                    "MozTransform": "translate(0px,0px)",
+                    "OTransform": "translate(0px,0px)",
+                    "WebkitTransform": "translate(0px,0px)",
                     "height": "304px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,0px)",
                     "position": "absolute",
-                    "top": "0px",
-                    "width": "49.375%",
+                    "transform": "translate(0px,0px)",
+                    "width": "632px",
                   }
                 }
                 type="VALUE"
@@ -10363,7 +10513,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--bar-chart-card iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--bar-chart-card iot--card--wrapper"
                 data-testid="Card"
                 id="barchartcard"
                 onMouseDown={[Function]}
@@ -10373,11 +10523,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "304px",
+                    "MozTransform": "translate(0px,320px)",
+                    "OTransform": "translate(0px,320px)",
+                    "WebkitTransform": "translate(0px,320px)",
                     "height": "304px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,320px)",
                     "position": "absolute",
-                    "top": "320px",
-                    "width": "100%",
+                    "transform": "translate(0px,320px)",
+                    "width": "1280px",
                   }
                 }
                 type="BAR"
@@ -10447,7 +10600,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-xs"
                 onMouseDown={[Function]}
@@ -10457,11 +10610,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(0px,640px)",
+                    "OTransform": "translate(0px,640px)",
+                    "WebkitTransform": "translate(0px,640px)",
                     "height": "144px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,640px)",
                     "position": "absolute",
-                    "top": "640px",
-                    "width": "24.0625%",
+                    "transform": "translate(0px,640px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -10542,7 +10698,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-tooltip"
                 onMouseDown={[Function]}
@@ -10552,11 +10708,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(324px,640px)",
+                    "OTransform": "translate(324px,640px)",
+                    "WebkitTransform": "translate(324px,640px)",
                     "height": "144px",
-                    "left": "25.3125%",
+                    "msTransform": "translate(324px,640px)",
                     "position": "absolute",
-                    "top": "640px",
-                    "width": "24.0625%",
+                    "transform": "translate(324px,640px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -10637,7 +10796,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="section-card"
                 onMouseDown={[Function]}
@@ -10647,11 +10806,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(648px,640px)",
+                    "OTransform": "translate(648px,640px)",
+                    "WebkitTransform": "translate(648px,640px)",
                     "height": "144px",
-                    "left": "50.625%",
+                    "msTransform": "translate(648px,640px)",
                     "position": "absolute",
-                    "top": "640px",
-                    "width": "49.375%",
+                    "transform": "translate(648px,640px)",
+                    "width": "632px",
                   }
                 }
                 type="CUSTOM"
@@ -10676,7 +10838,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-xs2"
                 onMouseDown={[Function]}
@@ -10686,11 +10848,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(0px,800px)",
+                    "OTransform": "translate(0px,800px)",
+                    "WebkitTransform": "translate(0px,800px)",
                     "height": "144px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,800px)",
                     "position": "absolute",
-                    "top": "800px",
-                    "width": "24.0625%",
+                    "transform": "translate(0px,800px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -10773,7 +10938,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-xs3"
                 onMouseDown={[Function]}
@@ -10783,11 +10948,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(324px,800px)",
+                    "OTransform": "translate(324px,800px)",
+                    "WebkitTransform": "translate(324px,800px)",
                     "height": "144px",
-                    "left": "25.3125%",
+                    "msTransform": "translate(324px,800px)",
                     "position": "absolute",
-                    "top": "800px",
-                    "width": "24.0625%",
+                    "transform": "translate(324px,800px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -10896,7 +11064,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-comfort-level"
                 onMouseDown={[Function]}
@@ -10906,11 +11074,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(648px,800px)",
+                    "OTransform": "translate(648px,800px)",
+                    "WebkitTransform": "translate(648px,800px)",
                     "height": "144px",
-                    "left": "50.625%",
+                    "msTransform": "translate(648px,800px)",
                     "position": "absolute",
-                    "top": "800px",
-                    "width": "24.0625%",
+                    "transform": "translate(648px,800px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -11007,7 +11178,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-xs4"
                 onMouseDown={[Function]}
@@ -11017,11 +11188,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(972px,800px)",
+                    "OTransform": "translate(972px,800px)",
+                    "WebkitTransform": "translate(972px,800px)",
                     "height": "144px",
-                    "left": "75.9375%",
+                    "msTransform": "translate(972px,800px)",
                     "position": "absolute",
-                    "top": "800px",
-                    "width": "24.0625%",
+                    "transform": "translate(972px,800px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -11138,11 +11312,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(0px,960px)",
+                    "OTransform": "translate(0px,960px)",
+                    "WebkitTransform": "translate(0px,960px)",
                     "height": "144px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,960px)",
                     "position": "absolute",
-                    "top": "960px",
-                    "width": "24.0625%",
+                    "transform": "translate(0px,960px)",
+                    "width": "308px",
                   }
                 }
                 type="GAUGE"
@@ -11208,7 +11385,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   }
                 >
                   <div
-                    className="iot--gauge-container react-grid-item react-resizable-hide react-resizable"
+                    className="iot--gauge-container react-grid-item cssTransforms react-resizable-hide react-resizable"
                     style={
                       Object {
                         "paddingBottom": 0,
@@ -11220,7 +11397,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   >
                     <svg
                       aria-labelledby="gauge-label"
-                      className="iot--gauge react-grid-item react-resizable-hide react-resizable"
+                      className="iot--gauge react-grid-item cssTransforms react-resizable-hide react-resizable"
                       percent="0"
                       style={
                         Object {
@@ -11279,7 +11456,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-health"
                 onMouseDown={[Function]}
@@ -11289,11 +11466,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(324px,960px)",
+                    "OTransform": "translate(324px,960px)",
+                    "WebkitTransform": "translate(324px,960px)",
                     "height": "144px",
-                    "left": "25.3125%",
+                    "msTransform": "translate(324px,960px)",
                     "position": "absolute",
-                    "top": "960px",
-                    "width": "49.375%",
+                    "transform": "translate(324px,960px)",
+                    "width": "632px",
                   }
                 }
                 type="VALUE"
@@ -11395,7 +11575,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facility-temperature-timeseries"
                 onMouseDown={[Function]}
@@ -11405,11 +11585,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "304px",
+                    "MozTransform": "translate(0px,1120px)",
+                    "OTransform": "translate(0px,1120px)",
+                    "WebkitTransform": "translate(0px,1120px)",
                     "height": "304px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,1120px)",
                     "position": "absolute",
-                    "top": "1120px",
-                    "width": "49.375%",
+                    "transform": "translate(0px,1120px)",
+                    "width": "632px",
                   }
                 }
                 type="TIMESERIES"
@@ -11524,7 +11707,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="alert-table1"
                 onMouseDown={[Function]}
@@ -11534,11 +11717,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "624px",
+                    "MozTransform": "translate(648px,1120px)",
+                    "OTransform": "translate(648px,1120px)",
+                    "WebkitTransform": "translate(648px,1120px)",
                     "height": "624px",
-                    "left": "50.625%",
+                    "msTransform": "translate(648px,1120px)",
                     "position": "absolute",
-                    "top": "1120px",
-                    "width": "49.375%",
+                    "transform": "translate(648px,1120px)",
+                    "width": "632px",
                   }
                 }
                 type="TABLE"
@@ -12067,7 +12253,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facility-multi-timeseries"
                 onMouseDown={[Function]}
@@ -12077,11 +12263,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "624px",
+                    "MozTransform": "translate(0px,1440px)",
+                    "OTransform": "translate(0px,1440px)",
+                    "WebkitTransform": "translate(0px,1440px)",
                     "height": "624px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,1440px)",
                     "position": "absolute",
-                    "top": "1440px",
-                    "width": "49.375%",
+                    "transform": "translate(0px,1440px)",
+                    "width": "632px",
                   }
                 }
                 type="TIMESERIES"
@@ -12197,7 +12386,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
               </div>
               <div
                 accept={null}
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="floor map picture"
                 onMouseDown={[Function]}
@@ -12207,11 +12396,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "304px",
+                    "MozTransform": "translate(648px,1760px)",
+                    "OTransform": "translate(648px,1760px)",
+                    "WebkitTransform": "translate(648px,1760px)",
                     "height": "304px",
-                    "left": "50.625%",
+                    "msTransform": "translate(648px,1760px)",
                     "position": "absolute",
-                    "top": "1760px",
-                    "width": "49.375%",
+                    "transform": "translate(648px,1760px)",
+                    "width": "632px",
                   }
                 }
                 type="IMAGE"
@@ -12666,7 +12858,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
             }
           >
             <div
-              className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+              className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
               data-testid="Card"
               id="nooptionscard"
               onMouseDown={[Function]}
@@ -12676,11 +12868,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
               style={
                 Object {
                   "--card-default-height": "624px",
+                  "MozTransform": "translate(0px,0px)",
+                  "OTransform": "translate(0px,0px)",
+                  "WebkitTransform": "translate(0px,0px)",
                   "height": "624px",
-                  "left": "0%",
+                  "msTransform": "translate(0px,0px)",
                   "position": "absolute",
-                  "top": "0px",
-                  "width": "49.375%",
+                  "transform": "translate(0px,0px)",
+                  "width": "632px",
                 }
               }
               type="TIMESERIES"
@@ -12827,7 +13022,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 }
               >
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-0"
                   onMouseDown={[Function]}
@@ -12837,11 +13032,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,0px)",
+                      "OTransform": "translate(0px,0px)",
+                      "WebkitTransform": "translate(0px,0px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(0px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -12917,7 +13115,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-1"
                   onMouseDown={[Function]}
@@ -12927,11 +13125,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(324px,0px)",
+                      "OTransform": "translate(324px,0px)",
+                      "WebkitTransform": "translate(324px,0px)",
                       "height": "144px",
-                      "left": "25.3125%",
+                      "msTransform": "translate(324px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(324px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -13009,7 +13210,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-2"
                   onMouseDown={[Function]}
@@ -13019,11 +13220,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,0px)",
+                      "OTransform": "translate(648px,0px)",
+                      "WebkitTransform": "translate(648px,0px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(648px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -13101,7 +13305,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-3"
                   onMouseDown={[Function]}
@@ -13111,11 +13315,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(972px,0px)",
+                      "OTransform": "translate(972px,0px)",
+                      "WebkitTransform": "translate(972px,0px)",
                       "height": "144px",
-                      "left": "75.9375%",
+                      "msTransform": "translate(972px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(972px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -13193,7 +13400,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-4"
                   onMouseDown={[Function]}
@@ -13203,11 +13410,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,160px)",
+                      "OTransform": "translate(0px,160px)",
+                      "WebkitTransform": "translate(0px,160px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,160px)",
                       "position": "absolute",
-                      "top": "160px",
-                      "width": "24.0625%",
+                      "transform": "translate(0px,160px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -13285,7 +13495,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-5"
                   onMouseDown={[Function]}
@@ -13295,11 +13505,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(324px,160px)",
+                      "OTransform": "translate(324px,160px)",
+                      "WebkitTransform": "translate(324px,160px)",
                       "height": "144px",
-                      "left": "25.3125%",
+                      "msTransform": "translate(324px,160px)",
                       "position": "absolute",
-                      "top": "160px",
-                      "width": "24.0625%",
+                      "transform": "translate(324px,160px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -13387,7 +13600,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-6"
                   onMouseDown={[Function]}
@@ -13397,11 +13610,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,160px)",
+                      "OTransform": "translate(648px,160px)",
+                      "WebkitTransform": "translate(648px,160px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,160px)",
                       "position": "absolute",
-                      "top": "160px",
-                      "width": "24.0625%",
+                      "transform": "translate(648px,160px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -13550,7 +13766,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 }
               >
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-0"
                   onMouseDown={[Function]}
@@ -13560,11 +13776,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,0px)",
+                      "OTransform": "translate(0px,0px)",
+                      "WebkitTransform": "translate(0px,0px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(0px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -13640,7 +13859,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-1"
                   onMouseDown={[Function]}
@@ -13650,11 +13869,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(324px,0px)",
+                      "OTransform": "translate(324px,0px)",
+                      "WebkitTransform": "translate(324px,0px)",
                       "height": "144px",
-                      "left": "25.3125%",
+                      "msTransform": "translate(324px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(324px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -13732,7 +13954,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-2"
                   onMouseDown={[Function]}
@@ -13742,11 +13964,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,0px)",
+                      "OTransform": "translate(648px,0px)",
+                      "WebkitTransform": "translate(648px,0px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(648px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -13824,7 +14049,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-3"
                   onMouseDown={[Function]}
@@ -13834,11 +14059,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(972px,0px)",
+                      "OTransform": "translate(972px,0px)",
+                      "WebkitTransform": "translate(972px,0px)",
                       "height": "144px",
-                      "left": "75.9375%",
+                      "msTransform": "translate(972px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(972px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -13916,7 +14144,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-4"
                   onMouseDown={[Function]}
@@ -13926,11 +14154,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,160px)",
+                      "OTransform": "translate(0px,160px)",
+                      "WebkitTransform": "translate(0px,160px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,160px)",
                       "position": "absolute",
-                      "top": "160px",
-                      "width": "24.0625%",
+                      "transform": "translate(0px,160px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -14008,7 +14239,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-5"
                   onMouseDown={[Function]}
@@ -14018,11 +14249,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(324px,160px)",
+                      "OTransform": "translate(324px,160px)",
+                      "WebkitTransform": "translate(324px,160px)",
                       "height": "144px",
-                      "left": "25.3125%",
+                      "msTransform": "translate(324px,160px)",
                       "position": "absolute",
-                      "top": "160px",
-                      "width": "24.0625%",
+                      "transform": "translate(324px,160px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -14110,7 +14344,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-6"
                   onMouseDown={[Function]}
@@ -14120,11 +14354,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,160px)",
+                      "OTransform": "translate(648px,160px)",
+                      "WebkitTransform": "translate(648px,160px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,160px)",
                       "position": "absolute",
-                      "top": "160px",
-                      "width": "24.0625%",
+                      "transform": "translate(648px,160px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -14273,7 +14510,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 }
               >
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-0"
                   onMouseDown={[Function]}
@@ -14283,11 +14520,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,0px)",
+                      "OTransform": "translate(0px,0px)",
+                      "WebkitTransform": "translate(0px,0px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(0px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -14365,7 +14605,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-1"
                   onMouseDown={[Function]}
@@ -14375,11 +14615,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(324px,0px)",
+                      "OTransform": "translate(324px,0px)",
+                      "WebkitTransform": "translate(324px,0px)",
                       "height": "144px",
-                      "left": "25.3125%",
+                      "msTransform": "translate(324px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(324px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -14459,7 +14702,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-2"
                   onMouseDown={[Function]}
@@ -14469,11 +14712,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,0px)",
+                      "OTransform": "translate(648px,0px)",
+                      "WebkitTransform": "translate(648px,0px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(648px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -14577,7 +14823,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-3"
                   onMouseDown={[Function]}
@@ -14587,11 +14833,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(972px,0px)",
+                      "OTransform": "translate(972px,0px)",
+                      "WebkitTransform": "translate(972px,0px)",
                       "height": "144px",
-                      "left": "75.9375%",
+                      "msTransform": "translate(972px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(972px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -14766,7 +15015,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 }
               >
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-0"
                   onMouseDown={[Function]}
@@ -14776,11 +15025,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,0px)",
+                      "OTransform": "translate(0px,0px)",
+                      "WebkitTransform": "translate(0px,0px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(0px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -14858,7 +15110,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-1"
                   onMouseDown={[Function]}
@@ -14868,11 +15120,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(324px,0px)",
+                      "OTransform": "translate(324px,0px)",
+                      "WebkitTransform": "translate(324px,0px)",
                       "height": "144px",
-                      "left": "25.3125%",
+                      "msTransform": "translate(324px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(324px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -14952,7 +15207,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-2"
                   onMouseDown={[Function]}
@@ -14962,11 +15217,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,0px)",
+                      "OTransform": "translate(648px,0px)",
+                      "WebkitTransform": "translate(648px,0px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(648px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -15070,7 +15328,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-3"
                   onMouseDown={[Function]}
@@ -15080,11 +15338,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(972px,0px)",
+                      "OTransform": "translate(972px,0px)",
+                      "WebkitTransform": "translate(972px,0px)",
                       "height": "144px",
-                      "left": "75.9375%",
+                      "msTransform": "translate(972px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(972px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -15259,7 +15520,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 }
               >
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-threshold-0"
                   onMouseDown={[Function]}
@@ -15269,11 +15530,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,0px)",
+                      "OTransform": "translate(0px,0px)",
+                      "WebkitTransform": "translate(0px,0px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(0px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -15367,7 +15631,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-threshold-1"
                   onMouseDown={[Function]}
@@ -15377,11 +15641,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(324px,0px)",
+                      "OTransform": "translate(324px,0px)",
+                      "WebkitTransform": "translate(324px,0px)",
                       "height": "144px",
-                      "left": "25.3125%",
+                      "msTransform": "translate(324px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(324px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -15480,7 +15747,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-threshold-2"
                   onMouseDown={[Function]}
@@ -15490,11 +15757,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,0px)",
+                      "OTransform": "translate(648px,0px)",
+                      "WebkitTransform": "translate(648px,0px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(648px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -15593,7 +15863,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-threshold-3"
                   onMouseDown={[Function]}
@@ -15603,11 +15873,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(972px,0px)",
+                      "OTransform": "translate(972px,0px)",
+                      "WebkitTransform": "translate(972px,0px)",
                       "height": "144px",
-                      "left": "75.9375%",
+                      "msTransform": "translate(972px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(972px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -15770,7 +16043,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 }
               >
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-threshold-0"
                   onMouseDown={[Function]}
@@ -15780,11 +16053,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,0px)",
+                      "OTransform": "translate(0px,0px)",
+                      "WebkitTransform": "translate(0px,0px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(0px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -15878,7 +16154,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-threshold-1"
                   onMouseDown={[Function]}
@@ -15888,11 +16164,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(324px,0px)",
+                      "OTransform": "translate(324px,0px)",
+                      "WebkitTransform": "translate(324px,0px)",
                       "height": "144px",
-                      "left": "25.3125%",
+                      "msTransform": "translate(324px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(324px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -15991,7 +16270,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-threshold-2"
                   onMouseDown={[Function]}
@@ -16001,11 +16280,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,0px)",
+                      "OTransform": "translate(648px,0px)",
+                      "WebkitTransform": "translate(648px,0px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(648px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -16104,7 +16386,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-number-threshold-3"
                   onMouseDown={[Function]}
@@ -16114,11 +16396,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(972px,0px)",
+                      "OTransform": "translate(972px,0px)",
+                      "WebkitTransform": "translate(972px,0px)",
                       "height": "144px",
-                      "left": "75.9375%",
+                      "msTransform": "translate(972px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(972px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -16281,7 +16566,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 }
               >
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-string-threshold-0"
                   onMouseDown={[Function]}
@@ -16291,11 +16576,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,0px)",
+                      "OTransform": "translate(0px,0px)",
+                      "WebkitTransform": "translate(0px,0px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(0px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -16373,7 +16661,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-string-threshold-1"
                   onMouseDown={[Function]}
@@ -16383,11 +16671,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(324px,0px)",
+                      "OTransform": "translate(324px,0px)",
+                      "WebkitTransform": "translate(324px,0px)",
                       "height": "144px",
-                      "left": "25.3125%",
+                      "msTransform": "translate(324px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(324px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -16465,7 +16756,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-string-threshold-2"
                   onMouseDown={[Function]}
@@ -16475,11 +16766,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,0px)",
+                      "OTransform": "translate(648px,0px)",
+                      "WebkitTransform": "translate(648px,0px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(648px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -16557,7 +16851,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-string-threshold-3"
                   onMouseDown={[Function]}
@@ -16567,11 +16861,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(972px,0px)",
+                      "OTransform": "translate(972px,0px)",
+                      "WebkitTransform": "translate(972px,0px)",
                       "height": "144px",
-                      "left": "75.9375%",
+                      "msTransform": "translate(972px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(972px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -16649,7 +16946,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-string-threshold-4"
                   onMouseDown={[Function]}
@@ -16659,11 +16956,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,160px)",
+                      "OTransform": "translate(0px,160px)",
+                      "WebkitTransform": "translate(0px,160px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,160px)",
                       "position": "absolute",
-                      "top": "160px",
-                      "width": "24.0625%",
+                      "transform": "translate(0px,160px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -16810,7 +17110,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 }
               >
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-string-threshold-0"
                   onMouseDown={[Function]}
@@ -16820,11 +17120,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,0px)",
+                      "OTransform": "translate(0px,0px)",
+                      "WebkitTransform": "translate(0px,0px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(0px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -16902,7 +17205,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-string-threshold-1"
                   onMouseDown={[Function]}
@@ -16912,11 +17215,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(324px,0px)",
+                      "OTransform": "translate(324px,0px)",
+                      "WebkitTransform": "translate(324px,0px)",
                       "height": "144px",
-                      "left": "25.3125%",
+                      "msTransform": "translate(324px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(324px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -16994,7 +17300,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-string-threshold-2"
                   onMouseDown={[Function]}
@@ -17004,11 +17310,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,0px)",
+                      "OTransform": "translate(648px,0px)",
+                      "WebkitTransform": "translate(648px,0px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(648px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -17086,7 +17395,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-string-threshold-3"
                   onMouseDown={[Function]}
@@ -17096,11 +17405,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(972px,0px)",
+                      "OTransform": "translate(972px,0px)",
+                      "WebkitTransform": "translate(972px,0px)",
                       "height": "144px",
-                      "left": "75.9375%",
+                      "msTransform": "translate(972px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "24.0625%",
+                      "transform": "translate(972px,0px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -17178,7 +17490,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmall-string-threshold-4"
                   onMouseDown={[Function]}
@@ -17188,11 +17500,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,160px)",
+                      "OTransform": "translate(0px,160px)",
+                      "WebkitTransform": "translate(0px,160px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,160px)",
                       "position": "absolute",
-                      "top": "160px",
-                      "width": "24.0625%",
+                      "transform": "translate(0px,160px)",
+                      "width": "308px",
                     }
                   }
                   type="VALUE"
@@ -17339,7 +17654,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 }
               >
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-0"
                   onMouseDown={[Function]}
@@ -17349,11 +17664,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,0px)",
+                      "OTransform": "translate(0px,0px)",
+                      "WebkitTransform": "translate(0px,0px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -17429,7 +17747,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-1"
                   onMouseDown={[Function]}
@@ -17439,11 +17757,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,0px)",
+                      "OTransform": "translate(648px,0px)",
+                      "WebkitTransform": "translate(648px,0px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -17521,7 +17842,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-2"
                   onMouseDown={[Function]}
@@ -17531,11 +17852,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,160px)",
+                      "OTransform": "translate(0px,160px)",
+                      "WebkitTransform": "translate(0px,160px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,160px)",
                       "position": "absolute",
-                      "top": "160px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,160px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -17613,7 +17937,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-3"
                   onMouseDown={[Function]}
@@ -17623,11 +17947,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,160px)",
+                      "OTransform": "translate(648px,160px)",
+                      "WebkitTransform": "translate(648px,160px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,160px)",
                       "position": "absolute",
-                      "top": "160px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,160px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -17705,7 +18032,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-4"
                   onMouseDown={[Function]}
@@ -17715,11 +18042,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,320px)",
+                      "OTransform": "translate(0px,320px)",
+                      "WebkitTransform": "translate(0px,320px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,320px)",
                       "position": "absolute",
-                      "top": "320px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,320px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -17797,7 +18127,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-5"
                   onMouseDown={[Function]}
@@ -17807,11 +18137,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,320px)",
+                      "OTransform": "translate(648px,320px)",
+                      "WebkitTransform": "translate(648px,320px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,320px)",
                       "position": "absolute",
-                      "top": "320px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,320px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -17891,7 +18224,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-6"
                   onMouseDown={[Function]}
@@ -17901,11 +18234,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,480px)",
+                      "OTransform": "translate(0px,480px)",
+                      "WebkitTransform": "translate(0px,480px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,480px)",
                       "position": "absolute",
-                      "top": "480px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,480px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -17985,7 +18321,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-trend-0"
                   onMouseDown={[Function]}
@@ -17995,11 +18331,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,480px)",
+                      "OTransform": "translate(648px,480px)",
+                      "WebkitTransform": "translate(648px,480px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,480px)",
                       "position": "absolute",
-                      "top": "480px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,480px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -18077,7 +18416,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-trend-1"
                   onMouseDown={[Function]}
@@ -18087,11 +18426,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,640px)",
+                      "OTransform": "translate(0px,640px)",
+                      "WebkitTransform": "translate(0px,640px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,640px)",
                       "position": "absolute",
-                      "top": "640px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,640px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -18171,7 +18513,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-trend-2"
                   onMouseDown={[Function]}
@@ -18181,11 +18523,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,640px)",
+                      "OTransform": "translate(648px,640px)",
+                      "WebkitTransform": "translate(648px,640px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,640px)",
                       "position": "absolute",
-                      "top": "640px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,640px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -18289,7 +18634,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-trend-3"
                   onMouseDown={[Function]}
@@ -18299,11 +18644,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,800px)",
+                      "OTransform": "translate(0px,800px)",
+                      "WebkitTransform": "translate(0px,800px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,800px)",
                       "position": "absolute",
-                      "top": "800px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,800px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -18409,7 +18757,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-threshold-0"
                   onMouseDown={[Function]}
@@ -18419,11 +18767,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,800px)",
+                      "OTransform": "translate(648px,800px)",
+                      "WebkitTransform": "translate(648px,800px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,800px)",
                       "position": "absolute",
-                      "top": "800px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,800px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -18517,7 +18868,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-threshold-1"
                   onMouseDown={[Function]}
@@ -18527,11 +18878,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,960px)",
+                      "OTransform": "translate(0px,960px)",
+                      "WebkitTransform": "translate(0px,960px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,960px)",
                       "position": "absolute",
-                      "top": "960px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,960px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -18630,7 +18984,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-threshold-2"
                   onMouseDown={[Function]}
@@ -18640,11 +18994,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,960px)",
+                      "OTransform": "translate(648px,960px)",
+                      "WebkitTransform": "translate(648px,960px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,960px)",
                       "position": "absolute",
-                      "top": "960px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,960px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -18743,7 +19100,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-threshold-3"
                   onMouseDown={[Function]}
@@ -18753,11 +19110,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,1120px)",
+                      "OTransform": "translate(0px,1120px)",
+                      "WebkitTransform": "translate(0px,1120px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,1120px)",
                       "position": "absolute",
-                      "top": "1120px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,1120px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -18851,7 +19211,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-string-threshold-0"
                   onMouseDown={[Function]}
@@ -18861,11 +19221,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,1120px)",
+                      "OTransform": "translate(648px,1120px)",
+                      "WebkitTransform": "translate(648px,1120px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,1120px)",
                       "position": "absolute",
-                      "top": "1120px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,1120px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -18943,7 +19306,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-string-threshold-1"
                   onMouseDown={[Function]}
@@ -18953,11 +19316,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,1280px)",
+                      "OTransform": "translate(0px,1280px)",
+                      "WebkitTransform": "translate(0px,1280px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,1280px)",
                       "position": "absolute",
-                      "top": "1280px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,1280px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -19035,7 +19401,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-string-threshold-2"
                   onMouseDown={[Function]}
@@ -19045,11 +19411,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,1280px)",
+                      "OTransform": "translate(648px,1280px)",
+                      "WebkitTransform": "translate(648px,1280px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,1280px)",
                       "position": "absolute",
-                      "top": "1280px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,1280px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -19127,7 +19496,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-string-threshold-3"
                   onMouseDown={[Function]}
@@ -19137,11 +19506,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,1440px)",
+                      "OTransform": "translate(0px,1440px)",
+                      "WebkitTransform": "translate(0px,1440px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,1440px)",
                       "position": "absolute",
-                      "top": "1440px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,1440px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -19219,7 +19591,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-string-threshold-4"
                   onMouseDown={[Function]}
@@ -19229,11 +19601,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,1440px)",
+                      "OTransform": "translate(648px,1440px)",
+                      "WebkitTransform": "translate(648px,1440px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,1440px)",
                       "position": "absolute",
-                      "top": "1440px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,1440px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -19380,7 +19755,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 }
               >
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-0"
                   onMouseDown={[Function]}
@@ -19390,11 +19765,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,0px)",
+                      "OTransform": "translate(0px,0px)",
+                      "WebkitTransform": "translate(0px,0px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -19470,7 +19848,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-1"
                   onMouseDown={[Function]}
@@ -19480,11 +19858,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,0px)",
+                      "OTransform": "translate(648px,0px)",
+                      "WebkitTransform": "translate(648px,0px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -19562,7 +19943,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-2"
                   onMouseDown={[Function]}
@@ -19572,11 +19953,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,160px)",
+                      "OTransform": "translate(0px,160px)",
+                      "WebkitTransform": "translate(0px,160px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,160px)",
                       "position": "absolute",
-                      "top": "160px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,160px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -19654,7 +20038,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-3"
                   onMouseDown={[Function]}
@@ -19664,11 +20048,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,160px)",
+                      "OTransform": "translate(648px,160px)",
+                      "WebkitTransform": "translate(648px,160px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,160px)",
                       "position": "absolute",
-                      "top": "160px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,160px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -19746,7 +20133,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-4"
                   onMouseDown={[Function]}
@@ -19756,11 +20143,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,320px)",
+                      "OTransform": "translate(0px,320px)",
+                      "WebkitTransform": "translate(0px,320px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,320px)",
                       "position": "absolute",
-                      "top": "320px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,320px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -19838,7 +20228,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-5"
                   onMouseDown={[Function]}
@@ -19848,11 +20238,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,320px)",
+                      "OTransform": "translate(648px,320px)",
+                      "WebkitTransform": "translate(648px,320px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,320px)",
                       "position": "absolute",
-                      "top": "320px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,320px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -19932,7 +20325,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-6"
                   onMouseDown={[Function]}
@@ -19942,11 +20335,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,480px)",
+                      "OTransform": "translate(0px,480px)",
+                      "WebkitTransform": "translate(0px,480px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,480px)",
                       "position": "absolute",
-                      "top": "480px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,480px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -20026,7 +20422,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-trend-0"
                   onMouseDown={[Function]}
@@ -20036,11 +20432,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,480px)",
+                      "OTransform": "translate(648px,480px)",
+                      "WebkitTransform": "translate(648px,480px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,480px)",
                       "position": "absolute",
-                      "top": "480px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,480px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -20118,7 +20517,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-trend-1"
                   onMouseDown={[Function]}
@@ -20128,11 +20527,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,640px)",
+                      "OTransform": "translate(0px,640px)",
+                      "WebkitTransform": "translate(0px,640px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,640px)",
                       "position": "absolute",
-                      "top": "640px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,640px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -20212,7 +20614,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-trend-2"
                   onMouseDown={[Function]}
@@ -20222,11 +20624,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,640px)",
+                      "OTransform": "translate(648px,640px)",
+                      "WebkitTransform": "translate(648px,640px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,640px)",
                       "position": "absolute",
-                      "top": "640px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,640px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -20330,7 +20735,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-trend-3"
                   onMouseDown={[Function]}
@@ -20340,11 +20745,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,800px)",
+                      "OTransform": "translate(0px,800px)",
+                      "WebkitTransform": "translate(0px,800px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,800px)",
                       "position": "absolute",
-                      "top": "800px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,800px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -20450,7 +20858,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-threshold-0"
                   onMouseDown={[Function]}
@@ -20460,11 +20868,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,800px)",
+                      "OTransform": "translate(648px,800px)",
+                      "WebkitTransform": "translate(648px,800px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,800px)",
                       "position": "absolute",
-                      "top": "800px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,800px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -20558,7 +20969,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-threshold-1"
                   onMouseDown={[Function]}
@@ -20568,11 +20979,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,960px)",
+                      "OTransform": "translate(0px,960px)",
+                      "WebkitTransform": "translate(0px,960px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,960px)",
                       "position": "absolute",
-                      "top": "960px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,960px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -20671,7 +21085,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-threshold-2"
                   onMouseDown={[Function]}
@@ -20681,11 +21095,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,960px)",
+                      "OTransform": "translate(648px,960px)",
+                      "WebkitTransform": "translate(648px,960px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,960px)",
                       "position": "absolute",
-                      "top": "960px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,960px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -20784,7 +21201,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-number-threshold-3"
                   onMouseDown={[Function]}
@@ -20794,11 +21211,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,1120px)",
+                      "OTransform": "translate(0px,1120px)",
+                      "WebkitTransform": "translate(0px,1120px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,1120px)",
                       "position": "absolute",
-                      "top": "1120px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,1120px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -20892,7 +21312,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-string-threshold-0"
                   onMouseDown={[Function]}
@@ -20902,11 +21322,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,1120px)",
+                      "OTransform": "translate(648px,1120px)",
+                      "WebkitTransform": "translate(648px,1120px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,1120px)",
                       "position": "absolute",
-                      "top": "1120px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,1120px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -20984,7 +21407,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-string-threshold-1"
                   onMouseDown={[Function]}
@@ -20994,11 +21417,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,1280px)",
+                      "OTransform": "translate(0px,1280px)",
+                      "WebkitTransform": "translate(0px,1280px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,1280px)",
                       "position": "absolute",
-                      "top": "1280px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,1280px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -21076,7 +21502,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-string-threshold-2"
                   onMouseDown={[Function]}
@@ -21086,11 +21512,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,1280px)",
+                      "OTransform": "translate(648px,1280px)",
+                      "WebkitTransform": "translate(648px,1280px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,1280px)",
                       "position": "absolute",
-                      "top": "1280px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,1280px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -21168,7 +21597,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-string-threshold-3"
                   onMouseDown={[Function]}
@@ -21178,11 +21607,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,1440px)",
+                      "OTransform": "translate(0px,1440px)",
+                      "WebkitTransform": "translate(0px,1440px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,1440px)",
                       "position": "absolute",
-                      "top": "1440px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,1440px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -21260,7 +21692,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-string-threshold-4"
                   onMouseDown={[Function]}
@@ -21270,11 +21702,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,1440px)",
+                      "OTransform": "translate(648px,1440px)",
+                      "WebkitTransform": "translate(648px,1440px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,1440px)",
                       "position": "absolute",
-                      "top": "1440px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,1440px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -21421,7 +21856,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 }
               >
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-0"
                   onMouseDown={[Function]}
@@ -21431,11 +21866,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,0px)",
+                      "OTransform": "translate(0px,0px)",
+                      "WebkitTransform": "translate(0px,0px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -21561,7 +21999,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-1"
                   onMouseDown={[Function]}
@@ -21571,11 +22009,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,0px)",
+                      "OTransform": "translate(648px,0px)",
+                      "WebkitTransform": "translate(648px,0px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -21699,7 +22140,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-2"
                   onMouseDown={[Function]}
@@ -21709,11 +22150,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,160px)",
+                      "OTransform": "translate(0px,160px)",
+                      "WebkitTransform": "translate(0px,160px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,160px)",
                       "position": "absolute",
-                      "top": "160px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,160px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -21908,7 +22352,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 }
               >
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-0"
                   onMouseDown={[Function]}
@@ -21918,11 +22362,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,0px)",
+                      "OTransform": "translate(0px,0px)",
+                      "WebkitTransform": "translate(0px,0px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -22048,7 +22495,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-1"
                   onMouseDown={[Function]}
@@ -22058,11 +22505,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,0px)",
+                      "OTransform": "translate(648px,0px)",
+                      "WebkitTransform": "translate(648px,0px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -22186,7 +22636,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-2"
                   onMouseDown={[Function]}
@@ -22196,11 +22646,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,160px)",
+                      "OTransform": "translate(0px,160px)",
+                      "WebkitTransform": "translate(0px,160px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,160px)",
                       "position": "absolute",
-                      "top": "160px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,160px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -22395,7 +22848,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 }
               >
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-0"
                   onMouseDown={[Function]}
@@ -22405,11 +22858,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,0px)",
+                      "OTransform": "translate(0px,0px)",
+                      "WebkitTransform": "translate(0px,0px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -22587,7 +23043,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-1"
                   onMouseDown={[Function]}
@@ -22597,11 +23053,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,0px)",
+                      "OTransform": "translate(648px,0px)",
+                      "WebkitTransform": "translate(648px,0px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -22751,7 +23210,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-2"
                   onMouseDown={[Function]}
@@ -22761,11 +23220,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,160px)",
+                      "OTransform": "translate(0px,160px)",
+                      "WebkitTransform": "translate(0px,160px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,160px)",
                       "position": "absolute",
-                      "top": "160px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,160px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -23011,7 +23473,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 }
               >
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-0"
                   onMouseDown={[Function]}
@@ -23021,11 +23483,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,0px)",
+                      "OTransform": "translate(0px,0px)",
+                      "WebkitTransform": "translate(0px,0px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -23203,7 +23668,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-1"
                   onMouseDown={[Function]}
@@ -23213,11 +23678,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,0px)",
+                      "OTransform": "translate(648px,0px)",
+                      "WebkitTransform": "translate(648px,0px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -23367,7 +23835,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-2"
                   onMouseDown={[Function]}
@@ -23377,11 +23845,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,160px)",
+                      "OTransform": "translate(0px,160px)",
+                      "WebkitTransform": "translate(0px,160px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,160px)",
                       "position": "absolute",
-                      "top": "160px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,160px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -23627,7 +24098,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 }
               >
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-number-threshold-0"
                   onMouseDown={[Function]}
@@ -23637,11 +24108,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,0px)",
+                      "OTransform": "translate(0px,0px)",
+                      "WebkitTransform": "translate(0px,0px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -23804,7 +24278,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-number-threshold-1"
                   onMouseDown={[Function]}
@@ -23814,11 +24288,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,0px)",
+                      "OTransform": "translate(648px,0px)",
+                      "WebkitTransform": "translate(648px,0px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -24050,7 +24527,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 }
               >
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-number-threshold-0"
                   onMouseDown={[Function]}
@@ -24060,11 +24537,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(0px,0px)",
+                      "OTransform": "translate(0px,0px)",
+                      "WebkitTransform": "translate(0px,0px)",
                       "height": "144px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -24227,7 +24707,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-number-threshold-1"
                   onMouseDown={[Function]}
@@ -24237,11 +24717,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,0px)",
+                      "OTransform": "translate(648px,0px)",
+                      "WebkitTransform": "translate(648px,0px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -24473,7 +24956,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 }
               >
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-number-threshold-0"
                   onMouseDown={[Function]}
@@ -24483,11 +24966,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "304px",
+                      "MozTransform": "translate(0px,0px)",
+                      "OTransform": "translate(0px,0px)",
+                      "WebkitTransform": "translate(0px,0px)",
                       "height": "304px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -24711,7 +25197,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-number-threshold-1"
                   onMouseDown={[Function]}
@@ -24721,11 +25207,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "304px",
+                      "MozTransform": "translate(648px,0px)",
+                      "OTransform": "translate(648px,0px)",
+                      "WebkitTransform": "translate(648px,0px)",
                       "height": "304px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -24891,7 +25380,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-number-threshold-2"
                   onMouseDown={[Function]}
@@ -24901,11 +25390,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "304px",
+                      "MozTransform": "translate(0px,320px)",
+                      "OTransform": "translate(0px,320px)",
+                      "WebkitTransform": "translate(0px,320px)",
                       "height": "304px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,320px)",
                       "position": "absolute",
-                      "top": "320px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,320px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -25198,7 +25690,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 }
               >
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-number-threshold-0"
                   onMouseDown={[Function]}
@@ -25208,11 +25700,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "304px",
+                      "MozTransform": "translate(0px,0px)",
+                      "OTransform": "translate(0px,0px)",
+                      "WebkitTransform": "translate(0px,0px)",
                       "height": "304px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -25436,7 +25931,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-number-threshold-1"
                   onMouseDown={[Function]}
@@ -25446,11 +25941,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "304px",
+                      "MozTransform": "translate(648px,0px)",
+                      "OTransform": "translate(648px,0px)",
+                      "WebkitTransform": "translate(648px,0px)",
                       "height": "304px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -25616,7 +26114,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="xsmallwide-multi-number-threshold-2"
                   onMouseDown={[Function]}
@@ -25626,11 +26124,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "304px",
+                      "MozTransform": "translate(0px,320px)",
+                      "OTransform": "translate(0px,320px)",
+                      "WebkitTransform": "translate(0px,320px)",
                       "height": "304px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,320px)",
                       "position": "absolute",
-                      "top": "320px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,320px)",
+                      "width": "632px",
                     }
                   }
                   type="VALUE"
@@ -25983,7 +26484,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
               }
             >
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard"
                 onMouseDown={[Function]}
@@ -25993,11 +26494,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "304px",
+                    "MozTransform": "translate(0px,0px)",
+                    "OTransform": "translate(0px,0px)",
+                    "WebkitTransform": "translate(0px,0px)",
                     "height": "304px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,0px)",
                     "position": "absolute",
-                    "top": "0px",
-                    "width": "49.375%",
+                    "transform": "translate(0px,0px)",
+                    "width": "632px",
                   }
                 }
                 type="VALUE"
@@ -26172,7 +26676,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--bar-chart-card iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--bar-chart-card iot--card--wrapper"
                 data-testid="Card"
                 id="barchartcard"
                 onMouseDown={[Function]}
@@ -26182,11 +26686,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "304px",
+                    "MozTransform": "translate(0px,320px)",
+                    "OTransform": "translate(0px,320px)",
+                    "WebkitTransform": "translate(0px,320px)",
                     "height": "304px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,320px)",
                     "position": "absolute",
-                    "top": "320px",
-                    "width": "100%",
+                    "transform": "translate(0px,320px)",
+                    "width": "1280px",
                   }
                 }
                 type="BAR"
@@ -26256,7 +26763,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-xs"
                 onMouseDown={[Function]}
@@ -26266,11 +26773,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(0px,640px)",
+                    "OTransform": "translate(0px,640px)",
+                    "WebkitTransform": "translate(0px,640px)",
                     "height": "144px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,640px)",
                     "position": "absolute",
-                    "top": "640px",
-                    "width": "24.0625%",
+                    "transform": "translate(0px,640px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -26351,7 +26861,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-tooltip"
                 onMouseDown={[Function]}
@@ -26361,11 +26871,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(324px,640px)",
+                    "OTransform": "translate(324px,640px)",
+                    "WebkitTransform": "translate(324px,640px)",
                     "height": "144px",
-                    "left": "25.3125%",
+                    "msTransform": "translate(324px,640px)",
                     "position": "absolute",
-                    "top": "640px",
-                    "width": "24.0625%",
+                    "transform": "translate(324px,640px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -26446,7 +26959,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="section-card"
                 onMouseDown={[Function]}
@@ -26456,11 +26969,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(648px,640px)",
+                    "OTransform": "translate(648px,640px)",
+                    "WebkitTransform": "translate(648px,640px)",
                     "height": "144px",
-                    "left": "50.625%",
+                    "msTransform": "translate(648px,640px)",
                     "position": "absolute",
-                    "top": "640px",
-                    "width": "49.375%",
+                    "transform": "translate(648px,640px)",
+                    "width": "632px",
                   }
                 }
                 type="CUSTOM"
@@ -26485,7 +27001,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-xs2"
                 onMouseDown={[Function]}
@@ -26495,11 +27011,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(0px,800px)",
+                    "OTransform": "translate(0px,800px)",
+                    "WebkitTransform": "translate(0px,800px)",
                     "height": "144px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,800px)",
                     "position": "absolute",
-                    "top": "800px",
-                    "width": "24.0625%",
+                    "transform": "translate(0px,800px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -26582,7 +27101,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-xs3"
                 onMouseDown={[Function]}
@@ -26592,11 +27111,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(324px,800px)",
+                    "OTransform": "translate(324px,800px)",
+                    "WebkitTransform": "translate(324px,800px)",
                     "height": "144px",
-                    "left": "25.3125%",
+                    "msTransform": "translate(324px,800px)",
                     "position": "absolute",
-                    "top": "800px",
-                    "width": "24.0625%",
+                    "transform": "translate(324px,800px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -26705,7 +27227,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-comfort-level"
                 onMouseDown={[Function]}
@@ -26715,11 +27237,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(648px,800px)",
+                    "OTransform": "translate(648px,800px)",
+                    "WebkitTransform": "translate(648px,800px)",
                     "height": "144px",
-                    "left": "50.625%",
+                    "msTransform": "translate(648px,800px)",
                     "position": "absolute",
-                    "top": "800px",
-                    "width": "24.0625%",
+                    "transform": "translate(648px,800px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -26816,7 +27341,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-xs4"
                 onMouseDown={[Function]}
@@ -26826,11 +27351,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(972px,800px)",
+                    "OTransform": "translate(972px,800px)",
+                    "WebkitTransform": "translate(972px,800px)",
                     "height": "144px",
-                    "left": "75.9375%",
+                    "msTransform": "translate(972px,800px)",
                     "position": "absolute",
-                    "top": "800px",
-                    "width": "24.0625%",
+                    "transform": "translate(972px,800px)",
+                    "width": "308px",
                   }
                 }
                 type="VALUE"
@@ -26947,11 +27475,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(0px,960px)",
+                    "OTransform": "translate(0px,960px)",
+                    "WebkitTransform": "translate(0px,960px)",
                     "height": "144px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,960px)",
                     "position": "absolute",
-                    "top": "960px",
-                    "width": "24.0625%",
+                    "transform": "translate(0px,960px)",
+                    "width": "308px",
                   }
                 }
                 type="GAUGE"
@@ -27017,7 +27548,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   }
                 >
                   <div
-                    className="iot--gauge-container react-grid-item react-resizable-hide react-resizable"
+                    className="iot--gauge-container react-grid-item cssTransforms react-resizable-hide react-resizable"
                     style={
                       Object {
                         "paddingBottom": 0,
@@ -27029,7 +27560,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   >
                     <svg
                       aria-labelledby="gauge-label"
-                      className="iot--gauge react-grid-item react-resizable-hide react-resizable"
+                      className="iot--gauge react-grid-item cssTransforms react-resizable-hide react-resizable"
                       percent="0"
                       style={
                         Object {
@@ -27088,7 +27619,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facilitycard-health"
                 onMouseDown={[Function]}
@@ -27098,11 +27629,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "144px",
+                    "MozTransform": "translate(324px,960px)",
+                    "OTransform": "translate(324px,960px)",
+                    "WebkitTransform": "translate(324px,960px)",
                     "height": "144px",
-                    "left": "25.3125%",
+                    "msTransform": "translate(324px,960px)",
                     "position": "absolute",
-                    "top": "960px",
-                    "width": "49.375%",
+                    "transform": "translate(324px,960px)",
+                    "width": "632px",
                   }
                 }
                 type="VALUE"
@@ -27204,7 +27738,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facility-temperature-timeseries"
                 onMouseDown={[Function]}
@@ -27214,11 +27748,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "304px",
+                    "MozTransform": "translate(0px,1120px)",
+                    "OTransform": "translate(0px,1120px)",
+                    "WebkitTransform": "translate(0px,1120px)",
                     "height": "304px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,1120px)",
                     "position": "absolute",
-                    "top": "1120px",
-                    "width": "49.375%",
+                    "transform": "translate(0px,1120px)",
+                    "width": "632px",
                   }
                 }
                 type="TIMESERIES"
@@ -27333,7 +27870,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="alert-table1"
                 onMouseDown={[Function]}
@@ -27343,11 +27880,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "624px",
+                    "MozTransform": "translate(648px,1120px)",
+                    "OTransform": "translate(648px,1120px)",
+                    "WebkitTransform": "translate(648px,1120px)",
                     "height": "624px",
-                    "left": "50.625%",
+                    "msTransform": "translate(648px,1120px)",
                     "position": "absolute",
-                    "top": "1120px",
-                    "width": "49.375%",
+                    "transform": "translate(648px,1120px)",
+                    "width": "632px",
                   }
                 }
                 type="TABLE"
@@ -27876,7 +28416,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 </div>
               </div>
               <div
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="facility-multi-timeseries"
                 onMouseDown={[Function]}
@@ -27886,11 +28426,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "624px",
+                    "MozTransform": "translate(0px,1440px)",
+                    "OTransform": "translate(0px,1440px)",
+                    "WebkitTransform": "translate(0px,1440px)",
                     "height": "624px",
-                    "left": "0%",
+                    "msTransform": "translate(0px,1440px)",
                     "position": "absolute",
-                    "top": "1440px",
-                    "width": "49.375%",
+                    "transform": "translate(0px,1440px)",
+                    "width": "632px",
                   }
                 }
                 type="TIMESERIES"
@@ -28006,7 +28549,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
               </div>
               <div
                 accept={null}
-                className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                 data-testid="Card"
                 id="floor map picture"
                 onMouseDown={[Function]}
@@ -28016,11 +28559,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 style={
                   Object {
                     "--card-default-height": "304px",
+                    "MozTransform": "translate(648px,1760px)",
+                    "OTransform": "translate(648px,1760px)",
+                    "WebkitTransform": "translate(648px,1760px)",
                     "height": "304px",
-                    "left": "50.625%",
+                    "msTransform": "translate(648px,1760px)",
                     "position": "absolute",
-                    "top": "1760px",
-                    "width": "49.375%",
+                    "transform": "translate(648px,1760px)",
+                    "width": "632px",
                   }
                 }
                 type="IMAGE"
@@ -28465,7 +29011,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                 }
               >
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="viewDashboards"
                   onMouseDown={[Function]}
@@ -28475,11 +29021,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "304px",
+                      "MozTransform": "translate(0px,0px)",
+                      "OTransform": "translate(0px,0px)",
+                      "WebkitTransform": "translate(0px,0px)",
                       "height": "304px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="CUSTOM"
@@ -28611,7 +29160,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="connectDevices"
                   onMouseDown={[Function]}
@@ -28621,11 +29170,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "304px",
+                      "MozTransform": "translate(648px,0px)",
+                      "OTransform": "translate(648px,0px)",
+                      "WebkitTransform": "translate(648px,0px)",
                       "height": "304px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,0px)",
                       "position": "absolute",
-                      "top": "0px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,0px)",
+                      "width": "632px",
                     }
                   }
                   type="CUSTOM"
@@ -29053,7 +29605,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="monitorEntities"
                   onMouseDown={[Function]}
@@ -29063,11 +29615,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "304px",
+                      "MozTransform": "translate(0px,320px)",
+                      "OTransform": "translate(0px,320px)",
+                      "WebkitTransform": "translate(0px,320px)",
                       "height": "304px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,320px)",
                       "position": "absolute",
-                      "top": "320px",
-                      "width": "49.375%",
+                      "transform": "translate(0px,320px)",
+                      "width": "632px",
                     }
                   }
                   type="CUSTOM"
@@ -29784,7 +30339,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="trackUsage"
                   onMouseDown={[Function]}
@@ -29794,11 +30349,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,320px)",
+                      "OTransform": "translate(648px,320px)",
+                      "WebkitTransform": "translate(648px,320px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,320px)",
                       "position": "absolute",
-                      "top": "320px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,320px)",
+                      "width": "632px",
                     }
                   }
                   type="CUSTOM"
@@ -29853,7 +30411,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   </div>
                 </div>
                 <div
-                  className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+                  className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
                   data-testid="Card"
                   id="administerUsers"
                   onMouseDown={[Function]}
@@ -29863,11 +30421,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "144px",
+                      "MozTransform": "translate(648px,480px)",
+                      "OTransform": "translate(648px,480px)",
+                      "WebkitTransform": "translate(648px,480px)",
                       "height": "144px",
-                      "left": "50.625%",
+                      "msTransform": "translate(648px,480px)",
                       "position": "absolute",
-                      "top": "480px",
-                      "width": "49.375%",
+                      "transform": "translate(648px,480px)",
+                      "width": "632px",
                     }
                   }
                   type="CUSTOM"
@@ -29964,11 +30525,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "304px",
+                      "MozTransform": "translate(0px,640px)",
+                      "OTransform": "translate(0px,640px)",
+                      "WebkitTransform": "translate(0px,640px)",
                       "height": "304px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,640px)",
                       "position": "absolute",
-                      "top": "640px",
-                      "width": "100%",
+                      "transform": "translate(0px,640px)",
+                      "width": "1280px",
                     }
                   }
                   type="LIST"
@@ -29996,7 +30560,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     }
                   >
                     <div
-                      className="list-card react-grid-item react-resizable-hide react-resizable"
+                      className="list-card react-grid-item cssTransforms react-resizable-hide react-resizable"
                       style={
                         Object {
                           "paddingBottom": 0,
@@ -30151,11 +30715,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                   style={
                     Object {
                       "--card-default-height": "304px",
+                      "MozTransform": "translate(0px,960px)",
+                      "OTransform": "translate(0px,960px)",
+                      "WebkitTransform": "translate(0px,960px)",
                       "height": "304px",
-                      "left": "0%",
+                      "msTransform": "translate(0px,960px)",
                       "position": "absolute",
-                      "top": "960px",
-                      "width": "100%",
+                      "transform": "translate(0px,960px)",
+                      "width": "1280px",
                     }
                   }
                   type="LIST"
@@ -30183,7 +30750,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
                     }
                   >
                     <div
-                      className="list-card react-grid-item react-resizable-hide react-resizable"
+                      className="list-card react-grid-item cssTransforms react-resizable-hide react-resizable"
                       style={
                         Object {
                           "paddingBottom": 0,

--- a/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
@@ -40,7 +40,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
           }
         >
           <div
-            className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
             data-testid="Card"
             id="Small"
             onMouseDown={[Function]}
@@ -50,11 +50,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "144px",
+                "MozTransform": "translate(0px,0px)",
+                "OTransform": "translate(0px,0px)",
+                "WebkitTransform": "translate(0px,0px)",
                 "height": "144px",
-                "left": "0%",
+                "msTransform": "translate(0px,0px)",
                 "position": "absolute",
-                "top": "0px",
-                "width": "24.0625%",
+                "transform": "translate(0px,0px)",
+                "width": "308px",
               }
             }
             type="VALUE"
@@ -99,7 +102,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             </div>
           </div>
           <div
-            className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
             data-testid="Card"
             id="Small Wide"
             onMouseDown={[Function]}
@@ -109,11 +112,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "144px",
+                "MozTransform": "translate(324px,0px)",
+                "OTransform": "translate(324px,0px)",
+                "WebkitTransform": "translate(324px,0px)",
                 "height": "144px",
-                "left": "25.3125%",
+                "msTransform": "translate(324px,0px)",
                 "position": "absolute",
-                "top": "0px",
-                "width": "49.375%",
+                "transform": "translate(324px,0px)",
+                "width": "632px",
               }
             }
             type="VALUE"
@@ -158,7 +164,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             </div>
           </div>
           <div
-            className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
             data-testid="Card"
             id="Medium Thin"
             onMouseDown={[Function]}
@@ -168,11 +174,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "304px",
+                "MozTransform": "translate(0px,160px)",
+                "OTransform": "translate(0px,160px)",
+                "WebkitTransform": "translate(0px,160px)",
                 "height": "304px",
-                "left": "0%",
+                "msTransform": "translate(0px,160px)",
                 "position": "absolute",
-                "top": "160px",
-                "width": "24.0625%",
+                "transform": "translate(0px,160px)",
+                "width": "308px",
               }
             }
             type="VALUE"
@@ -217,7 +226,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             </div>
           </div>
           <div
-            className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
             data-testid="Card"
             id="Medium"
             onMouseDown={[Function]}
@@ -227,11 +236,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "304px",
+                "MozTransform": "translate(324px,160px)",
+                "OTransform": "translate(324px,160px)",
+                "WebkitTransform": "translate(324px,160px)",
                 "height": "304px",
-                "left": "25.3125%",
+                "msTransform": "translate(324px,160px)",
                 "position": "absolute",
-                "top": "160px",
-                "width": "49.375%",
+                "transform": "translate(324px,160px)",
+                "width": "632px",
               }
             }
             type="VALUE"
@@ -276,7 +288,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             </div>
           </div>
           <div
-            className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
             data-testid="Card"
             id="Medium Wide"
             onMouseDown={[Function]}
@@ -286,11 +298,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "304px",
+                "MozTransform": "translate(0px,480px)",
+                "OTransform": "translate(0px,480px)",
+                "WebkitTransform": "translate(0px,480px)",
                 "height": "304px",
-                "left": "0%",
+                "msTransform": "translate(0px,480px)",
                 "position": "absolute",
-                "top": "480px",
-                "width": "100%",
+                "transform": "translate(0px,480px)",
+                "width": "1280px",
               }
             }
             type="VALUE"
@@ -335,7 +350,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             </div>
           </div>
           <div
-            className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
             data-testid="Card"
             id="Large Thin"
             onMouseDown={[Function]}
@@ -345,11 +360,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "624px",
+                "MozTransform": "translate(0px,800px)",
+                "OTransform": "translate(0px,800px)",
+                "WebkitTransform": "translate(0px,800px)",
                 "height": "624px",
-                "left": "0%",
+                "msTransform": "translate(0px,800px)",
                 "position": "absolute",
-                "top": "800px",
-                "width": "24.0625%",
+                "transform": "translate(0px,800px)",
+                "width": "308px",
               }
             }
             type="VALUE"
@@ -394,7 +412,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             </div>
           </div>
           <div
-            className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
             data-testid="Card"
             id="Large"
             onMouseDown={[Function]}
@@ -404,11 +422,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "624px",
+                "MozTransform": "translate(324px,800px)",
+                "OTransform": "translate(324px,800px)",
+                "WebkitTransform": "translate(324px,800px)",
                 "height": "624px",
-                "left": "25.3125%",
+                "msTransform": "translate(324px,800px)",
                 "position": "absolute",
-                "top": "800px",
-                "width": "49.375%",
+                "transform": "translate(324px,800px)",
+                "width": "632px",
               }
             }
             type="VALUE"
@@ -453,7 +474,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             </div>
           </div>
           <div
-            className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
             data-testid="Card"
             id="Large Wide"
             onMouseDown={[Function]}
@@ -463,11 +484,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "624px",
+                "MozTransform": "translate(0px,1440px)",
+                "OTransform": "translate(0px,1440px)",
+                "WebkitTransform": "translate(0px,1440px)",
                 "height": "624px",
-                "left": "0%",
+                "msTransform": "translate(0px,1440px)",
                 "position": "absolute",
-                "top": "1440px",
-                "width": "100%",
+                "transform": "translate(0px,1440px)",
+                "width": "1280px",
               }
             }
             type="VALUE"
@@ -583,7 +607,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
           }
         >
           <div
-            className="iot--card react-grid-item react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item cssTransforms react-resizable iot--card--wrapper"
             data-testid="Card"
             id="card"
             onMouseDown={[Function]}
@@ -593,11 +617,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "144px",
+                "MozTransform": "translate(0px,0px)",
+                "OTransform": "translate(0px,0px)",
+                "WebkitTransform": "translate(0px,0px)",
                 "height": "144px",
-                "left": "0%",
+                "msTransform": "translate(0px,0px)",
                 "position": "absolute",
-                "top": "0px",
-                "width": "24.0625%",
+                "transform": "translate(0px,0px)",
+                "width": "308px",
               }
             }
           >
@@ -656,7 +683,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             />
           </div>
           <div
-            className="iot--card react-grid-item react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item cssTransforms react-resizable iot--card--wrapper"
             data-testid="Card"
             id="valueCard"
             onMouseDown={[Function]}
@@ -666,11 +693,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "144px",
+                "MozTransform": "translate(324px,0px)",
+                "OTransform": "translate(324px,0px)",
+                "WebkitTransform": "translate(324px,0px)",
                 "height": "144px",
-                "left": "25.3125%",
+                "msTransform": "translate(324px,0px)",
                 "position": "absolute",
-                "top": "0px",
-                "width": "49.375%",
+                "transform": "translate(324px,0px)",
+                "width": "632px",
               }
             }
           >
@@ -806,11 +836,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "304px",
+                "MozTransform": "translate(0px,160px)",
+                "OTransform": "translate(0px,160px)",
+                "WebkitTransform": "translate(0px,160px)",
                 "height": "304px",
-                "left": "0%",
+                "msTransform": "translate(0px,160px)",
                 "position": "absolute",
-                "top": "160px",
-                "width": "24.0625%",
+                "transform": "translate(0px,160px)",
+                "width": "308px",
               }
             }
           >
@@ -875,7 +908,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
               }
             >
               <div
-                className="iot--gauge-container react-grid-item react-resizable"
+                className="iot--gauge-container react-grid-item cssTransforms react-resizable"
                 style={
                   Object {
                     "paddingBottom": 0,
@@ -887,7 +920,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
               >
                 <svg
                   aria-labelledby="gauge-label"
-                  className="iot--gauge react-grid-item react-resizable"
+                  className="iot--gauge react-grid-item cssTransforms react-resizable"
                   percent="0"
                   style={
                     Object {
@@ -958,7 +991,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             />
           </div>
           <div
-            className="iot--card react-grid-item react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item cssTransforms react-resizable iot--card--wrapper"
             data-testid="Card"
             id="pieChartCard"
             onMouseDown={[Function]}
@@ -968,11 +1001,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "304px",
+                "MozTransform": "translate(324px,160px)",
+                "OTransform": "translate(324px,160px)",
+                "WebkitTransform": "translate(324px,160px)",
                 "height": "304px",
-                "left": "25.3125%",
+                "msTransform": "translate(324px,160px)",
                 "position": "absolute",
-                "top": "160px",
-                "width": "49.375%",
+                "transform": "translate(324px,160px)",
+                "width": "632px",
               }
             }
           >
@@ -1032,7 +1068,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             />
           </div>
           <div
-            className="iot--card react-grid-item react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item cssTransforms react-resizable iot--card--wrapper"
             data-testid="Card"
             id="tableCard"
             onMouseDown={[Function]}
@@ -1042,11 +1078,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "624px",
+                "MozTransform": "translate(324px,1120px)",
+                "OTransform": "translate(324px,1120px)",
+                "WebkitTransform": "translate(324px,1120px)",
                 "height": "624px",
-                "left": "25.3125%",
+                "msTransform": "translate(324px,1120px)",
                 "position": "absolute",
-                "top": "1120px",
-                "width": "49.375%",
+                "transform": "translate(324px,1120px)",
+                "width": "632px",
               }
             }
           >
@@ -2428,7 +2467,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
           </div>
           <div
             accept={null}
-            className="iot--card react-grid-item react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item cssTransforms react-resizable iot--card--wrapper"
             data-testid="Card"
             id="imageCard"
             onMouseDown={[Function]}
@@ -2438,11 +2477,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "624px",
+                "MozTransform": "translate(648px,480px)",
+                "OTransform": "translate(648px,480px)",
+                "WebkitTransform": "translate(648px,480px)",
                 "height": "624px",
-                "left": "50.625%",
+                "msTransform": "translate(648px,480px)",
                 "position": "absolute",
-                "top": "480px",
-                "width": "49.375%",
+                "transform": "translate(648px,480px)",
+                "width": "632px",
               }
             }
           >
@@ -2669,7 +2711,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             />
           </div>
           <div
-            className="iot--card react-grid-item react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item cssTransforms react-resizable iot--card--wrapper"
             data-testid="Card"
             id="timeSeriesCard"
             onMouseDown={[Function]}
@@ -2679,11 +2721,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "624px",
+                "MozTransform": "translate(0px,480px)",
+                "OTransform": "translate(0px,480px)",
+                "WebkitTransform": "translate(0px,480px)",
                 "height": "624px",
-                "left": "0%",
+                "msTransform": "translate(0px,480px)",
                 "position": "absolute",
-                "top": "480px",
-                "width": "24.0625%",
+                "transform": "translate(0px,480px)",
+                "width": "308px",
               }
             }
           >
@@ -2742,11 +2787,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "624px",
+                "MozTransform": "translate(324px,1760px)",
+                "OTransform": "translate(324px,1760px)",
+                "WebkitTransform": "translate(324px,1760px)",
                 "height": "624px",
-                "left": "25.3125%",
+                "msTransform": "translate(324px,1760px)",
                 "position": "absolute",
-                "top": "1760px",
-                "width": "24.0625%",
+                "transform": "translate(324px,1760px)",
+                "width": "308px",
               }
             }
           >
@@ -2773,7 +2821,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
               }
             >
               <div
-                className="list-card react-grid-item react-resizable"
+                className="list-card react-grid-item cssTransforms react-resizable"
                 style={
                   Object {
                     "paddingBottom": 0,
@@ -2963,7 +3011,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             />
           </div>
           <div
-            className="iot--card react-grid-item react-resizable iot--bar-chart-card iot--card--wrapper"
+            className="iot--card react-grid-item cssTransforms react-resizable iot--bar-chart-card iot--card--wrapper"
             data-testid="Card"
             id="barChartCard"
             onMouseDown={[Function]}
@@ -2973,11 +3021,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "624px",
+                "MozTransform": "translate(0px,2400px)",
+                "OTransform": "translate(0px,2400px)",
+                "WebkitTransform": "translate(0px,2400px)",
                 "height": "624px",
-                "left": "0%",
+                "msTransform": "translate(0px,2400px)",
                 "position": "absolute",
-                "top": "2400px",
-                "width": "100%",
+                "transform": "translate(0px,2400px)",
+                "width": "1280px",
               }
             }
           >
@@ -3094,7 +3145,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
           }
         >
           <div
-            className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
             content="My Facility Metrics"
             data-testid="Card"
             id="facility"
@@ -3105,11 +3156,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "304px",
+                "MozTransform": "translate(324px,320px)",
+                "OTransform": "translate(324px,320px)",
+                "WebkitTransform": "translate(324px,320px)",
                 "height": "304px",
-                "left": "25.3125%",
+                "msTransform": "translate(324px,320px)",
                 "position": "absolute",
-                "top": "320px",
-                "width": "49.375%",
+                "transform": "translate(324px,320px)",
+                "width": "632px",
               }
             }
             type="VALUE"
@@ -3154,7 +3208,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             </div>
           </div>
           <div
-            className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
             content="My Humidity Values"
             data-testid="Card"
             id="humidity"
@@ -3165,11 +3219,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "144px",
+                "MozTransform": "translate(0px,0px)",
+                "OTransform": "translate(0px,0px)",
+                "WebkitTransform": "translate(0px,0px)",
                 "height": "144px",
-                "left": "0%",
+                "msTransform": "translate(0px,0px)",
                 "position": "absolute",
-                "top": "0px",
-                "width": "24.0625%",
+                "transform": "translate(0px,0px)",
+                "width": "308px",
               }
             }
             type="VALUE"
@@ -3214,7 +3271,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             </div>
           </div>
           <div
-            className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
             content="My utilization chart"
             data-testid="Card"
             id="utilization"
@@ -3225,11 +3282,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "144px",
+                "MozTransform": "translate(243px,160px)",
+                "OTransform": "translate(243px,160px)",
+                "WebkitTransform": "translate(243px,160px)",
                 "height": "144px",
-                "left": "18.984375%",
+                "msTransform": "translate(243px,160px)",
                 "position": "absolute",
-                "top": "160px",
-                "width": "24.0625%",
+                "transform": "translate(243px,160px)",
+                "width": "308px",
               }
             }
             type="VALUE"
@@ -3326,200 +3386,226 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
       <div
         style={
           Object {
-            "flex": 1,
+            "display": "flex",
           }
         }
       >
         <div
-          className="react-grid-layout iot--dashboard-grid"
-          onDragEnter={[Function]}
-          onDragLeave={[Function]}
-          onDragOver={[Function]}
-          onDrop={[Function]}
           style={
             Object {
-              "height": "304px",
+              "width": "200px",
+            }
+          }
+        >
+          Sample sidebar
+        </div>
+        <div
+          style={
+            Object {
+              "flex": 1,
             }
           }
         >
           <div
-            className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
-            content="My Facility Metrics"
-            data-testid="Card"
-            id="facility"
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            role="presentation"
+            className="react-grid-layout iot--dashboard-grid"
+            onDragEnter={[Function]}
+            onDragLeave={[Function]}
+            onDragOver={[Function]}
+            onDrop={[Function]}
             style={
               Object {
-                "--card-default-height": "304px",
                 "height": "304px",
-                "left": "0%",
-                "position": "absolute",
-                "top": "0px",
-                "width": "49.375%",
               }
             }
-            type="VALUE"
           >
             <div
-              className="iot--card--header"
-            >
-              <span
-                className="iot--card--title"
-                title="Facility Metrics"
-              >
-                <div
-                  className="iot--card--title--text"
-                >
-                  Facility Metrics
-                </div>
-              </span>
-              <div
-                className="iot--card--toolbar"
-              />
-            </div>
-            <div
-              className="iot--card--content"
+              className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
+              content="My Facility Metrics"
+              data-testid="Card"
+              id="facility"
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              role="presentation"
               style={
                 Object {
-                  "--card-content-height": "256px",
+                  "--card-default-height": "304px",
+                  "MozTransform": "translate(0px,0px)",
+                  "OTransform": "translate(0px,0px)",
+                  "WebkitTransform": "translate(0px,0px)",
+                  "height": "304px",
+                  "msTransform": "translate(0px,0px)",
+                  "position": "absolute",
+                  "transform": "translate(0px,0px)",
+                  "width": "632px",
                 }
               }
+              type="VALUE"
             >
-              <span
-                className="react-resizable-handle react-resizable-handle-se"
-                onMouseDown={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchStart={[Function]}
+              <div
+                className="iot--card--header"
+              >
+                <span
+                  className="iot--card--title"
+                  title="Facility Metrics"
+                >
+                  <div
+                    className="iot--card--title--text"
+                  >
+                    Facility Metrics
+                  </div>
+                </span>
+                <div
+                  className="iot--card--toolbar"
+                />
+              </div>
+              <div
+                className="iot--card--content"
                 style={
                   Object {
-                    "touchAction": "none",
+                    "--card-content-height": "256px",
                   }
                 }
-              />
-            </div>
-          </div>
-          <div
-            className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
-            content="My Humidity Values"
-            data-testid="Card"
-            id="humidity"
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            role="presentation"
-            style={
-              Object {
-                "--card-default-height": "144px",
-                "height": "144px",
-                "left": "50.625%",
-                "position": "absolute",
-                "top": "0px",
-                "width": "24.0625%",
-              }
-            }
-            type="VALUE"
-          >
-            <div
-              className="iot--card--header"
-            >
-              <span
-                className="iot--card--title"
-                title="Humidity"
               >
-                <div
-                  className="iot--card--title--text"
-                >
-                  Humidity
-                </div>
-              </span>
-              <div
-                className="iot--card--toolbar"
-              />
+                <span
+                  className="react-resizable-handle react-resizable-handle-se"
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                />
+              </div>
             </div>
             <div
-              className="iot--card--content"
+              className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
+              content="My Humidity Values"
+              data-testid="Card"
+              id="humidity"
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              role="presentation"
               style={
                 Object {
-                  "--card-content-height": "96px",
+                  "--card-default-height": "144px",
+                  "MozTransform": "translate(648px,0px)",
+                  "OTransform": "translate(648px,0px)",
+                  "WebkitTransform": "translate(648px,0px)",
+                  "height": "144px",
+                  "msTransform": "translate(648px,0px)",
+                  "position": "absolute",
+                  "transform": "translate(648px,0px)",
+                  "width": "308px",
                 }
               }
+              type="VALUE"
             >
-              <span
-                className="react-resizable-handle react-resizable-handle-se"
-                onMouseDown={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchStart={[Function]}
+              <div
+                className="iot--card--header"
+              >
+                <span
+                  className="iot--card--title"
+                  title="Humidity"
+                >
+                  <div
+                    className="iot--card--title--text"
+                  >
+                    Humidity
+                  </div>
+                </span>
+                <div
+                  className="iot--card--toolbar"
+                />
+              </div>
+              <div
+                className="iot--card--content"
                 style={
                   Object {
-                    "touchAction": "none",
+                    "--card-content-height": "96px",
                   }
                 }
-              />
-            </div>
-          </div>
-          <div
-            className="iot--card react-grid-item react-resizable-hide react-resizable iot--card--wrapper"
-            content="My utilization chart"
-            data-testid="Card"
-            id="utilization"
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            role="presentation"
-            style={
-              Object {
-                "--card-default-height": "144px",
-                "height": "144px",
-                "left": "75.9375%",
-                "position": "absolute",
-                "top": "0px",
-                "width": "24.0625%",
-              }
-            }
-            type="VALUE"
-          >
-            <div
-              className="iot--card--header"
-            >
-              <span
-                className="iot--card--title"
-                title="Utilization"
               >
-                <div
-                  className="iot--card--title--text"
-                >
-                  Utilization
-                </div>
-              </span>
-              <div
-                className="iot--card--toolbar"
-              />
+                <span
+                  className="react-resizable-handle react-resizable-handle-se"
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                />
+              </div>
             </div>
             <div
-              className="iot--card--content"
+              className="iot--card react-grid-item cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
+              content="My utilization chart"
+              data-testid="Card"
+              id="utilization"
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              role="presentation"
               style={
                 Object {
-                  "--card-content-height": "96px",
+                  "--card-default-height": "144px",
+                  "MozTransform": "translate(972px,0px)",
+                  "OTransform": "translate(972px,0px)",
+                  "WebkitTransform": "translate(972px,0px)",
+                  "height": "144px",
+                  "msTransform": "translate(972px,0px)",
+                  "position": "absolute",
+                  "transform": "translate(972px,0px)",
+                  "width": "308px",
                 }
               }
+              type="VALUE"
             >
-              <span
-                className="react-resizable-handle react-resizable-handle-se"
-                onMouseDown={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchStart={[Function]}
+              <div
+                className="iot--card--header"
+              >
+                <span
+                  className="iot--card--title"
+                  title="Utilization"
+                >
+                  <div
+                    className="iot--card--title--text"
+                  >
+                    Utilization
+                  </div>
+                </span>
+                <div
+                  className="iot--card--toolbar"
+                />
+              </div>
+              <div
+                className="iot--card--content"
                 style={
                   Object {
-                    "touchAction": "none",
+                    "--card-content-height": "96px",
                   }
                 }
-              />
+              >
+                <span
+                  className="react-resizable-handle react-resizable-handle-se"
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -3592,7 +3678,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
           }
         >
           <div
-            className="iot--card react-grid-item react-draggable react-resizable-hide react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item react-draggable cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
             content="My Facility Metrics"
             data-testid="Card"
             id="facility"
@@ -3603,11 +3689,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "304px",
+                "MozTransform": "translate(0px,0px)",
+                "OTransform": "translate(0px,0px)",
+                "WebkitTransform": "translate(0px,0px)",
                 "height": "304px",
-                "left": "0%",
+                "msTransform": "translate(0px,0px)",
                 "position": "absolute",
-                "top": "0px",
-                "width": "49.375%",
+                "transform": "translate(0px,0px)",
+                "width": "632px",
               }
             }
             type="VALUE"
@@ -3652,7 +3741,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             </div>
           </div>
           <div
-            className="iot--card react-grid-item react-draggable react-resizable-hide react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item react-draggable cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
             content="My Humidity Values"
             data-testid="Card"
             id="humidity"
@@ -3663,11 +3752,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "144px",
+                "MozTransform": "translate(648px,0px)",
+                "OTransform": "translate(648px,0px)",
+                "WebkitTransform": "translate(648px,0px)",
                 "height": "144px",
-                "left": "50.625%",
+                "msTransform": "translate(648px,0px)",
                 "position": "absolute",
-                "top": "0px",
-                "width": "24.0625%",
+                "transform": "translate(648px,0px)",
+                "width": "308px",
               }
             }
             type="VALUE"
@@ -3712,7 +3804,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             </div>
           </div>
           <div
-            className="iot--card react-grid-item react-draggable react-resizable-hide react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item react-draggable cssTransforms react-resizable-hide react-resizable iot--card--wrapper"
             content="My utilization chart"
             data-testid="Card"
             id="utilization"
@@ -3723,11 +3815,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "144px",
+                "MozTransform": "translate(972px,0px)",
+                "OTransform": "translate(972px,0px)",
+                "WebkitTransform": "translate(972px,0px)",
                 "height": "144px",
-                "left": "75.9375%",
+                "msTransform": "translate(972px,0px)",
                 "position": "absolute",
-                "top": "0px",
-                "width": "24.0625%",
+                "transform": "translate(972px,0px)",
+                "width": "308px",
               }
             }
             type="VALUE"
@@ -3841,7 +3936,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
           }
         >
           <div
-            className="iot--card react-grid-item react-resizable iot--card--wrapper"
+            className="iot--card react-grid-item cssTransforms react-resizable iot--card--wrapper"
             data-testid="Card"
             id="card"
             onMouseDown={[Function]}
@@ -3851,11 +3946,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
             style={
               Object {
                 "--card-default-height": "144px",
+                "MozTransform": "translate(0px,0px)",
+                "OTransform": "translate(0px,0px)",
+                "WebkitTransform": "translate(0px,0px)",
                 "height": "144px",
-                "left": "0%",
+                "msTransform": "translate(0px,0px)",
                 "position": "absolute",
-                "top": "0px",
-                "width": "24.0625%",
+                "transform": "translate(0px,0px)",
+                "width": "308px",
               }
             }
           >

--- a/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -555,11 +555,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                       style={
                         Object {
                           "--card-default-height": "624px",
+                          "MozTransform": "translate(0px,0px)",
+                          "OTransform": "translate(0px,0px)",
+                          "WebkitTransform": "translate(0px,0px)",
                           "height": "624px",
-                          "left": "0%",
+                          "msTransform": "translate(0px,0px)",
                           "position": "absolute",
-                          "top": "0px",
-                          "width": "49.375%",
+                          "transform": "translate(0px,0px)",
+                          "width": "632px",
                         }
                       }
                       tabIndex={0}
@@ -1651,11 +1654,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                       style={
                         Object {
                           "--card-default-height": "304px",
+                          "MozTransform": "translate(648px,0px)",
+                          "OTransform": "translate(648px,0px)",
+                          "WebkitTransform": "translate(648px,0px)",
                           "height": "304px",
-                          "left": "50.625%",
+                          "msTransform": "translate(648px,0px)",
                           "position": "absolute",
-                          "top": "0px",
-                          "width": "49.375%",
+                          "transform": "translate(648px,0px)",
+                          "width": "632px",
                         }
                       }
                       tabIndex={0}
@@ -1748,11 +1754,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                       style={
                         Object {
                           "--card-default-height": "304px",
+                          "MozTransform": "translate(648px,320px)",
+                          "OTransform": "translate(648px,320px)",
+                          "WebkitTransform": "translate(648px,320px)",
                           "height": "304px",
-                          "left": "50.625%",
+                          "msTransform": "translate(648px,320px)",
                           "position": "absolute",
-                          "top": "320px",
-                          "width": "49.375%",
+                          "transform": "translate(648px,320px)",
+                          "width": "632px",
                         }
                       }
                       tabIndex={0}
@@ -1919,11 +1928,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                       style={
                         Object {
                           "--card-default-height": "304px",
+                          "MozTransform": "translate(0px,640px)",
+                          "OTransform": "translate(0px,640px)",
+                          "WebkitTransform": "translate(0px,640px)",
                           "height": "304px",
-                          "left": "0%",
+                          "msTransform": "translate(0px,640px)",
                           "position": "absolute",
-                          "top": "640px",
-                          "width": "100%",
+                          "transform": "translate(0px,640px)",
+                          "width": "1280px",
                         }
                       }
                       tabIndex={0}
@@ -2035,11 +2047,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                       style={
                         Object {
                           "--card-default-height": "304px",
+                          "MozTransform": "translate(0px,960px)",
+                          "OTransform": "translate(0px,960px)",
+                          "WebkitTransform": "translate(0px,960px)",
                           "height": "144px",
-                          "left": "0%",
+                          "msTransform": "translate(0px,960px)",
                           "position": "absolute",
-                          "top": "960px",
-                          "width": "5.078125%",
+                          "transform": "translate(0px,960px)",
+                          "width": "65px",
                         }
                       }
                       tabIndex={0}
@@ -3366,11 +3381,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     style={
                       Object {
                         "--card-default-height": "304px",
+                        "MozTransform": "translate(0px,0px)",
+                        "OTransform": "translate(0px,0px)",
+                        "WebkitTransform": "translate(0px,0px)",
                         "height": "304px",
-                        "left": "0%",
+                        "msTransform": "translate(0px,0px)",
                         "position": "absolute",
-                        "top": "0px",
-                        "width": "49.375%",
+                        "transform": "translate(0px,0px)",
+                        "width": "632px",
                       }
                     }
                     tabIndex={0}
@@ -3476,11 +3494,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     style={
                       Object {
                         "--card-default-height": "304px",
+                        "MozTransform": "translate(648px,0px)",
+                        "OTransform": "translate(648px,0px)",
+                        "WebkitTransform": "translate(648px,0px)",
                         "height": "304px",
-                        "left": "50.625%",
+                        "msTransform": "translate(648px,0px)",
                         "position": "absolute",
-                        "top": "0px",
-                        "width": "49.375%",
+                        "transform": "translate(648px,0px)",
+                        "width": "632px",
                       }
                     }
                     tabIndex={0}
@@ -11980,11 +12001,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     style={
                       Object {
                         "--card-default-height": "304px",
+                        "MozTransform": "translate(0px,0px)",
+                        "OTransform": "translate(0px,0px)",
+                        "WebkitTransform": "translate(0px,0px)",
                         "height": "304px",
-                        "left": "0%",
+                        "msTransform": "translate(0px,0px)",
                         "position": "absolute",
-                        "top": "0px",
-                        "width": "100%",
+                        "transform": "translate(0px,0px)",
+                        "width": "1280px",
                       }
                     }
                     tabIndex={0}
@@ -13310,11 +13334,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     style={
                       Object {
                         "--card-default-height": "624px",
+                        "MozTransform": "translate(0px,0px)",
+                        "OTransform": "translate(0px,0px)",
+                        "WebkitTransform": "translate(0px,0px)",
                         "height": "624px",
-                        "left": "0%",
+                        "msTransform": "translate(0px,0px)",
                         "position": "absolute",
-                        "top": "0px",
-                        "width": "49.375%",
+                        "transform": "translate(0px,0px)",
+                        "width": "632px",
                       }
                     }
                     tabIndex={0}
@@ -14406,11 +14433,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     style={
                       Object {
                         "--card-default-height": "304px",
+                        "MozTransform": "translate(648px,0px)",
+                        "OTransform": "translate(648px,0px)",
+                        "WebkitTransform": "translate(648px,0px)",
                         "height": "304px",
-                        "left": "50.625%",
+                        "msTransform": "translate(648px,0px)",
                         "position": "absolute",
-                        "top": "0px",
-                        "width": "49.375%",
+                        "transform": "translate(648px,0px)",
+                        "width": "632px",
                       }
                     }
                     tabIndex={0}
@@ -14503,11 +14533,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     style={
                       Object {
                         "--card-default-height": "304px",
+                        "MozTransform": "translate(648px,320px)",
+                        "OTransform": "translate(648px,320px)",
+                        "WebkitTransform": "translate(648px,320px)",
                         "height": "304px",
-                        "left": "50.625%",
+                        "msTransform": "translate(648px,320px)",
                         "position": "absolute",
-                        "top": "320px",
-                        "width": "49.375%",
+                        "transform": "translate(648px,320px)",
+                        "width": "632px",
                       }
                     }
                     tabIndex={0}
@@ -14720,11 +14753,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     style={
                       Object {
                         "--card-default-height": "304px",
+                        "MozTransform": "translate(0px,640px)",
+                        "OTransform": "translate(0px,640px)",
+                        "WebkitTransform": "translate(0px,640px)",
                         "height": "304px",
-                        "left": "0%",
+                        "msTransform": "translate(0px,640px)",
                         "position": "absolute",
-                        "top": "640px",
-                        "width": "100%",
+                        "transform": "translate(0px,640px)",
+                        "width": "1280px",
                       }
                     }
                     tabIndex={0}
@@ -14836,11 +14872,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                     style={
                       Object {
                         "--card-default-height": "304px",
+                        "MozTransform": "translate(0px,960px)",
+                        "OTransform": "translate(0px,960px)",
+                        "WebkitTransform": "translate(0px,960px)",
                         "height": "144px",
-                        "left": "0%",
+                        "msTransform": "translate(0px,960px)",
                         "position": "absolute",
-                        "top": "960px",
-                        "width": "5.078125%",
+                        "transform": "translate(0px,960px)",
+                        "width": "65px",
                       }
                     }
                     tabIndex={0}


### PR DESCRIPTION
Closes #

**Summary**

- Persistent bug with react-grid-layout where if the grid doesn't take up the full screen, it doesn't size itself correctly.

**Change List (commits, features, bugs, etc)**

- test(DashboardGrid): I added a sidebar to the grid story so this kind of bug would show up in the future
- fix(DashboardGrid): manual workaround to trigger window resize event (Which updates the react-grid-layout) whenever the Dashboard pane resizes. This happens when the two flex items are placed in the same layout next to each other

**Acceptance Test (how to verify the PR)**

- http://127.0.0.1:3000/?path=/story/watson-iot-%E2%9A%A0%EF%B8%8F-dashboard-grid--dashboard-default-layouts
If the cards don't scroll off screen to the right, the fix worked
