### PR TITLE
feat(timeseriescard): expose the thresholds for x and y axis for time series chart

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -166,6 +166,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.13.16",
+    "@babel/helper-builder-react-jsx": "^7.12.13",
     "@babel/plugin-proposal-class-properties": "^7.13.0",
     "@babel/plugin-proposal-decorators": "^7.13.15",
     "@babel/plugin-proposal-do-expressions": "^7.12.13",

--- a/packages/react/src/components/StorybookSnapshots.test.js
+++ b/packages/react/src/components/StorybookSnapshots.test.js
@@ -87,6 +87,10 @@ describe(`Storybook Snapshot tests and console checks`, () => {
     // https://stackoverflow.com/questions/53271193/typeerror-scrollintoview-is-not-a-function
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
     window.HTMLElement.prototype.scrollTo = jest.fn();
+    window.getComputedStyle = () => ({
+      getPropertyValue: () => '25',
+    });
+    window.document = new Document();
   });
   initStoryshots({
     storyKindRegex: /Watson\sIoT.*$|.*Getting\sStarted/g,

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -93,6 +93,26 @@ const TimeSeriesCardPropTypes = {
     legendPosition: PropTypes.string,
     /** carbon charts legend truncation options */
     truncation: TruncationPropTypes,
+    /** if there are alerts associated with this chart (used to markup datapoints), this is a start/end set of alert ranges for each alert */
+    alertRanges: PropTypes.arrayOf(
+      PropTypes.shape({
+        endTimestamp: PropTypes.number,
+        startTimestamp: PropTypes.number,
+        /** color of the alert */
+        color: PropTypes.string,
+        /** more information about the alert */
+        details: PropTypes.string,
+      })
+    ),
+    /** set of thresholds these render dotted lines on the graph to indicate that the line values might be crossing logical thresholds */
+    thresholds: PropTypes.arrayOf(
+      PropTypes.shape({
+        axis: PropTypes.oneOf('x', 'y'),
+        value: PropTypes.number,
+        label: PropTypes.string,
+        fillColor: PropTypes.string,
+      })
+    ),
   }).isRequired,
   i18n: PropTypes.shape({
     alertDetected: PropTypes.string,
@@ -200,6 +220,7 @@ const TimeSeriesCard = ({
       legendPosition,
       addSpaceOnEdges,
       truncation,
+      thresholds,
     },
     values: valuesProp,
   } = handleCardVariables(titleProp, contentWithDefaults, initialValues, others);
@@ -380,6 +401,7 @@ const TimeSeriesCard = ({
             number: maxTicksPerSize,
             formatter: formatTick,
           },
+          thresholds: thresholds?.filter((threshold) => threshold.axis === 'x'),
           includeZero: includeZeroOnXaxis,
           ...(domainRange ? { domain: domainRange } : {}),
         },
@@ -390,6 +412,7 @@ const TimeSeriesCard = ({
             formatter: (axisValue) =>
               chartValueFormatter(axisValue, newSize, null, locale, decimalPrecision),
           },
+          thresholds: thresholds?.filter((threshold) => threshold.axis === 'y'),
           ...(chartType !== TIME_SERIES_TYPES.BAR
             ? { yMaxAdjuster: (yMaxValue) => yMaxValue * 1.3 }
             : {}),
@@ -442,6 +465,7 @@ const TimeSeriesCard = ({
       xLabel,
       maxTicksPerSize,
       formatTick,
+      thresholds,
       includeZeroOnXaxis,
       domainRange,
       yLabel,

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
@@ -1293,3 +1293,57 @@ export const Locale = () => {
 Locale.story = {
   name: 'locale',
 };
+
+export const Thresholds = () => {
+  const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGE);
+  const interval = select('interval', ['hour', 'day', 'week', 'quarter', 'month', 'year'], 'hour');
+  const values = getIntervalChartData(interval, 20, { min: 10, max: 100 }, 100);
+  return (
+    <div
+      style={{
+        width: `${getCardMinSize('lg', size).x}px`,
+        margin: spacing05 + 4,
+      }}
+    >
+      <TimeSeriesCard
+        {...commonProps}
+        title={text('title', 'Pressure')}
+        isLoading={boolean('isLoading', false)}
+        isExpanded={boolean('isExpanded', false)}
+        content={object('content-thresholds', {
+          series: [
+            {
+              label: 'Pressure',
+              dataSourceId: 'pressure',
+              color: text('color', COLORS.MAGENTA),
+            },
+          ],
+          unit: 'm/sec',
+          xLabel: 'Time',
+          yLabel: 'Pressure',
+          includeZeroOnXaxis: true,
+          includeZeroOnYaxis: true,
+          timeDataSourceId: 'timestamp',
+          addSpaceOnEdges: 1,
+          thresholds: [
+            { axis: 'y', value: values[0].pressure, fillColor: 'red', label: 'Alert 1' },
+            { axis: 'x', value: values[0].timestamp, fillColor: 'yellow', label: 'Alert 2' },
+          ],
+        })}
+        values={values}
+        interval="day"
+        breakpoint="lg"
+        showTimeInGMT={boolean('showTimeInGMT', false)}
+        size={size}
+        onCardAction={action('onCardAction')}
+        i18n={{
+          tooltipGroupLabel: 'Translated Group',
+        }}
+      />
+    </div>
+  );
+};
+
+Thresholds.story = {
+  name: 'thresholds',
+};

--- a/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -5813,6 +5813,174 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/TimeSeriesCard thresholds 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": "1rem4",
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="iot--card iot--card--wrapper"
+        data-testid="Card"
+        id="facility-temperature"
+        role="presentation"
+        style={
+          Object {
+            "--card-default-height": "624px",
+          }
+        }
+      >
+        <div
+          className="iot--card--header"
+        >
+          <span
+            className="iot--card--title"
+            title="Pressure"
+          >
+            <div
+              className="iot--card--title--text"
+            >
+              Pressure
+            </div>
+          </span>
+          <div
+            className="iot--card--toolbar"
+          >
+            <div
+              className="iot--card--toolbar-date-range-wrapper"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                aria-label="open and close list of options"
+                className="iot--card--toolbar-date-range-action bx--overflow-menu"
+                onClick={[Function]}
+                onClose={[Function]}
+                onKeyDown={[Function]}
+                open={false}
+                title="Select time range"
+                type="button"
+              >
+                <svg
+                  aria-label="Select time range"
+                  className="bx--overflow-menu__icon"
+                  fill="currentColor"
+                  focusable="false"
+                  height={16}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
+                  />
+                  <path
+                    d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                  />
+                  <path
+                    d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
+                  />
+                  <title>
+                    Select time range
+                  </title>
+                </svg>
+              </button>
+            </div>
+            <button
+              aria-pressed={null}
+              className="iot--card--toolbar-action iot--card--toolbar-svg-wrapper bx--btn--icon-only bx--btn bx--btn--ghost"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              title="Expand to fullscreen"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                aria-label="Expand to fullscreen"
+                className="bx--btn__icon"
+                fill="currentColor"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M28,4H10A2.0059,2.0059,0,0,0,8,6V20a2.0059,2.0059,0,0,0,2,2H28a2.0059,2.0059,0,0,0,2-2V6A2.0059,2.0059,0,0,0,28,4Zm0,16H10V6H28Z"
+                />
+                <path
+                  d="M18,26H4V16H6V14H4a2.0059,2.0059,0,0,0-2,2V26a2.0059,2.0059,0,0,0,2,2H18a2.0059,2.0059,0,0,0,2-2V24H18Z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          className="iot--card--content"
+          style={
+            Object {
+              "--card-content-height": "576px",
+            }
+          }
+        >
+          <div
+            className="iot--time-series-card--wrapper"
+          >
+            <div
+              id="mock-line-chart"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/TimeSeriesCard with variables 1`] = `
 <div
   className="storybook-container"

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -13516,6 +13516,30 @@ Map {
             "addSpaceOnEdges": Object {
               "type": "number",
             },
+            "alertRanges": Object {
+              "args": Array [
+                Object {
+                  "args": Array [
+                    Object {
+                      "color": Object {
+                        "type": "string",
+                      },
+                      "details": Object {
+                        "type": "string",
+                      },
+                      "endTimestamp": Object {
+                        "type": "number",
+                      },
+                      "startTimestamp": Object {
+                        "type": "number",
+                      },
+                    },
+                  ],
+                  "type": "shape",
+                },
+              ],
+              "type": "arrayOf",
+            },
             "chartType": [Function],
             "decimalPrecision": Object {
               "type": "number",
@@ -13596,6 +13620,34 @@ Map {
             },
             "showLegend": Object {
               "type": "bool",
+            },
+            "thresholds": Object {
+              "args": Array [
+                Object {
+                  "args": Array [
+                    Object {
+                      "axis": Object {
+                        "args": Array [
+                          "x",
+                          "y",
+                        ],
+                        "type": "oneOf",
+                      },
+                      "fillColor": Object {
+                        "type": "string",
+                      },
+                      "label": Object {
+                        "type": "string",
+                      },
+                      "value": Object {
+                        "type": "number",
+                      },
+                    },
+                  ],
+                  "type": "shape",
+                },
+              ],
+              "type": "arrayOf",
             },
             "timeDataSourceId": Object {
               "type": "string",

--- a/yarn.lock
+++ b/yarn.lock
@@ -732,6 +732,14 @@
     "@babel/helper-explode-assignable-expression" "^7.12.13"
     "@babel/types" "^7.12.13"
 
+"@babel/helper-builder-react-jsx@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.12.13.tgz#df6a76fb83feb6b8e6dcfb46bb49010098cb51f0"
+  integrity sha512-QN7Z5FByIOFESQXxoNYVPU7xONzrDW2fv7oKKVkj+62N3Dx1IZaVu/RF9QhV9XyCZE/xiYNfuQ1JsiL1jduT1A==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.12.13"
+    "@babel/types" "^7.12.13"
+
 "@babel/helper-compilation-targets@^7.12.5":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.13.tgz#d689cdef88810aa74e15a7a94186f26a3d773c98"
@@ -8907,21 +8915,6 @@ cheerio@^1.0.0-rc.2:
     htmlparser2 "^3.9.1"
     lodash "^4.15.0"
     parse5 "^3.0.1"
-
-chokidar@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.1.tgz#c84e5b3d18d9a4d77558fef466b1bf16bbeb3450"
-  integrity sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==
-  dependencies:
-    anymatch "~3.1.1"
-    braces "~3.0.2"
-    glob-parent "~5.1.0"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.3.0"
-  optionalDependencies:
-    fsevents "~2.1.2"
 
 "chokidar@>=2.0.0 <4.0.0", "chokidar@>=3.0.0 <4.0.0", chokidar@^3.0.0, chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.5.1:
   version "3.5.1"
@@ -19646,11 +19639,6 @@ picomatch@^2.0.5:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.1.1.tgz#ecdfbea7704adb5fe6fb47f9866c4c0e15e905c5"
   integrity sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==
 
-picomatch@^2.0.7:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.3.tgz#465547f359ccc206d3c48e46a1bcb89bf7ee619d"
-  integrity sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==
-
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -21258,7 +21246,7 @@ react-syntax-highlighter@^13.5.3:
     prismjs "^1.21.0"
     refractor "^3.1.0"
 
-react-test-renderer@16.14.0, react-test-renderer@^16.0.0-0, "react-test-renderer@^16.8.0 || ^17.0.0", react-test-renderer@^16.8.6:
+react-test-renderer@^16.0.0-0, "react-test-renderer@^16.8.0 || ^17.0.0", react-test-renderer@^16.8.6:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.14.0.tgz#e98360087348e260c56d4fe2315e970480c228ae"
   integrity sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==
@@ -21518,13 +21506,6 @@ readdirp@^2.2.1:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
-
-readdirp@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.3.0.tgz#984458d13a1e42e2e9f5841b129e162f369aff17"
-  integrity sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==
-  dependencies:
-    picomatch "^2.0.7"
 
 readdirp@~3.5.0:
   version "3.5.0"


### PR DESCRIPTION
Closes #

**Summary**

- Carbon charts has added a thresholds prop and we're exposing this now in the TimeSeriesCard

**Change List (commits, features, bugs, etc)**

- fix(package.json): add helper builder react jsx to support builds, they started breaking
- fix(storybooksnapshots): mock the document and window for getComputedStyle
- feat(TimeSeriesCard): add thresholds prop

**Acceptance Test (how to verify the PR)**

- view the thresholds story of the TimeSeriesCard

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Verify a few of the other TimeSeriesCard stories
