### PR TITLE
chore(testing): split up react and angular test jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+        filters: |
+          react:
+            - 'packages/react/**'
+
       - name: Use Node.js
         uses: actions/setup-node@v1
+        if: steps.changes.outputs.react == 'true'
         with:
           node-version: '14.x'
 
       - name: Cache dependencies
         uses: actions/cache@v2
+        if: steps.changes.outputs.react == 'true'
         with:
           path: |
             node_modules
@@ -25,18 +34,21 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
+        if: steps.changes.outputs.react == 'true'
         run: |
           yarn --frozen-lockfile
           yarn lerna run --stream postinstall
           yarn lerna link
 
       - name: Run tests, collect coverage
+        if: steps.changes.outputs.react == 'true'
         run: |
           cd packages/react
           yarn test:ci
 
       - name: Coveralls
         uses: coverallsapp/github-action@master
+        if: steps.changes.outputs.react == 'true'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: './packages/react/coverage/lcov.info'
@@ -50,13 +62,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+        filters: |
+          angular:
+            - 'packages/angular/**'
+
       - name: Use Node.js
         uses: actions/setup-node@v1
+        if: steps.changes.outputs.angular == 'true'
         with:
           node-version: '14.x'
 
       - name: Cache dependencies
         uses: actions/cache@v2
+        if: steps.changes.outputs.angular == 'true'
         with:
           path: |
             node_modules
@@ -64,12 +85,14 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
+        if: steps.changes.outputs.angular == 'true'
         run: |
           yarn --frozen-lockfile
           yarn lerna run --stream postinstall
           yarn lerna link
 
       - name: Run tests, collect coverage
+        if: steps.changes.outputs.angular == 'true'
         run: |
           cd packages/angular
           yarn test:ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,8 @@ name: Test
 on: [push, pull_request]
 
 jobs:
-  test:
-    name: '`yarn test`'
+  test-react:
+    name: Test React
     runs-on: ubuntu-latest
 
     steps:
@@ -31,11 +31,45 @@ jobs:
           yarn lerna link
 
       - name: Run tests, collect coverage
-        run: yarn test:ci
+        run: |
+          cd packages/react
+          yarn test:ci
 
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: "./packages/react/coverage/lcov.info"
-          base-path: "packages/react"
+          path-to-lcov: './packages/react/coverage/lcov.info'
+          base-path: 'packages/react'
+
+  test-angular:
+    name: Test Angular
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        run: |
+          yarn --frozen-lockfile
+          yarn lerna run --stream postinstall
+          yarn lerna link
+
+      - name: Run tests, collect coverage
+        run: |
+          cd packages/angular
+          yarn test:ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: dorny/paths-filter@v2
         id: changes
         with:
-        filters: |
-          react:
-            - 'packages/react/**'
+          filters: |
+            react:
+              - 'packages/react/**'
 
       - name: Use Node.js
         uses: actions/setup-node@v1
@@ -65,9 +65,9 @@ jobs:
       - uses: dorny/paths-filter@v2
         id: changes
         with:
-        filters: |
-          angular:
-            - 'packages/angular/**'
+          filters: |
+            angular:
+              - 'packages/angular/**'
 
       - name: Use Node.js
         uses: actions/setup-node@v1


### PR DESCRIPTION
This splits up the React and Angular test runs into separate jobs. This should make it clearer which package is failing, lower overall run time, and not gate React PRs on Angular issues and vice-versa.

This also makes use of https://github.com/dorny/paths-filter to skip running react/angular tests based on which files have changed.