### PR TITLE
feat(errortable): add an error state to the table

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,7 +17,7 @@
 # These users own any files in the following directory at the root of
 # the repository and any of its subdirectories.
 
-* @bryancboyd @scottdickerson @davidicus @leetosc @cgirani @stuckless @tomklapiscak @JoelArmendariz @jessieyan @blechner @sstone2423
+* @bryancboyd @scottdickerson @davidicus @leetosc @cgirani @stuckless @tomklapiscak @JoelArmendariz @jessieyan @blechner @sstone2423 @herleraja
 
 #####
 # Core admin team should be notified of changes to build/test/deploy

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,14 +13,12 @@
     },
     {
       "type": "node",
-      "runtimeVersion": "14.4.0",
       "request": "launch",
       "name": "Launch Program",
       "program": "${workspaceFolder}/lib/index.js"
     },
     {
       "type": "node",
-      "runtimeVersion": "14.4.0",
       "request": "launch",
       "name": "Jest All",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
@@ -28,7 +26,9 @@
         "NODE_ICU_DATA": "node_modules/full-icu",
         "TZ": "America/Chicago"
       },
-      "args": ["--runInBand"],
+      "args": [
+        "--runInBand"
+      ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
       "disableOptimisticBPs": true,
@@ -38,11 +38,15 @@
     },
     {
       "type": "node",
-      "runtimeVersion": "14.4.0",
       "request": "launch",
       "name": "Jest Current File",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
-      "args": ["${relativeFile}", "--config", "jest.config.js"],
+      "args": [
+        "${relativeFile}",
+        "--config",
+        "jest.config.js",
+        "--detectOpenHandles"
+      ],
       "cwd": "${workspaceFolder}/packages/react",
       "env": {
         "NODE_ICU_DATA": "node_modules/full-icu",

--- a/packages/react/src/components/EmptyState/_emptystate.scss
+++ b/packages/react/src/components/EmptyState/_emptystate.scss
@@ -17,19 +17,16 @@
   &--content {
     max-width: 30rem;
     overflow-wrap: break-word;
-    text-align: left;
   }
 
   &--title {
     @include type-style('productive-heading-03');
     color: $text-01;
-    text-align: left;
     margin-bottom: $spacing-03;
   }
 
   &--text {
     color: $text-01;
-    text-align: left;
     @include type-style('body-short-01');
   }
 

--- a/packages/react/src/components/EmptyState/_emptystate.scss
+++ b/packages/react/src/components/EmptyState/_emptystate.scss
@@ -5,7 +5,6 @@
 .#{$iot-prefix}--empty-state {
   display: flex;
   flex-flow: column;
-  align-items: center;
   justify-content: center;
   height: 100%;
   padding: $spacing-06;

--- a/packages/react/src/components/Table/ErrorTable/ErrorTable.jsx
+++ b/packages/react/src/components/Table/ErrorTable/ErrorTable.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { DataTable } from 'carbon-components-react';
+
+import EmptyState from '../../EmptyState';
+import { settings } from '../../../constants/Settings';
+
+const { TableBody, TableCell, TableRow } = DataTable;
+const { iotPrefix } = settings;
+
+const propTypes = {
+  /** The unique id of the table */
+  id: PropTypes.string,
+  testID: PropTypes.string,
+  /** set of internationalized labels */
+  i18n: PropTypes.objectOf(
+    PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.element])
+  ).isRequired,
+  totalColumns: PropTypes.number.isRequired,
+  /** Empty error state to render */
+  errorState: PropTypes.element,
+  error: PropTypes.string,
+  onErrorStateAction: PropTypes.func,
+};
+
+const defaultProps = {
+  id: 'ErrorTable',
+  testID: 'ErrorTable',
+  error: null,
+  errorState: null,
+  onErrorStateAction: null,
+};
+
+const ErrorTable = ({ id, testID, i18n, totalColumns, error, errorState, onErrorStateAction }) => (
+  <TableBody id={id} data-testid={testID}>
+    <TableRow className={`${iotPrefix}--empty-table--table-row`}>
+      <TableCell colSpan={totalColumns}>
+        {React.isValidElement(errorState) ? (
+          errorState
+        ) : (
+          <div className="empty-table-cell--default">
+            <EmptyState
+              icon="error"
+              title={i18n.tableErrorStateTitle}
+              body={error || ''}
+              action={
+                onErrorStateAction
+                  ? {
+                      label: i18n.buttonLabelOnTableError,
+                      onClick: onErrorStateAction,
+                      kind: 'secondary',
+                    }
+                  : null
+              }
+            />
+          </div>
+        )}
+      </TableCell>
+    </TableRow>
+  </TableBody>
+);
+
+ErrorTable.propTypes = propTypes;
+ErrorTable.defaultProps = defaultProps;
+
+export default ErrorTable;

