### PR TITLE
fix(repo): ts ext were breaking downstream consumers

### DIFF
--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -14,7 +14,7 @@ const packageJson = require('./package.json');
 const env = process.env.NODE_ENV || 'development';
 const prodSettings = env === 'development' ? [] : [uglify(), filesize()];
 
-const extensions = ['.mjs', '.js', '.jsx', '.json'];
+const extensions = ['.mjs', '.js', '.jsx', '.json', '.ts'];
 
 const external = (id) => {
   return (
@@ -22,7 +22,6 @@ const external = (id) => {
     Object.keys(packageJson.dependencies).some((element) => id === element) ||
     id.includes('lodash/') ||
     id.includes('core-js/') ||
-    id.includes('moment/') ||
     id.includes('@babel/runtime')
   );
 };


### PR DESCRIPTION
Closes #2319 

**Summary**

Proposed fix for build errors that stem from the addition of the dayjs library. This should solve the immediate issue with our build but we should open up a bug on the dayjs repo. 

@scottdickerson can you please check that this fixes your build issues before we merge.