### PR TITLE
fix(bar-chart-card): prop error on grouped BarChartCard

### DIFF
--- a/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
@@ -321,6 +321,7 @@ const defaultProps = {
     openJSONButton: 'Open JSON editor',
     noDataLabel: 'No data source is defined',
     defaultCardTitle: 'Untitled',
+    selectAGroupBy: 'Select a group by',
     layoutInfoLg: 'Edit dashboard at large layout (1057 - 1312px)',
     layoutInfoMd: 'Edit dashboard at medium layout (673 - 1056px)',
     layoutInfoSm: 'Edit dashboard at small layout (481 - 672px)',

--- a/packages/react/src/components/DashboardEditor/editorUtils.jsx
+++ b/packages/react/src/components/DashboardEditor/editorUtils.jsx
@@ -159,6 +159,7 @@ export const getDefaultCard = (type, i18n) => {
           type: BAR_CHART_TYPES.GROUPED,
           layout: BAR_CHART_LAYOUTS.VERTICAL,
           series: [],
+          categoryDataSourceId: i18n.selectAGroupBy,
         },
       };
     case DASHBOARD_EDITOR_CARD_TYPES.STACKED_BAR:

--- a/packages/react/src/constants/CardPropTypes.js
+++ b/packages/react/src/constants/CardPropTypes.js
@@ -328,7 +328,7 @@ export const BarChartCardPropTypes = {
       } // all charts must have oneOf[categoryDataSourceId, timeDataSourceId]
       else if (!props[propName] && !props.timeDataSourceId) {
         error = new Error(
-          `\`${componentName}\` must have \`${props[propName]}\` OR \`timeDataSourceId\`.`
+          `\`${componentName}\` must have \`${propName}\` OR \`timeDataSourceId\`.`
         );
       }
       return error;

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -9046,6 +9046,7 @@ Map {
         "openGalleryButton": "Open gallery",
         "openJSONButton": "Open JSON editor",
         "searchPlaceHolderText": "Enter a value",
+        "selectAGroupBy": "Select a group by",
       },
       "initialValue": Object {
         "cards": Array [],


### PR DESCRIPTION
Closes #2118 

**Summary**

- When adding a grouped BarChartCard via the dashboard editor, a `categoryDataSourceId` or `timeDataSourceId` must be specified. Since a grouped card doesn't support `timeDataSourceId` yet, I added an i18n prop for a placeholder to assign to the `categoryDataSourceId` to prevent the prop error until the actual group dimension can be selected in card editor form.

**Change List (commits, features, bugs, etc)**

- pass a new i18n prop to the DashboardEditor, that can be passed to the getDefaultCard props function and assigned to the `categoryDataSourceId`.
- Fixed the BarChartCard proptypes so that it displays the name of the missing prop not the value to clarify this error in the future

**Acceptance Test (how to verify the PR)**

- When adding a Group BarChartCard via the DashboardEditor no prop errors should be thrown.