--- a/packages/react/src/components/Table/ErrorTable/ErrorTable.jsx
+++ b/packages/react/src/components/Table/ErrorTable/ErrorTable.jsx
@@ -35,10 +35,10 @@ const ErrorTable = ({ id, testID, i18n, totalColumns, error, errorState, onError
   <TableBody id={id} data-testid={testID}>
     <TableRow className={`${iotPrefix}--empty-table--table-row`}>
       <TableCell colSpan={totalColumns}>
-        {React.isValidElement(errorState) ? (
-          errorState
-        ) : (
-          <div className="empty-table-cell--default">
+        <div className="empty-table-cell--default">
+          {React.isValidElement(errorState) ? (
+            errorState
+          ) : (
             <EmptyState
               icon="error"
               title={i18n.tableErrorStateTitle}
@@ -53,8 +53,8 @@ const ErrorTable = ({ id, testID, i18n, totalColumns, error, errorState, onError
                   : null
               }
             />
-          </div>
-        )}
+          )}
+        </div>
       </TableCell>
     </TableRow>
   </TableBody>

--- a/packages/react/src/components/Table/ErrorTable/__tests__/ErrorTable.test.jsx
+++ b/packages/react/src/components/Table/ErrorTable/__tests__/ErrorTable.test.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import ErrorTable from '../ErrorTable';
+
+const commonTableProps = {
+  id: 'tableid',
+  totalColumns: 3,
+  isFiltered: false,
+  error: 'error occured',
+  i18n: {
+    tableErrorStateTitle: 'Unable to load the page',
+    buttonLabelOnTableError: 'Refresh the page',
+  },
+};
+
+describe('ErrorTable', () => {
+  it('custom error state', () => {
+    render(<ErrorTable {...commonTableProps} errorState={<span>my custom element</span>} />);
+    expect(screen.queryAllByText('my custom element')).toHaveLength(1);
+  });
+  it('error state action with no error button', () => {
+    render(<ErrorTable {...commonTableProps} />);
+    expect(screen.queryAllByText('Unable to load the page')).toHaveLength(1);
+    expect(screen.queryAllByText('error occured')).toHaveLength(1);
+    expect(screen.queryAllByText('Refresh the page')).toHaveLength(0);
+  });
+  it('error state action with error button', () => {
+    const onErrorStateAction = jest.fn();
+    render(<ErrorTable {...commonTableProps} onErrorStateAction={onErrorStateAction} />);
+    expect(screen.queryAllByText('Unable to load the page')).toHaveLength(1);
+    expect(screen.queryAllByText('error occured')).toHaveLength(1);
+    fireEvent.click(screen.getByText('Refresh the page'));
+    expect(onErrorStateAction).toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/components/Table/README.md
+++ b/packages/react/src/components/Table/README.md
@@ -732,6 +732,7 @@ the following props:
 | actions        | object |         | Callbacks for actions of the table, can be used to update state in wrapper component to update `view` props (see [actions prop](#actions-prop))                                                        |
 | locale         | string |         | what locale should we use to format table values if left empty no locale formatting happens                                                                                                            |
 | i18n           | object |         | (see [i18n prop](#i18n-prop))                                                                                                                                                                          |
+| error          | string |         | Specify the error message that need to be displayed by default. Incase we use `view.table.errorState` property then the error state element will be rendered instead of error message                  |
 
 ### Column Prop
 
@@ -873,7 +874,8 @@ the following props:
 | table.emptyState.messageWithFilters     | node                             |         | Show a different message if no content is in the table matching the filters                                                                         |
 | table.emptyState.buttonLabel            | node                             |         | If a label is not provided, no action button will be rendered                                                                                       |
 | table.emptyState.buttonLabelWithFilters | node                             |         | Show a different button label if no content is in the table matching the filters                                                                    |
-| table.loadingState                      | object                           |         |                                                                                                                                                     |
+| table.errorState                        | element                          |         | Show the table errorState element when there is any error occure                                                                                    |
+| table.loadingState                      | object                           |         |
 | table.loadingState.isLoading            | bool                             |         | If the table is currently loading                                                                                                                   |
 | table.loadingState.rowCount             | number                           |         | The number of rows loaded                                                                                                                           |
 
@@ -912,6 +914,7 @@ the following props:
 | table.onColumnSelectionConfig   | func   |         |                                                                                                                                                                                                                 |
 | table.onColumnResize            | func   |         |                                                                                                                                                                                                                 |
 | table.onOverflowItemClicked     | func   |         |                                                                                                                                                                                                                 |
+| table.onTableErrorStateAction   | func   |         | callback action relavent on error state. This can be used with `error` message. When `view.table.errorState` property is used then this callback function has no effect.                                        |
 | onUserViewModified              | func   |         | callback for actions relevant for view management                                                                                                                                                               |
 
 ### i18n Prop

--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -30,6 +30,7 @@ import TableSkeletonWithHeaders from './TableSkeletonWithHeaders/TableSkeletonWi
 import TableBody from './TableBody/TableBody';
 import Pagination from './Pagination';
 import TableFoot from './TableFoot/TableFoot';
+import ErrorTable from './ErrorTable/ErrorTable';
 
 const { iotPrefix } = settings;
 
@@ -195,6 +196,7 @@ const propTypes = {
       singleRowEditButtons: PropTypes.element,
       expandedIds: PropTypes.arrayOf(PropTypes.string),
       emptyState: EmptyStatePropTypes,
+      errorState: PropTypes.element,
       loadingState: PropTypes.shape({
         isLoading: PropTypes.bool,
         rowCount: PropTypes.number,
@@ -248,6 +250,7 @@ const propTypes = {
       onColumnSelectionConfig: PropTypes.func,
       onColumnResize: PropTypes.func,
       onOverflowItemClicked: PropTypes.func,
+      onTableErrorStateAction: PropTypes.func,
     }).isRequired,
     /** callback for actions relevant for view management */
     onUserViewModified: PropTypes.func,
@@ -255,6 +258,8 @@ const propTypes = {
   /** what locale should we use to format table values if left empty no locale formatting happens */
   locale: PropTypes.string,
   i18n: I18NPropTypes,
+  /** Form Error Details */
+  error: PropTypes.string,
 };
 
 export const defaultProps = (baseProps) => ({
@@ -338,6 +343,7 @@ export const defaultProps = (baseProps) => ({
       onRowClicked: defaultFunction('actions.table.onRowClicked'),
       onApplyRowAction: defaultFunction('actions.table.onApplyRowAction'),
       onEmptyStateAction: null,
+      onErrorStateAction: null,
       onChangeOrdering: defaultFunction('actions.table.onChangeOrdering'),
       onColumnSelectionConfig: defaultFunction('actions.table.onColumnSelectionConfig'),
       onColumnResize: defaultFunction('actions.table.onColumnResize'),
@@ -390,7 +396,11 @@ export const defaultProps = (baseProps) => ({
     filterNone: 'Unsort rows by this header',
     filterAscending: 'Sort rows by this header in ascending order',
     filterDescending: 'Sort rows by this header in descending order',
+    // table error state
+    tableErrorStateTitle: 'Unable to load the page',
+    buttonLabelOnTableError: 'Refresh the page',
   },
+  error: null,
 });
 
 const Table = (props) => {
@@ -411,6 +421,7 @@ const Table = (props) => {
     // Table Toolbar props
     secondaryTitle,
     tooltip,
+    error,
     ...others
   } = merge({}, defaultProps(props), props);
 
@@ -461,7 +472,7 @@ const Table = (props) => {
     view.table.ordering,
     // Remove the error as it's a React.Element/Node which can not be compared
     view.table.rowActions.map((action) => {
-      const { error, ...nonElements } = action;
+      const { error: errorElement, ...nonElements } = action;
       return nonElements;
     }),
     view.table.expandedIds,
@@ -774,88 +785,102 @@ const Table = (props) => {
             hasFastFilter={options?.hasFilter === 'onKeyPress'}
             testID={`${id}-table-head`}
           />
-          {view.table.loadingState.isLoading ? (
-            <TableSkeletonWithHeaders
-              columns={visibleColumns}
-              {...pick(options, 'hasRowSelection', 'hasRowExpansion', 'hasRowActions')}
-              rowCount={view.table.loadingState.rowCount}
-              testID={`${id}-table-skeleton`}
-            />
-          ) : visibleData && visibleData.length ? (
-            <TableBody
-              langDir={langDir}
-              tableId={id || tableId}
-              rows={visibleData}
-              locale={locale}
-              rowActionsState={view.table.rowActions}
-              singleRowEditButtons={view.table.singleRowEditButtons}
-              expandedRows={expandedData}
-              columns={visibleColumns}
-              expandedIds={view.table.expandedIds}
-              selectedIds={view.table.selectedIds}
-              {...pick(
-                i18n,
-                'overflowMenuAria',
-                'clickToExpandAria',
-                'clickToCollapseAria',
-                'inProgressText',
-                'actionFailedText',
-                'learnMoreText',
-                'dismissText',
-                'selectRowAria'
-              )}
-              totalColumns={totalColumns}
-              {...pick(
-                options,
-                'hasRowSelection',
-                'hasRowExpansion',
-                'hasRowActions',
-                'hasRowNesting',
-                'shouldExpandOnRowClick',
-                'shouldLazyRender'
-              )}
-              wrapCellText={options.wrapCellText}
-              truncateCellText={useCellTextTruncate}
-              ordering={view.table.ordering}
-              rowEditMode={rowEditMode}
-              actions={pick(
-                actions.table,
-                'onRowSelected',
-                'onApplyRowAction',
-                'onClearRowError',
-                'onRowExpanded',
-                'onRowClicked'
-              )}
-              testID={`${id}-table-body`}
-            />
-          ) : (
-            <EmptyTable
-              id={id}
-              totalColumns={totalColumns}
-              isFiltered={isFiltered}
-              emptyState={
-                // only show emptyState if no filters or search is applied
-                view.table.emptyState && !isFiltered
-                  ? view.table.emptyState
-                  : {
-                      message: i18n.emptyMessage,
-                      messageBody: i18n.emptyMessageBody,
-                      messageWithFilters: i18n.emptyMessageWithFilters,
-                      messageWithFiltersBody: i18n.emptyMessageWithFiltersBody,
-                      buttonLabel: i18n.emptyButtonLabel,
-                      buttonLabelWithFilters: i18n.emptyButtonLabelWithFilters,
-                    }
-              }
-              onEmptyStateAction={
-                isFiltered && i18n.emptyButtonLabelWithFilters
-                  ? handleClearFilters // show clear filters
-                  : !isFiltered && actions.table.onEmptyStateAction
-                  ? actions.table.onEmptyStateAction
-                  : undefined // if not filtered then show normal empty state
-              }
-              testID={`${id}-table-empty`}
-            />
-          )}
+
+          {
+            // Table contents
+            view.table.loadingState.isLoading ? (
+              <TableSkeletonWithHeaders
+                columns={visibleColumns}
+                {...pick(options, 'hasRowSelection', 'hasRowExpansion', 'hasRowActions')}
+                rowCount={view.table.loadingState.rowCount}
+                testID={`${id}-table-skeleton`}
+              />
+            ) : error ? (
+              <ErrorTable
+                id={id}
+                testID={`${id}-table-error-body`}
+                i18n={i18n}
+                totalColumns={totalColumns}
+                error={error}
+                errorState={view.table.errorState}
+                onErrorStateAction={actions.table.onErrorStateAction}
+              />
+            ) : visibleData && visibleData.length ? (
+              <TableBody
+                langDir={langDir}
+                tableId={id || tableId}
+                rows={visibleData}
+                locale={locale}
+                rowActionsState={view.table.rowActions}
+                singleRowEditButtons={view.table.singleRowEditButtons}
+                expandedRows={expandedData}
+                columns={visibleColumns}
+                expandedIds={view.table.expandedIds}
+                selectedIds={view.table.selectedIds}
+                {...pick(
+                  i18n,
+                  'overflowMenuAria',
+                  'clickToExpandAria',
+                  'clickToCollapseAria',
+                  'inProgressText',
+                  'actionFailedText',
+                  'learnMoreText',
+                  'dismissText',
+                  'selectRowAria'
+                )}
+                totalColumns={totalColumns}
+                {...pick(
+                  options,
+                  'hasRowSelection',
+                  'hasRowExpansion',
+                  'hasRowActions',
+                  'hasRowNesting',
+                  'shouldExpandOnRowClick',
+                  'shouldLazyRender'
+                )}
+                wrapCellText={options.wrapCellText}
+                truncateCellText={useCellTextTruncate}
+                ordering={view.table.ordering}
+                rowEditMode={rowEditMode}
+                actions={pick(
+                  actions.table,
+                  'onRowSelected',
+                  'onApplyRowAction',
+                  'onClearRowError',
+                  'onRowExpanded',
+                  'onRowClicked'
+                )}
+                testID={`${id}-table-body`}
+              />
+            ) : (
+              <EmptyTable
+                id={id}
+                totalColumns={totalColumns}
+                isFiltered={isFiltered}
+                emptyState={
+                  // only show emptyState if no filters or search is applied
+                  view.table.emptyState && !isFiltered
+                    ? view.table.emptyState
+                    : {
+                        message: i18n.emptyMessage,
+                        messageBody: i18n.emptyMessageBody,
+                        messageWithFilters: i18n.emptyMessageWithFilters,
+                        messageWithFiltersBody: i18n.emptyMessageWithFiltersBody,
+                        buttonLabel: i18n.emptyButtonLabel,
+                        buttonLabelWithFilters: i18n.emptyButtonLabelWithFilters,
+                      }
+                }
+                onEmptyStateAction={
+                  isFiltered && i18n.emptyButtonLabelWithFilters
+                    ? handleClearFilters // show clear filters
+                    : !isFiltered && actions.table.onEmptyStateAction
+                    ? actions.table.onEmptyStateAction
+                    : undefined // if not filtered then show normal empty state
+                }
+                testID={`${id}-table-empty`}
+              />
+            )
+          }
           {hasAggregations ? (
             <TableFoot
               options={{

--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -196,6 +196,7 @@ const propTypes = {
       singleRowEditButtons: PropTypes.element,
       expandedIds: PropTypes.arrayOf(PropTypes.string),
       emptyState: EmptyStatePropTypes,
+      /** use custom error state or use error message directly */
       errorState: PropTypes.element,
       loadingState: PropTypes.shape({
         isLoading: PropTypes.bool,
@@ -258,7 +259,8 @@ const propTypes = {
   /** what locale should we use to format table values if left empty no locale formatting happens */
   locale: PropTypes.string,
   i18n: I18NPropTypes,
-  /** Form Error Details */
+  /** Specify the error message that need to be displayed by default.
+   * Incase we use view.table.errorState property then the error state will be displayed instead of error message */
   error: PropTypes.string,
 };
 

--- a/packages/react/src/components/Table/Table.story.jsx
+++ b/packages/react/src/components/Table/Table.story.jsx
@@ -34,6 +34,7 @@ import { getSortedData, csvDownloadHandler } from '../../utils/componentUtilityF
 import FullWidthWrapper from '../../internal/FullWidthWrapper';
 import FlyoutMenu, { FlyoutMenuDirection } from '../FlyoutMenu/FlyoutMenu';
 import StoryNotice from '../../internal/StoryNotice';
+import EmptyState from '../EmptyState';
 
 import README from './README.md';
 import Table from './Table';
@@ -81,13 +82,6 @@ const selectTextWrapping = ['always', 'never', 'auto', 'alwaysTruncate'];
 
 const renderStatusIcon = ({ value: status }) => {
   switch (status) {
-    case STATUS.RUNNING:
-    default:
-      return (
-        <svg height="10" width="10">
-          <circle cx="5" cy="5" r="3" stroke="none" strokeWidth="1" fill="green" />
-        </svg>
-      );
     case STATUS.NOT_RUNNING:
       return (
         <svg height="10" width="10">
@@ -98,6 +92,14 @@ const renderStatusIcon = ({ value: status }) => {
       return (
         <svg height="10" width="10">
           <circle cx="5" cy="5" r="3" stroke="none" strokeWidth="1" fill="red" />
+        </svg>
+      );
+
+    case STATUS.RUNNING:
+    default:
+      return (
+        <svg height="10" width="10">
+          <circle cx="5" cy="5" r="3" stroke="none" strokeWidth="1" fill="green" />
         </svg>
       );
   }
@@ -314,13 +316,13 @@ const getString = (index, length) =>
 const getStatus = (idx) => {
   const modStatus = idx % 3;
   switch (modStatus) {
-    case 0:
-    default:
-      return STATUS.RUNNING;
     case 1:
       return STATUS.NOT_RUNNING;
     case 2:
       return STATUS.BROKEN;
+    case 0:
+    default:
+      return STATUS.RUNNING;
   }
 };
 
@@ -421,6 +423,7 @@ const actions = {
     onRowSelected: action('onRowSelected'),
     onSelectAll: action('onSelectAll'),
     onEmptyStateAction: action('onEmptyStateAction'),
+    onErrorStateAction: action('onErrorStateAction'),
     onApplyRowAction: action('onApplyRowAction'),
     onRowExpanded: action('onRowExpanded'),
     onChangeOrdering: action('onChangeOrdering'),
@@ -3466,6 +3469,60 @@ WithNoDataAndCustomEmptyState.story = {
   name: 'with no data and custom empty state',
 };
 
+export const WithErrorState = withReadme(README, () => (
+  <Table
+    id="table"
+    columns={tableColumns}
+    data={[]}
+    actions={actions}
+    view={{
+      table: {
+        ordering: defaultOrdering,
+      },
+    }}
+    options={{ hasPagination: true }}
+    error={text('error', 'Error occured')}
+  />
+));
+
+WithErrorState.story = {
+  name: 'with error state',
+};
+
+const errorState = (
+  <EmptyState
+    icon="error"
+    title="Error occured while loading"
+    body={text('error', 'Error message')}
+    action={{
+      label: 'Reload',
+      onClick: action('onErrorStateAction'),
+      kind: 'ghost',
+    }}
+  />
+);
+
+export const WithCustomErrorState = withReadme(README, () => (
+  <Table
+    id="table"
+    columns={tableColumns}
+    data={[]}
+    actions={actions}
+    view={{
+      table: {
+        ordering: defaultOrdering,
+        errorState,
+      },
+    }}
+    options={{ hasPagination: true }}
+    error={text('error', 'Error occured')}
+  />
+));
+
+WithCustomErrorState.story = {
+  name: 'with custom error state',
+};
+
 export const WithLoadingState = withReadme(README, () => (
   <Table
     id="table"
@@ -3567,6 +3624,7 @@ export const WithResizeAndInitialColumnWidthsAndHiddenColumn = withReadme(README
           ordering: defaultOrdering,
         },
       }}
+      error={text('error', undefined)}
     />
   </FullWidthWrapper>
 ));
@@ -4128,6 +4186,9 @@ export const StatefulExampleWithI18NStrings = withReadme(README, () => (
       actionFailedText: text('i18n.actionFailedText', '__Action Failed__'),
       learnMoreText: text('i18n.learnMoreText', '__Learn More__'),
       dismissText: text('i18n.dismissText', '__Dismiss__'),
+      // table error state
+      tableErrorStateTitle: text('i18n.tableErrorStateTitle', 'Unable to load the page'),
+      buttonLabelOnTableError: text('i18n.buttonLabelOnTableError', 'Refresh the page'),
     }}
   />
 ));

--- a/packages/react/src/components/Table/TablePropTypes.js
+++ b/packages/react/src/components/Table/TablePropTypes.js
@@ -48,8 +48,10 @@ export const RowActionsStatePropTypes = PropTypes.arrayOf(
 export const EmptyStatePropTypes = PropTypes.oneOfType([
   PropTypes.shape({
     message: PropTypes.node.isRequired,
+    messageBody: PropTypes.node,
     /* Show a different message if no content is in the table matching the filters */
     messageWithFilters: PropTypes.node,
+    messageWithFiltersBody: PropTypes.node,
     /* If a label is not provided, no action button will be rendered */
     buttonLabel: PropTypes.node,
     /* Show a different button label if no content is in the table matching the filters */

--- a/packages/react/src/components/Table/_table.scss
+++ b/packages/react/src/components/Table/_table.scss
@@ -60,7 +60,7 @@ html[dir='rtl'] {
   }
   .empty-table-cell--default {
     display: flex;
-    align-items: center;
+    align-items: left;
     justify-content: middle;
     flex-direction: column;
     padding: $spacing-09;

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -312,7 +312,13 @@ Map {
                     "isRequired": true,
                     "type": "node",
                   },
+                  "messageBody": Object {
+                    "type": "node",
+                  },
                   "messageWithFilters": Object {
+                    "type": "node",
+                  },
+                  "messageWithFiltersBody": Object {
                     "type": "node",
                   },
                 },
@@ -360,6 +366,7 @@ Map {
           "onColumnResize": [Function],
           "onColumnSelectionConfig": [Function],
           "onEmptyStateAction": null,
+          "onErrorStateAction": null,
           "onOverflowItemClicked": [Function],
           "onRowClicked": [Function],
           "onRowExpanded": [Function],
@@ -378,8 +385,10 @@ Map {
           "onToggleFilter": [Function],
         },
       },
+      "error": null,
       "i18n": Object {
         "batchCancel": "Cancel",
+        "buttonLabelOnTableError": "Refresh the page",
         "clearAllFilters": "Clear all filters",
         "clearFilterAria": "Clear filter",
         "clearSelectionAria": "Clear selection",
@@ -417,6 +426,7 @@ Map {
         "searchPlaceholder": "Search",
         "selectAllAria": "Select all items",
         "selectRowAria": "Select row",
+        "tableErrorStateTitle": "Unable to load the page",
         "toggleAggregations": "Toggle Aggregations",
       },
       "id": null,
@@ -538,6 +548,9 @@ Map {
                     "type": "func",
                   },
                   "onSelectAll": Object {
+                    "type": "func",
+                  },
+                  "onTableErrorStateAction": Object {
                     "type": "func",
                   },
                 },
@@ -856,6 +869,9 @@ Map {
         ],
         "isRequired": true,
         "type": "arrayOf",
+      },
+      "error": Object {
+        "type": "string",
       },
       "expandedData": Object {
         "args": Array [
@@ -1316,7 +1332,13 @@ Map {
                                 "isRequired": true,
                                 "type": "node",
                               },
+                              "messageBody": Object {
+                                "type": "node",
+                              },
                               "messageWithFilters": Object {
+                                "type": "node",
+                              },
+                              "messageWithFiltersBody": Object {
                                 "type": "node",
                               },
                             },
@@ -1329,6 +1351,9 @@ Map {
                       ],
                     ],
                     "type": "oneOfType",
+                  },
+                  "errorState": Object {
+                    "type": "element",
                   },
                   "expandedIds": Object {
                     "args": Array [


### PR DESCRIPTION
Related to https://github.ibm.com/wiotp/Maximo-Asset-Monitor/issues/2330

**Summary**

- Display an error state on any table error messages

**Change List (commits, features, bugs, etc)**

- feat(ErrorTable): added to display the error state, with or without error state button and error state element
- feat(EmptyState): left-align the empty state in the table
- chore(codeowners): adding amritha raj to the code owners list

**Acceptance Test (how to verify the PR)**

- Able to display custom error component
![image](https://user-images.githubusercontent.com/18572477/118476381-b2f83180-b70d-11eb-85b2-091ec94fe761.png)
- Able to display an error message without any error action button
![image](https://user-images.githubusercontent.com/18572477/118476575-f81c6380-b70d-11eb-8cbb-26e7e45abb54.png)
- Able to display an error message with any error action button
![image](https://user-images.githubusercontent.com/18572477/118476652-12564180-b70e-11eb-837d-b779bcf8d0b7.png)

**Regression Test (how to make sure this PR doesn't break old functionality)**

- table component should work without any issues. 
