### PR TITLE
feat(dashboard-editor): add decimal precision to ImageCards

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
@@ -341,8 +341,11 @@ const DataSeriesFormItemModal = ({
               />
             </div>
           )}
-          {type === CARD_TYPES.IMAGE && (
-            <div className={`${baseClassName}--input-group--item-half-no-helper-text`}>
+        </div>
+
+        {type === CARD_TYPES.IMAGE && (
+          <div className={`${baseClassName}--input-group`}>
+            <div className={`${baseClassName}--input-group--item`}>
               <TextInput
                 id={`${id}_attribute-unit`}
                 labelText={mergedI18n.dataItemEditorDataItemUnit}
@@ -357,8 +360,30 @@ const DataSeriesFormItemModal = ({
                 value={editDataItem.unit}
               />
             </div>
-          )}
-        </div>
+            <div className={`${baseClassName}--input-group--item-end`}>
+              <Dropdown
+                id={`${id}_value-card-decimal-place`}
+                titleText="Decimal places"
+                direction="bottom"
+                label=""
+                items={[mergedI18n.notSet, '0', '1', '2', '3', '4']}
+                light
+                selectedItem={editDataItem.precision?.toString() || mergedI18n.notSet}
+                onChange={({ selectedItem }) => {
+                  const isSet = selectedItem !== mergedI18n.notSet;
+                  if (isSet) {
+                    setEditDataItem({
+                      ...editDataItem,
+                      precision: Number(selectedItem),
+                    });
+                  } else {
+                    setEditDataItem(omit(editDataItem, 'precision'));
+                  }
+                }}
+              />
+            </div>
+          </div>
+        )}
 
         {type === CARD_TYPES.VALUE && (
           <div className={`${baseClassName}--input-group`}>

--- a/packages/react/src/components/CardEditor/CardEditForm/_card-edit-form.scss
+++ b/packages/react/src/components/CardEditor/CardEditForm/_card-edit-form.scss
@@ -169,6 +169,10 @@
     }
     &--item-end {
       width: 100%;
+
+      .#{$prefix}--number input[type='number'] {
+        padding-right: 0;
+      }
     }
     &--item-dropdown {
       margin-right: $spacing-05;

--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/HotspotEditorDataSourceTab.test.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/HotspotEditorDataSourceTab.test.jsx
@@ -168,9 +168,9 @@ describe('HotspotEditorDataSourceTab', () => {
     // edit button
     userEvent.click(screen.getAllByRole('button')[1]);
     // add threshold
-    userEvent.click(screen.getAllByRole('button')[2]);
+    userEvent.click(screen.getAllByRole('button')[3]);
     // save
-    userEvent.click(screen.getAllByRole('button')[10]);
+    userEvent.click(screen.getAllByRole('button')[11]);
     // Card config with the elevators hotspot removed
     expect(onChange).toHaveBeenCalledWith({
       dataItemId: 'temp_last',
@@ -203,11 +203,11 @@ describe('HotspotEditorDataSourceTab', () => {
     // edit button
     userEvent.click(screen.getAllByRole('button')[1]);
     // add threshold
-    userEvent.click(screen.getAllByRole('button')[2]);
+    userEvent.click(screen.getAllByRole('button')[3]);
     // increment value of threshold
     userEvent.click(screen.getByTitle('Increment number'));
     // save
-    userEvent.click(screen.getAllByRole('button')[10]);
+    userEvent.click(screen.getAllByRole('button')[11]);
     // Card config with the elevators hotspot removed
     expect(onChange).toHaveBeenCalledWith({
       dataItemId: 'temp_last',

--- a/packages/react/src/components/HotspotEditorModal/hooks/hotspotStateHook.js
+++ b/packages/react/src/components/HotspotEditorModal/hooks/hotspotStateHook.js
@@ -105,6 +105,7 @@ function hotspotEditorReducer(state, { type, payload }) {
                 unit: payload.unit,
                 dataFilter: payload.dataFilter,
                 thresholds: payload.thresholds,
+                precision: payload.precision,
               },
             },
           },


### PR DESCRIPTION
Closes #2045 

**Summary**

- Adds precision to data items on ImageCards in the DashboardEditor

**Change List (commits, features, bugs, etc)**

- display precision dropdown on ImageCards
- add precision to the reducer to save its state
- update styles to fix increment/decrement on thresholds
- update test cases to account for the extra buttons in the modal

**Acceptance Test (how to verify the PR)**

- Add an image card to the DashboardEditor
- Edit the image
- add Pressure as a data item
- edit Pressure
- Ensure Aggregate/Precision fields are available and persist after change/save
