### PR TITLE
fix(dashboardeditor): stop scrolling on render and fix padding

### DIFF
--- a/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
@@ -404,6 +404,8 @@ const DashboardEditor = ({
   const mergedI18n = useMemo(() => ({ ...defaultProps.i18n, ...i18n }), [i18n]);
   // Need to keep track of whether the image gallery is open or not
   const [isImageGalleryModalOpen, setIsImageGalleryModalOpen] = useState(false);
+  // Keep track of whether we need to scroll for new card or not
+  const [needsScroll, setNeedsScroll] = useState(false);
 
   // show the card gallery if no card is being edited
   const [dashboardJson, setDashboardJson] = useState(initialValue);
@@ -434,8 +436,9 @@ const DashboardEditor = ({
   // when a new card is added, scroll to the bottom of the page. Instead of trying to attach the ref to the card itself,
   // check if the scrollHeight has changed in the scroll container, meaning a new card has been added
   useEffect(() => {
-    if (scrollContainerRef.current) {
+    if (scrollContainerRef.current && needsScroll) {
       scrollContainerRef.current.scrollTo(0, scrollContainerRef.current.scrollHeight);
+      setNeedsScroll(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scrollContainerRef.current?.scrollHeight]);
@@ -457,6 +460,7 @@ const DashboardEditor = ({
         cards: [...dashboardJson.cards, cardConfig],
       }));
       setSelectedCardId(cardConfig.id);
+      setNeedsScroll(true);
     },
     [dashboardJson, mergedI18n, onCardChange]
   );
@@ -476,6 +480,7 @@ const DashboardEditor = ({
       };
     });
     setSelectedCardId(id);
+    setNeedsScroll(true);
   }, []);
 
   /**

--- a/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
@@ -441,7 +441,7 @@ const DashboardEditor = ({
       setNeedsScroll(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [scrollContainerRef.current?.scrollHeight]);
+  }, [scrollContainerRef.current?.scrollHeight, needsScroll]);
 
   /**
    * Adds a default, empty card to the preview

--- a/packages/react/src/components/DashboardEditor/_dashboard-editor.scss
+++ b/packages/react/src/components/DashboardEditor/_dashboard-editor.scss
@@ -109,6 +109,7 @@
       // 3rem for the navbar, 100px for the PageTitleBar header
       min-height: calc(100vh - 7rem - 100px);
       background-color: $ui-background;
+      padding-top: 1rem;
     }
   }
 


### PR DESCRIPTION
Closes #
https://github.ibm.com/wiotp/Maximo-Asset-Monitor/issues/2354
https://github.ibm.com/wiotp/Maximo-Asset-Monitor/issues/2129

**Summary**

- Fixes two issues, a padding issue, then an issue where if you load a DashboardEditor with an initialValue it always scrolls to the bottom of the dashboard.  The original idea there was only to scroll down when adding/duplicating a card

**Change List (commits, features, bugs, etc)**

- fix(dashboardEditor.scss): add padding (was there originally, not sure which change injected it
- fix(DashboardEditor): only scroll if a new card is added

**Acceptance Test (how to verify the PR)**

- To see the original scrolling and padding bug, go here: https://next.carbon-addons-iot-react.com/?path=/story/watson-iot-experimental-%E2%98%A2%EF%B8%8F-dashboardeditor--with-initial-value
- Now go to the same story in the deploy preview.  the scrolling should only happen if you add or duplicate a card

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Make sure the scrolling still happens on add/duplicate card
