### PR TITLE
feat(Tablecard): allow passing of filters

### DIFF
--- a/packages/react/src/components/TableCard/TableCard.jsx
+++ b/packages/react/src/components/TableCard/TableCard.jsx
@@ -120,6 +120,7 @@ const defaultProps = {
   size: CARD_SIZES.LARGE,
   locale: 'en',
   values: [],
+  filters: [],
   i18n: {
     criticalLabel: 'Critical',
     moderateLabel: 'Moderate',
@@ -161,6 +162,7 @@ const TableCard = ({
   size,
   onCardAction,
   values: valuesProp,
+  filters,
   isEditable,
   isResizable,
   i18n,
@@ -681,7 +683,7 @@ const TableCard = ({
                 isDisabled: isEditable,
                 customToolbarContent: cardToolbar,
               },
-              filters: [],
+              filters,
               table: {
                 ...(columnStartSort
                   ? {

--- a/packages/react/src/components/TableCard/TableCard.story.jsx
+++ b/packages/react/src/components/TableCard/TableCard.story.jsx
@@ -108,10 +108,10 @@ WithLinks.story = {
 
   parameters: {
     info: {
-      text: `<p>Links can added by providing a linkTemplate prop to the content.columns[i] property. 
-                2 additional properties can be configured within the linkTemplate object: href and target</p> 
+      text: `<p>Links can added by providing a linkTemplate prop to the content.columns[i] property.
+                2 additional properties can be configured within the linkTemplate object: href and target</p>
             <p>href is the url the link will use. This property is required.</p>
-            <p>target is whether you would like to open the link in a new window or not. 
+            <p>target is whether you would like to open the link in a new window or not.
                 This property defaults to opening in the current window. Use '_blank' to open in a new window
             </p>
             <p> Note: if using row-specific variables in a TableCard href (ie a variable that has a different value per row),
@@ -491,7 +491,7 @@ WithThresholds.story = {
   parameters: {
     info: {
       text: `
-     Thresholds can be based off 1 specific data source with the unique key: dataSourceId . 
+     Thresholds can be based off 1 specific data source with the unique key: dataSourceId .
 
      Comparisons can then be added by defined the comparison key with one of the following: <,<=,=,>,>= .
 
@@ -499,7 +499,7 @@ WithThresholds.story = {
 
      Value is the number limit being compared in the comparison that was defined.
 
-     Label is a custom label that can be defined and displayed in the column. If a custom label is not set, 
+     Label is a custom label that can be defined and displayed in the column. If a custom label is not set,
      the label will default to '<dataSourceId> Severity'
 
      In addition, if the dataSourceId does not have a column displayed, a new column will be added at the end
@@ -1013,6 +1013,34 @@ export const EditableWithExpandedRows = () => {
 
 EditableWithExpandedRows.story = {
   name: 'editable with expanded rows',
+};
+
+export const WithCustomFilters = () => {
+  const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGEWIDE);
+
+  return (
+    <div
+      style={{
+        width: `${getCardMinSize('lg', size).x}px`,
+        margin: spacing05 + 4,
+      }}
+    >
+      <TableCard
+        title="Open Alerts"
+        content={{
+          columns: tableColumns,
+        }}
+        values={tableData}
+        filters={[{ columnId: 'alert', value: 'failure' }]}
+        size={CARD_SIZES.LARGE}
+      />
+      );
+    </div>
+  );
+};
+
+WithCustomFilters.story = {
+  name: 'with custom filters',
 };
 
 export const WithIsLoading = () => {

--- a/packages/react/src/components/TableCard/TableCard.test.jsx
+++ b/packages/react/src/components/TableCard/TableCard.test.jsx
@@ -564,6 +564,23 @@ describe('TableCard', () => {
     expect(screen.queryAllByText('Pressure')).toHaveLength(1);
   });
 
+  it('can accept filter options', () => {
+    const wrapper = mount(
+      <TableCard
+        title="Open Alerts"
+        content={{
+          columns: tableColumns,
+        }}
+        values={tableData}
+        filters={[{ columnId: 'alert', value: 'failure' }]}
+        size={CARD_SIZES.LARGE}
+      />
+    );
+
+    const totalRows = tableData.filter((item) => item.values.alert.match(/failure/));
+    expect(wrapper.find('tr').length).toBe(totalRows.length + 1); // +1 for action column
+  });
+
   it('hides low priority columns for LARGE and LARGETHIN sizes', () => {
     const { rerender } = render(
       <TableCard

--- a/packages/react/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/packages/react/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -13109,8 +13109,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-51"
-                  id="bx-pagination-select-51-count-label"
+                  htmlFor="bx-pagination-select-52"
+                  id="bx-pagination-select-52-count-label"
                 >
                   Items per page:
                 </label>
@@ -13129,7 +13129,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-51"
+                          id="bx-pagination-select-52"
                           onChange={[Function]}
                           value={10}
                         >
@@ -13194,7 +13194,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-51-right"
+                      htmlFor="bx-pagination-select-52-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -13207,7 +13207,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-51-right"
+                          id="bx-pagination-select-52-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -16519,6 +16519,859 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           </div>
         </div>
       </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TableCard with custom filters 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": "1rem4",
+          "width": "1056px",
+        }
+      }
+    >
+      <div
+        className="iot--card iot--card--wrapper"
+        data-testid="Card"
+        role="presentation"
+        style={
+          Object {
+            "--card-default-height": "624px",
+          }
+        }
+      >
+        <div
+          className="iot--card--content"
+          style={
+            Object {
+              "--card-content-height": "576px",
+            }
+          }
+        >
+          <div
+            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
+            data-testid="table-for-card-undefined-table-container"
+          >
+            <section
+              aria-label="data table toolbar"
+              className="bx--table-toolbar"
+              data-testid="table-for-card-undefined-table-toolbar"
+            >
+              <div
+                aria-hidden={true}
+                className="bx--batch-actions iot--table-batch-actions"
+                data-testID="table-for-card-undefined-table-toolbar-batch-actions"
+              >
+                <div
+                  className="bx--batch-summary"
+                >
+                  <p
+                    className="bx--batch-summary__para"
+                  >
+                    <span>
+                      0 items selected
+                    </span>
+                  </p>
+                </div>
+                <div
+                  className="bx--action-list"
+                >
+                  <button
+                    aria-pressed={null}
+                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={-1}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+              <label
+                className="iot--table-toolbar-secondary-title"
+              >
+                Open Alerts
+              </label>
+              <div
+                className="bx--toolbar-content iot--table-toolbar-content"
+                data-testid="table-for-card-undefined-table-toolbar-content"
+              >
+                <div
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  tabIndex="0"
+                >
+                  <div
+                    aria-labelledby="table-for-card-undefined-toolbar-search-search"
+                    className="bx--search bx--search--sm table-toolbar-search"
+                    role="search"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="bx--search-magnifier"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                      />
+                    </svg>
+                    <label
+                      className="bx--label"
+                      htmlFor="table-for-card-undefined-toolbar-search"
+                      id="table-for-card-undefined-toolbar-search-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      autoComplete="off"
+                      className="bx--search-input"
+                      data-testid="table-for-card-undefined-table-toolbar-search"
+                      id="table-for-card-undefined-toolbar-search"
+                      onChange={[Function]}
+                      onKeyDown={[Function]}
+                      placeholder="Search"
+                      role="searchbox"
+                      tabIndex="-1"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <button
+                  aria-pressed={null}
+                  className="bx--btn bx--btn--secondary"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  type="button"
+                >
+                  Clear all filters
+                </button>
+                <button
+                  aria-pressed={null}
+                  className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
+                  data-testid="download-button"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  title="Download table content"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Download table content"
+                    className="bx--btn__icon"
+                    fill="currentColor"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M26 24v4H6V24H4v4H4a2 2 0 002 2H26a2 2 0 002-2h0V24zM26 14L24.59 12.59 17 20.17 17 2 15 2 15 20.17 7.41 12.59 6 14 16 24 26 14z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-pressed={null}
+                  className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
+                  data-testid="filter-button"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  title="Filters"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Filters"
+                    className="bx--btn__icon"
+                    fill="currentColor"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M18,28H14a2,2,0,0,1-2-2V18.41L4.59,11A2,2,0,0,1,4,9.59V6A2,2,0,0,1,6,4H26a2,2,0,0,1,2,2V9.59A2,2,0,0,1,27.41,11L20,18.41V26A2,2,0,0,1,18,28ZM6,6V9.59l8,8V26h4V17.59l8-8V6Z"
+                    />
+                  </svg>
+                </button>
+                <div
+                  className="iot--card--toolbar"
+                >
+                  <div
+                    className="iot--card--toolbar-date-range-wrapper"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="open and close list of options"
+                      className="iot--card--toolbar-date-range-action bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      title="Select time range"
+                      type="button"
+                    >
+                      <svg
+                        aria-label="Select time range"
+                        className="bx--overflow-menu__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
+                        />
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        />
+                        <path
+                          d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
+                        />
+                        <title>
+                          Select time range
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                  <button
+                    aria-pressed={null}
+                    className="iot--card--toolbar-action iot--card--toolbar-svg-wrapper bx--btn--icon-only bx--btn bx--btn--ghost"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    title="Expand to fullscreen"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Expand to fullscreen"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M28,4H10A2.0059,2.0059,0,0,0,8,6V20a2.0059,2.0059,0,0,0,2,2H28a2.0059,2.0059,0,0,0,2-2V6A2.0059,2.0059,0,0,0,28,4Zm0,16H10V6H28Z"
+                      />
+                      <path
+                        d="M18,26H4V16H6V14H4a2.0059,2.0059,0,0,0-2,2V26a2.0059,2.0059,0,0,0,2,2H18a2.0059,2.0059,0,0,0,2-2V24H18Z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </section>
+            <div
+              className="addons-iot-table-container"
+            >
+              <div
+                className="bx--data-table-content"
+              >
+                <table
+                  className="bx--data-table bx--data-table--no-border"
+                  data-testid="table-for-card-undefined"
+                  title={null}
+                >
+                  <thead
+                    data-testid="table-for-card-undefined-table-head"
+                    onMouseMove={null}
+                    onMouseUp={null}
+                  >
+                    <tr>
+                      <th
+                        aria-sort="none"
+                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
+                        data-testid="table-for-card-undefined-table-head-column-alert"
+                        scope="col"
+                        style={
+                          Object {
+                            "width": undefined,
+                          }
+                        }
+                        width=""
+                      >
+                        <button
+                          align="start"
+                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
+                          data-column="alert"
+                          data-floating-menu-container={true}
+                          id="column-alert"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "--table-header-width": "",
+                            }
+                          }
+                          width=""
+                        >
+                          <span
+                            className="bx--table-header-label"
+                          >
+                            <span
+                              className=""
+                              title="Alert"
+                            >
+                              Alert
+                            </span>
+                          </span>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                            />
+                          </svg>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon-unsorted"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                            />
+                          </svg>
+                        </button>
+                      </th>
+                      <th
+                        aria-sort="none"
+                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
+                        data-testid="table-for-card-undefined-table-head-column-hour"
+                        scope="col"
+                        style={
+                          Object {
+                            "width": undefined,
+                          }
+                        }
+                        width=""
+                      >
+                        <button
+                          align="start"
+                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
+                          data-column="hour"
+                          data-floating-menu-container={true}
+                          id="column-hour"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "--table-header-width": "",
+                            }
+                          }
+                          width=""
+                        >
+                          <span
+                            className="bx--table-header-label"
+                          >
+                            <span
+                              className=""
+                              title="Hour"
+                            >
+                              Hour
+                            </span>
+                          </span>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                            />
+                          </svg>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon-unsorted"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                            />
+                          </svg>
+                        </button>
+                      </th>
+                      <th
+                        aria-sort="none"
+                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
+                        data-testid="table-for-card-undefined-table-head-column-pressure"
+                        scope="col"
+                        style={
+                          Object {
+                            "width": undefined,
+                          }
+                        }
+                        width=""
+                      >
+                        <button
+                          align="start"
+                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
+                          data-column="pressure"
+                          data-floating-menu-container={true}
+                          id="column-pressure"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "--table-header-width": "",
+                            }
+                          }
+                          width=""
+                        >
+                          <span
+                            className="bx--table-header-label"
+                          >
+                            <span
+                              className=""
+                              title="Pressure"
+                            >
+                              Pressure
+                            </span>
+                          </span>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                            />
+                          </svg>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon-unsorted"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                            />
+                          </svg>
+                        </button>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    aria-live="polite"
+                    data-testID="table-for-card-undefined-table-body"
+                  >
+                    <tr
+                      className="TableBodyRow__StyledTableRow-sc-103itxu-0 kJwmjb"
+                      onClick={[Function]}
+                    >
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-undefined-row-1-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI005 Asset failure"
+                          >
+                            AHI005 Asset failure
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-undefined-row-1-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="07/23/2019 05:26"
+                          >
+                            07/23/2019 05:26
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-undefined-row-1-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="0"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div
+              className="bx--pagination iot--pagination iot--pagination--hide-page"
+              data-testid="table-for-card-undefined-table-pagination"
+              style={
+                Object {
+                  "--pagination-text-display": "flex",
+                }
+              }
+            >
+              <div
+                className="bx--pagination__left"
+              >
+                <label
+                  className="bx--pagination__text"
+                  htmlFor="bx-pagination-select-51"
+                  id="bx-pagination-select-51-count-label"
+                >
+                  Items per page:
+                </label>
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__item-count"
+                  >
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-51"
+                          onChange={[Function]}
+                          value={10}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={10}
+                          >
+                            10
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={25}
+                          >
+                            25
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={100}
+                          >
+                            100
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden={true}
+                          className="bx--select__arrow"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text bx--pagination__items-count"
+                >
+                  1–1 of 1 items
+                </span>
+              </div>
+              <div
+                className="bx--pagination__right"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__page-number"
+                  >
+                    <label
+                      className="bx--label bx--visually-hidden"
+                      htmlFor="bx-pagination-select-51-right"
+                    >
+                      Page number, of 1 pages
+                    </label>
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-51-right"
+                          onChange={[Function]}
+                          value={1}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={1}
+                          >
+                            1
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden={true}
+                          className="bx--select__arrow"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1 of 1 pages
+                </span>
+                <div
+                  className="bx--pagination__control-buttons"
+                >
+                  <button
+                    className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index bx--btn bx--btn--ghost bx--btn--disabled bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                    disabled={true}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Previous page
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Previous page"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M20 24L10 16 20 8z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="bx--pagination__button bx--pagination__button--forward bx--pagination__button--no-index bx--btn bx--btn--ghost bx--btn--disabled bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-end"
+                    disabled={true}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Next page
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Next page"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M12 8L22 16 12 24z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      );
     </div>
   </div>
   <button

--- a/packages/react/src/components/TileCatalogNew/__snapshots__/TileCatalogNew.story.storyshot
+++ b/packages/react/src/components/TileCatalogNew/__snapshots__/TileCatalogNew.story.storyshot
@@ -43,7 +43,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 tabIndex="0"
               >
                 <div
-                  aria-labelledby="43-search"
+                  aria-labelledby="44-search"
                   className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
                   role="search"
                 >
@@ -64,15 +64,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </svg>
                   <label
                     className="bx--label"
-                    htmlFor="43"
-                    id="43-search"
+                    htmlFor="44"
+                    id="44-search"
                   >
                     Filter table
                   </label>
                   <input
                     autoComplete="off"
                     className="bx--search-input"
-                    id="43"
+                    id="44"
                     onChange={[Function]}
                     onKeyDown={[Function]}
                     placeholder="Enter a value"
@@ -412,7 +412,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 tabIndex="0"
               >
                 <div
-                  aria-labelledby="44-search"
+                  aria-labelledby="45-search"
                   className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
                   role="search"
                 >
@@ -433,15 +433,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </svg>
                   <label
                     className="bx--label"
-                    htmlFor="44"
-                    id="44-search"
+                    htmlFor="45"
+                    id="45-search"
                   >
                     Filter table
                   </label>
                   <input
                     autoComplete="off"
                     className="bx--search-input"
-                    id="44"
+                    id="45"
                     onChange={[Function]}
                     onKeyDown={[Function]}
                     placeholder="Enter a value"
@@ -688,7 +688,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 tabIndex="0"
               >
                 <div
-                  aria-labelledby="46-search"
+                  aria-labelledby="47-search"
                   className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
                   role="search"
                 >
@@ -709,15 +709,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </svg>
                   <label
                     className="bx--label"
-                    htmlFor="46"
-                    id="46-search"
+                    htmlFor="47"
+                    id="47-search"
                   >
                     Filter table
                   </label>
                   <input
                     autoComplete="off"
                     className="bx--search-input"
-                    id="46"
+                    id="47"
                     onChange={[Function]}
                     onKeyDown={[Function]}
                     placeholder="Enter a value"
@@ -945,7 +945,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 tabIndex="0"
               >
                 <div
-                  aria-labelledby="45-search"
+                  aria-labelledby="46-search"
                   className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
                   role="search"
                 >
@@ -966,15 +966,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </svg>
                   <label
                     className="bx--label"
-                    htmlFor="45"
-                    id="45-search"
+                    htmlFor="46"
+                    id="46-search"
                   >
                     Filter table
                   </label>
                   <input
                     autoComplete="off"
                     className="bx--search-input"
-                    id="45"
+                    id="46"
                     onChange={[Function]}
                     onKeyDown={[Function]}
                     placeholder="Enter a value"
@@ -1173,7 +1173,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 tabIndex="0"
               >
                 <div
-                  aria-labelledby="49-search"
+                  aria-labelledby="50-search"
                   className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
                   role="search"
                 >
@@ -1194,15 +1194,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </svg>
                   <label
                     className="bx--label"
-                    htmlFor="49"
-                    id="49-search"
+                    htmlFor="50"
+                    id="50-search"
                   >
                     Filter table
                   </label>
                   <input
                     autoComplete="off"
                     className="bx--search-input"
-                    id="49"
+                    id="50"
                     onChange={[Function]}
                     onKeyDown={[Function]}
                     placeholder="Enter a value"
@@ -1655,7 +1655,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 tabIndex="0"
               >
                 <div
-                  aria-labelledby="47-search"
+                  aria-labelledby="48-search"
                   className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
                   role="search"
                 >
@@ -1676,15 +1676,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </svg>
                   <label
                     className="bx--label"
-                    htmlFor="47"
-                    id="47-search"
+                    htmlFor="48"
+                    id="48-search"
                   >
                     Filter table
                   </label>
                   <input
                     autoComplete="off"
                     className="bx--search-input"
-                    id="47"
+                    id="48"
                     onChange={[Function]}
                     onKeyDown={[Function]}
                     placeholder="Enter a value"
@@ -2258,7 +2258,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 tabIndex="0"
               >
                 <div
-                  aria-labelledby="48-search"
+                  aria-labelledby="49-search"
                   className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
                   role="search"
                 >
@@ -2279,15 +2279,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </svg>
                   <label
                     className="bx--label"
-                    htmlFor="48"
-                    id="48-search"
+                    htmlFor="49"
+                    id="49-search"
                   >
                     Filter table
                   </label>
                   <input
                     autoComplete="off"
                     className="bx--search-input"
-                    id="48"
+                    id="49"
                     onChange={[Function]}
                     onKeyDown={[Function]}
                     placeholder="Enter a value"

--- a/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -2897,8 +2897,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
                 >
                   <label
                     className="bx--pagination__text"
-                    htmlFor="bx-pagination-select-52"
-                    id="bx-pagination-select-52-count-label"
+                    htmlFor="bx-pagination-select-53"
+                    id="bx-pagination-select-53-count-label"
                   >
                     Items per page:
                   </label>
@@ -2917,7 +2917,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
                         >
                           <select
                             className="bx--select-input"
-                            id="bx-pagination-select-52"
+                            id="bx-pagination-select-53"
                             onChange={[Function]}
                             value={10}
                           >
@@ -2982,7 +2982,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
                     >
                       <label
                         className="bx--label bx--visually-hidden"
-                        htmlFor="bx-pagination-select-52-right"
+                        htmlFor="bx-pagination-select-53-right"
                       >
                         Page number, of 1 pages
                       </label>
@@ -2995,7 +2995,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TimeS
                         >
                           <select
                             className="bx--select-input"
-                            id="bx-pagination-select-52-right"
+                            id="bx-pagination-select-53-right"
                             onChange={[Function]}
                             value={1}
                           >

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -14724,6 +14724,7 @@ Map {
   },
   "TableCard" => Object {
     "defaultProps": Object {
+      "filters": Array [],
       "i18n": Object {
         "cloneCardLabel": "Clone card",
         "closeLabel": "Close",


### PR DESCRIPTION
Closes #1409

**Summary**
Pass filter options from TableCard along to underlying Table. 

** Acceptance test **
https://deploy-preview-2208--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-tablecard--with-custom-filters
- only one table row should be rendered. Clearing filters should show all rows.