### PR TITLE
fix(simplepagination): add aria-label

### DIFF
--- a/packages/react/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
+++ b/packages/react/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
@@ -427,14 +427,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Hiera
                 tabIndex={-1}
               >
                 <svg
-                  aria-hidden={true}
+                  aria-label="Prev page"
                   className="iot-simple-pagination-caret-disabled"
-                  description="Prev page"
                   dir="ltr"
                   fill="currentColor"
                   focusable="false"
                   height={16}
                   preserveAspectRatio="xMidYMid meet"
+                  role="img"
                   viewBox="0 0 32 32"
                   width={16}
                   xmlns="http://www.w3.org/2000/svg"
@@ -452,14 +452,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Hiera
                 tabIndex={0}
               >
                 <svg
-                  aria-hidden={true}
+                  aria-label="Next page"
                   className="iot-simple-pagination-caret"
-                  description="Next page"
                   dir="ltr"
                   fill="currentColor"
                   focusable="false"
                   height={16}
                   preserveAspectRatio="xMidYMid meet"
+                  role="img"
                   viewBox="0 0 32 32"
                   width={16}
                   xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/List/SimpleList/__snapshots__/SimpleList.story.storyshot
+++ b/packages/react/src/components/List/SimpleList/__snapshots__/SimpleList.story.storyshot
@@ -1164,14 +1164,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Simpl
                 tabIndex={-1}
               >
                 <svg
-                  aria-hidden={true}
+                  aria-label="Prev page"
                   className="iot-simple-pagination-caret-disabled"
-                  description="Prev page"
                   dir="ltr"
                   fill="currentColor"
                   focusable="false"
                   height={16}
                   preserveAspectRatio="xMidYMid meet"
+                  role="img"
                   viewBox="0 0 32 32"
                   width={16}
                   xmlns="http://www.w3.org/2000/svg"
@@ -1189,14 +1189,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Simpl
                 tabIndex={0}
               >
                 <svg
-                  aria-hidden={true}
+                  aria-label="Next page"
                   className="iot-simple-pagination-caret"
-                  description="Next page"
                   dir="ltr"
                   fill="currentColor"
                   focusable="false"
                   height={16}
                   preserveAspectRatio="xMidYMid meet"
+                  role="img"
                   viewBox="0 0 32 32"
                   width={16}
                   xmlns="http://www.w3.org/2000/svg"
@@ -3687,14 +3687,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Simpl
                 tabIndex={-1}
               >
                 <svg
-                  aria-hidden={true}
+                  aria-label="Prev page"
                   className="iot-simple-pagination-caret-disabled"
-                  description="Prev page"
                   dir="ltr"
                   fill="currentColor"
                   focusable="false"
                   height={16}
                   preserveAspectRatio="xMidYMid meet"
+                  role="img"
                   viewBox="0 0 32 32"
                   width={16}
                   xmlns="http://www.w3.org/2000/svg"
@@ -3712,14 +3712,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Simpl
                 tabIndex={0}
               >
                 <svg
-                  aria-hidden={true}
+                  aria-label="Next page"
                   className="iot-simple-pagination-caret"
-                  description="Next page"
                   dir="ltr"
                   fill="currentColor"
                   focusable="false"
                   height={16}
                   preserveAspectRatio="xMidYMid meet"
+                  role="img"
                   viewBox="0 0 32 32"
                   width={16}
                   xmlns="http://www.w3.org/2000/svg"
@@ -6227,14 +6227,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Simpl
                 tabIndex={-1}
               >
                 <svg
-                  aria-hidden={true}
+                  aria-label="Prev page"
                   className="iot-simple-pagination-caret-disabled"
-                  description="Prev page"
                   dir="ltr"
                   fill="currentColor"
                   focusable="false"
                   height={16}
                   preserveAspectRatio="xMidYMid meet"
+                  role="img"
                   viewBox="0 0 32 32"
                   width={16}
                   xmlns="http://www.w3.org/2000/svg"
@@ -6252,14 +6252,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Simpl
                 tabIndex={0}
               >
                 <svg
-                  aria-hidden={true}
+                  aria-label="Next page"
                   className="iot-simple-pagination-caret"
-                  description="Next page"
                   dir="ltr"
                   fill="currentColor"
                   focusable="false"
                   height={16}
                   preserveAspectRatio="xMidYMid meet"
+                  role="img"
                   viewBox="0 0 32 32"
                   width={16}
                   xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/SimplePagination/SimplePagination.jsx
