### PR TITLE
style(page-title-bar): fix offsets

### DIFF
--- a/packages/react/src/components/DashboardEditor/DashboardEditorHeader/__snapshots__/DashboardEditorHeader.story.storyshot
+++ b/packages/react/src/components/DashboardEditor/DashboardEditorHeader/__snapshots__/DashboardEditorHeader.story.storyshot
@@ -24,6 +24,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "48px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"
@@ -289,6 +294,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "48px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"

--- a/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -30,6 +30,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           >
             <div
               className="page-title-bar-header"
+              style={
+                Object {
+                  "--header-offset": "48px",
+                }
+              }
             >
               <div
                 className="page-title-bar-header-left"
@@ -2855,6 +2860,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         >
           <div
             className="page-title-bar-header"
+            style={
+              Object {
+                "--header-offset": "48px",
+              }
+            }
           >
             <div
               className="page-title-bar-header-left"
@@ -5592,6 +5602,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         >
           <div
             className="page-title-bar-header"
+            style={
+              Object {
+                "--header-offset": "48px",
+              }
+            }
           >
             <div
               className="page-title-bar-header-left"
@@ -7807,6 +7822,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         >
           <div
             className="page-title-bar-header"
+            style={
+              Object {
+                "--header-offset": "48px",
+              }
+            }
           >
             <div
               className="page-title-bar-header-left"
@@ -10143,6 +10163,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
           >
             <div
               className="page-title-bar-header"
+              style={
+                Object {
+                  "--header-offset": "48px",
+                }
+              }
             >
               <div
                 className="page-title-bar-header-left"
@@ -11501,6 +11526,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         >
           <div
             className="page-title-bar-header"
+            style={
+              Object {
+                "--header-offset": "48px",
+              }
+            }
           >
             <div
               className="page-title-bar-header-left"
@@ -12839,6 +12869,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         >
           <div
             className="page-title-bar-header"
+            style={
+              Object {
+                "--header-offset": "48px",
+              }
+            }
           >
             <div
               className="page-title-bar-header-left"
@@ -15709,6 +15744,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
         >
           <div
             className="page-title-bar-header"
+            style={
+              Object {
+                "--header-offset": "48px",
+              }
+            }
           >
             <div
               className="page-title-bar-header-left"

--- a/packages/react/src/components/NavigationBar/__snapshots__/NavigationBar.story.storyshot
+++ b/packages/react/src/components/NavigationBar/__snapshots__/NavigationBar.story.storyshot
@@ -25,6 +25,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Navig
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "48px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"
@@ -253,6 +258,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Navig
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "48px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"
@@ -468,6 +478,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Navig
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "48px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"
@@ -683,6 +698,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Navig
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "48px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"

