### PR TITLE
fix(repo): un-scope monorepo-utils to prevent npm from trying to publish it

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -40,7 +40,7 @@
     "zone.js": "^0.8.26 || ^0.9.0 || ^0.10.0"
   },
   "devDependencies": {
-    "@ai-apps/monorepo-utils": "^2.145.0-next.33",
+    "ai-apps-monorepo-utils": "^2.145.0-next.33",
     "@angular-builders/custom-webpack": "^11.0.0",
     "@angular-devkit/build-angular": "0.1101.1",
     "@angular-devkit/build-ng-packagr": "0.1002.1",

--- a/packages/angular/scripts/vendor.js
+++ b/packages/angular/scripts/vendor.js
@@ -1,4 +1,4 @@
-const { vendor } = require('@ai-apps/monorepo-utils');
+const { vendor } = require('ai-apps-monorepo-utils');
 
 vendor({
   packages: ['@ai-apps/styles'],

--- a/packages/monorepo-utils/README.md
+++ b/packages/monorepo-utils/README.md
@@ -1,4 +1,4 @@
-# @ai-apps/monorepo-utils
+# ai-apps-monorepo-utils
 
 As the monorepo grows a variety of custom tools and integrations are required. This (private!) package can be included in `devDependencies` and allows us to centralize and de-duplicate our utility tooling.
 
@@ -26,7 +26,7 @@ By using a pattern/file based vendoring strategy we can reduce the number of fil
 Example usage:
 
 ```javascript
-const { vendor } = require('@ai-apps/monorepo-utils');
+const { vendor } = require('ai-apps-monorepo-utils');
 
 vendor({
   packages: ['@ai-apps/styles'],

--- a/packages/monorepo-utils/package.json
+++ b/packages/monorepo-utils/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ai-apps/monorepo-utils",
+  "name": "ai-apps-monorepo-utils",
   "version": "2.145.0-next.33",
   "description": "Internal monorepo tools",
   "main": "index.js",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -22,7 +22,7 @@
     "css/**/*"
   ],
   "devDependencies": {
-    "@ai-apps/monorepo-utils": "^2.145.0-next.33",
+    "ai-apps-monorepo-utils": "^2.145.0-next.33",
     "@carbon/charts": "0.41.31",
     "@carbon/motion": "10.12.0",
     "@carbon/themes": "10.26.0",

--- a/packages/styles/scripts/copy-styles-from-react.js
+++ b/packages/styles/scripts/copy-styles-from-react.js
@@ -1,6 +1,6 @@
 const { dirname, join, sep } = require('path');
 const { copy, readFile, writeFile, ensureDir } = require('fs-extra');
-const { promiseGlob, packagePath } = require('@ai-apps/monorepo-utils');
+const { promiseGlob, packagePath } = require('ai-apps-monorepo-utils');
 
 const reactPath = packagePath('carbon-addons-iot-react');
 

--- a/packages/styles/scripts/vendor.js
+++ b/packages/styles/scripts/vendor.js
@@ -1,4 +1,4 @@
-const { vendor } = require('@ai-apps/monorepo-utils');
+const { vendor } = require('ai-apps-monorepo-utils');
 
 vendor({
   packages: [


### PR DESCRIPTION
npm has two different notions of private packages it seems. Packages of the form `my-package-name`, with `"private": true` set in the `package.json` will never be published to npm (this is what we want). Packages of the form `@my-scope/my-package-name`, with `"private": true` however _will_ be published as a "private scoped package" (a specific thing for paid npm accounts). To avoid this I've updated `@ai-apps/monorepo-utils` to be `ai-apps-monorepo-utils`, since this isn't a package that we should publish.

Some info about npms **scoped** private packages: https://docs.npmjs.com/about-private-packages