+++ b/packages/react/src/components/SimplePagination/SimplePagination.jsx
@@ -85,7 +85,7 @@ const SimplePagination = ({
             >
               <CaretLeft16
                 dir="ltr"
-                description={prevPageText}
+                aria-label={prevPageText}
                 className={
                   hasPrev
                     ? `${iotPrefix}-simple-pagination-caret`
@@ -106,7 +106,7 @@ const SimplePagination = ({
             >
               <CaretRight16
                 dir="ltr"
-                description={nextPageText}
+                aria-label={nextPageText}
                 className={
                   hasNext
                     ? `${iotPrefix}-simple-pagination-caret`

--- a/packages/react/src/components/SimplePagination/__snapshots__/SimplePagination.story.storyshot
+++ b/packages/react/src/components/SimplePagination/__snapshots__/SimplePagination.story.storyshot
@@ -40,14 +40,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Simpl
             tabIndex={-1}
           >
             <svg
-              aria-hidden={true}
+              aria-label="Prev page"
               className="iot-simple-pagination-caret-disabled"
-              description="Prev page"
               dir="ltr"
               fill="currentColor"
               focusable="false"
               height={16}
               preserveAspectRatio="xMidYMid meet"
+              role="img"
               viewBox="0 0 32 32"
               width={16}
               xmlns="http://www.w3.org/2000/svg"
@@ -65,14 +65,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Simpl
             tabIndex={0}
           >
             <svg
-              aria-hidden={true}
+              aria-label="Next page"
               className="iot-simple-pagination-caret"
-              description="Next page"
               dir="ltr"
               fill="currentColor"
               focusable="false"
               height={16}
               preserveAspectRatio="xMidYMid meet"
+              role="img"
               viewBox="0 0 32 32"
               width={16}
               xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/Table/TableManageViewsModal/__snapshots__/TableManageViewsModal.story.storyshot
+++ b/packages/react/src/components/Table/TableManageViewsModal/__snapshots__/TableManageViewsModal.story.storyshot
@@ -1238,14 +1238,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     tabIndex={-1}
                   >
                     <svg
-                      aria-hidden={true}
+                      aria-label="Prev page"
                       className="iot-simple-pagination-caret-disabled"
-                      description="Prev page"
                       dir="ltr"
                       fill="currentColor"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
+                      role="img"
                       viewBox="0 0 32 32"
                       width={16}
                       xmlns="http://www.w3.org/2000/svg"
@@ -1263,14 +1263,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     tabIndex={0}
                   >
                     <svg
-                      aria-hidden={true}
+                      aria-label="Next page"
                       className="iot-simple-pagination-caret"
-                      description="Next page"
                       dir="ltr"
                       fill="currentColor"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
+                      role="img"
                       viewBox="0 0 32 32"
                       width={16}
                       xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/TileCatalog/__snapshots__/TileCatalog.story.storyshot
+++ b/packages/react/src/components/TileCatalog/__snapshots__/TileCatalog.story.storyshot
@@ -2263,14 +2263,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             tabIndex={-1}
           >
             <svg
-              aria-hidden={true}
+              aria-label="Prev page"
               className="iot-simple-pagination-caret-disabled"
-              description="Prev page"
               dir="ltr"
               fill="currentColor"
               focusable="false"
               height={16}
               preserveAspectRatio="xMidYMid meet"
+              role="img"
               viewBox="0 0 32 32"
               width={16}
               xmlns="http://www.w3.org/2000/svg"
@@ -2288,14 +2288,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             tabIndex={0}
           >
             <svg
-              aria-hidden={true}
+              aria-label="Next page"
               className="iot-simple-pagination-caret"
-              description="Next page"
               dir="ltr"
               fill="currentColor"
               focusable="false"
               height={16}
               preserveAspectRatio="xMidYMid meet"
+              role="img"
               viewBox="0 0 32 32"
               width={16}
               xmlns="http://www.w3.org/2000/svg"
@@ -2954,14 +2954,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             tabIndex={-1}
           >
             <svg
-              aria-hidden={true}
+              aria-label="Prev page"
               className="iot-simple-pagination-caret-disabled"
-              description="Prev page"
               dir="ltr"
               fill="currentColor"
               focusable="false"
               height={16}
               preserveAspectRatio="xMidYMid meet"
+              role="img"
               viewBox="0 0 32 32"
               width={16}
               xmlns="http://www.w3.org/2000/svg"
@@ -2979,14 +2979,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             tabIndex={0}
           >
             <svg
-              aria-hidden={true}
+              aria-label="Next page"
               className="iot-simple-pagination-caret"
-              description="Next page"
               dir="ltr"
               fill="currentColor"
               focusable="false"
               height={16}
               preserveAspectRatio="xMidYMid meet"
+              role="img"
               viewBox="0 0 32 32"
               width={16}
               xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION


**Summary**

- The `description` prop doesn't seem to have any affect on `svg` elements so it has been swapped to use `aria-label` so that it can be queried and read by screen readers

**Acceptance Test (how to verify the PR)**

- The next and previous button should now have `aria-label` set

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Shouldn't affect existing functionality