--- a/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
@@ -118,7 +118,7 @@ const PageTitleBar = ({
     }
 
     return () => window.removeEventListener('scroll', handleScroll);
-  }, [dynamicTransitionOffset, headerMode, stickyHeaderOffsetProp]);
+  }, [dynamicTransitionOffset, headerMode]);
 
   const titleActions = useMemo(
     () => (

--- a/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
@@ -106,7 +106,7 @@ const PageTitleBar = ({
   useEffect(() => {
     // if we have scrolled passed the offset, we should be in condensed state
     const handleScroll = throttle(() => {
-      if (Math.round(window.scrollY) > 5 + dynamicTransitionOffset || stickyHeaderOffsetProp) {
+      if (Math.round(window.scrollY) > 5 + dynamicTransitionOffset) {
         setCondensed(true);
       } else {
         setCondensed(false);

--- a/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
@@ -22,8 +22,10 @@ const PageTitleBarPropTypes = {
   description: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   /** How the header should react to scrolling */
   headerMode: PropTypes.oneOf(Object.values(HEADER_MODES)),
-  /** offset for when the dynamic headerMode flips the header size to condensed  */
-  headerModeDynamicOffSet: PropTypes.number,
+  /** offset for the 'top' attribute on the sticky header. Number will be converted to px */
+  stickyHeaderOffset: PropTypes.number,
+  /** offset for the dynamic transition from 'STATIC' size to 'CONDENSED' size. Number will be converted to px */
+  dynamicTransitionOffset: PropTypes.number,
   /** Optional node to render in the right side of the PageTitleBar
    *  NOTE: Deprecated in favor of extraContent
    */
@@ -74,7 +76,8 @@ const defaultProps = {
   tabs: undefined,
   content: undefined,
   headerMode: HEADER_MODES.STATIC,
-  headerModeDynamicOffSet: 0,
+  stickyHeaderOffset: 48, // default to 3rem to stick to the bottom of the suite header
+  dynamicTransitionOffset: 48, // default to 3rem to stick to the bottom of the suite header
 };
 
 const PageTitleBar = ({
@@ -86,7 +89,8 @@ const PageTitleBar = ({
   breadcrumb,
   collapsed,
   headerMode,
-  headerModeDynamicOffSet,
+  stickyHeaderOffset: stickyHeaderOffsetProp,
+  dynamicTransitionOffset,
   editable,
   isLoading,
   i18n: { editIconDescription, tooltipIconDescription },
@@ -97,10 +101,12 @@ const PageTitleBar = ({
   const titleBarContent = content || tabs;
   const [condensed, setCondensed] = useState(headerMode === HEADER_MODES.CONDENSED);
 
+  const stickyHeaderOffset = `${stickyHeaderOffsetProp}px`; // convert to px for styling
+
   useEffect(() => {
     // if we have scrolled passed the offset, we should be in condensed state
     const handleScroll = throttle(() => {
-      if (Math.round(window.scrollY) > 5 + headerModeDynamicOffSet) {
+      if (Math.round(window.scrollY) > 5 + dynamicTransitionOffset || stickyHeaderOffsetProp) {
         setCondensed(true);
       } else {
         setCondensed(false);
@@ -112,7 +118,7 @@ const PageTitleBar = ({
     }
 
     return () => window.removeEventListener('scroll', handleScroll);
-  }, [headerMode, headerModeDynamicOffSet]);
+  }, [dynamicTransitionOffset, headerMode, stickyHeaderOffsetProp]);
 
   const titleActions = useMemo(
     () => (
@@ -162,6 +168,7 @@ const PageTitleBar = ({
       ) : (
         <>
           <div
+            style={{ '--header-offset': stickyHeaderOffset }}
             className={classnames('page-title-bar-header', {
               'page-title-bar-header-sticky': headerMode === HEADER_MODES.STICKY,
               'page-title-bar-header-condensed': headerMode === HEADER_MODES.CONDENSED,
@@ -223,6 +230,9 @@ const PageTitleBar = ({
         <>
           {breadcrumb ? (
             <div
+              style={{
+                '--header-offset': stickyHeaderOffset,
+              }}
               className={classnames(
                 'page-title-bar-breadcrumb',
                 'page-title-bar-breadcrumb-dynamic',
@@ -249,7 +259,10 @@ const PageTitleBar = ({
           ) : null}
           <div
             className={classnames('page-title-bar-title', 'page-title-bar-title-dynamic')}
-            style={{ '--bar-title-position': extraContent || rightContent ? 'absolute' : 'static' }}
+            style={{
+              '--bar-title-position': extraContent || rightContent ? 'absolute' : 'static',
+              '--header-offset': stickyHeaderOffset,
+            }}
           >
             <div className="page-title-bar-title--text">
               <h2>{title}</h2>
@@ -261,6 +274,9 @@ const PageTitleBar = ({
           ) : null}
           {extraContent || rightContent ? (
             <div
+              style={{
+                '--header-offset': stickyHeaderOffset,
+              }}
               className={classnames(
                 'page-title-bar-header-right',
                 'page-title-bar-header-right-dynamic'

--- a/packages/react/src/components/PageTitleBar/PageTitleBar.story.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.story.jsx
@@ -211,13 +211,15 @@ WithEverything.story = {
   name: 'with everything',
 };
 
+/* Note: We need to set the sticky offset to 0 (from the default 3rem) because storybook sets everything relative to their container with 3rem padding.
+   The dynamicTransitionOffset isn't needed here, because the default 3rem is relative to the overall window scrollY and handles the storybook padding */
 export const WithDynamicScrolling = () => (
   <PageTitleBar
+    stickyHeaderOffset={0}
     title={commonPageTitleBarProps.title}
     description={commonPageTitleBarProps.description}
     breadcrumb={pageTitleBarBreadcrumb}
     headerMode={select('headerMode', ['DYNAMIC', 'STATIC', 'STICKY', 'CONDENSED'])}
-    headerModeDynamicOffSet={50} // need to offset the padding that storybook forces
     extraContent={
       <div>
         <div

--- a/packages/react/src/components/PageTitleBar/PageTitleBar.story.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.story.jsx
@@ -211,8 +211,6 @@ WithEverything.story = {
   name: 'with everything',
 };
 
-/* Note: We need to set the sticky offset to 0 (from the default 3rem) because storybook sets everything relative to their container with 3rem padding.
-   The dynamicTransitionOffset isn't needed here, because the default 3rem is relative to the overall window scrollY and handles the storybook padding */
 export const WithDynamicScrolling = () => (
   <PageTitleBar
     stickyHeaderOffset={0}
@@ -274,6 +272,13 @@ export const WithDynamicScrolling = () => (
 
 WithDynamicScrolling.story = {
   name: 'With dynamic scrolling',
+};
+
+WithDynamicScrolling.parameters = {
+  info: {
+    text: `Note: We need to set the sticky offset here to 0 (from the default 3rem) because storybook sets everything relative to their container with 3rem padding.
+      The dynamicTransitionOffset isn't needed here, because the default 3rem is relative to the overall window scrollY and handles the storybook padding`,
+  },
 };
 
 export const IsLoading = () => <PageTitleBar title={commonPageTitleBarProps.title} isLoading />;

--- a/packages/react/src/components/PageTitleBar/PageTitleBar.test.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.test.jsx
@@ -153,7 +153,7 @@ describe('PageTitleBar', () => {
     );
     expect(container.querySelector('.page-title-bar-title--condensed-before')).toBeInTheDocument();
     expect(container.querySelector('.page-title-bar-title--condensed-after')).toBeFalsy();
-    fireEvent.scroll(window, { target: { scrollY: 25 } });
+    fireEvent.scroll(window, { target: { scrollY: 55 } });
     expect(container.querySelector('.page-title-bar-title--condensed-after')).toBeInTheDocument();
   });
 });

--- a/packages/react/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
+++ b/packages/react/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
@@ -24,6 +24,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "0px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"
@@ -464,6 +469,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "48px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"
@@ -593,6 +603,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "48px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"
@@ -704,6 +719,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "48px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"
@@ -1014,6 +1034,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "48px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"
@@ -1089,6 +1114,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "48px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"
@@ -1195,6 +1225,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "48px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"
@@ -1629,6 +1664,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "48px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"
@@ -1789,6 +1829,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "48px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"

--- a/packages/react/src/components/PageTitleBar/_page-title-bar.scss
+++ b/packages/react/src/components/PageTitleBar/_page-title-bar.scss
@@ -61,17 +61,19 @@
       position: sticky;
       top: var(--header-offset);
       width: 100%;
-      border-bottom: $ui-03;
+      border-bottom: 1px solid $ui-03;
       background-color: $ui-01;
+      z-index: 1000;
     }
     &-condensed {
       position: sticky;
       top: var(--header-offset);
-      border-bottom: $ui-03;
+      border-bottom: 1px solid $ui-03;
       height: unset;
       padding: 0 $spacing-07;
       transition: background-color $duration--moderate-02;
       background-color: $ui-01;
+      z-index: 1000;
     }
     &-left {
       float: left;
@@ -114,7 +116,7 @@
       transition: all $duration--moderate-02;
       background: $ui-01;
       z-index: 1000;
-      border-bottom: $ui-03;
+      border-bottom: 1px solid $ui-03;
     }
   }
 

--- a/packages/react/src/components/PageTitleBar/_page-title-bar.scss
+++ b/packages/react/src/components/PageTitleBar/_page-title-bar.scss
@@ -59,14 +59,14 @@
 
     &-sticky {
       position: sticky;
-      top: 0;
+      top: var(--header-offset);
       width: 100%;
       border-bottom: $ui-03;
       background-color: $ui-01;
     }
     &-condensed {
       position: sticky;
-      top: 0;
+      top: var(--header-offset);
       border-bottom: $ui-03;
       height: unset;
       padding: 0 $spacing-07;
@@ -82,7 +82,7 @@
         margin: -$spacing-03 $spacing-07 $spacing-06 0;
         margin-left: $spacing-05;
         position: sticky;
-        top: 0;
+        top: var(--header-offset);
         z-index: 2000;
       }
     }
@@ -102,7 +102,7 @@
       padding: $spacing-05 0 $spacing-05 $spacing-07;
       transition: all $duration--moderate-02;
       position: sticky;
-      top: 0;
+      top: var(--header-offset);
     }
     &-condensed-static {
       display: flex;
@@ -110,7 +110,7 @@
     }
     &-condensed {
       position: sticky;
-      top: 0;
+      top: var(--header-offset);
       transition: all $duration--moderate-02;
       background: $ui-01;
       z-index: 1000;

--- a/packages/react/src/components/PageWizard/__snapshots__/PageWizard.story.storyshot
+++ b/packages/react/src/components/PageWizard/__snapshots__/PageWizard.story.storyshot
@@ -626,6 +626,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageW
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "48px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"
@@ -1037,6 +1042,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageW
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "48px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"
@@ -1497,6 +1507,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageW
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "48px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"
@@ -2335,6 +2350,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageW
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "48px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"
@@ -3354,6 +3374,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageW
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "48px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"

--- a/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
+++ b/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
@@ -399,6 +399,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/SideN
         >
           <div
             className="page-title-bar-header"
+            style={
+              Object {
+                "--header-offset": "48px",
+              }
+            }
           >
             <div
               className="page-title-bar-header-left"

--- a/packages/react/src/components/TileGallery/__snapshots__/TileGallery.story.storyshot
+++ b/packages/react/src/components/TileGallery/__snapshots__/TileGallery.story.storyshot
@@ -24,6 +24,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileG
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "48px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"
@@ -1407,6 +1412,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileG
       >
         <div
           className="page-title-bar-header"
+          style={
+            Object {
+              "--header-offset": "48px",
+            }
+          }
         >
           <div
             className="page-title-bar-header-left"

--- a/packages/react/src/components/WizardInline/__snapshots__/WizardInline.story.storyshot
+++ b/packages/react/src/components/WizardInline/__snapshots__/WizardInline.story.storyshot
@@ -24,6 +24,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
         >
           <div
             className="page-title-bar-header"
+            style={
+              Object {
+                "--header-offset": "48px",
+              }
+            }
           >
             <div
               className="page-title-bar-header-left"
@@ -451,6 +456,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
         >
           <div
             className="page-title-bar-header"
+            style={
+              Object {
+                "--header-offset": "48px",
+              }
+            }
           >
             <div
               className="page-title-bar-header-left"
@@ -852,6 +862,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
         >
           <div
             className="page-title-bar-header"
+            style={
+              Object {
+                "--header-offset": "48px",
+              }
+            }
           >
             <div
               className="page-title-bar-header-left"
@@ -1252,6 +1267,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
         >
           <div
             className="page-title-bar-header"
+            style={
+              Object {
+                "--header-offset": "48px",
+              }
+            }
           >
             <div
               className="page-title-bar-header-left"
@@ -1665,6 +1685,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
         >
           <div
             className="page-title-bar-header"
+            style={
+              Object {
+                "--header-offset": "48px",
+              }
+            }
           >
             <div
               className="page-title-bar-header-left"
@@ -2066,6 +2091,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/🚫 
         >
           <div
             className="page-title-bar-header"
+            style={
+              Object {
+                "--header-offset": "48px",
+              }
+            }
           >
             <div
               className="page-title-bar-header-left"

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -4517,10 +4517,10 @@ Map {
       "collapsed": false,
       "content": undefined,
       "description": null,
+      "dynamicTransitionOffset": 48,
       "editable": false,
       "extraContent": undefined,
       "headerMode": "STATIC",
-      "headerModeDynamicOffSet": 0,
       "i18n": Object {
         "editIconDescription": "Edit page title",
         "tooltipIconDescription": "More information",
@@ -4528,6 +4528,7 @@ Map {
       "isLoading": false,
       "onEdit": null,
       "rightContent": undefined,
+      "stickyHeaderOffset": 48,
       "tabs": undefined,
     },
     "propTypes": Object {
@@ -4561,6 +4562,9 @@ Map {
         ],
         "type": "oneOfType",
       },
+      "dynamicTransitionOffset": Object {
+        "type": "number",
+      },
       "editable": Object {
         "type": "bool",
       },
@@ -4577,9 +4581,6 @@ Map {
           ],
         ],
         "type": "oneOf",
-      },
-      "headerModeDynamicOffSet": Object {
-        "type": "number",
       },
       "i18n": Object {
         "args": Array [
@@ -4598,6 +4599,9 @@ Map {
         "type": "func",
       },
       "rightContent": [Function],
+      "stickyHeaderOffset": Object {
+        "type": "number",
+      },
       "tabs": [Function],
       "title": Object {
         "isRequired": true,


### PR DESCRIPTION
**Summary**

The sticky header styles where ignoring the suite header because the offset was only setting the position for the dynamic transition from `STATIC` to `CONDENSED` in the `DYNAMIC` headerMode.

**Change List (commits, features, bugs, etc)**

 - Create a new `stickyHeaderOffset` prop and rename the `headerModeDynamicOffSet` offset to `dynamicTransitionOffset`
 - Pass the offsets to the proper `top` attribute

**Acceptance Test (how to verify the PR)**
Not much of a change to see in the storybook. This basically just allows the consumer to specify where the sticky headers should "stick".
Make sure that the different headerModes still work properly in the `PageTitleBar` `with dynamic scrolling` story.
