### PR TITLE
fix(dataseriesformitemmodal): grain selector is showing incorrectly for certain card types

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
@@ -176,7 +176,8 @@ const DataSeriesFormItemModal = ({
 
   const isTimeBasedCard =
     type === CARD_TYPES.TIMESERIES ||
-    type === CARD_TYPES.TABLE ||
+    (type === CARD_TYPES.TABLE &&
+      content?.columns?.find((column) => column.type === 'TIMESTAMP')) ||
     (content?.type === BAR_CHART_TYPES.SIMPLE && content?.timeDataSourceId) ||
     (content?.type === BAR_CHART_TYPES.STACKED && content?.timeDataSourceId);
 

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
@@ -177,8 +177,8 @@ const DataSeriesFormItemModal = ({
   const isTimeBasedCard =
     type === CARD_TYPES.TIMESERIES ||
     type === CARD_TYPES.TABLE ||
-    content?.type === BAR_CHART_TYPES.SIMPLE ||
-    content?.type === BAR_CHART_TYPES.STACKED;
+    (content?.type === BAR_CHART_TYPES.SIMPLE && content?.timeDataSourceId) ||
+    (content?.type === BAR_CHART_TYPES.STACKED && content?.timeDataSourceId);
 
   const handleTranslation = useCallback(
     (idToTranslate) => {

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.test.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.test.jsx
@@ -160,6 +160,343 @@ describe('DataSeriesFormItemModal', () => {
     expect(label).toBeInTheDocument();
     expect(legendColorLabel).toBeInTheDocument();
   });
+  it('Non-timebased simple bar should hide grain', () => {
+    const simpleNonTimeBasedBar = {
+      title: 'Untitled',
+      size: 'MEDIUM',
+      type: 'BAR',
+      content: {
+        type: 'SIMPLE',
+        layout: 'VERTICAL',
+        series: [
+          {
+            dataItemId: 'torque',
+            dataSourceId: 'torque_4b840252-adca-4075-8272-edd6705c2353',
+            label: 'Torque',
+            aggregationMethod: 'mean',
+            color: '#6929c4',
+          },
+        ],
+        categoryDataSourceId: 'deviceid',
+      },
+      dataSource: {
+        groupBy: ['deviceid'],
+      },
+    };
+
+    const aggregatedBarChartDataItem = {
+      label: 'Temperature Max',
+      dataSourceId: 'torque_4b840252-adca-4075-8272-edd6705c2353',
+      color: 'red',
+      aggregationMethods: [
+        { id: 'none', text: 'None' },
+        { id: 'last', text: 'Last' },
+        { id: 'mean', text: 'Mean' },
+        { id: 'max', text: 'Max' },
+        { id: 'min', text: 'Min' },
+      ],
+      aggregationMethod: 'max',
+    };
+
+    render(
+      <DataSeriesFormItemModal
+        {...commonProps}
+        showEditor
+        isSummaryDashboard
+        cardConfig={simpleNonTimeBasedBar}
+        editDataItem={aggregatedBarChartDataItem}
+      />
+    );
+    // grain field should be hidden though aggregator should be shown
+    expect(screen.queryByLabelText('Grain')).not.toBeInTheDocument();
+    const aggregationValue = screen.getByText('Max');
+    expect(aggregationValue).toBeInTheDocument();
+  });
+  it('Timebased simple bar should show grain', () => {
+    const simpleTimeBasedBar = {
+      title: 'Untitled',
+      size: 'MEDIUM',
+      type: 'BAR',
+      content: {
+        type: 'SIMPLE',
+        layout: 'VERTICAL',
+        series: [
+          {
+            dataItemId: 'torque',
+            dataSourceId: 'torque_4b840252-adca-4075-8272-edd6705c2353',
+            label: 'Torque',
+            aggregationMethod: 'mean',
+            color: '#6929c4',
+          },
+        ],
+        timeDataSourceId: 'timestamp',
+      },
+      dataSource: {},
+    };
+
+    const aggregatedBarChartDataItem = {
+      label: 'Temperature Max',
+      dataSourceId: 'torque_4b840252-adca-4075-8272-edd6705c2353',
+      color: 'red',
+      aggregationMethods: [
+        { id: 'none', text: 'None' },
+        { id: 'last', text: 'Last' },
+        { id: 'mean', text: 'Mean' },
+        { id: 'max', text: 'Max' },
+        { id: 'min', text: 'Min' },
+      ],
+      aggregationMethod: 'max',
+    };
+
+    render(
+      <DataSeriesFormItemModal
+        {...commonProps}
+        showEditor
+        isSummaryDashboard
+        cardConfig={simpleTimeBasedBar}
+        editDataItem={aggregatedBarChartDataItem}
+      />
+    );
+    // grain field and aggregator should be shown
+    expect(screen.queryAllByLabelText('Grain')[0]).toBeInTheDocument();
+    const aggregationValue = screen.getByText('Max');
+    expect(aggregationValue).toBeInTheDocument();
+  });
+  it('Non-timebased stacked bar should hide grain', () => {
+    const stackedNonTimeBasedBar = {
+      title: 'Untitled',
+      size: 'MEDIUM',
+      type: 'BAR',
+      content: {
+        type: 'STACKED',
+        layout: 'VERTICAL',
+        series: [
+          {
+            dataItemId: 'torque',
+            dataSourceId: 'torque_565ba583-dc00-4ee2-a480-5ed7d3e47ab1',
+            label: 'Torque',
+            aggregationMethod: 'mean',
+            color: '#6929c4',
+          },
+        ],
+        categoryDataSourceId: 'deviceid',
+      },
+      dataSource: {
+        groupBy: ['deviceid'],
+      },
+    };
+
+    const aggregatedBarChartDataItem = {
+      label: 'Temperature Max',
+      dataSourceId: 'torque_565ba583-dc00-4ee2-a480-5ed7d3e47ab1',
+      color: 'red',
+      aggregationMethods: [
+        { id: 'none', text: 'None' },
+        { id: 'last', text: 'Last' },
+        { id: 'mean', text: 'Mean' },
+        { id: 'max', text: 'Max' },
+        { id: 'min', text: 'Min' },
+      ],
+      aggregationMethod: 'max',
+    };
+
+    render(
+      <DataSeriesFormItemModal
+        {...commonProps}
+        showEditor
+        isSummaryDashboard
+        cardConfig={stackedNonTimeBasedBar}
+        editDataItem={aggregatedBarChartDataItem}
+      />
+    );
+
+    // grain field should be hidden though aggregator should be shown
+    expect(screen.queryByLabelText('Grain')).not.toBeInTheDocument();
+    const aggregationValue = screen.getByText('Max');
+    expect(aggregationValue).toBeInTheDocument();
+  });
+  it('timebased stacked bar should show grain', () => {
+    const stackedTimeBasedBar = {
+      title: 'Untitled',
+      size: 'MEDIUM',
+      type: 'BAR',
+      content: {
+        type: 'STACKED',
+        layout: 'VERTICAL',
+        series: [
+          {
+            dataItemId: 'torque',
+            dataSourceId: 'torque_565ba583-dc00-4ee2-a480-5ed7d3e47ab1',
+            label: 'Torque',
+            aggregationMethod: 'mean',
+            color: '#6929c4',
+          },
+        ],
+        timeDataSourceId: 'timestamp',
+      },
+      dataSource: {},
+    };
+
+    const aggregatedBarChartDataItem = {
+      label: 'Temperature Max',
+      dataSourceId: 'torque_565ba583-dc00-4ee2-a480-5ed7d3e47ab1',
+      color: 'red',
+      aggregationMethods: [
+        { id: 'none', text: 'None' },
+        { id: 'last', text: 'Last' },
+        { id: 'mean', text: 'Mean' },
+        { id: 'max', text: 'Max' },
+        { id: 'min', text: 'Min' },
+      ],
+      aggregationMethod: 'max',
+    };
+
+    render(
+      <DataSeriesFormItemModal
+        {...commonProps}
+        showEditor
+        isSummaryDashboard
+        cardConfig={stackedTimeBasedBar}
+        editDataItem={aggregatedBarChartDataItem}
+      />
+    );
+
+    // grain field and aggregator should be shown
+    expect(screen.queryAllByLabelText('Grain')[0]).toBeInTheDocument();
+    const aggregationValue = screen.getByText('Max');
+    expect(aggregationValue).toBeInTheDocument();
+  });
+  it('Non-timebased table card should hide grain', () => {
+    const stackedNonTimeBasedTableCard = {
+      title: 'table without timestamp',
+      size: 'LARGE',
+      type: 'TABLE',
+      content: {
+        columns: [
+          {
+            dataItemId: 'deviceid',
+            dataSourceId: 'deviceid',
+            label: 'deviceid',
+            type: 'DIMENSION',
+            destination: 'groupBy',
+          },
+          {
+            dataItemId: 'torque',
+            dataSourceId: 'torque_308e4cf2-7da1-4dd1-be90-d99db81da6f5',
+            label: 'Torque',
+          },
+          {
+            dataItemId: 'temperature',
+            dataSourceId: 'temperature_b7853ab7-49ab-4337-9682-4be94b31fd06',
+            label: 'Temperature',
+          },
+        ],
+        allowNavigation: true,
+        showHeader: true,
+      },
+      dataSource: {
+        groupBy: ['deviceid'],
+      },
+    };
+
+    const aggregatedBarChartDataItem = {
+      label: 'Temperature Max',
+      dataSourceId: 'torque_565ba583-dc00-4ee2-a480-5ed7d3e47ab1',
+      color: 'red',
+      aggregationMethods: [
+        { id: 'none', text: 'None' },
+        { id: 'last', text: 'Last' },
+        { id: 'mean', text: 'Mean' },
+        { id: 'max', text: 'Max' },
+        { id: 'min', text: 'Min' },
+      ],
+      aggregationMethod: 'max',
+    };
+
+    render(
+      <DataSeriesFormItemModal
+        {...commonProps}
+        showEditor
+        isSummaryDashboard
+        cardConfig={stackedNonTimeBasedTableCard}
+        editDataItem={aggregatedBarChartDataItem}
+      />
+    );
+
+    // grain field should be hidden though aggregator should be shown
+    expect(screen.queryByLabelText('Grain')).not.toBeInTheDocument();
+    const aggregationValue = screen.getByText('Max');
+    expect(aggregationValue).toBeInTheDocument();
+  });
+  it('timebased table card should show grain', () => {
+    const stackedTimeBasedTableCard = {
+      title: 'table without timestamp',
+      size: 'LARGE',
+      type: 'TABLE',
+      content: {
+        columns: [
+          {
+            dataSourceId: 'timestamp',
+            dataItemId: 'timestamp',
+            label: 'Timestamp',
+            type: 'TIMESTAMP',
+            sort: 'DESC',
+          },
+          {
+            dataItemId: 'deviceid',
+            dataSourceId: 'deviceid',
+            label: 'deviceid',
+            type: 'DIMENSION',
+            destination: 'groupBy',
+          },
+          {
+            dataItemId: 'torque',
+            dataSourceId: 'torque_308e4cf2-7da1-4dd1-be90-d99db81da6f5',
+            label: 'Torque',
+          },
+          {
+            dataItemId: 'temperature',
+            dataSourceId: 'temperature_b7853ab7-49ab-4337-9682-4be94b31fd06',
+            label: 'Temperature',
+          },
+        ],
+        allowNavigation: true,
+        showHeader: true,
+      },
+      dataSource: {
+        groupBy: ['deviceid'],
+      },
+    };
+
+    const aggregatedBarChartDataItem = {
+      label: 'Temperature Max',
+      dataSourceId: 'torque_565ba583-dc00-4ee2-a480-5ed7d3e47ab1',
+      color: 'red',
+      aggregationMethods: [
+        { id: 'none', text: 'None' },
+        { id: 'last', text: 'Last' },
+        { id: 'mean', text: 'Mean' },
+        { id: 'max', text: 'Max' },
+        { id: 'min', text: 'Min' },
+      ],
+      aggregationMethod: 'max',
+    };
+
+    render(
+      <DataSeriesFormItemModal
+        {...commonProps}
+        showEditor
+        isSummaryDashboard
+        cardConfig={stackedTimeBasedTableCard}
+        editDataItem={aggregatedBarChartDataItem}
+      />
+    );
+
+    // grain field and aggregator should be shown
+    expect(screen.queryAllByLabelText('Grain')[0]).toBeInTheDocument();
+    const aggregationValue = screen.getByText('Max');
+    expect(aggregationValue).toBeInTheDocument();
+  });
   it('Renders for value card data', () => {
     render(
       <DataSeriesFormItemModal

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
@@ -523,6 +523,7 @@ const DataSeriesFormItem = ({
                   {
                     id: selectedItem,
                     ...(itemWithMetaData && { ...itemWithMetaData }),
+                    dataSourceId: `${selectedItem}_${uuid.v4()}`,
                   },
                 ],
                 cardConfig,


### PR DESCRIPTION
Closes #

**Summary**

- fix(DataSeriesFormItemModal): table, simple bar, and stacked bar charts may not be time-based in certain cases.  We should be more careful showing the grain and only show it for the real time-based cases
- fix(DataSeriesFormItemContent): when selecting an attribute for a simple bar chart, we should also generate a unique id so that it's clear this was selected by the user.  This allows a non-mean aggregator to be selected for that attribute

**Acceptance Test (how to verify the PR)**

- Verify in the DashboardEditor story that if you popup the DataSeriesFormModal for a Simple Bar, Stacked Bar or Table Card attribute that is NOT time-based, that the grain selector is hidden and no grain is set for the item.
- Here are the scenarios, a Simple Bar that's grouped by dimension NOT time
- A Stacked Bar that's grouped by dimension NOT time
- A table card whose autogenerated TIMESTAMP column has been removed
- Verify when selecting a SimpleBar chart attribute, that the dataSourceId contains a UUID
