### PR TITLE
fix: use test:ci in the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,8 +34,7 @@ jobs:
         run: yarn lint
 
       - name: Test, collect coverage
-        # we need the "-- --" to pass the options through yarn and lerna and back to yarn
-        run: yarn test -- -- --maxWorkers=2 --ci --logHeapUsage --coverage
+        run: yarn test:ci
 
       - name: Coveralls
         uses: coverallsapp/github-action@master


### PR DESCRIPTION
`test:ci` gives packages explicit control over testing behaviour when running in a workflow. This enables that for the publishing workflow (already enabled for the test workflow)