### PR TITLE
fix(table): prevent prop warnings and fix testids

### DIFF
--- a/packages/react/src/components/BarChartCard/__snapshots__/BarChartCard.story.storyshot
+++ b/packages/react/src/components/BarChartCard/__snapshots__/BarChartCard.story.storyshot
@@ -2184,7 +2184,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/B
                       </thead>
                       <tbody
                         aria-live="polite"
-                        data-testID="BarChartCard-table-table-body"
+                        data-testid="BarChartCard-table-table-body"
                       >
                         <tr
                           className="TableBodyRow__StyledTableRow-sc-103itxu-0 gZGpiK"

--- a/packages/react/src/components/Card/__snapshots__/Card.story.storyshot
+++ b/packages/react/src/components/Card/__snapshots__/Card.story.storyshot
@@ -748,7 +748,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                 </thead>
                 <tbody
                   aria-live="polite"
-                  data-testID="my table-table-body"
+                  data-testid="my table-table-body"
                 >
                   <tr
                     className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"

--- a/packages/react/src/components/ComboChartCard/__snapshots__/ComboChartCard.story.storyshot
+++ b/packages/react/src/components/ComboChartCard/__snapshots__/ComboChartCard.story.storyshot
@@ -675,7 +675,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       </thead>
                       <tbody
                         aria-live="polite"
-                        data-testID="BarChartCard-table-table-body"
+                        data-testid="BarChartCard-table-table-body"
                       >
                         <tr
                           className="TableBodyRow__StyledTableRow-sc-103itxu-0 gZGpiK"

--- a/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -9818,7 +9818,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           </thead>
                           <tbody
                             aria-live="polite"
-                            data-testID="table-for-card-expandedcard-table-body"
+                            data-testid="table-for-card-expandedcard-table-body"
                           >
                             <tr
                               className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"

--- a/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
@@ -1586,7 +1586,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                       </thead>
                       <tbody
                         aria-live="polite"
-                        data-testID="table-for-card-tableCard-table-body"
+                        data-testid="table-for-card-tableCard-table-body"
                       >
                         <tr
                           className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"

--- a/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -913,7 +913,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                                 </thead>
                                 <tbody
                                   aria-live="polite"
-                                  data-testID="table-for-card-Table-table-body"
+                                  data-testid="table-for-card-Table-table-body"
                                 >
                                   <tr
                                     className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"
@@ -16832,7 +16832,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                               </thead>
                               <tbody
                                 aria-live="polite"
-                                data-testID="table-for-card-Table-table-body"
+                                data-testid="table-for-card-Table-table-body"
                               >
                                 <tr
                                   className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"

--- a/packages/react/src/components/PieChartCard/__snapshots__/PieChartCard.story.storyshot
+++ b/packages/react/src/components/PieChartCard/__snapshots__/PieChartCard.story.storyshot
@@ -403,7 +403,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                       </thead>
                       <tbody
                         aria-live="polite"
-                        data-testID="basicCardStory-table-table-body"
+                        data-testid="basicCardStory-table-table-body"
                       >
                         <tr
                           className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"

--- a/packages/react/src/components/RuleBuilder/__snapshots__/RuleBuilder.story.storyshot
+++ b/packages/react/src/components/RuleBuilder/__snapshots__/RuleBuilder.story.storyshot
@@ -5430,7 +5430,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                             </thead>
                             <tbody
                               aria-live="polite"
-                              data-testID="edit-table-table-body"
+                              data-testid="edit-table-table-body"
                             >
                               <tr
                                 className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"
@@ -5702,7 +5702,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                             </thead>
                             <tbody
                               aria-live="polite"
-                              data-testID="read-table-table-body"
+                              data-testid="read-table-table-body"
                             >
                               <tr
                                 className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"

