### PR TITLE
Flyout menu tooltip option

### DIFF
--- a/packages/react/src/components/FlyoutMenu/FlyoutMenu.jsx
+++ b/packages/react/src/components/FlyoutMenu/FlyoutMenu.jsx
@@ -207,8 +207,12 @@ const FlyoutMenu = ({
   ) : (
     <DefaultFooter setIsOpen={setIsOpen} onCancel={onCancel} onApply={onApply} i18n={i18n} />
   );
+
   return (
     <div
+      style={{
+        '--tooltip-visibility': iconDescription ? 'visible' : 'hidden',
+      }}
       ref={buttonRef}
       className={classnames(
         [`${iotPrefix}--flyout-menu`],
@@ -220,6 +224,7 @@ const FlyoutMenu = ({
       )}
     >
       <Button
+        {...buttonProps}
         aria-label={iconDescription}
         iconDescription={iconDescription}
         className={classnames(`${iotPrefix}--flyout-menu--trigger-button`, buttonProps?.className)}

--- a/packages/react/src/components/FlyoutMenu/FlyoutMenu.jsx
+++ b/packages/react/src/components/FlyoutMenu/FlyoutMenu.jsx
@@ -90,6 +90,7 @@ const FlyoutMenu = ({
   tabIndex,
   tooltipClassName,
   passive,
+  hideTooltip,
   customFooter: CustomFooter,
   onApply,
   onCancel,
@@ -211,7 +212,7 @@ const FlyoutMenu = ({
   return (
     <div
       style={{
-        '--tooltip-visibility': iconDescription ? 'visible' : 'hidden',
+        '--tooltip-visibility': hideTooltip ? 'hidden' : 'visible',
       }}
       ref={buttonRef}
       className={classnames(
@@ -352,6 +353,11 @@ const propTypes = {
   passive: PropTypes.bool,
 
   /**
+   * Whether to show the iconDescription tooltip on the trigger button
+   */
+  hideTooltip: PropTypes.bool,
+
+  /**
    * Content to be rendered in place of the normal footer (ie. MyComponent).
    */
   customFooter: PropTypes.elementType,
@@ -408,6 +414,7 @@ const defaultProps = {
   children: undefined,
   tooltipClassName: '',
   passive: false,
+  hideTooltip: true,
   customFooter: null,
   tabIndex: 0,
   testId: 'flyout-menu',

--- a/packages/react/src/components/FlyoutMenu/FlyoutMenu.story.jsx
+++ b/packages/react/src/components/FlyoutMenu/FlyoutMenu.story.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { boolean, number, select, text } from '@storybook/addon-knobs';
+import { boolean, number, object, select, text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import {
   SettingsAdjust16 as SettingsAdjust,
@@ -49,6 +49,9 @@ export const DefaultExample = () => (
       buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
       renderIcon={ShareKnowledge}
       disabled={boolean('Disabled', false)}
+      buttonProps={object('buttonProps', {
+        tooltipPosition: 'top',
+      })}
       hideTooltip={boolean('Hide tooltip', true)}
       iconDescription={text('iconDescription', 'Helpful description')}
       passive={boolean('Passive Flyout', false)}
@@ -73,6 +76,9 @@ export const LargeFlyoutExample = () => (
       buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
       renderIcon={ShareKnowledge}
       disabled={boolean('Disabled', false)}
+      buttonProps={object('buttonProps', {
+        tooltipPosition: 'top',
+      })}
       hideTooltip={boolean('Hide tooltip', true)}
       iconDescription={text('iconDescription', 'Helpful description')}
       passive={boolean('Passive Flyout', false)}
@@ -101,6 +107,9 @@ export const CustomFooterExample = () => (
       buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
       renderIcon={SettingsAdjust}
       disabled={boolean('Disabled', false)}
+      buttonProps={object('buttonProps', {
+        tooltipPosition: 'top',
+      })}
       hideTooltip={boolean('Hide tooltip', true)}
       iconDescription={text('iconDescription', 'Helpful description')}
       passive={false}
@@ -147,6 +156,9 @@ export const AutoPositioningExample = () => {
             buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
             renderIcon={ShareKnowledge}
             disabled={boolean('Disabled', false)}
+            buttonProps={object('buttonProps', {
+              tooltipPosition: 'top',
+            })}
             hideTooltip={boolean('Hide tooltip', true)}
             iconDescription={text('iconDescription', 'Helpful description')}
             passive={boolean('Passive Flyout', false)}
@@ -184,6 +196,9 @@ export const AutoPositioningExample = () => {
             buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
             renderIcon={ShareKnowledge}
             disabled={boolean('Disabled', false)}
+            buttonProps={object('buttonProps', {
+              tooltipPosition: 'top',
+            })}
             hideTooltip={boolean('Hide tooltip', true)}
             iconDescription={text('iconDescription', 'Helpful description')}
             passive={boolean('Passive Flyout', false)}
@@ -213,6 +228,9 @@ export const AutoPositioningExample = () => {
             buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
             renderIcon={ShareKnowledge}
             disabled={boolean('Disabled', false)}
+            buttonProps={object('buttonProps', {
+              tooltipPosition: 'top',
+            })}
             hideTooltip={boolean('Hide tooltip', true)}
             iconDescription={text('iconDescription', 'Helpful description')}
             passive={boolean('Passive Flyout', false)}
@@ -244,6 +262,9 @@ export const AutoPositioningExample = () => {
             buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
             renderIcon={ShareKnowledge}
             disabled={boolean('Disabled', false)}
+            buttonProps={object('buttonProps', {
+              tooltipPosition: 'top',
+            })}
             hideTooltip={boolean('Hide tooltip', true)}
             iconDescription={text('iconDescription', 'Helpful description')}
             passive={boolean('Passive Flyout', false)}
@@ -273,6 +294,9 @@ export const AutoPositioningExample = () => {
             buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
             renderIcon={ShareKnowledge}
             disabled={boolean('Disabled', false)}
+            buttonProps={object('buttonProps', {
+              tooltipPosition: 'top',
+            })}
             hideTooltip={boolean('Hide tooltip', true)}
             iconDescription={text('iconDescription', 'Helpful description')}
             passive={boolean('Passive Flyout', false)}
@@ -302,6 +326,9 @@ export const AutoPositioningExample = () => {
             buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
             renderIcon={ShareKnowledge}
             disabled={boolean('Disabled', false)}
+            buttonProps={object('buttonProps', {
+              tooltipPosition: 'top',
+            })}
             hideTooltip={boolean('Hide tooltip', true)}
             iconDescription={text('iconDescription', 'Helpful description')}
             passive={boolean('Passive Flyout', false)}
@@ -333,6 +360,9 @@ export const AutoPositioningExample = () => {
             buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
             renderIcon={ShareKnowledge}
             disabled={boolean('Disabled', false)}
+            buttonProps={object('buttonProps', {
+              tooltipPosition: 'top',
+            })}
             hideTooltip={boolean('Hide tooltip', true)}
             iconDescription={text('iconDescription', 'Helpful description')}
             passive={boolean('Passive Flyout', false)}
@@ -362,6 +392,9 @@ export const AutoPositioningExample = () => {
             buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
             renderIcon={ShareKnowledge}
             disabled={boolean('Disabled', false)}
+            buttonProps={object('buttonProps', {
+              tooltipPosition: 'top',
+            })}
             hideTooltip={boolean('Hide tooltip', true)}
             iconDescription={text('iconDescription', 'Helpful description')}
             passive={boolean('Passive Flyout', false)}
@@ -391,6 +424,9 @@ export const AutoPositioningExample = () => {
             buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
             renderIcon={ShareKnowledge}
             disabled={boolean('Disabled', false)}
+            buttonProps={object('buttonProps', {
+              tooltipPosition: 'top',
+            })}
             hideTooltip={boolean('Hide tooltip', true)}
             iconDescription={text('iconDescription', 'Helpful description')}
             passive={boolean('Passive Flyout', false)}

--- a/packages/react/src/components/FlyoutMenu/FlyoutMenu.story.jsx
+++ b/packages/react/src/components/FlyoutMenu/FlyoutMenu.story.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { boolean, number, select } from '@storybook/addon-knobs';
+import { boolean, number, select, text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import {
   SettingsAdjust16 as SettingsAdjust,
@@ -49,7 +49,8 @@ export const DefaultExample = () => (
       buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
       renderIcon={ShareKnowledge}
       disabled={boolean('Disabled', false)}
-      iconDescription="Helpful description"
+      hideTooltip={boolean('Hide tooltip', true)}
+      iconDescription={text('iconDescription', 'Helpful description')}
       passive={boolean('Passive Flyout', false)}
       triggerId="test-trigger-id-2"
       light={boolean('Light Mode', false)}
@@ -72,7 +73,8 @@ export const LargeFlyoutExample = () => (
       buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
       renderIcon={ShareKnowledge}
       disabled={boolean('Disabled', false)}
-      iconDescription="Helpful description"
+      hideTooltip={boolean('Hide tooltip', true)}
+      iconDescription={text('iconDescription', 'Helpful description')}
       passive={boolean('Passive Flyout', false)}
       triggerId="test-trigger-id-2"
       light={boolean('Light Mode', true)}
@@ -99,7 +101,8 @@ export const CustomFooterExample = () => (
       buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
       renderIcon={SettingsAdjust}
       disabled={boolean('Disabled', false)}
-      iconDescription="Helpful description"
+      hideTooltip={boolean('Hide tooltip', true)}
+      iconDescription={text('iconDescription', 'Helpful description')}
       passive={false}
       customFooter={CustomFooter}
       triggerId="test-trigger-id-2"
@@ -144,7 +147,8 @@ export const AutoPositioningExample = () => {
             buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
             renderIcon={ShareKnowledge}
             disabled={boolean('Disabled', false)}
-            iconDescription="Helpful description"
+            hideTooltip={boolean('Hide tooltip', true)}
+            iconDescription={text('iconDescription', 'Helpful description')}
             passive={boolean('Passive Flyout', false)}
             triggerId="test-trigger-id-2"
             light={boolean('Light Mode', false)}
@@ -180,7 +184,8 @@ export const AutoPositioningExample = () => {
             buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
             renderIcon={ShareKnowledge}
             disabled={boolean('Disabled', false)}
-            iconDescription="Helpful description"
+            hideTooltip={boolean('Hide tooltip', true)}
+            iconDescription={text('iconDescription', 'Helpful description')}
             passive={boolean('Passive Flyout', false)}
             triggerId="test-trigger-id-2"
             light={boolean('Light Mode', false)}
@@ -208,7 +213,8 @@ export const AutoPositioningExample = () => {
             buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
             renderIcon={ShareKnowledge}
             disabled={boolean('Disabled', false)}
-            iconDescription="Helpful description"
+            hideTooltip={boolean('Hide tooltip', true)}
+            iconDescription={text('iconDescription', 'Helpful description')}
             passive={boolean('Passive Flyout', false)}
             triggerId="test-trigger-id-2"
             light={boolean('Light Mode', false)}
@@ -238,7 +244,8 @@ export const AutoPositioningExample = () => {
             buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
             renderIcon={ShareKnowledge}
             disabled={boolean('Disabled', false)}
-            iconDescription="Helpful description"
+            hideTooltip={boolean('Hide tooltip', true)}
+            iconDescription={text('iconDescription', 'Helpful description')}
             passive={boolean('Passive Flyout', false)}
             triggerId="test-trigger-id-2"
             light={boolean('Light Mode', false)}
@@ -266,7 +273,8 @@ export const AutoPositioningExample = () => {
             buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
             renderIcon={ShareKnowledge}
             disabled={boolean('Disabled', false)}
-            iconDescription="Helpful description"
+            hideTooltip={boolean('Hide tooltip', true)}
+            iconDescription={text('iconDescription', 'Helpful description')}
             passive={boolean('Passive Flyout', false)}
             triggerId="test-trigger-id-2"
             light={boolean('Light Mode', false)}
@@ -294,7 +302,8 @@ export const AutoPositioningExample = () => {
             buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
             renderIcon={ShareKnowledge}
             disabled={boolean('Disabled', false)}
-            iconDescription="Helpful description"
+            hideTooltip={boolean('Hide tooltip', true)}
+            iconDescription={text('iconDescription', 'Helpful description')}
             passive={boolean('Passive Flyout', false)}
             triggerId="test-trigger-id-2"
             light={boolean('Light Mode', false)}
@@ -324,7 +333,8 @@ export const AutoPositioningExample = () => {
             buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
             renderIcon={ShareKnowledge}
             disabled={boolean('Disabled', false)}
-            iconDescription="Helpful description"
+            hideTooltip={boolean('Hide tooltip', true)}
+            iconDescription={text('iconDescription', 'Helpful description')}
             passive={boolean('Passive Flyout', false)}
             triggerId="test-trigger-id-2"
             light={boolean('Light Mode', false)}
@@ -352,7 +362,8 @@ export const AutoPositioningExample = () => {
             buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
             renderIcon={ShareKnowledge}
             disabled={boolean('Disabled', false)}
-            iconDescription="Helpful description"
+            hideTooltip={boolean('Hide tooltip', true)}
+            iconDescription={text('iconDescription', 'Helpful description')}
             passive={boolean('Passive Flyout', false)}
             triggerId="test-trigger-id-2"
             light={boolean('Light Mode', false)}
@@ -380,7 +391,8 @@ export const AutoPositioningExample = () => {
             buttonSize={select('Button Size', buttonSizes, buttonSizes.Default)}
             renderIcon={ShareKnowledge}
             disabled={boolean('Disabled', false)}
-            iconDescription="Helpful description"
+            hideTooltip={boolean('Hide tooltip', true)}
+            iconDescription={text('iconDescription', 'Helpful description')}
             passive={boolean('Passive Flyout', false)}
             triggerId="test-trigger-id-2"
             light={boolean('Light Mode', false)}

--- a/packages/react/src/components/FlyoutMenu/__snapshots__/FlyoutMenu.story.storyshot
+++ b/packages/react/src/components/FlyoutMenu/__snapshots__/FlyoutMenu.story.storyshot
@@ -43,6 +43,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Flyou
         >
           <div
             className="iot--flyout-menu iot--flyout-menu__left"
+            style={
+              Object {
+                "--tooltip-visibility": "hidden",
+              }
+            }
           >
             <button
               aria-label="Helpful description"
@@ -111,6 +116,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Flyou
         >
           <div
             className="iot--flyout-menu iot--flyout-menu__top"
+            style={
+              Object {
+                "--tooltip-visibility": "hidden",
+              }
+            }
           >
             <button
               aria-label="Helpful description"
@@ -179,6 +189,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Flyou
         >
           <div
             className="iot--flyout-menu iot--flyout-menu__right"
+            style={
+              Object {
+                "--tooltip-visibility": "hidden",
+              }
+            }
           >
             <button
               aria-label="Helpful description"
@@ -257,6 +272,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Flyou
         >
           <div
             className="iot--flyout-menu iot--flyout-menu__left"
+            style={
+              Object {
+                "--tooltip-visibility": "hidden",
+              }
+            }
           >
             <button
               aria-label="Helpful description"
@@ -325,6 +345,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Flyou
         >
           <div
             className="iot--flyout-menu iot--flyout-menu__top"
+            style={
+              Object {
+                "--tooltip-visibility": "hidden",
+              }
+            }
           >
             <button
               aria-label="Helpful description"
@@ -393,6 +418,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Flyou
         >
           <div
             className="iot--flyout-menu iot--flyout-menu__right"
+            style={
+              Object {
+                "--tooltip-visibility": "hidden",
+              }
+            }
           >
             <button
               aria-label="Helpful description"
@@ -471,6 +501,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Flyou
         >
           <div
             className="iot--flyout-menu iot--flyout-menu__bottom"
+            style={
+              Object {
+                "--tooltip-visibility": "hidden",
+              }
+            }
           >
             <button
               aria-label="Helpful description"
@@ -539,6 +574,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Flyou
         >
           <div
             className="iot--flyout-menu iot--flyout-menu__bottom"
+            style={
+              Object {
+                "--tooltip-visibility": "hidden",
+              }
+            }
           >
             <button
               aria-label="Helpful description"
@@ -607,6 +647,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Flyou
         >
           <div
             className="iot--flyout-menu iot--flyout-menu__bottom"
+            style={
+              Object {
+                "--tooltip-visibility": "hidden",
+              }
+            }
           >
             <button
               aria-label="Helpful description"
@@ -714,6 +759,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Flyou
     >
       <div
         className="iot--flyout-menu iot--flyout-menu__bottom iot--flyout-menu__light iot--flyout-menu__open"
+        style={
+          Object {
+            "--tooltip-visibility": "hidden",
+          }
+        }
       >
         <button
           aria-label="Helpful description"
@@ -917,6 +967,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Flyou
     >
       <div
         className="iot--flyout-menu iot--flyout-menu__bottom"
+        style={
+          Object {
+            "--tooltip-visibility": "hidden",
+          }
+        }
       >
         <button
           aria-label="Helpful description"
@@ -1022,6 +1077,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Flyou
     >
       <div
         className="iot--flyout-menu iot--flyout-menu__bottom iot--flyout-menu__light"
+        style={
+          Object {
+            "--tooltip-visibility": "hidden",
+          }
+        }
       >
         <button
           aria-label="Helpful description"

--- a/packages/react/src/components/FlyoutMenu/_flyout-menu.scss
+++ b/packages/react/src/components/FlyoutMenu/_flyout-menu.scss
@@ -287,6 +287,6 @@ $shadow: 0.4rem;
   // What are we doing with these tool tips for buttons. We will want to be consistent across all button types.
   .#{$prefix}--assistive-text,
   &.#{$prefix}--tooltip--a11y::before {
-    visibility: hidden;
+    visibility: var(--tooltip-visibility);
   }
 }

--- a/packages/react/src/components/PieChartCard/__snapshots__/PieChartCard.story.storyshot
+++ b/packages/react/src/components/PieChartCard/__snapshots__/PieChartCard.story.storyshot
@@ -170,6 +170,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PieCh
                     </button>
                     <div
                       className="iot--flyout-menu iot--flyout-menu__bottom iot--flyout-menu__light"
+                      style={
+                        Object {
+                          "--tooltip-visibility": "hidden",
+                        }
+                      }
                     >
                       <button
                         aria-label=""

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -18779,6 +18779,7 @@ Map {
       "defaultOpen": false,
       "direction": "bottom-start",
       "disabled": false,
+      "hideTooltip": true,
       "i18n": Object {
         "applyButtonText": "Apply",
         "cancelButtonText": "Cancel",
@@ -18843,6 +18844,9 @@ Map {
         "type": "oneOf",
       },
       "disabled": Object {
+        "type": "bool",
+      },
+      "hideTooltip": Object {
         "type": "bool",
       },
       "i18n": Object {


### PR DESCRIPTION
**Summary**
We need to add the ability to show the onHover tooltips for the `FlyoutMenu` trigger button.

**Change List (commits, features, bugs, etc)**
 - Add `hideTooltip` prop. (defaults to true)
 - Pass the rest of the `buttonProps` through to the trigger button

**Acceptance Test (how to verify the PR)**
Go to any `FlyoutMenu` story and use the knobs for `hideTooltip`, `buttonProps`, and `iconDescription`. See that the component is updated accordingly.

**Regression Test (how to make sure this PR doesn't break old functionality)**
Make sure basic functionality is still working properly.

![image](https://user-images.githubusercontent.com/53092833/115429682-400ca100-a1c9-11eb-8e0a-be3b539aca49.png)

