### PR TITLE
fix(cardrenderer): custom and default cards should be resizable

### DIFF
--- a/packages/react/src/components/DashboardEditor/DashboardEditor.story.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.story.jsx
@@ -850,6 +850,11 @@ export const CustomCardPreviewRenderer = () => (
             property on the card will be rendered here:
             <h3>{cardConfig.value}</h3>
           </div>
+
+          {
+            // if you want the resizable handles you need to render the children
+            cardProps.children
+          }
         </Card>
       ) : undefined;
     }}

--- a/packages/react/src/components/DashboardEditor/DashboardEditorCardRenderer.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditorCardRenderer.jsx
@@ -29,6 +29,7 @@ import { timeRangeToJSON, isCardJsonValid, handleKeyDown, handleOnClick } from '
 const renderDefaultCard = (props) => (
   <Card isEditable {...props}>
     <div style={{ padding: '1rem' }}>{JSON.stringify(props.id, null, 4)}</div>
+    {props.children}
   </Card>
 );
 
@@ -122,6 +123,7 @@ const renderCustomCard = (props) => {
       {...omit(props, 'content')}
     >
       {props.content}
+      {props.children}
     </Card>
   );
 };

--- a/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -1765,6 +1765,31 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                             "--card-content-height": "256px",
                           }
                         }
+                      >
+                        <span
+                          className="react-resizable-handle react-resizable-handle-se"
+                          onMouseDown={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchStart={[Function]}
+                          style={
+                            Object {
+                              "touchAction": "none",
+                            }
+                          }
+                        />
+                      </div>
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
                       />
                     </div>
                     <div
@@ -14663,6 +14688,31 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                       style={
                         Object {
                           "--card-content-height": "256px",
+                        }
+                      }
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </div>
+                    <span
+                      className="react-resizable-handle react-resizable-handle-se"
+                      onMouseDown={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                      style={
+                        Object {
+                          "touchAction": "none",
                         }
                       }
                     />

--- a/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -3543,7 +3543,31 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Exper
                           35
                         </h3>
                       </div>
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
                     </div>
+                    <span
+                      className="react-resizable-handle react-resizable-handle-se"
+                      onMouseDown={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                      style={
+                        Object {
+                          "touchAction": "none",
+                        }
+                      }
+                    />
                   </div>
                   <div
                     className="iot--card iot--dashboard-editor--preview__card iot--card--wrapper"


### PR DESCRIPTION
Closes #

**Summary**

- Small issue where for default and custom card types, the DashboardEditor was not adding the children prop (which contains the draggable resizable widget)

**Change List (commits, features, bugs, etc)**

- fix(DashboardEditorCardRenderer): pass the child prop along as well.

**Acceptance Test (how to verify the PR)**

- Verify the DashboardEditor story, when you add an Alert or Custom card they are both resizable

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Verify the other card types are still resizable
