### PR TITLE
fix(dashboard-editor): always use dataSourceId in selectedData array

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
@@ -299,7 +299,7 @@ const DataSeriesFormItem = ({
             ? omit(cardConfig, 'content.categoryDataSourceId')
             : cardConfig;
         const newCard = handleDataSeriesChange(selectedItems, card, setEditDataSeries);
-        setSelectedDataItems(selectedItems.map(({ text }) => text));
+        setSelectedDataItems(selectedItems.map(({ dataSourceId }) => dataSourceId));
         onChange(newCard);
       }
     },


### PR DESCRIPTION
Closes #2051 

**Summary**

- always use the dataSourceId in the selectedItems array to ensure the proper labels are used by the dropdown and in the list of selected data points

**Change List (commits, features, bugs, etc)**

- use dataSourceId when adding new data items to be used.

**Acceptance Test (how to verify the PR)**

- In the [DashboardEditor default story](https://deploy-preview-2241--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-experimental-dashboardeditor--default) add a TimeSeriesCard and ensure the labels always match in the dropdown and in the list of data items for the card.
