### PR TITLE
chore(dashboard): ignore Dashboard/CardRenderer coverage

### DIFF
--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
     '!src/components/FileUploader/stories/*.jsx',
     '!src/components/Table/AsyncTable/*.js?(x)',
     '!src/components/Page/EditPage.jsx',
+    '!src/components/Dashboard/(Dashboard|CardRenderer).jsx',
   ],
   coveragePathIgnorePatterns: ['/node_modules/', '/lib/', '/coverage/'],
   coverageReporters: ['html', 'text-summary', 'lcov'],
@@ -17,7 +18,7 @@ module.exports = {
       functions: 80,
       lines: 80,
     },
-    './src/components/**/!(WizardInline|WizardHeader|FilterHeaderRow|RowActionsCell|RowActionsError|TableHead|StatefulTable|StatefulTableDetailWizard|CatalogContent|Dashboard|CardRenderer|ImageHotspots|PageHero|PageTitle|TableHead|ColumnResize|ColorDropdown|TimeSeriesCard|BarChartCard|DashboardGrid|DashboardEditor).jsx': {
+    './src/components/**/!(WizardInline|WizardHeader|FilterHeaderRow|RowActionsCell|RowActionsError|TableHead|StatefulTable|StatefulTableDetailWizard|CatalogContent|ImageHotspots|PageHero|PageTitle|TableHead|ColumnResize|ColorDropdown|TimeSeriesCard|BarChartCard|DashboardGrid|DashboardEditor).jsx': {
       statements: 80,
       branches: 80,
       functions: 80,
@@ -69,17 +70,6 @@ module.exports = {
     },
     './src/components/Table/StatefulTable.jsx': { branches: 66 },
     './src/components/TileCatalog/CatalogContent.jsx': { branches: 50 },
-    './src/components/Dashboard/Dashboard.jsx': {
-      statements: 79,
-      branches: 50,
-      lines: 78,
-    },
-    './src/components/Dashboard/CardRenderer.jsx': {
-      statements: 51,
-      branches: 38,
-      lines: 51,
-      functions: 66,
-    },
     './src/components/ImageCard/ImageHotspots.jsx': {
       branches: 79,
     },

--- a/packages/react/src/components/Page/PageTitle.test.jsx
+++ b/packages/react/src/components/Page/PageTitle.test.jsx
@@ -14,4 +14,10 @@ describe('PageTitle', () => {
 
     expect(wrapper.find('h1 span').text()).toEqual('section text /');
   });
+
+  it('renders empty div if no title is given', () => {
+    const wrapper = mount(<PageTitle />);
+
+    expect(wrapper.find('h1')).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Closes #2162 

**Summary**

Dashboard and CardRenderer are deprecated, so ignore from test coverage