### PR TITLE
fix(time-series-card): use number instead of min/max for ticks

### DIFF
--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -466,7 +466,6 @@ const TimeSeriesCard = ({
     ]
   );
 
-  console.log({ ticks: options.axes.bottom.ticks });
   return (
     <Card
       title={title}

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -234,6 +234,7 @@ const TimeSeriesCard = ({
         return 4;
       case CARD_SIZES.MEDIUMWIDE:
       case CARD_SIZES.LARGE:
+      case CARD_SIZES.LARGETHIN:
         return 6;
       case CARD_SIZES.LARGEWIDE:
         return 14;
@@ -371,7 +372,7 @@ const TimeSeriesCard = ({
           mapsTo: 'date',
           scaleType: 'time',
           ticks: {
-            max: maxTicksPerSize,
+            number: maxTicksPerSize,
             formatter: formatTick,
           },
           includeZero: includeZeroOnXaxis,
@@ -465,6 +466,7 @@ const TimeSeriesCard = ({
     ]
   );
 
+  console.log({ ticks: options.axes.bottom.ticks });
   return (
     <Card
       title={title}


### PR DESCRIPTION
Closes #2055 

**Summary**

- `min`/`max` on ticks is used for the minimum/maximum tick value, not the number of ticks to be shown. (See [carbon docs](https://github.com/carbon-design-system/carbon-charts/blob/da7918594ff9c8f8fb74e547ec352a498c7151da/packages/core/src/interfaces/axis-scales.ts#L63)) Switched it to the `number` prop, so that the number of ticks shown changes on different size cards.

**Change List (commits, features, bugs, etc)**

- use number instead of min/max for axis ticks
- add LARGETHIN to use only 6 ticks, since at 10 it's very crowded.

**Acceptance Test (how to verify the PR)**

- the medium / single line - interval hour story should adjust the number of ticks when changing size between medium/medium wide, large wide, etc.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests pass and other timeseriescard stories function as expected
