### PR TITLE
fix(table): need to handle null values in filtering

### DIFF
--- a/packages/react/src/components/Table/Table.story.jsx
+++ b/packages/react/src/components/Table/Table.story.jsx
@@ -335,7 +335,7 @@ const getNewRow = (idx, suffix = '', withActions = false) => ({
     date: new Date(100000000000 + 1000000000 * idx * idx).toISOString(),
     select: selectData[idx % 3].id,
     secretField: getString(idx, 10) + suffix,
-    number: idx * idx,
+    number: idx % 3 === 0 ? null : idx * idx,
     status: getStatus(idx),
     boolean: getBoolean(idx),
     node: <Add20 />,

--- a/packages/react/src/components/Table/tableReducer.js
+++ b/packages/react/src/components/Table/tableReducer.js
@@ -43,9 +43,8 @@ import { baseTableReducer } from './baseTableReducer';
 export const defaultComparison = (value1, value2) =>
   !isNil(value1) && typeof value1 === 'number' // only if the column value filter is not null/undefined
     ? value1 === Number(value2) // for a number type, attempt to convert filter to number and direct compare
-    : value1 !== undefined && // type string do a lowercase includes comparison
-      value1.toString &&
-      caseInsensitiveSearch([value1.toString()], value2.toString());
+    : !isNil(value1) && // type string do a lowercase includes comparison
+      caseInsensitiveSearch([value1?.toString()], value2?.toString());
 
 export const runSimpleFilters = (data, filters, columns) => {
   return data.filter(({ values }) =>
@@ -119,7 +118,7 @@ const reduceRuleGroup = (logic, rules, values) => {
       return reduceRuleGroup(childLogic, childRules, values);
     }
 
-    const columnValue = values[columnId].toString();
+    const columnValue = values[columnId]?.toString();
     const comparitor = operands[operand];
 
     return comparitor(columnValue, filterValue);


### PR DESCRIPTION
Closes #https://github.ibm.com/wiotp/Maximo-Asset-Monitor/issues/2132

**Summary**

- If a column had null values in it (only currently happens with numeric values I believe) then attempting to perform a column filteration would throw an error to the console and crash the component
``` TypeError: te is null
    defaultComparison tableReducer.js:43
    filterData tableReducer.js:76
    filterData tableReducer.js:59
    filterData tableReducer.js:56
    filterSearchAndSort tableReducer.js:122
    tableReducer tableReducer.js:156
    React 2
    StatefulTable StatefulTable.jsx:64
    React 7
    unstable_runWithPriority scheduler.production.min.js:19
    React 5
```

**Change List (commits, features, bugs, etc)**

- story(Table): change the default generated values to contain some null values in the number column
- fix(tableReducer): verify the toString actually exists before attempting to sort on both values, handle null values in defaultComparison function as well as runSimpleFilters function

**Acceptance Test (how to verify the PR)**

- Verify that column filtering on the number column in the table stories no longer throws an error

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Verify that sorting and filtering continue to work correctly for other column types
