### PR TITLE
fix(suite-header): fix keyboard keyboard navigation in header panel

### DIFF
--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.test.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.test.jsx
@@ -56,6 +56,15 @@ describe('SuiteHeaderAppSwitcher', () => {
       commonProps.applications.find((app) => app.id === 'monitor').href
     );
   });
+  it('keyboard navigates an application link', async () => {
+    delete window.location;
+    window.location = { href: '' };
+    render(<SuiteHeaderAppSwitcher {...commonProps} />);
+    await userEvent.type(screen.getByTestId('suite-header-app-switcher--monitor'), '{enter}');
+    expect(window.location.href).toBe(
+      commonProps.applications.find((app) => app.id === 'monitor').href
+    );
+  });
   it('clicks an external application link', async () => {
     delete window.location;
     window.location = { href: '' };

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/__snapshots__/SuiteHeaderAppSwitcher.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/__snapshots__/SuiteHeaderAppSwitcher.story.storyshot
@@ -35,6 +35,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
             data-testid="suite-header-app-switcher--all-applications"
             disabled={false}
             onClick={[Function]}
+            onKeyDown={[Function]}
             tabIndex={0}
             type="button"
           >
@@ -156,6 +157,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
             data-testid="suite-header-app-switcher--all-applications"
             disabled={false}
             onClick={[Function]}
+            onKeyDown={[Function]}
             tabIndex={0}
             type="button"
           >
@@ -279,6 +281,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
             data-testid="suite-header-app-switcher--all-applications"
             disabled={false}
             onClick={[Function]}
+            onKeyDown={[Function]}
             tabIndex={0}
             type="button"
           >
@@ -307,25 +310,35 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
           className="iot--suite-header-app-switcher--app-link"
           id="suite-header-application-monitor"
         >
-          <a
+          <button
+            aria-pressed={null}
+            className="iot--btn bx--btn bx--btn--ghost"
             data-testid="suite-header-app-switcher--monitor"
-            href="javascript:void(0)"
+            disabled={false}
             onClick={[Function]}
+            onKeyDown={[Function]}
+            tabIndex={0}
+            type="button"
           >
             Monitor
-          </a>
+          </button>
         </li>
         <li
           className="iot--suite-header-app-switcher--app-link"
           id="suite-header-application-health"
         >
-          <a
+          <button
+            aria-pressed={null}
+            className="iot--btn bx--btn bx--btn--ghost"
             data-testid="suite-header-app-switcher--health"
-            href="javascript:void(0)"
+            disabled={false}
             onClick={[Function]}
+            onKeyDown={[Function]}
+            tabIndex={0}
+            type="button"
           >
             Health
-          </a>
+          </button>
         </li>
       </ul>
     </div>

--- a/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
@@ -601,6 +601,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                           data-testid="suite-header-app-switcher--all-applications"
                           disabled={false}
                           onClick={[Function]}
+                          onKeyDown={[Function]}
                           tabIndex={0}
                           type="button"
                         >
@@ -629,25 +630,35 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                         className="iot--suite-header-app-switcher--app-link"
                         id="suite-header-application-monitor"
                       >
-                        <a
+                        <button
+                          aria-pressed={null}
+                          className="iot--btn bx--btn bx--btn--ghost"
                           data-testid="suite-header-app-switcher--monitor"
-                          href="javascript:void(0)"
+                          disabled={false}
                           onClick={[Function]}
+                          onKeyDown={[Function]}
+                          tabIndex={0}
+                          type="button"
                         >
                           Monitor
-                        </a>
+                        </button>
                       </li>
                       <li
                         className="iot--suite-header-app-switcher--app-link"
                         id="suite-header-application-health"
                       >
-                        <a
+                        <button
+                          aria-pressed={null}
+                          className="iot--btn bx--btn bx--btn--ghost"
                           data-testid="suite-header-app-switcher--health"
-                          href="javascript:void(0)"
+                          disabled={false}
                           onClick={[Function]}
+                          onKeyDown={[Function]}
+                          tabIndex={0}
+                          type="button"
                         >
                           Health
-                        </a>
+                        </button>
                       </li>
                     </ul>
                   </a>
@@ -1632,6 +1643,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                           data-testid="suite-header-app-switcher--all-applications"
                           disabled={false}
                           onClick={[Function]}
+                          onKeyDown={[Function]}
                           tabIndex={0}
                           type="button"
                         >
@@ -1660,49 +1672,69 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                         className="iot--suite-header-app-switcher--app-link"
                         id="suite-header-application-customapp1"
                       >
-                        <a
+                        <button
+                          aria-pressed={null}
+                          className="iot--btn bx--btn bx--btn--ghost"
                           data-testid="suite-header-app-switcher--customapp1"
-                          href="javascript:void(0)"
+                          disabled={false}
                           onClick={[Function]}
+                          onKeyDown={[Function]}
+                          tabIndex={0}
+                          type="button"
                         >
                           Custom Application
-                        </a>
+                        </button>
                       </li>
                       <li
                         className="iot--suite-header-app-switcher--app-link"
                         id="suite-header-application-customapp2"
                       >
-                        <a
+                        <button
+                          aria-pressed={null}
+                          className="iot--btn bx--btn bx--btn--ghost"
                           data-testid="suite-header-app-switcher--customapp2"
-                          href="javascript:void(0)"
+                          disabled={false}
                           onClick={[Function]}
+                          onKeyDown={[Function]}
+                          tabIndex={0}
+                          type="button"
                         >
                           Another Custom Application
-                        </a>
+                        </button>
                       </li>
                       <li
                         className="iot--suite-header-app-switcher--app-link"
                         id="suite-header-application-monitor"
                       >
-                        <a
+                        <button
+                          aria-pressed={null}
+                          className="iot--btn bx--btn bx--btn--ghost"
                           data-testid="suite-header-app-switcher--monitor"
-                          href="javascript:void(0)"
+                          disabled={false}
                           onClick={[Function]}
+                          onKeyDown={[Function]}
+                          tabIndex={0}
+                          type="button"
                         >
                           Monitor
-                        </a>
+                        </button>
                       </li>
                       <li
                         className="iot--suite-header-app-switcher--app-link"
                         id="suite-header-application-health"
                       >
-                        <a
+                        <button
+                          aria-pressed={null}
+                          className="iot--btn bx--btn bx--btn--ghost"
                           data-testid="suite-header-app-switcher--health"
-                          href="javascript:void(0)"
+                          disabled={false}
                           onClick={[Function]}
+                          onKeyDown={[Function]}
+                          tabIndex={0}
+                          type="button"
                         >
                           Health
-                        </a>
+                        </button>
                       </li>
                     </ul>
                   </a>
@@ -2340,6 +2372,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                           data-testid="suite-header-app-switcher--all-applications"
                           disabled={false}
                           onClick={[Function]}
+                          onKeyDown={[Function]}
                           tabIndex={0}
                           type="button"
                         >
@@ -2368,25 +2401,35 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                         className="iot--suite-header-app-switcher--app-link"
                         id="suite-header-application-monitor"
                       >
-                        <a
+                        <button
+                          aria-pressed={null}
+                          className="iot--btn bx--btn bx--btn--ghost"
                           data-testid="suite-header-app-switcher--monitor"
-                          href="javascript:void(0)"
+                          disabled={false}
                           onClick={[Function]}
+                          onKeyDown={[Function]}
+                          tabIndex={0}
+                          type="button"
                         >
                           Monitor
-                        </a>
+                        </button>
                       </li>
                       <li
                         className="iot--suite-header-app-switcher--app-link"
                         id="suite-header-application-health"
                       >
-                        <a
+                        <button
+                          aria-pressed={null}
+                          className="iot--btn bx--btn bx--btn--ghost"
                           data-testid="suite-header-app-switcher--health"
-                          href="javascript:void(0)"
+                          disabled={false}
                           onClick={[Function]}
+                          onKeyDown={[Function]}
+                          tabIndex={0}
+                          type="button"
                         >
                           Health
-                        </a>
+                        </button>
                       </li>
                     </ul>
                   </a>
@@ -3025,6 +3068,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                           data-testid="suite-header-app-switcher--all-applications"
                           disabled={false}
                           onClick={[Function]}
+                          onKeyDown={[Function]}
                           tabIndex={0}
                           type="button"
                         >
@@ -3053,25 +3097,35 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                         className="iot--suite-header-app-switcher--app-link"
                         id="suite-header-application-monitor"
                       >
-                        <a
+                        <button
+                          aria-pressed={null}
+                          className="iot--btn bx--btn bx--btn--ghost"
                           data-testid="suite-header-app-switcher--monitor"
-                          href="javascript:void(0)"
+                          disabled={false}
                           onClick={[Function]}
+                          onKeyDown={[Function]}
+                          tabIndex={0}
+                          type="button"
                         >
                           Monitor
-                        </a>
+                        </button>
                       </li>
                       <li
                         className="iot--suite-header-app-switcher--app-link"
                         id="suite-header-application-health"
                       >
-                        <a
+                        <button
+                          aria-pressed={null}
+                          className="iot--btn bx--btn bx--btn--ghost"
                           data-testid="suite-header-app-switcher--health"
-                          href="javascript:void(0)"
+                          disabled={false}
                           onClick={[Function]}
+                          onKeyDown={[Function]}
+                          tabIndex={0}
+                          type="button"
                         >
                           Health
-                        </a>
+                        </button>
                       </li>
                     </ul>
                   </a>
@@ -4064,6 +4118,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                           data-testid="suite-header-app-switcher--all-applications"
                           disabled={false}
                           onClick={[Function]}
+                          onKeyDown={[Function]}
                           tabIndex={0}
                           type="button"
                         >
@@ -4092,25 +4147,35 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                         className="iot--suite-header-app-switcher--app-link"
                         id="suite-header-application-monitor"
                       >
-                        <a
+                        <button
+                          aria-pressed={null}
+                          className="iot--btn bx--btn bx--btn--ghost"
                           data-testid="suite-header-app-switcher--monitor"
-                          href="javascript:void(0)"
+                          disabled={false}
                           onClick={[Function]}
+                          onKeyDown={[Function]}
+                          tabIndex={0}
+                          type="button"
                         >
                           Monitor
-                        </a>
+                        </button>
                       </li>
                       <li
                         className="iot--suite-header-app-switcher--app-link"
                         id="suite-header-application-health"
                       >
-                        <a
+                        <button
+                          aria-pressed={null}
+                          className="iot--btn bx--btn bx--btn--ghost"
                           data-testid="suite-header-app-switcher--health"
-                          href="javascript:void(0)"
+                          disabled={false}
                           onClick={[Function]}
+                          onKeyDown={[Function]}
+                          tabIndex={0}
+                          type="button"
                         >
                           Health
-                        </a>
+                        </button>
                       </li>
                     </ul>
                   </a>
@@ -5275,6 +5340,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                           data-testid="suite-header-app-switcher--all-applications"
                           disabled={false}
                           onClick={[Function]}
+                          onKeyDown={[Function]}
                           tabIndex={0}
                           type="button"
                         >
@@ -5303,25 +5369,35 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                         className="iot--suite-header-app-switcher--app-link"
                         id="suite-header-application-monitor"
                       >
-                        <a
+                        <button
+                          aria-pressed={null}
+                          className="iot--btn bx--btn bx--btn--ghost"
                           data-testid="suite-header-app-switcher--monitor"
-                          href="javascript:void(0)"
+                          disabled={false}
                           onClick={[Function]}
+                          onKeyDown={[Function]}
+                          tabIndex={0}
+                          type="button"
                         >
                           Monitor
-                        </a>
+                        </button>
                       </li>
                       <li
                         className="iot--suite-header-app-switcher--app-link"
                         id="suite-header-application-health"
                       >
-                        <a
+                        <button
+                          aria-pressed={null}
+                          className="iot--btn bx--btn bx--btn--ghost"
                           data-testid="suite-header-app-switcher--health"
-                          href="javascript:void(0)"
+                          disabled={false}
                           onClick={[Function]}
+                          onKeyDown={[Function]}
+                          tabIndex={0}
+                          type="button"
                         >
                           Health
-                        </a>
+                        </button>
                       </li>
                     </ul>
                   </a>

--- a/packages/react/src/components/SuiteHeader/_suite-header.scss
+++ b/packages/react/src/components/SuiteHeader/_suite-header.scss
@@ -160,7 +160,7 @@
   }
 
   &--app-link {
-    a {
+    button {
       @include type-style('productive-heading-01');
       text-decoration: none;
       color: $text-02;

--- a/packages/react/src/utils/componentUtilityFunctions.js
+++ b/packages/react/src/utils/componentUtilityFunctions.js
@@ -392,3 +392,16 @@ export const isNumberValidForMinMax = (value, min, max) => {
   }
   return valid;
 };
+
+/**
+ * Given an array of keys and a callback, fire the callback only when the event.key matches one of the keys included in the array
+ *
+ * @param {string[]} keys An array of key names you want to match and fire the callback on
+ * @param {func} callback A callback to be fired when the specific keys are pressed
+ * @returns void
+ */
+export const handleSpecificKeyDown = (keys, callback) => (evt) => {
+  if (keys.includes(evt.key)) {
+    callback(evt);
+  }
+};


### PR DESCRIPTION
Closes #2324 

**Summary**

- fixes keyboard navigation in the application switcher by adding keyDown handlers
- fixes nested A tags by changing the inner A tag to a Button.

**Change List (commits, features, bugs, etc)**

- add onKeyDown handlers for keyboard navigation
- add keyboard navigation tests

**Acceptance Test (how to verify the PR)**

- open the default SuiteHeader story
- click on the 9-dot menu to open to the application switcher panel
- tab navigate to the monitor or health links
- press enter or space to trigger those links
- confirm links take you to the new page

**Regression Test (how to make sure this PR doesn't break old functionality)**

- no other changes to suiteheader.
