### PR TITLE
fix(suiteheader) Fixing text wrapping for user name and display name in `SuiteHeader`.

### DIFF
--- a/packages/react/src/components/SuiteHeader/_suite-header.scss
+++ b/packages/react/src/components/SuiteHeader/_suite-header.scss
@@ -26,6 +26,11 @@
     &--detail {
       flex: 1;
       padding-left: $spacing-05;
+      overflow: hidden;
+      div {
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
     }
   }
 


### PR DESCRIPTION
**Summary**

Long user names and display names were overflowing outside of the profile panel

Before the fix

![image](https://user-images.githubusercontent.com/12237934/116927614-43287800-ac32-11eb-81e6-5ecac18884b1.png)

After the fix

![image](https://user-images.githubusercontent.com/12237934/116927700-618e7380-ac32-11eb-9292-a55d8eaccb92.png)

