### PR TITLE
fix(value-card): fix error/warning icons not visible on card

### DIFF
--- a/packages/react/src/components/Card/_data-state-renderer.scss
+++ b/packages/react/src/components/Card/_data-state-renderer.scss
@@ -9,6 +9,7 @@
 .#{$iot-prefix}--data-state-dashes {
   color: $gray-20;
   font-size: 4rem;
+  line-height: 0.67;
 }
 
 .#{$iot-prefix}--data-state-grid {


### PR DESCRIPTION
Closes #2179 

**Summary**

- fixed line height on the valuecard dashes to prevent them from pushing the icons off the card.

**Acceptance Test (how to verify the PR)**

1. go to storybook: https://deploy-preview-2185--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-valuecard--data-state-error-small
2. Click on data state - error - small
3. select dataStateType for either ERROR or NO_DATA
3. The icons should be visible

