### PR TITLE
fix(overflow-menu): use es import from carbon

### DIFF
--- a/packages/react/src/components/FileUploader/stories/drop-container.jsx
+++ b/packages/react/src/components/FileUploader/stories/drop-container.jsx
@@ -10,7 +10,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import classnames from 'classnames';
 import { settings } from 'carbon-components';
-import uid from 'carbon-components-react/lib/tools/uniqueId';
+import uid from 'carbon-components-react/es/tools/uniqueId';
 
 import { FileUploaderItem, FileUploaderDropContainer } from '..';
 

--- a/packages/react/src/components/OverflowMenu/index.jsx
+++ b/packages/react/src/components/OverflowMenu/index.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { OverflowMenu as CarbonOverflowMenu } from 'carbon-components-react';
 import PropTypes from 'prop-types';
-import { getMenuOffset } from 'carbon-components-react/lib/components/OverflowMenu/OverflowMenu';
+import { getMenuOffset } from 'carbon-components-react/es/components/OverflowMenu/OverflowMenu';
 
 import { usePopoverPositioning } from '../../hooks/usePopoverPositioning';
 

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 import React from 'react';
-import Chip from '@carbon/icons-react/lib/chip/24';
+import Chip from '@carbon/icons-react/es/chip/24';
 
 import SuiteHeader from './SuiteHeader';
 import SuiteHeaderI18N from './i18n';


### PR DESCRIPTION
Closes #

**Summary**

- use es not lib when importing overflow menu.