### PR TITLE
fix(table): distribute widths between all columns when re-inserting

### DIFF
--- a/packages/react/src/components/Table/TableHead/TableHead.test.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.test.jsx
@@ -305,9 +305,9 @@ describe('TableHead', () => {
       onColumnToggleFunc('col1', orderingAfterTogleShow);
 
       expect(myActions.onColumnResize).toHaveBeenCalledWith([
-        { id: 'col1', name: 'Column 1', width: '200px' },
-        { id: 'col2', name: 'Column 2', width: '100px' },
-        { id: 'col3', name: 'Column 3', width: '100px' },
+        { id: 'col1', name: 'Column 1', width: '133px' },
+        { id: 'col2', name: 'Column 2', width: '133px' },
+        { id: 'col3', name: 'Column 3', width: '133px' },
       ]);
       expect(myActions.onChangeOrdering).toHaveBeenCalledWith(orderingAfterTogleShow);
     });
@@ -338,10 +338,15 @@ describe('TableHead', () => {
       onColumnToggleFunc('col1', orderingAfterTogleShow);
 
       expect(myActions.onColumnResize).toHaveBeenCalledWith([
-        { id: 'col1', name: 'Column 1', width: '100px' },
-        { id: 'col2', name: 'Column 2', width: `${MIN_COLUMN_WIDTH}px` },
-        { id: 'col3', name: 'Column 3', width: `${MIN_COLUMN_WIDTH}px` },
+        { id: 'col1', name: 'Column 1', width: '67px' },
+        { id: 'col2', name: 'Column 2', width: `67px` },
+        { id: 'col3', name: 'Column 3', width: `67px` },
       ]);
+
+      myActions.onColumnResize.mock.calls[0][0].forEach((column) => {
+        expect(parseInt(column.width, 10)).toBeGreaterThanOrEqual(MIN_COLUMN_WIDTH);
+      });
+
       expect(myActions.onChangeOrdering).toHaveBeenCalledWith(orderingAfterTogleShow);
     });
 
@@ -375,9 +380,9 @@ describe('TableHead', () => {
       onColumnToggleFunc('col3', orderingAfterTogleShow);
 
       expect(myActions.onColumnResize).toHaveBeenCalledWith([
-        { id: 'col1', name: 'Column 1', width: '100px' },
-        { id: 'col2', name: 'Column 2', width: '100px' },
-        { id: 'col3', name: 'Column 3', width: '200px' },
+        { id: 'col1', name: 'Column 1', width: '133px' },
+        { id: 'col2', name: 'Column 2', width: '133px' },
+        { id: 'col3', name: 'Column 3', width: '133px' },
       ]);
       expect(myActions.onChangeOrdering).toHaveBeenCalledWith(orderingAfterTogleShow);
     });
@@ -590,19 +595,19 @@ describe('TableHead', () => {
       rerender(<TableHead {...myProps} />);
 
       expect(screen.getAllByText('Column 1')[0].closest('th')).toHaveStyle({
-        width: '100px',
+        width: '120px',
       });
       expect(screen.getAllByText('Column 2')[0].closest('th')).toHaveStyle({
-        width: '100px',
+        width: '120px',
       });
       expect(screen.getAllByText('Column 3')[0].closest('th')).toHaveStyle({
-        width: '100px',
+        width: '120px',
       });
       expect(screen.getAllByText('Column 4')[0].closest('th')).toHaveStyle({
-        width: '150px',
+        width: '120px',
       });
       expect(screen.getAllByText('Column 5')[0].closest('th')).toHaveStyle({
-        width: '150px',
+        width: '120px',
       });
     });
 
@@ -644,13 +649,13 @@ describe('TableHead', () => {
       rerender(<TableHead {...myProps} />);
 
       expect(screen.getAllByText('Column 2')[0].closest('th')).toHaveStyle({
-        width: '100px',
+        width: '150px',
       });
       expect(screen.getAllByText('Column 3')[0].closest('th')).toHaveStyle({
-        width: '100px',
+        width: '150px',
       });
       expect(screen.getAllByText('Column 4')[0].closest('th')).toHaveStyle({
-        width: '200px',
+        width: '150px',
       });
     });
 


### PR DESCRIPTION
Closes #2061 

**Summary**

- Changed behavior to automatically split available space evenly between all columns when re-inserting

**Change List (commits, features, bugs, etc)**

- split space evenly between columns when re-inserting
- updated tests to reflect new behavior

**Acceptance Test (how to verify the PR)**

- check #2061 and follow instructions there. All columns should be evenly spaced when re-inserting.
