### PR TITLE
feat(tablecolumn): add optional tooltip to table column

### DIFF
--- a/packages/react/src/components/Table/Table.story.jsx
+++ b/packages/react/src/components/Table/Table.story.jsx
@@ -210,6 +210,7 @@ export const tableColumnsWithAlignment = [
 
 export const tableColumnsFixedWidth = tableColumns.map((i) => ({
   ...i,
+  name: `${i.name} long text should get truncated`,
   width:
     i.id === 'string'
       ? '50px'
@@ -638,6 +639,37 @@ SimpleStatefulExample.story = {
     info: {
       text:
         'This is an example of the <StatefulTable> component that uses local state to handle all the table actions. This is produced by wrapping the <Table> in a container component and managing the state associated with features such the toolbar, filters, row select, etc. For more robust documentation on the prop model and source, see the other "with function" stories.',
+      propTables: [Table],
+      propTablesExclude: [StatefulTable],
+    },
+  },
+};
+
+export const StatefulExampleWithColumnTooltip = () => (
+  <FullWidthWrapper>
+    <StatefulTable
+      id="table"
+      {...initialState}
+      columns={tableColumns.map((column) => ({
+        ...column,
+        tooltip: column.id === 'select' ? 'Select an option' : undefined,
+      }))}
+      actions={actions}
+      lightweight={boolean('lightweight', false)}
+      options={{
+        hasRowSelection: select('hasRowSelection', ['multi', 'single'], 'multi'),
+        hasRowExpansion: boolean('hasRowExpansion', false),
+        hasRowNesting: boolean('hasRowNesting', false),
+        wrapCellText: 'alwaysTruncate',
+      }}
+      view={{ table: { selectedIds: array('selectedIds', []) } }}
+    />
+  </FullWidthWrapper>
+);
+
+StatefulExampleWithColumnTooltip.story = {
+  parameters: {
+    info: {
       propTables: [Table],
       propTablesExclude: [StatefulTable],
     },

--- a/packages/react/src/components/Table/TableCellRenderer/TableCellRenderer.jsx
+++ b/packages/react/src/components/Table/TableCellRenderer/TableCellRenderer.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { Tooltip } from 'carbon-components-react';
+import { Tooltip, TooltipDefinition } from 'carbon-components-react';
 
 import { settings } from '../../../constants/Settings';
 
@@ -49,6 +49,7 @@ const TableCellRenderer = ({
   allowTooltip,
   truncateCellText,
   locale,
+  tooltip,
   renderDataFunction,
   columnId,
   rowId,
@@ -62,8 +63,17 @@ const TableCellRenderer = ({
 
   const [useTooltip, setUseTooltip] = useState(false);
 
-  const withTooltip = (element) => {
-    return (
+  const withTooltip = (element, tooltipForExtraInformation) => {
+    return tooltip ? (
+      <TooltipDefinition
+        showIcon={false}
+        triggerClassName={`${iotPrefix}--table__cell-tooltip`}
+        tooltipText={tooltipForExtraInformation}
+        id="table-header-tooltip"
+      >
+        {element}
+      </TooltipDefinition>
+    ) : (
       <Tooltip
         showIcon={false}
         triggerText={element}
@@ -107,7 +117,7 @@ const TableCellRenderer = ({
     children
   );
 
-  return useTooltip ? withTooltip(cellContent) : cellContent;
+  return useTooltip || tooltip ? withTooltip(cellContent, tooltip) : cellContent;
 };
 
 TableCellRenderer.propTypes = propTypes;

--- a/packages/react/src/components/Table/TableCellRenderer/_table-cell-renderer.scss
+++ b/packages/react/src/components/Table/TableCellRenderer/_table-cell-renderer.scss
@@ -16,6 +16,10 @@
   }
 }
 
+.bx--tooltip__trigger.bx--tooltip--a11y.#{$iot-prefix}--table__cell-tooltip {
+  @include type-style('productive-heading-01');
+}
+
 .#{$iot-prefix}--table__cell-text--truncate {
   @include text-overflow();
   display: block;

--- a/packages/react/src/components/Table/TableHead/TableHead.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.jsx
@@ -365,6 +365,7 @@ const TableHead = ({
               data-column={matchingColumnMeta.id}
               isSortable={matchingColumnMeta.isSortable && !isDisabled}
               isSortHeader={hasSort}
+              hasTooltip={!!matchingColumnMeta.tooltip}
               ref={columnRef[matchingColumnMeta.id]}
               thStyle={{
                 width:
@@ -397,6 +398,7 @@ const TableHead = ({
                 wrapText={wrapCellText}
                 truncateCellText={truncateCellText}
                 allowTooltip={false}
+                tooltip={matchingColumnMeta.tooltip}
               >
                 {matchingColumnMeta.name}
               </TableCellRenderer>

--- a/packages/react/src/components/Table/TableHead/TableHeader.js
+++ b/packages/react/src/components/Table/TableHead/TableHeader.js
@@ -59,6 +59,7 @@ const TableHeader = React.forwardRef(function TableHeader(
     // eslint-disable-next-line react/prop-types
     onClick,
     scope,
+    hasTooltip,
     sortDirection,
     translateWithId: t,
     thStyle,
@@ -80,7 +81,11 @@ const TableHeader = React.forwardRef(function TableHeader(
         ref={ref}
         style={thStyle}
       >
-        <span className={`${prefix}--table-header-label`}>{children}</span>
+        {!hasTooltip ? (
+          <span className={`${prefix}--table-header-label`}>{children}</span>
+        ) : (
+          children
+        )}
       </th>
     );
   }
@@ -103,7 +108,11 @@ const TableHeader = React.forwardRef(function TableHeader(
       data-testid={testID}
     >
       <button className={className} onClick={onClick} {...rest}>
-        <span className={`${prefix}--table-header-label`}>{children}</span>
+        {!hasTooltip ? (
+          <span className={`${prefix}--table-header-label`}>{children}</span>
+        ) : (
+          children
+        )}
         <Arrow
           className={`${prefix}--table-sort__icon`}
           aria-label={t('carbon.table.header.icon.description', {
@@ -138,6 +147,8 @@ TableHeader.propTypes = {
    */
   children: PropTypes.node,
 
+  /** does the header have a tooltip, if so do not truncate */
+  hasTooltip: PropTypes.bool,
   /**
    * The initial width of the column when resize is active and the fixed with
    * if resize is inactive. E.g. '200px'
@@ -191,6 +202,7 @@ TableHeader.defaultProps = {
   className: '',
   children: '',
   isSortHeader: false,
+  hasTooltip: false,
   isSortable: false,
   sortDirection: 'NONE',
   onClick: (onClick) => `${onClick}`,

--- a/packages/react/src/components/Table/TablePropTypes.js
+++ b/packages/react/src/components/Table/TablePropTypes.js
@@ -105,7 +105,8 @@ export const TableColumnsPropTypes = PropTypes.arrayOf(
      *    row: PropTypes.object like this {col: value, col2: value}
      * }, you should return the node that should render within that cell */
     renderDataFunction: PropTypes.func,
-
+    /** tooltip to show with the column, for instance to provide more information */
+    tooltip: PropTypes.string,
     /**
      * If omitted, no filter input will be shown for this column
      */

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -711,6 +711,9 @@ Map {
                 "sortFunction": Object {
                   "type": "func",
                 },
+                "tooltip": Object {
+                  "type": "string",
+                },
                 "width": Object {
                   "type": "string",
                 },
@@ -1730,6 +1733,9 @@ Map {
                 "sortFunction": Object {
                   "type": "func",
                 },
+                "tooltip": Object {
+                  "type": "string",
+                },
                 "width": Object {
                   "type": "string",
                 },
@@ -2206,6 +2212,9 @@ Map {
                 },
                 "sortFunction": Object {
                   "type": "func",
+                },
+                "tooltip": Object {
+                  "type": "string",
                 },
                 "width": Object {
                   "type": "string",


### PR DESCRIPTION
Closes #https://github.ibm.com/wiotp/Maximo-Asset-Monitor/issues/2221

**Summary**

- Adds new tooltip prop to each table column and it will render this as a description of the tooltip

**Change List (commits, features, bugs, etc)**

- feat(TableCellRenderer): preserve the existing TableCell truncation UX inside the Data section, but if the tooltip property is passed, then show a TooltipDefinition (currently only supported for column headers)
- feat(tableCellRenderer.scss): make the header class match for the tooltip
- feat(TableHead/TableHeader): need to allow overflow if a tooltip is being used
- feat(TablePropTypes): expose the tooltip prop on the column

**Acceptance Test (how to verify the PR)**

- Check the new story that has a column tooltip

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Verify the existing overflow tooltips work for normal table cells
