### PR TITLE
fix(dayjs): dynamic import needs .js

### DIFF
--- a/packages/react/src/utils/dayjs.js
+++ b/packages/react/src/utils/dayjs.js
@@ -152,6 +152,7 @@ dayjs.extend(localeData); // gives local specific data
   'zh-tw',
   'zh',
 ].forEach((locale) => {
+  // .js needed because of webpack dynamic import behavior https://github.com/iamkun/dayjs/issues/792
   // eslint-disable-next-line global-require, import/no-dynamic-require
   require(`dayjs/locale/${locale}.js`);
 });

--- a/packages/react/src/utils/dayjs.js
+++ b/packages/react/src/utils/dayjs.js
@@ -153,7 +153,7 @@ dayjs.extend(localeData); // gives local specific data
   'zh',
 ].forEach((locale) => {
   // eslint-disable-next-line global-require, import/no-dynamic-require
-  require(`dayjs/locale/${locale}`);
+  require(`dayjs/locale/${locale}.js`);
 });
 
 export default dayjs;


### PR DESCRIPTION
Closes #2319 

**Summary**

- Adds `.js` to the end of the dynamic dayjs locale imports to fix an issue where downstream consumers were unable to compile projects with this library

**Acceptance Test (how to verify the PR)**

- Link this library to a separate React project (can't be tested with storybook) and ensure the project is able to build and compile with no errors

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Check that locales are still working
