### PR TITLE
fix(wizard-modal): do not pass onBack to ComposedModal

### DIFF
--- a/packages/react/src/components/WizardModal/WizardModal.jsx
+++ b/packages/react/src/components/WizardModal/WizardModal.jsx
@@ -170,7 +170,7 @@ class WizardModal extends Component {
   };
 
   render() {
-    const { steps, className, currentStepIndex, isClickable, ...other } = this.props;
+    const { steps, className, currentStepIndex, isClickable, onBack, ...other } = this.props;
     // Transform object to be what Progress Indicator expects
     const items = steps.map((step, index) => ({
       id: index,

--- a/packages/react/src/components/WizardModal/__snapshots__/WizardModal.story.storyshot
+++ b/packages/react/src/components/WizardModal/__snapshots__/WizardModal.story.storyshot
@@ -16,7 +16,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Wizar
       className="bx--modal is-visible iot--wizard-modal iot--composed-modal"
       data-floating-menu-container={true}
       data-testid="ComposedModal"
-      onBack={[Function]}
       onBlur={[Function]}
       onClick={[Function]}
       onClose={[Function]}
@@ -338,7 +337,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Wizar
       className="bx--modal is-visible iot--wizard-modal WizardModalstory__StyledWizard-sc-1z46gj-0 eiobyI iot--composed-modal"
       data-floating-menu-container={true}
       data-testid="ComposedModal"
-      onBack={[Function]}
       onBlur={[Function]}
       onClick={[Function]}
       onClose={[Function]}
@@ -667,7 +665,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Wizar
       className="bx--modal is-visible iot--wizard-modal iot--composed-modal"
       data-floating-menu-container={true}
       data-testid="ComposedModal"
-      onBack={[Function]}
       onBlur={[Function]}
       onClick={[Function]}
       onClose={[Function]}


### PR DESCRIPTION
Closes #1828 

**Summary**

- fix the onBack error by not passing the onBack prop in the spread.

**Acceptance Test (how to verify the PR)**

- no more onBack error in the console

**Regression Test (how to make sure this PR doesn't break old functionality)**

- wizard modal should function normally
