### PR TITLE
fix(button): update spacing in loading state

### DIFF
--- a/packages/react/src/components/Button/_button.scss
+++ b/packages/react/src/components/Button/_button.scss
@@ -7,6 +7,7 @@
   .#{$prefix}--loading {
     margin-top: -$spacing-05;
     margin-bottom: -$spacing-05;
+    margin-right: $spacing-03;
   }
   .#{$prefix}--loading__stroke {
     stroke: $carbon--gray-50;


### PR DESCRIPTION
Closes #2114

**Summary**

- Small fix to the padding between the loading and the button text, caused by a change to loading made in carbon-components-react upgrade

**Acceptance Test (how to verify the PR)**

- Verify the Loading Button story looks good
