### PR TITLE
feat(table): improve nested row selections

### DIFF
--- a/packages/react/src/components/Table/README.md
+++ b/packages/react/src/components/Table/README.md
@@ -348,7 +348,7 @@ The `Table` component supports row selection when using the options.hasRowSelect
   actions={{
     table: {
       onRowClicked: (rowId: string) => {},
-      onRowSelected: (rowId: string, selected: boolean) => {},
+      onRowSelected: (rowId: string, selected: boolean, selectedIds: array) => {},
     },
   }}
   options={{
@@ -678,7 +678,7 @@ the following props:
       /** rowId is a string */
       onRowClicked: (rowId) => {},
       /** rowId is a string, selected is a boolean */
-      onRowSelected: (rowId, selected) => {},
+      onRowSelected: (rowId, selected, selectedIds: array) => {},
       /** allSelected is a boolean. true is all are selected, false otherwise */
       onSelectAll: (allSelected) => {},
     }

--- a/packages/react/src/components/Table/StatefulTable.jsx
+++ b/packages/react/src/components/Table/StatefulTable.jsx
@@ -241,9 +241,10 @@ const StatefulTable = ({ data: initialData, expandedData, ...other }) => {
         dispatch(tableColumnSort(column, columns));
         callbackParent(onChangeSort, column, sortDirection);
       },
-      onRowSelected: (rowId, isSelected) => {
-        dispatch(tableRowSelect(rowId, isSelected, options.hasRowSelection));
-        callbackParent(onRowSelected, rowId, isSelected);
+      onRowSelected: (rowId, isSelected, newSelectedIds) => {
+        dispatch(tableRowSelect(newSelectedIds, options.hasRowSelection));
+        // Params rowId & isSelected kept for backwards compatability
+        callbackParent(onRowSelected, rowId, isSelected, newSelectedIds);
       },
       onRowClicked: (rowId) => {
         // This action doesn't update our table state, it's up to the user

--- a/packages/react/src/components/Table/StatefulTable.test.jsx
+++ b/packages/react/src/components/Table/StatefulTable.test.jsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 
 import StatefulTable from './StatefulTable';
 import TableSkeletonWithHeaders from './TableSkeletonWithHeaders/TableSkeletonWithHeaders';
-import { mockActions } from './Table.test.helpers';
+import { mockActions, getNestedRows, getNestedRowIds } from './Table.test.helpers';
 import { initialState, StatefulTableWithNestedRowItems } from './Table.story';
 import RowActionsCell from './TableBody/RowActionsCell/RowActionsCell';
 
@@ -639,5 +639,88 @@ describe('stateful table with real reducer', () => {
       expect(container.querySelectorAll('tbody > tr')).toHaveLength(10);
       expect(screen.getByText('1–10 of 11 items')).toBeVisible();
     });
+  });
+
+  it('properly changes state of child and parent row selections', () => {
+    const onRowSelectedMock = jest.fn();
+    const selectRowLabel = 'Select row';
+    render(
+      <StatefulTable
+        columns={[
+          {
+            id: 'string',
+            name: 'String',
+            isSortable: false,
+          },
+        ]}
+        data={getNestedRows()}
+        options={{ hasRowSelection: 'multi', hasRowNesting: true }}
+        view={{
+          table: {
+            selectedIds: [],
+            expandedIds: ['row-0', 'row-1', 'row-1_B', 'row-1_B-2', 'row-1_D'],
+          },
+        }}
+        actions={{ table: { onRowSelected: onRowSelectedMock } }}
+      />
+    );
+
+    fireEvent.click(
+      screen.getAllByLabelText(selectRowLabel)[getNestedRowIds().indexOf('row-1_B-2')]
+    );
+
+    expect(
+      screen.getAllByLabelText(selectRowLabel)[getNestedRowIds().indexOf('row-1')]
+    ).toBePartiallyChecked();
+    expect(
+      screen.getAllByLabelText(selectRowLabel)[getNestedRowIds().indexOf('row-1_A')]
+    ).not.toBeChecked();
+
+    expect(
+      screen.getAllByLabelText(selectRowLabel)[getNestedRowIds().indexOf('row-1_B')]
+    ).toBePartiallyChecked();
+    expect(
+      screen.getAllByLabelText(selectRowLabel)[getNestedRowIds().indexOf('row-1_B-1')]
+    ).not.toBeChecked();
+
+    expect(
+      screen.getAllByLabelText(selectRowLabel)[getNestedRowIds().indexOf('row-1_B-2')]
+    ).toBeChecked();
+
+    expect(
+      screen.getAllByLabelText(selectRowLabel)[getNestedRowIds().indexOf('row-1_B-2-A')]
+    ).toBeChecked();
+    expect(
+      screen.getAllByLabelText(selectRowLabel)[getNestedRowIds().indexOf('row-1_B-2-B')]
+    ).toBeChecked();
+
+    expect(
+      screen.getAllByLabelText(selectRowLabel)[getNestedRowIds().indexOf('row-1_B-3')]
+    ).not.toBeChecked();
+
+    expect(
+      screen.getAllByLabelText(selectRowLabel)[getNestedRowIds().indexOf('row-1_B-3')]
+    ).not.toBeChecked();
+    expect(
+      screen.getAllByLabelText(selectRowLabel)[getNestedRowIds().indexOf('row-1_C')]
+    ).not.toBeChecked();
+    expect(
+      screen.getAllByLabelText(selectRowLabel)[getNestedRowIds().indexOf('row-1_D')]
+    ).not.toBeChecked();
+    expect(
+      screen.getAllByLabelText(selectRowLabel)[getNestedRowIds().indexOf('row-1_D-1')]
+    ).not.toBeChecked();
+    expect(
+      screen.getAllByLabelText(selectRowLabel)[getNestedRowIds().indexOf('row-1_D-2')]
+    ).not.toBeChecked();
+    expect(
+      screen.getAllByLabelText(selectRowLabel)[getNestedRowIds().indexOf('row-1_D-3')]
+    ).not.toBeChecked();
+
+    expect(onRowSelectedMock).toHaveBeenCalledWith('row-1_B-2', true, [
+      'row-1_B-2',
+      'row-1_B-2-A',
+      'row-1_B-2-B',
+    ]);
   });
 });

