### PR TITLE
fix(dayjs): need to rename the dayjs variable or we lose the extends

### DIFF
--- a/packages/react/src/utils/dayjs.js
+++ b/packages/react/src/utils/dayjs.js
@@ -1,4 +1,4 @@
-import dayjs from 'dayjs';
+import originalDayJS from 'dayjs';
 
 const localizedFormat = require('dayjs/plugin/localizedFormat');
 const utc = require('dayjs/plugin/utc');
@@ -6,6 +6,7 @@ const pluralGetSet = require('dayjs/plugin/pluralGetSet');
 const timezone = require('dayjs/plugin/timezone');
 const localeData = require('dayjs/plugin/localeData');
 
+const dayjs = originalDayJS;
 dayjs.extend(localizedFormat); // gives the 'L' formatting ability for .format
 dayjs.extend(utc); // gives .utc() and .local()
 dayjs.extend(pluralGetSet); // gives .hour .minute get/set ability


### PR DESCRIPTION
Closes #

**Summary**

- For some reason the utils/dayjs extension doesn't work in downstream consumers (so functions like utc() break)

**Change List (commits, features, bugs, etc)**

- fix(utils/dayjs): rename the constant used to extend dayjs on export

**Acceptance Test (how to verify the PR)**

- Verify in a built project that TimeSeriesCard can be used in isEditable mode

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Verify the existing TimeSeriesCard stories (especially isEditable) do not break
