### PR TITLE
Expose legend position prop on bar and time cards

### DIFF
--- a/packages/react/src/components/BarChartCard/BarChartCard.jsx
+++ b/packages/react/src/components/BarChartCard/BarChartCard.jsx
@@ -48,6 +48,7 @@ const defaultProps = {
   content: {
     type: BAR_CHART_TYPES.SIMPLE,
     layout: BAR_CHART_LAYOUTS.VERTICAL,
+    legendPosition: 'bottom',
     truncation: {
       type: 'end_line',
       threshold: 20,
@@ -100,6 +101,7 @@ const BarChartCard = ({
       yLabel,
       unit,
       type,
+      legendPosition,
       zoomBar,
       decimalPrecision,
       truncation,
@@ -288,7 +290,7 @@ const BarChartCard = ({
         },
       },
       legend: {
-        position: 'bottom',
+        position: legendPosition,
         enabled: chartData.length > 1,
         clickable: !isEditable,
         truncation,
@@ -343,6 +345,7 @@ const BarChartCard = ({
       xLabel,
       yLabel,
       zoomBar,
+      legendPosition,
     ]
   );
 

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -89,6 +89,8 @@ const TimeSeriesCardPropTypes = {
      * if not explicitly stated, the card will show based on the length of the series
      */
     showLegend: PropTypes.bool,
+    /** Where to place the chart legend */
+    legendPosition: PropTypes.string,
     /** carbon charts legend truncation options */
     truncation: TruncationPropTypes,
   }).isRequired,
@@ -142,6 +144,7 @@ const defaultProps = {
     includeZeroOnXaxis: false,
     includeZeroOnYaxis: false,
     showLegend: true,
+    legendPosition: 'bottom',
     truncation: {
       type: 'end_line',
       threshold: 20,
@@ -194,6 +197,7 @@ const TimeSeriesCard = ({
       chartType,
       zoomBar,
       showLegend,
+      legendPosition,
       addSpaceOnEdges,
       truncation,
     },
@@ -393,7 +397,7 @@ const TimeSeriesCard = ({
         },
       },
       legend: {
-        position: 'bottom',
+        position: legendPosition,
         clickable: !isEditable,
         enabled: showLegend ?? series.length > 1,
         truncation,
@@ -443,6 +447,7 @@ const TimeSeriesCard = ({
       chartType,
       series.length,
       includeZeroOnYaxis,
+      legendPosition,
       isEditable,
       showLegend,
       truncation,

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -4838,6 +4838,7 @@ Map {
     "defaultProps": Object {
       "content": Object {
         "layout": "VERTICAL",
+        "legendPosition": "bottom",
         "series": Array [],
         "truncation": Object {
           "numCharacter": 20,
@@ -12904,6 +12905,7 @@ Map {
       "content": Object {
         "includeZeroOnXaxis": false,
         "includeZeroOnYaxis": false,
+        "legendPosition": "bottom",
         "series": Array [],
         "showLegend": true,
         "timeDataSourceId": "timestamp",
@@ -13422,6 +13424,9 @@ Map {
             },
             "includeZeroOnYaxis": Object {
               "type": "bool",
+            },
+            "legendPosition": Object {
+              "type": "string",
             },
             "series": Object {
               "args": Array [


### PR DESCRIPTION
**Summary**
Need to give the consumer the ability to set the `legendPosition` on `TimeSeries` and `Bar` cards.

**Change List (commits, features, bugs, etc)**
Expose new `legendPosition` prop.

**Acceptance Test (how to verify the PR)**
Make sure you can control the legendPosition via the new prop.

**Regression Test (how to make sure this PR doesn't break old functionality)**
Make sure that BarChart and TimeSeries cards still properly show the legend on the bottom by default.
