### PR TITLE
fix(suiteheader): Making the transition of “loading state” to “data ready state” in SuiteHeader seamless

### DIFF
--- a/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
@@ -4232,6 +4232,45 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
       <div
         className="bx--header__global"
       >
+        <button
+          aria-label="Administration"
+          aria-pressed={null}
+          className="bx--header-action-btn admin-icon admin-icon__hidden bx--header__action bx--btn bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+          data-testid="menu-item-Administration-global"
+          disabled={false}
+          onClick={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          <span
+            className="bx--assistive-text"
+          >
+            Administration
+          </span>
+          <span
+            id="suite-header-action-item-admin"
+          >
+            <svg
+              aria-hidden={true}
+              data-testid="admin-icon"
+              description="Settings"
+              fill="white"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M27,16.76c0-.25,0-.5,0-.76s0-.51,0-.77l1.92-1.68A2,2,0,0,0,29.3,11L26.94,7a2,2,0,0,0-1.73-1,2,2,0,0,0-.64.1l-2.43.82a11.35,11.35,0,0,0-1.31-.75l-.51-2.52a2,2,0,0,0-2-1.61H13.64a2,2,0,0,0-2,1.61l-.51,2.52a11.48,11.48,0,0,0-1.32.75L7.43,6.06A2,2,0,0,0,6.79,6,2,2,0,0,0,5.06,7L2.7,11a2,2,0,0,0,.41,2.51L5,15.24c0,.25,0,.5,0,.76s0,.51,0,.77L3.11,18.45A2,2,0,0,0,2.7,21L5.06,25a2,2,0,0,0,1.73,1,2,2,0,0,0,.64-.1l2.43-.82a11.35,11.35,0,0,0,1.31.75l.51,2.52a2,2,0,0,0,2,1.61h4.72a2,2,0,0,0,2-1.61l.51-2.52a11.48,11.48,0,0,0,1.32-.75l2.42.82a2,2,0,0,0,.64.1,2,2,0,0,0,1.73-1L29.3,21a2,2,0,0,0-.41-2.51ZM25.21,24l-3.43-1.16a8.86,8.86,0,0,1-2.71,1.57L18.36,28H13.64l-.71-3.55a9.36,9.36,0,0,1-2.7-1.57L6.79,24,4.43,20l2.72-2.4a8.9,8.9,0,0,1,0-3.13L4.43,12,6.79,8l3.43,1.16a8.86,8.86,0,0,1,2.71-1.57L13.64,4h4.72l.71,3.55a9.36,9.36,0,0,1,2.7,1.57L25.21,8,27.57,12l-2.72,2.4a8.9,8.9,0,0,1,0,3.13L27.57,20Z"
+              />
+              <path
+                d="M16,22a6,6,0,1,1,6-6A5.94,5.94,0,0,1,16,22Zm0-10a3.91,3.91,0,0,0-4,4,3.91,3.91,0,0,0,4,4,3.91,3.91,0,0,0,4-4A3.91,3.91,0,0,0,16,12Z"
+              />
+            </svg>
+          </span>
+        </button>
         <div
           className="bx--header__submenu bx--header-action-btn action-btn__group"
           data-testid="action-btn__group"

--- a/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
@@ -4294,48 +4294,48 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
       <div
         className="bx--header__global"
       >
-        <button
-          aria-label="Administration"
-          aria-pressed={null}
-          className="bx--header-action-btn admin-icon admin-icon__hidden bx--header__action bx--btn bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-          data-testid="menu-item-Administration-global"
-          disabled={false}
-          onClick={[Function]}
-          tabIndex={0}
-          type="button"
-        >
-          <span
-            className="bx--assistive-text"
-          >
-            Administration
-          </span>
-          <span
-            id="suite-header-action-item-admin"
-          >
-            <svg
-              aria-hidden={true}
-              data-testid="admin-icon"
-              description="Settings"
-              fill="white"
-              focusable="false"
-              height={20}
-              preserveAspectRatio="xMidYMid meet"
-              viewBox="0 0 32 32"
-              width={20}
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M27,16.76c0-.25,0-.5,0-.76s0-.51,0-.77l1.92-1.68A2,2,0,0,0,29.3,11L26.94,7a2,2,0,0,0-1.73-1,2,2,0,0,0-.64.1l-2.43.82a11.35,11.35,0,0,0-1.31-.75l-.51-2.52a2,2,0,0,0-2-1.61H13.64a2,2,0,0,0-2,1.61l-.51,2.52a11.48,11.48,0,0,0-1.32.75L7.43,6.06A2,2,0,0,0,6.79,6,2,2,0,0,0,5.06,7L2.7,11a2,2,0,0,0,.41,2.51L5,15.24c0,.25,0,.5,0,.76s0,.51,0,.77L3.11,18.45A2,2,0,0,0,2.7,21L5.06,25a2,2,0,0,0,1.73,1,2,2,0,0,0,.64-.1l2.43-.82a11.35,11.35,0,0,0,1.31.75l.51,2.52a2,2,0,0,0,2,1.61h4.72a2,2,0,0,0,2-1.61l.51-2.52a11.48,11.48,0,0,0,1.32-.75l2.42.82a2,2,0,0,0,.64.1,2,2,0,0,0,1.73-1L29.3,21a2,2,0,0,0-.41-2.51ZM25.21,24l-3.43-1.16a8.86,8.86,0,0,1-2.71,1.57L18.36,28H13.64l-.71-3.55a9.36,9.36,0,0,1-2.7-1.57L6.79,24,4.43,20l2.72-2.4a8.9,8.9,0,0,1,0-3.13L4.43,12,6.79,8l3.43,1.16a8.86,8.86,0,0,1,2.71-1.57L13.64,4h4.72l.71,3.55a9.36,9.36,0,0,1,2.7,1.57L25.21,8,27.57,12l-2.72,2.4a8.9,8.9,0,0,1,0,3.13L27.57,20Z"
-              />
-              <path
-                d="M16,22a6,6,0,1,1,6-6A5.94,5.94,0,0,1,16,22Zm0-10a3.91,3.91,0,0,0-4,4,3.91,3.91,0,0,0,4,4,3.91,3.91,0,0,0,4-4A3.91,3.91,0,0,0,16,12Z"
-              />
-            </svg>
-          </span>
-        </button>
         <div
           className="bx--header__global"
         >
+          <button
+            aria-label="Administration"
+            aria-pressed={null}
+            className="bx--header-action-btn admin-icon admin-icon__hidden bx--header__action bx--btn bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+            data-testid="menu-item-Administration-global"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            <span
+              className="bx--assistive-text"
+            >
+              Administration
+            </span>
+            <span
+              id="suite-header-action-item-admin"
+            >
+              <svg
+                aria-hidden={true}
+                data-testid="admin-icon"
+                description="Settings"
+                fill="white"
+                focusable="false"
+                height={20}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M27,16.76c0-.25,0-.5,0-.76s0-.51,0-.77l1.92-1.68A2,2,0,0,0,29.3,11L26.94,7a2,2,0,0,0-1.73-1,2,2,0,0,0-.64.1l-2.43.82a11.35,11.35,0,0,0-1.31-.75l-.51-2.52a2,2,0,0,0-2-1.61H13.64a2,2,0,0,0-2,1.61l-.51,2.52a11.48,11.48,0,0,0-1.32.75L7.43,6.06A2,2,0,0,0,6.79,6,2,2,0,0,0,5.06,7L2.7,11a2,2,0,0,0,.41,2.51L5,15.24c0,.25,0,.5,0,.76s0,.51,0,.77L3.11,18.45A2,2,0,0,0,2.7,21L5.06,25a2,2,0,0,0,1.73,1,2,2,0,0,0,.64-.1l2.43-.82a11.35,11.35,0,0,0,1.31.75l.51,2.52a2,2,0,0,0,2,1.61h4.72a2,2,0,0,0,2-1.61l.51-2.52a11.48,11.48,0,0,0,1.32-.75l2.42.82a2,2,0,0,0,.64.1,2,2,0,0,0,1.73-1L29.3,21a2,2,0,0,0-.41-2.51ZM25.21,24l-3.43-1.16a8.86,8.86,0,0,1-2.71,1.57L18.36,28H13.64l-.71-3.55a9.36,9.36,0,0,1-2.7-1.57L6.79,24,4.43,20l2.72-2.4a8.9,8.9,0,0,1,0-3.13L4.43,12,6.79,8l3.43,1.16a8.86,8.86,0,0,1,2.71-1.57L13.64,4h4.72l.71,3.55a9.36,9.36,0,0,1,2.7,1.57L25.21,8,27.57,12l-2.72,2.4a8.9,8.9,0,0,1,0,3.13L27.57,20Z"
+                />
+                <path
+                  d="M16,22a6,6,0,1,1,6-6A5.94,5.94,0,0,1,16,22Zm0-10a3.91,3.91,0,0,0-4,4,3.91,3.91,0,0,0,4,4,3.91,3.91,0,0,0,4-4A3.91,3.91,0,0,0,16,12Z"
+                />
+              </svg>
+            </span>
+          </button>
           <div
             className="bx--header__submenu bx--header-action-btn action-btn__group"
             data-testid="action-btn__group"

--- a/packages/react/src/components/SuiteHeader/_suite-header.scss
+++ b/packages/react/src/components/SuiteHeader/_suite-header.scss
@@ -211,6 +211,9 @@
       fill: $ui-01;
     }
   }
