### PR TITLE
fix(combo-box): allow item ids to be numbers

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.jsx
+++ b/packages/react/src/components/ComboBox/ComboBox.jsx
@@ -113,13 +113,13 @@ const ComboBox = ({
   const handleOnChange = ({ selectedItem: downShiftSelectedItem }) => {
     const newItem =
       downShiftSelectedItem &&
-      Object.keys(downShiftSelectedItem).reduce(
-        (acc, currentId) => ({
+      Object.keys(downShiftSelectedItem).reduce((acc, currentId) => {
+        const value = downShiftSelectedItem[currentId];
+        return {
           ...acc,
-          [currentId]: downShiftSelectedItem[currentId].trim(),
-        }),
-        {}
-      );
+          [currentId]: typeof value === 'string' ? value.trim() : value,
+        };
+      }, {});
 
     const currentValue = itemToString(newItem);
     // Check that there is no existing tag
@@ -141,6 +141,7 @@ const ComboBox = ({
 
     if (
       (addToList || hasMultiValue) &&
+      typeof newItem?.id === 'string' &&
       newItem?.id.startsWith(`${iotPrefix}-input-`) &&
       !isInList
     ) {
@@ -148,6 +149,7 @@ const ComboBox = ({
       setListItems((currentList) => [newItem, ...currentList]);
     }
 
+    console.log({ newItem });
     setInputValue(null);
   };
 

--- a/packages/react/src/components/ComboBox/ComboBox.jsx
+++ b/packages/react/src/components/ComboBox/ComboBox.jsx
@@ -149,7 +149,6 @@ const ComboBox = ({
       setListItems((currentList) => [newItem, ...currentList]);
     }
 
-    console.log({ newItem });
     setInputValue(null);
   };
 

--- a/packages/react/src/components/ComboBox/ComboBox.story.jsx
+++ b/packages/react/src/components/ComboBox/ComboBox.story.jsx
@@ -16,7 +16,7 @@ import ComboBox from './ComboBox';
 
 export const items = [
   {
-    id: 'option-0',
+    id: 0,
     text: 'Option 1',
   },
   {

--- a/packages/react/src/components/ComboBox/ComboBox.test.jsx
+++ b/packages/react/src/components/ComboBox/ComboBox.test.jsx
@@ -204,4 +204,12 @@ describe('ComboBox', () => {
     expect(defaultProps.onChange.mock.calls.length).toBe(1);
     expect(defaultProps.onChange.mock.calls[0][0][0].text).toBe('Option 1');
   });
+
+  it('handles number ids', async () => {
+    render(<ComboBox {...defaultProps} />);
+
+    userEvent.click(screen.getByRole('button', { name: 'Open' }));
+    userEvent.click(screen.getByText('Option 1'));
+    expect(defaultProps.onChange).toHaveBeenCalledWith([{ id: 0, text: 'Option 1' }]);
+  });
 });


### PR DESCRIPTION
Closes #2041 

**Summary**

- Allows items passed to ComboBox to use numbers as their ids

**Acceptance Test (how to verify the PR)**

- Clicking "Option 1" in the Default ComboBox story should fire an onChange action with {id: 0, text: 'Option 1'} without any issues.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- all tests pass and no changes to existing ComboBox stories