--- a/packages/react/src/components/Table/Table.story.jsx
+++ b/packages/react/src/components/Table/Table.story.jsx
@@ -2457,7 +2457,7 @@ export const WithSingleSelectAndNestedTableRows = withReadme(README, () => (
     }))}
     options={{
       hasPagination: true,
-      hasRowSelection: 'multi',
+      hasRowSelection: 'single',
       hasRowExpansion: true,
       hasRowNesting: true,
     }}

--- a/packages/react/src/components/Table/Table.test.helpers.js
+++ b/packages/react/src/components/Table/Table.test.helpers.js
@@ -53,3 +53,71 @@ export const getTableColumns = (selectData) => [
     filter: { placeholderText: 'pick a number' },
   },
 ];
+
+const getNewRow = (idx, suffix = '') => ({
+  id: `row-${idx}${suffix ? `_${suffix}` : ''}`,
+  values: {
+    string: `test string ${idx} ${suffix}`,
+  },
+});
+
+export const getNestedRows = () => {
+  return Array(3)
+    .fill(0)
+    .map((i, idx) => ({
+      id: `row-${idx}`,
+      values: {
+        string: `row-${idx}`,
+      },
+      children:
+        idx !== 1
+          ? [getNewRow(idx, 'A', true), getNewRow(idx, 'B', true)]
+          : idx === 1
+          ? [
+              getNewRow(idx, 'A', true),
+              {
+                ...getNewRow(idx, 'B'),
+                children: [
+                  getNewRow(idx, 'B-1', true),
+                  {
+                    ...getNewRow(idx, 'B-2'),
+                    children: [getNewRow(idx, 'B-2-A', true), getNewRow(idx, 'B-2-B', true)],
+                  },
+                  getNewRow(idx, 'B-3', true),
+                ],
+              },
+              getNewRow(idx, 'C', true),
+              {
+                ...getNewRow(idx, 'D', true),
+                children: [
+                  getNewRow(idx, 'D-1', true),
+                  getNewRow(idx, 'D-2', true),
+                  getNewRow(idx, 'D-3', true),
+                ],
+              },
+            ]
+          : undefined,
+    }));
+};
+
+export const getNestedRowIds = () => [
+  'row-0',
+  'row-0_A',
+  'row-0_B',
+  'row-1',
+  'row-1_A',
+  'row-1_B',
+  'row-1_B-1',
+  'row-1_B-2',
+  'row-1_B-2-A',
+  'row-1_B-2-B',
+  'row-1_B-3',
+  'row-1_C',
+  'row-1_D',
+  'row-1_D-1',
+  'row-1_D-2',
+  'row-1_D-3',
+  'row-2',
+  'row-2_A',
+  'row-2_B',
+];

