### PR TITLE
fix(value-card): use auto positioning tooltip

### DIFF
--- a/packages/react/.storybook/story-styles.scss
+++ b/packages/react/.storybook/story-styles.scss
@@ -1,3 +1,5 @@
+@import '../src/globals/vars';
+
 /* stylelint-disable */
 .storybook-container {
   padding: 3rem;

--- a/packages/react/src/components/Card/DataStateRenderer.jsx
+++ b/packages/react/src/components/Card/DataStateRenderer.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import classnames from 'classnames';
-import { Tooltip } from 'carbon-components-react';
 import { ErrorFilled24, WarningFilled24 } from '@carbon/icons-react';
 
+import { Tooltip } from '../Tooltip';
 import { settings } from '../../constants/Settings';
 import { ValueCardPropTypes, CardPropTypes } from '../../constants/CardPropTypes';
 import { CARD_SIZES, CARD_CONTENT_PADDING, CARD_DATA_STATE } from '../../constants/LayoutConstants';
@@ -35,6 +35,7 @@ const DataStateRenderer = ({ dataState, size, id }) => {
     return (
       <Tooltip
         showIcon={false}
+        useAutoPositioning
         triggerText={element}
         triggerId={triggerId}
         tooltipId={`${triggerId}-tooltip`}

--- a/packages/react/src/hooks/usePopoverPositioning.jsx
+++ b/packages/react/src/hooks/usePopoverPositioning.jsx
@@ -100,7 +100,10 @@ export const usePopoverPositioning = ({
   const getAdjustedOffset = React.useCallback(
     (tooltipElement, flyoutDirection, buttonElement) => {
       const tooltipRect = tooltipElement.getBoundingClientRect();
-      const buttonRect = buttonElement.parentNode.getBoundingClientRect();
+      const buttonRect = flyoutAlignment
+        ? buttonElement.parentNode.getBoundingClientRect()
+        : buttonElement.getBoundingClientRect();
+      const windowWidth = window.innerWidth || document.documentElement.clientWidth;
       const directionChange = `${previousDirection.current}->${adjustedDirection}`;
 
       if (previousDirection.current !== adjustedDirection && flyoutAlignment) {
@@ -109,6 +112,27 @@ export const usePopoverPositioning = ({
             return {
               top: tooltipRect.y - buttonRect.y,
               left: tooltipRect.x - buttonRect.x,
+            };
+        }
+      }
+
+      if (previousDirection.current !== adjustedDirection) {
+        switch (directionChange) {
+          case 'bottom->left':
+            return {
+              top: tooltipRect.right >= windowWidth ? 9 : 0,
+              left: tooltipRect.right >= windowWidth ? tooltipRect.right - buttonRect.left + 3 : 0,
+            };
+          case 'top->left': {
+            return {
+              top: tooltipRect.right >= windowWidth ? 9 : 0,
+              left: tooltipRect.right >= windowWidth ? tooltipRect.right - buttonRect.right + 3 : 0,
+            };
+          }
+          default:
+            return {
+              top: 0,
+              left: 0,
             };
         }
       }


### PR DESCRIPTION
Closes #2192 

**Summary**

- use auto positioning on tooltip to keep it on the screen

**Change List (commits, features, bugs, etc)**

- use auto positioning on tooltip
- adjust offset settings to get tooltip to position correctly.

**Acceptance Test (how to verify the PR)**

- go to https://deploy-preview-2219--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-%F0%9F%9A%AB-dashboard--only-value-cards
- shrink the window size
- click the warning icon and confirm the tooltip stays on the screen.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- check the autopositioning stories for flyout menu, tooltip, and overflow menu to ensure it doesn't break existing functionality.