+  button.admin-icon__hidden {
+    display: none !important;
+  }
   button.admin-icon__selected {
     background-color: $interactive-02;
     border: none;

--- a/packages/react/src/components/SuiteHeader/_suite-header.scss
+++ b/packages/react/src/components/SuiteHeader/_suite-header.scss
@@ -212,7 +212,7 @@
     }
   }
   button.admin-icon__hidden {
-    display: none !important;
+    visibility: hidden !important;
   }
   button.admin-icon__selected {
     background-color: $interactive-02;


### PR DESCRIPTION
Closes #

Closes an issue where any open panel (profile or app switcher) was automatically closing when SuiteHeader transitioned from "loading" to "data ready" state.

**Summary**

The use of Carbon's `HeaderContainer` to control the state of the side nav panel was causing the entire tree returned by its "render props" function to remount on every update in `SuiteHeader`'s properties. The solution was to remove the `HeaderContainer` component and manage the side nav toggle state in `SuiteHeader`. There was no possible solution to avoid a complete remounting of the components under `HeaderContainer` if we still used the "render props" approach.

Another change that was necessary was to avoid changing the `actionItems` array length. When API data becomes available, if the user is an admin, then `SuiteHeader` will include the "Cog" menu item by pushing a new element at the beginning of the `acionItems` array. This approach makes React think that all components in subsequent positions in the array are new and need to be created from scratch. The solution was to always include the "Cog" menu item, even before API data is received, so that `actionItems[0]` is already created beforehand (with `display: none`), to avoid remounting all action items that come after the "Cog" in the array.

**Acceptance Test (how to verify the PR)**

All tests are still passing, which means that side nav functionality did not break after this change.

**Regression Test (how to make sure this PR doesn't break old functionality)**

All tests are still passing, which means that side nav functionality did not break after this change.


Hint when looking at the file changes: add `?w=1` to the URL to ignore spaces and tabs, as most changes in `SuiteHeader.jsx` that show in the diff comparison were caused by the removal of a wrapper component, i.e. the child content of the removed wrapper has only an indentation change.