### PR TITLE
fix(dashboardgrid): should not set state if component unmounts

### DIFF
--- a/packages/react/src/components/Dashboard/DashboardGrid.jsx
+++ b/packages/react/src/components/Dashboard/DashboardGrid.jsx
@@ -245,9 +245,10 @@ const DashboardGrid = ({
 
   const [shouldAnimate, setShouldAnimate] = useState(false);
   useEffect(() => {
-    requestAnimationFrame(() => {
+    const animationFramePromise = requestAnimationFrame(() => {
       setShouldAnimate(isEditable);
     });
+    return () => animationFramePromise && cancelAnimationFrame(animationFramePromise);
   }, [isEditable]);
 
   const breakpointSizes = useMemo(
@@ -312,6 +313,7 @@ const DashboardGrid = ({
           // Stop the initial animation unless we need to support editing drag-and-drop
           [`${iotPrefix}--dashboard-grid__animate`]: shouldAnimate,
         })}
+        key={shouldAnimate} // forced to throw away and regen the GridLayout as it doesn't update when className is updated for shouldAnimate
         layouts={generatedLayouts}
         cols={DASHBOARD_COLUMNS}
         breakpoints={pick(DASHBOARD_BREAKPOINTS, supportedLayouts)}


### PR DESCRIPTION
Closes #1577

**Summary**

- The setShouldAnimate call was happening after the component unmounted in some cases.  This cancels the function if the component unmounts

**Change List (commits, features, bugs, etc)**

- fix(DashboardGrid): cancel function and regen GridLayout when the bit changes

fixes this problem
```
onsole.error
      Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
          in DashboardGrid (created by DashboardEditor)
          in ErrorBoundary (created by DashboardEditor)
          in div (created by DashboardEditor)
          in div (created by DashboardEditor)
          in div (created by DashboardEditor)
          in div (created by DashboardEditor)
```

**Acceptance Test (how to verify the PR)**

- Verify that in the Dashboard stories, if isEditable is set, then it's still draggable.
- Verify in non editable, it's not draggable
