### PR TITLE
fix(overflow-menu): getMenuOffset import fix

### DIFF
--- a/packages/react/src/components/OverflowMenu/index.jsx
+++ b/packages/react/src/components/OverflowMenu/index.jsx
@@ -1,14 +1,11 @@
 import * as React from 'react';
 import { OverflowMenu as CarbonOverflowMenu } from 'carbon-components-react';
 import PropTypes from 'prop-types';
-// no idea why import { getMenuOffset } won't work, but it causes an 'getMenuOffset' is not exported by node_modules/carbon-components-react/lib/components/OverflowMenu/OverflowMenu.js error
-import * as OM from 'carbon-components-react/lib/components/OverflowMenu/OverflowMenu';
+import { getMenuOffset } from 'carbon-components-react/lib/components/OverflowMenu/OverflowMenu';
 
 import { usePopoverPositioning } from '../../hooks/usePopoverPositioning';
 
 export { OverflowMenuItem } from 'carbon-components-react';
-
-const { getMenuOffset } = OM;
 
 export const OverflowMenu = ({ direction, menuOffset, useAutoPositioning, flipped, ...props }) => {
   const [calculateMenuOffset, { adjustedDirection, adjustedFlipped }] = usePopoverPositioning({


### PR DESCRIPTION
Closes #

**Summary**

- using a wildcard import to pull in getMenuOffset was causing build errors downstream. Reverted back to the original import method and it magically works now. 🤕 