--- a/packages/react/src/components/Table/TableBody/TableBody.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBody.jsx
@@ -15,6 +15,22 @@ import TableBodyRow from './TableBodyRow/TableBodyRow';
 
 const { TableBody: CarbonTableBody } = DataTable;
 
+/**
+ * Use this function to traverse the tree structure of a set of table rows using Depth-first search (DFS)
+ * and apply some function on each row. The function is applied once the recursion starts back-tracking.
+ * @param rows The root node of your search space, an array of rows.
+ * @param functionToApply Any function that should be applied on every row. Params are a row and an optional aggregatorObj.
+ * @param aggregatorObj Used as a container to aggregate the result (e.g. a count or needle) if needed.
+ */
+const tableTraverser = (rows, functionToApply, aggregatorObj) => {
+  rows.forEach((row) => {
+    if (row.children) {
+      tableTraverser(row.children, functionToApply, aggregatorObj);
+    }
+    functionToApply(row, aggregatorObj);
+  });
+};
+
 const propTypes = {
   /** The unique id of the table */
   tableId: PropTypes.string.isRequired,
@@ -151,7 +167,91 @@ const TableBody = ({
     [columns, ordering]
   );
 
+  const findAllAncestorRows = (childId, myRows) => {
+    const result = [];
+    const applyFunc = (row, ancestors) => {
+      const lastChildId = result[result.length - 1]?.id || childId;
+      const currentRowIsParent = row.children?.filter((child) => child.id === lastChildId).length;
+      if (currentRowIsParent) {
+        ancestors.push(row);
+      }
+    };
+    tableTraverser(myRows, applyFunc, result);
+    return result;
+  };
+
+  const findAllChildRowIds = ({ children = [] }) => {
+    const result = [];
+    tableTraverser(children, (row, aggr) => aggr.push(row.id), result);
+    return result;
+  };
+
+  const findRow = (rowId, myRows) => {
+    const result = [];
+    const applyFunc = (row, aggr) => {
+      if (row.id === rowId) {
+        aggr.push(row);
+      }
+    };
+    tableTraverser(myRows, applyFunc, result);
+    return result[0];
+  };
+
+  const updateChildIdSelection = (triggeringRowId, myRows, selection) => {
+    const row = findRow(triggeringRowId, myRows);
+    const childRowIds = findAllChildRowIds(row);
+    const triggeringRowSelected = selection.includes(triggeringRowId);
+
+    return triggeringRowSelected
+      ? [...new Set(selection.concat(childRowIds))]
+      : selection.filter((id) => !childRowIds.includes(id));
+  };
+
+  const updateAncestorSelection = (allAncestorRows, selection) => {
+    const newSelection = [...selection];
+    allAncestorRows.forEach((ancestorRow) => {
+      if (ancestorRow.children.every((child) => newSelection.includes(child.id))) {
+        newSelection.push(ancestorRow.id);
+      } else if (newSelection.includes(ancestorRow.id)) {
+        newSelection.splice(newSelection.indexOf(ancestorRow.id), 1);
+      }
+    });
+    return newSelection;
+  };
+
+  const onRowSelected = (rowId, selected) => {
+    if (hasRowSelection === 'single') {
+      actions.onRowSelected(rowId, selected, selected ? [rowId] : []);
+    } else {
+      const allAncestorRows = findAllAncestorRows(rowId, rows) || [];
+      const withNewSelection = selected
+        ? [...selectedIds, rowId]
+        : selectedIds.filter((id) => id !== rowId);
+      const withUpdatedAncestors = updateAncestorSelection(allAncestorRows, withNewSelection);
+      const withUpdatedChildren = updateChildIdSelection(rowId, rows, withUpdatedAncestors);
+      actions.onRowSelected(rowId, selected, withUpdatedChildren.sort());
+    }
+  };
+
+  const getIndeterminateRowSelectionIds = (myRows, mySelectedIds) => {
+    const result = [];
+    if (hasRowNesting && mySelectedIds.length) {
+      const applyFunc = (row, indeterminateList) => {
+        const allChildren = findAllChildRowIds(row);
+        const allAreSelected = allChildren.every((childId) => mySelectedIds.includes(childId));
+        const someAreSelected =
+          !allAreSelected && allChildren.some((childId) => mySelectedIds.includes(childId));
+        if (someAreSelected) {
+          indeterminateList.push(row.id);
+        }
+      };
+      tableTraverser(myRows, applyFunc, result);
+    }
+    return result;
+  };
+
   const someRowHasSingleRowEditMode = rowActionsState.some((rowAction) => rowAction.isEditMode);
+  const indeterminateSelectionIds = getIndeterminateRowSelectionIds(rows, selectedIds);
 
   const renderRow = (row, nestingLevel = 0) => {
     const isRowExpanded = expandedIds.includes(row.id);
@@ -168,6 +268,7 @@ const TableBody = ({
         isExpanded={isRowExpanded}
         isSelectable={isSelectable}
         isSelected={selectedIds.includes(row.id)}
+        isIndeterminate={indeterminateSelectionIds.includes(row.id)}
         rowEditMode={rowEditMode}
         singleRowEditMode={rowHasSingleRowEditMode}
         singleRowEditButtons={singleRowEditButtons}
@@ -203,14 +304,10 @@ const TableBody = ({
         }}
         nestingLevel={nestingLevel}
         nestingChildCount={row.children ? row.children.length : 0}
-        tableActions={pick(
-          actions,
-          'onRowSelected',
-          'onApplyRowAction',
-          'onRowExpanded',
-          'onRowClicked',
-          'onClearRowError'
-        )}
+        tableActions={{
+          ...pick(actions, 'onApplyRowAction', 'onRowExpanded', 'onRowClicked', 'onClearRowError'),
+          onRowSelected,
+        }}
         rowActions={row.rowActions}
         values={row.values}
       />

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -73,6 +73,8 @@ const propTypes = {
 
   /** is the row currently selected */
   isSelected: PropTypes.bool,
+  /** is the row currently in an indeterminate state, i.e. some but not all children are checked */
+  isIndeterminate: PropTypes.bool,
   /** is the row currently expanded */
   isExpanded: PropTypes.bool,
   /** optional row details */
@@ -114,6 +116,7 @@ const propTypes = {
 
 const defaultProps = {
   isSelected: false,
+  isIndeterminate: false,
   isExpanded: false,
   selectRowAria: 'Select row',
   overflowMenuAria: 'More actions',
@@ -381,6 +384,7 @@ const TableBodyRow = ({
   tableActions: { onRowSelected, onRowExpanded, onRowClicked, onApplyRowAction, onClearRowError },
   isExpanded,
   isSelected,
+  isIndeterminate,
   selectRowAria,
   overflowMenuAria,
   clickToExpandAria,
@@ -427,6 +431,7 @@ const TableBodyRow = ({
             id={`select-row-${tableId}-${id}`}
             labelText={selectRowAria}
             hideLabel
+            indeterminate={isIndeterminate}
             checked={isSelected}
             disabled={isSelectable === false}
           />

--- a/packages/react/src/components/Table/baseTableReducer.js
+++ b/packages/react/src/components/Table/baseTableReducer.js
@@ -233,27 +233,19 @@ export const baseTableReducer = (state = {}, action) => {
 
     // Row operations
     case TABLE_ROW_SELECT: {
-      const { rowId, isSelected, hasRowSelection } = action.payload;
-      const isClearing =
-        hasRowSelection === 'multi' && !isSelected && state.view.table.selectedIds.length <= 1;
-      const isSelectingAll =
-        hasRowSelection === 'multi' &&
-        isSelected &&
-        state.view.table.selectedIds.length + 1 === state.data.length;
+      const { selectedIds, hasRowSelection } = action.payload;
+      const isMultiSelect = hasRowSelection === 'multi';
+      const isClearing = isMultiSelect && selectedIds.length === 0;
+      const isSelectingAll = isMultiSelect && selectedIds.length === state.data.length;
 
-      // multi-select should add to the array. single-select should only allow one at a time, so replace the array
-      const addOrReplace =
-        hasRowSelection === 'multi' ? state.view.table.selectedIds.concat([rowId]) : [rowId];
       return update(state, {
         view: {
           table: {
             selectedIds: {
-              $set: isSelected
-                ? addOrReplace
-                : state.view.table.selectedIds.filter((i) => i !== rowId),
+              $set: selectedIds,
             },
             isSelectAllIndeterminate: {
-              $set: !(hasRowSelection === 'multi' && (isClearing || isSelectingAll)),
+              $set: !(isClearing || isSelectingAll),
             },
             isSelectAllSelected: {
               $set: isSelectingAll,

--- a/packages/react/src/components/Table/tableActionCreators.js
+++ b/packages/react/src/components/Table/tableActionCreators.js
@@ -131,9 +131,9 @@ export const tableRowActionError = (rowId, error, instanceId = null) => ({
 });
 
 /** Select a row of the table */
-export const tableRowSelect = (rowId, isSelected, hasRowSelection, instanceId = null) => ({
+export const tableRowSelect = (selectedIds, hasRowSelection, instanceId = null) => ({
   type: TABLE_ROW_SELECT,
-  payload: { rowId, isSelected, hasRowSelection },
+  payload: { selectedIds, hasRowSelection },
   instanceId,
 });
 

--- a/packages/react/src/components/Table/tableReducer.test.jsx
+++ b/packages/react/src/components/Table/tableReducer.test.jsx
@@ -195,20 +195,8 @@ describe('table reducer', () => {
     it('TABLE_ROW_SELECT', () => {
       expect(initialState.view.table.selectedIds).toEqual([]);
 
-      // Negative case where I unselect a row
-      const tableWithNoRowsSelected = tableReducer(
-        initialState,
-        tableRowSelect('row-1', false, 'multi')
-      );
-      expect(tableWithNoRowsSelected.view.table.selectedIds).toEqual([]);
-      expect(tableWithNoRowsSelected.view.table.isSelectAllSelected).toEqual(false);
-      expect(tableWithNoRowsSelected.view.table.isSelectAllIndeterminate).toEqual(false);
-
       // Select a row
-      const tableWithSelectedRow = tableReducer(
-        initialState,
-        tableRowSelect('row-1', true, 'multi')
-      );
+      const tableWithSelectedRow = tableReducer(initialState, tableRowSelect(['row-1'], 'multi'));
       expect(tableWithSelectedRow.view.table.selectedIds).toEqual(['row-1']);
       expect(tableWithSelectedRow.view.table.isSelectAllSelected).toEqual(false);
       expect(tableWithSelectedRow.view.table.isSelectAllIndeterminate).toEqual(true);
@@ -216,7 +204,7 @@ describe('table reducer', () => {
       // Unselect the row
       const tableWithUnSelectedRow = tableReducer(
         tableWithSelectedRow,
-        tableRowSelect('row-1', false, 'multi')
+        tableRowSelect([], 'multi')
       );
       expect(tableWithUnSelectedRow.view.table.selectedIds).toEqual([]);
       expect(tableWithUnSelectedRow.view.table.isSelectAllSelected).toEqual(false);
@@ -239,7 +227,7 @@ describe('table reducer', () => {
       // Select a row
       const tableWithSelectedRow = tableReducer(
         updatedInitialState,
-        tableRowSelect('row-1', true, 'single')
+        tableRowSelect(['row-1'], 'single')
       );
       expect(tableWithSelectedRow.view.table.selectedIds).toEqual(['row-1']);
       expect(tableWithSelectedRow.view.table.isSelectAllSelected).toEqual(false);
@@ -257,7 +245,7 @@ describe('table reducer', () => {
             },
           },
         },
-        tableRowSelect('row-2', true, 'single')
+        tableRowSelect(['row-2'], 'single')
       );
       expect(tableWithPreviouslySelectedRow.view.table.selectedIds).toEqual(['row-2']);
       expect(tableWithPreviouslySelectedRow.view.table.isSelectAllSelected).toEqual(false);


### PR DESCRIPTION
#124

Closes #124

**Summary**

Improved the selection logic for nested rows with multi select according to specs in the issue comment:

_1. Selection states are none (empty), all (filled), partial (dash). There are selection icons for each.
2. Selecting the parent will select all children
3. Unselecting the parent will unselect all children
4. Changing the selection of a child will change the state of the parent to partial
5. Selecting a partial parent will make the parent and children selected_

I interpreted 4 as unselecting a child will set parent to partial if there still are additional children selected. Selecting a child when all other children are selected will select parent as well. 

**Change List (commits, features, bugs, etc)**
- Added logic to the TableComponent that handles selection/deselection of rows and how that affects the parent and children rows.
- Added prop isIndeterminate to the TableBodyRow component
- Extended the onRowSelected callback params to include an array with the ids of all  currently selected rows
- Simplified the StatefulTable and the baseTableReducer since more logic was put in the table.
- Removed isSelectAllIndeterminate & isSelectAllSelected from the table view of the
StatefulTable since it was not use.
- Updated unit tests for tableReducer since the API for tableRowSelect was modified
- Added new unit tests to Table and StatefulTable
- Fixed the story `WithSingleSelectAndNestedTableRows` that despite the name didn't use `hasRowSelection: 'single'`

**Acceptance Test (how to verify the PR)**
Test the selection scenarios described in the spec above using the story https://deploy-preview-2337--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table--stateful-example-with-row-nesting-and-fixed-columns Verify that automatic selections to parents and children are propagated all the way up and down.

**Regression Test (how to make sure this PR doesn't break old functionality)**
- Verify that single select stories still work
- Verify that all other table stories work as expected