--- a/packages/react/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
+++ b/packages/react/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
@@ -156,7 +156,7 @@ class RowActionsCell extends React.Component {
                   .filter((action) => !action.isOverflow)
                   .map(({ id: actionId, labelText, iconDescription, ...others }) => (
                     <Button
-                      {...omit(others, ['isOverflow'])}
+                      {...omit(others, ['isOverflow', 'isDelete', 'isEdit', 'hasDivider'])}
                       iconDescription={labelText || iconDescription}
                       key={`${tableId}-${id}-row-actions-button-${actionId}`}
                       data-testid={`${tableId}-${id}-row-actions-button-${actionId}`}

--- a/packages/react/src/components/Table/TableBody/TableBody.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBody.jsx
@@ -221,7 +221,7 @@ const TableBody = ({
   };
 
   return (
-    <CarbonTableBody data-testID={testID}>
+    <CarbonTableBody data-testid={testID}>
       {rows.map((row) => {
         return shouldLazyRender ? (
           <VisibilitySensor

--- a/packages/react/src/components/Table/TableHead/TableHead.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.jsx
@@ -312,7 +312,7 @@ const TableHead = ({
       <TableRow>
         {hasRowExpansion || hasRowNesting ? (
           <TableExpandHeader
-            testID={`${testID}-row-expansion-column`}
+            data-testid={`${testID}-row-expansion-column`}
             className={classnames({
               [`${iotPrefix}--table-expand-resize`]: hasResize,
             })}

--- a/packages/react/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/packages/react/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -750,7 +750,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </thead>
                   <tbody
                     aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
+                    data-testid="table-for-card-table-list-table-body"
                   >
                     <tr
                       className="TableBodyRow__StyledTableRow-sc-103itxu-0 gZGpiK"
@@ -2985,7 +2985,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </thead>
                   <tbody
                     aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
+                    data-testid="table-for-card-table-list-table-body"
                   >
                     <tr
                       className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"
@@ -4575,7 +4575,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </thead>
                   <tbody
                     aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
+                    data-testid="table-for-card-table-list-table-body"
                   >
                     <tr
                       className="TableBodyRow__StyledTableRow-sc-103itxu-0 gZGpiK"
@@ -7011,7 +7011,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </thead>
                   <tbody
                     aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
+                    data-testid="table-for-card-table-list-table-body"
                   >
                     <tr
                       className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"
@@ -8244,8 +8244,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     <tr>
                       <th
                         className="bx--table-expand"
+                        data-testid="table-for-card-table-list-table-head-row-expansion-column"
                         scope="col"
-                        testID="table-for-card-table-list-table-head-row-expansion-column"
                       />
                       <th
                         aria-sort="none"
@@ -8461,7 +8461,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </thead>
                   <tbody
                     aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
+                    data-testid="table-for-card-table-list-table-body"
                   >
                     <tr
                       className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
@@ -11401,7 +11401,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </thead>
                   <tbody
                     aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
+                    data-testid="table-for-card-table-list-table-body"
                   >
                     <tr
                       className="TableBodyRow__StyledTableRow-sc-103itxu-0 gZGpiK"
@@ -13926,7 +13926,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </thead>
                   <tbody
                     aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
+                    data-testid="table-for-card-table-list-table-body"
                   >
                     <tr
                       className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"
@@ -15446,7 +15446,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </thead>
                   <tbody
                     aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
+                    data-testid="table-for-card-table-list-table-body"
                   >
                     <tr
                       className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"
@@ -17092,7 +17092,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </thead>
                   <tbody
                     aria-live="polite"
-                    data-testID="table-for-card-undefined-table-body"
+                    data-testid="table-for-card-undefined-table-body"
                   >
                     <tr
                       className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"
@@ -17979,7 +17979,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </thead>
                   <tbody
                     aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
+                    data-testid="table-for-card-table-list-table-body"
                   >
                     <tr
                       className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"
@@ -19930,8 +19930,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     <tr>
                       <th
                         className="bx--table-expand"
+                        data-testid="table-for-card-table-list-table-head-row-expansion-column"
                         scope="col"
-                        testID="table-for-card-table-list-table-head-row-expansion-column"
                       />
                       <th
                         aria-sort="none"
@@ -20217,7 +20217,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </thead>
                   <tbody
                     aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
+                    data-testid="table-for-card-table-list-table-body"
                   >
                     <tr
                       className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
@@ -22634,7 +22634,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </thead>
                   <tbody
                     aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
+                    data-testid="table-for-card-table-list-table-body"
                   >
                     <tr
                       className="TableBodyRow__StyledTableRow-sc-103itxu-0 gZGpiK"
@@ -24462,8 +24462,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     <tr>
                       <th
                         className="bx--table-expand"
+                        data-testid="table-for-card-table-list-table-head-row-expansion-column"
                         scope="col"
-                        testID="table-for-card-table-list-table-head-row-expansion-column"
                       />
                       <th
                         aria-sort="none"
@@ -24679,7 +24679,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </thead>
                   <tbody
                     aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
+                    data-testid="table-for-card-table-list-table-body"
                   >
                     <tr
                       className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
@@ -26277,8 +26277,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     <tr>
                       <th
                         className="bx--table-expand"
+                        data-testid="table-for-card-table-list-table-head-row-expansion-column"
                         scope="col"
-                        testID="table-for-card-table-list-table-head-row-expansion-column"
                       />
                       <th
                         aria-sort="none"
@@ -26494,7 +26494,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </thead>
                   <tbody
                     aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
+                    data-testid="table-for-card-table-list-table-body"
                   >
                     <tr
                       className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
@@ -28092,8 +28092,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     <tr>
                       <th
                         className="bx--table-expand"
+                        data-testid="table-for-card-table-list-table-head-row-expansion-column"
                         scope="col"
-                        testID="table-for-card-table-list-table-head-row-expansion-column"
                       />
                       <th
                         aria-sort="none"
@@ -28309,7 +28309,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </thead>
                   <tbody
                     aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
+                    data-testid="table-for-card-table-list-table-body"
                   >
                     <tr
                       className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
@@ -29907,8 +29907,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     <tr>
                       <th
                         className="bx--table-expand"
+                        data-testid="table-for-card-table-list-table-head-row-expansion-column"
                         scope="col"
-                        testID="table-for-card-table-list-table-head-row-expansion-column"
                       />
                       <th
                         aria-sort="none"
@@ -30124,7 +30124,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </thead>
                   <tbody
                     aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
+                    data-testid="table-for-card-table-list-table-body"
                   >
                     <tr
                       className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
@@ -31960,7 +31960,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </thead>
                   <tbody
                     aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
+                    data-testid="table-for-card-table-list-table-body"
                   >
                     <tr
                       className="TableBodyRow__StyledTableRow-sc-103itxu-0 gZGpiK"
@@ -33970,7 +33970,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </thead>
                   <tbody
                     aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
+                    data-testid="table-for-card-table-list-table-body"
                   >
                     <tr
                       className="TableBodyRow__StyledTableRow-sc-103itxu-0 gZGpiK"
@@ -36535,7 +36535,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </thead>
                   <tbody
                     aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
+                    data-testid="table-for-card-table-list-table-body"
                   >
                     <tr
                       className="TableBodyRow__StyledTableRow-sc-103itxu-0 gZGpiK"
@@ -38418,8 +38418,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     <tr>
                       <th
                         className="bx--table-expand"
+                        data-testid="table-for-card-table-list-table-head-row-expansion-column"
                         scope="col"
-                        testID="table-for-card-table-list-table-head-row-expansion-column"
                       />
                       <th
                         aria-sort="none"
@@ -38845,7 +38845,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </thead>
                   <tbody
                     aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
+                    data-testid="table-for-card-table-list-table-body"
                   >
                     <tr
                       className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"

--- a/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -1954,7 +1954,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     </thead>
                     <tbody
                       aria-live="polite"
-                      data-testID="TimeSeries-table-table-body"
+                      data-testid="TimeSeries-table-table-body"
                     >
                       <tr
                         className="TableBodyRow__StyledTableRow-sc-103itxu-0 gZGpiK"


### PR DESCRIPTION
Closes #2005 

**Summary**

- omit isDelete, isEdit, and isDivider props from being passed to the button
- fix data-testids on TableBody and TableExpandHeader.

**Acceptance Test (how to verify the PR)**

- no errors in the console when isEdit or isDelete is included in a table action when _not_ in the overflow menu.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- no other changes to table
