### PR TITLE
fix(timeseries): support 0 values in the line chart

### DIFF
--- a/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.js
+++ b/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.js
@@ -198,7 +198,7 @@ export const formatChartData = (timeDataSourceId = 'timestamp', series, values) 
           })
           .forEach((dataItem) => {
             // Check to see if the data Item actually exists in this timestamp before adding to data (to support sparse data in the values)
-            if (dataItem[dataSourceId]) {
+            if (!isNil(dataItem[dataSourceId])) {
               data.push({
                 date:
                   dataItem[timeDataSourceId] instanceof Date


### PR DESCRIPTION
Closes #https://github.ibm.com/wiotp/Maximo-Asset-Monitor/issues/2290

**Summary**

- Fixes issue with the timeSeriesUtils where a chart with all zero values never showed data

**Change List (commits, features, bugs, etc)**

- fix(timeSeriesUtils): check inNil rather than the value comparison (which skips for 0)

**Acceptance Test (how to verify the PR)**

- Verify if you pass zero values to a TimeSeriesChart that it still renders

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Verify that the existing TimeSeries stories haven't changed
