### PR TITLE
fix(table): include search.defaultValue in filtering logic

### DIFF
--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -4,7 +4,6 @@ import merge from 'lodash/merge';
 import pick from 'lodash/pick';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import { Table as CarbonTable, TableContainer, Tag } from 'carbon-components-react';
-import isNil from 'lodash/isNil';
 import uniqueId from 'lodash/uniqueId';
 import classnames from 'classnames';
 import { useLangDirection } from 'use-lang-direction';
@@ -562,10 +561,8 @@ const Table = (props) => {
   const isFiltered =
     view.filters.length > 0 ||
     view.selectedAdvancedFilterIds.length ||
-    (!isNil(view.toolbar) &&
-      !isNil(view.toolbar.search) &&
-      !isNil(view.toolbar.search.value) &&
-      view.toolbar.search.value !== '');
+    (view?.toolbar?.search?.value ?? '') !== '' ||
+    (view?.toolbar?.search?.defaultValue ?? '') !== '';
 
   const rowEditMode = view.toolbar.activeBar === 'rowEdit';
   const singleRowEditMode = !!view.table.rowActions.find((action) => action.isEditMode);

--- a/packages/react/src/components/Table/Table.story.jsx
+++ b/packages/react/src/components/Table/Table.story.jsx
@@ -834,7 +834,7 @@ export const StatefulExampleWithCreateSaveViews = () => {
         },
         toolbar: {
           activeBar: 'column',
-          search: { defaultValue: 'pinoc' },
+          search: { defaultValue: text('defaultSearchValue', 'pinoc') },
         },
       },
       columns: defaultState.columns,


### PR DESCRIPTION
Closes #1901 

**Summary**

- include search.defaultValue to determine if the "no data" or "no results" message should be displayed

**Change List (commits, features, bugs, etc)**

- included search.defaultValue in isFiltered logic on the table

**Acceptance Test (how to verify the PR)**

- The [no data story](https://deploy-preview-2231--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-table--with-no-data) should still show "no data"
- The [no results story](https://deploy-preview-2231--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-table--with-no-results) should still show "no results"
- In the [Stateful Example with Create & Save Views](https://deploy-preview-2231--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-table--stateful-example-with-create-save-views) change the "defaultSearchValue" knob to "test" and then change to the "My view 1" view and it should show the "no results" message
