### PR TITLE
feat(cardeditor): support custom settings panels for all card types, even default ones

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
@@ -146,7 +146,6 @@ const CardEditFormContent = ({
   );
 
   const editContentSections = renderEditContent && renderEditContent(onChange, cardConfig);
-
   return (
     <>
       <CommonCardEditFormFields
@@ -160,6 +159,7 @@ const CardEditFormContent = ({
         setSelectedTimeRange={setSelectedTimeRange}
         translateWithId={handleTranslation}
       />
+
       {type === CARD_TYPES.IMAGE ? (
         <ImageCardFormContent
           cardConfig={cardConfig}
@@ -207,14 +207,15 @@ const CardEditFormContent = ({
           dataSeriesItemLinks={dataSeriesItemLinks}
           translateWithId={handleTranslation}
         />
-      ) : Array.isArray(editContentSections) ? (
-        editContentSections.map(({ header: { title, tooltip }, content }) => (
-          <>
-            <ContentFormItemTitle title={title} tooltip={tooltip} />
-            {content}
-          </>
-        ))
       ) : null}
+      {Array.isArray(editContentSections) // render the content sections for all types of card if set
+        ? editContentSections.map(({ header: { title, tooltip }, content }) => (
+            <>
+              <ContentFormItemTitle title={title} tooltip={tooltip} />
+              {content}
+            </>
+          ))
+        : null}
     </>
   );
 };

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
@@ -210,10 +210,10 @@ const CardEditFormContent = ({
       ) : null}
       {Array.isArray(editContentSections) // render the content sections for all types of card if set
         ? editContentSections.map(({ header: { title, tooltip }, content }) => (
-            <>
+            <React.Fragment key="custom-content-section">
               <ContentFormItemTitle title={title} tooltip={tooltip} />
               {content}
-            </>
+            </React.Fragment>
           ))
         : null}
     </>

--- a/packages/react/src/components/CardEditor/CardEditor.story.jsx
+++ b/packages/react/src/components/CardEditor/CardEditor.story.jsx
@@ -308,6 +308,7 @@ const renderCustomEditContent = (onChange, cardConfig) => {
       header: { title: 'customTitle', tooltip: { tooltipText: 'Custom Tooltip' } },
       content: (
         <TextInput
+          id="custom-content-textinput"
           value={cardConfig.title}
           labelText="Title"
           onChange={(event) => onChange({ ...cardConfig, title: event.currentTarget.value })}

--- a/packages/react/src/components/CardEditor/CardEditor.story.jsx
+++ b/packages/react/src/components/CardEditor/CardEditor.story.jsx
@@ -3,9 +3,14 @@ import { action } from '@storybook/addon-actions';
 import { withKnobs, object } from '@storybook/addon-knobs';
 import { EscalatorDown } from '@carbon/pictograms-react';
 import { Basketball32, Code24 } from '@carbon/icons-react';
+import { TextInput } from 'carbon-components-react';
 
 import munichBuilding from '../ImageCard/MunichBuilding.png';
-import { CARD_SIZES, DASHBOARD_EDITOR_CARD_TYPES } from '../../constants/LayoutConstants';
+import {
+  CARD_TYPES,
+  CARD_SIZES,
+  DASHBOARD_EDITOR_CARD_TYPES,
+} from '../../constants/LayoutConstants';
 import StoryNotice, { experimentalStoryTitle } from '../../internal/StoryNotice';
 
 import CardEditor from './CardEditor';
@@ -295,4 +300,79 @@ export const WithTooltipLink = () => (
 
 Default.story = {
   name: 'default',
+};
+
+const renderCustomEditContent = (onChange, cardConfig) => {
+  return [
+    {
+      header: { title: 'customTitle', tooltip: { tooltipText: 'Custom Tooltip' } },
+      content: (
+        <TextInput
+          value={cardConfig.title}
+          labelText="Title"
+          onChange={(event) => onChange({ ...cardConfig, title: event.currentTarget.value })}
+        />
+      ),
+    },
+  ];
+};
+
+export const TimeSeriesCardWithCustom = () => {
+  return (
+    <div style={{ position: 'absolute', right: 0, height: 'calc(100vh - 6rem)' }}>
+      <CardEditor
+        cardConfig={{
+          renderEditContent: renderCustomEditContent,
+          type: CARD_TYPES.TIMESERIES,
+          content: {
+            attributes: [
+              {
+                dataSourceId: 'discharge_flow_rate',
+                label: 'Discharge flow',
+                precision: 3,
+              },
+              {
+                dataSourceId: 'discharge_perc',
+                label: 'Max Discharge %',
+                precision: 3,
+              },
+            ],
+          },
+          dataSource: {
+            attributes: [
+              {
+                aggregator: 'mean',
+                attribute: 'discharge_flow_rate',
+                id: 'discharge_flow_rate',
+              },
+              {
+                aggregator: 'max',
+                attribute: 'discharge_perc',
+                id: 'discharge_perc',
+              },
+            ],
+          },
+          id: 'calculated',
+          size: 'MEDIUMTHIN',
+          title: 'Calculated',
+        }}
+        dataItems={[
+          { dataItemId: 'torque', dataSourceId: 'torque_max', label: 'Torque Max' },
+          { dataItemId: 'torque', dataSourceId: 'torque_min', label: 'Torque Min' },
+          { dataItemId: 'torque', dataSourceId: 'torque_mean', label: 'Torque Mean' },
+          { dataItemId: 'temperature', dataSourceId: 'temperature', label: 'Temperature' },
+          { dataItemId: 'pressure', dataSourceId: 'pressure', label: 'Pressure' },
+        ]}
+        errors={{}}
+        onShowGallery={action('onShowGallery')}
+        onChange={action('onChange')}
+        onAddCard={action('onAddCard')}
+        dataSeriesItemLinks={{ value: 'www.ibm.com' }}
+      />
+    </div>
+  );
+};
+
+TimeSeriesCardWithCustom.story = {
+  name: 'custom edit content',
 };

--- a/packages/react/src/components/CardEditor/__snapshots__/CardEditor.story.storyshot
+++ b/packages/react/src/components/CardEditor/__snapshots__/CardEditor.story.storyshot
@@ -1130,6 +1130,914 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT Experimental/☢️ CardEditor custom edit content 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "height": "calc(100vh - 6rem)",
+          "position": "absolute",
+          "right": 0,
+        }
+      }
+    >
+      <div
+        className="iot--card-editor"
+        data-testid="card-editor"
+      >
+        <div
+          className="iot--card-editor--header"
+        >
+          <button
+            aria-pressed={null}
+            className="gallery-button iot--btn bx--btn bx--btn--sm bx--btn--ghost"
+            data-testid="Button"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            Add card
+            <svg
+              aria-hidden={true}
+              className="bx--btn__icon"
+              fill="currentColor"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M4 2v2H2V2h2zm1-1H1v4h4V1zM9 2v2H7V2h2zm1-1H6v4h4V1zM14 2v2h-2V2h2zm1-1h-4v4h4V1zM4 7v2H2V7h2zm1-1H1v4h4V6zM9 7v2H7V7h2zm1-1H6v4h4V6zM14 7v2h-2V7h2zm1-1h-4v4h4V6zM4 12v2H2v-2h2zm1-1H1v4h4v-4zM9 12v2H7v-2h2zm1-1H6v4h4v-4zM14 12v2h-2v-2h2zm1-1h-4v4h4v-4z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className="iot--card-editor--content"
+        >
+          <div
+            className="iot--card-edit-form"
+          >
+            <div
+              className="bx--tabs--scrollable"
+              onScroll={[Function]}
+              selected={0}
+            >
+              <button
+                aria-hidden="true"
+                aria-label="Scroll left"
+                className="bx--tab--overflow-nav-button--hidden"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                tabIndex="-1"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  fill="currentColor"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M5 8L10 3 10.7 3.7 6.4 8 10.7 12.3 10 13z"
+                  />
+                </svg>
+              </button>
+              <ul
+                className="bx--tabs--scrollable__nav"
+                role="tablist"
+                tabIndex={-1}
+              >
+                <li
+                  className="bx--tabs--scrollable__nav-item bx--tabs__nav-item--selected bx--tabs--scrollable__nav-item--selected"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="presentation"
+                >
+                  <button
+                    aria-controls="tab-11__panel"
+                    aria-selected={true}
+                    className="bx--tabs--scrollable__nav-link"
+                    href="#"
+                    id="tab-11"
+                    role="tab"
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Content
+                  </button>
+                </li>
+                <li
+                  className="bx--tabs--scrollable__nav-item"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="presentation"
+                >
+                  <button
+                    aria-controls="tab-12__panel"
+                    aria-selected={false}
+                    className="bx--tabs--scrollable__nav-link"
+                    href="#"
+                    id="tab-12"
+                    role="tab"
+                    tabIndex={-1}
+                    type="button"
+                  >
+                    Settings
+                  </button>
+                </li>
+              </ul>
+              <button
+                aria-hidden="true"
+                aria-label="Scroll right"
+                className="bx--tab--overflow-nav-button--hidden"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                tabIndex="-1"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  fill="currentColor"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                  />
+                </svg>
+              </button>
+            </div>
+            <div
+              className="bx--tab-content"
+              hidden={false}
+              role="tabpanel"
+              selected={true}
+              tabIndex={0}
+            >
+              <div
+                className="iot--card-edit-form--input"
+              >
+                <div
+                  className="bx--form-item bx--text-input-wrapper bx--text-input-wrapper--light"
+                >
+                  <label
+                    className="bx--label"
+                    htmlFor="calculated_title"
+                  >
+                    Card title
+                  </label>
+                  <div
+                    className="bx--text-input__field-outer-wrapper"
+                  >
+                    <div
+                      className="bx--text-input__field-wrapper"
+                      data-invalid={null}
+                    >
+                      <input
+                        className="bx--text-input bx--text__input bx--text-input--light"
+                        disabled={false}
+                        id="calculated_title"
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        type="text"
+                        value="Calculated"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--card-edit-form--input"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <label
+                    className="bx--label"
+                    htmlFor="calculated_description"
+                  >
+                    Description (Optional)
+                  </label>
+                  <div
+                    className="bx--text-area__wrapper"
+                    data-invalid={null}
+                  >
+                    <textarea
+                      aria-describedby={null}
+                      aria-invalid={null}
+                      className="bx--text-area bx--text-area--light"
+                      cols={50}
+                      disabled={false}
+                      id="calculated_description"
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      placeholder={null}
+                      rows={4}
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--card-edit-form--input"
+              >
+                <div
+                  className="bx--dropdown__wrapper bx--list-box__wrapper"
+                >
+                  <label
+                    className="bx--label"
+                    htmlFor="downshift-0-toggle-button"
+                    id="downshift-0-label"
+                  >
+                    Size
+                  </label>
+                  <div
+                    className="bx--dropdown bx--dropdown--light bx--list-box bx--list-box--light"
+                    id="calculated_size"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                  >
+                    <button
+                      aria-disabled={false}
+                      aria-expanded={false}
+                      aria-haspopup="listbox"
+                      aria-labelledby="downshift-0-label downshift-0-toggle-button"
+                      className="bx--list-box__field"
+                      disabled={false}
+                      id="downshift-0-toggle-button"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--list-box__label"
+                      >
+                        Medium thin (4x2)
+                      </span>
+                      <div
+                        className="bx--list-box__menu-icon"
+                      >
+                        <svg
+                          aria-label="Open menu"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          name="chevron--down"
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                          />
+                          <title>
+                            Open menu
+                          </title>
+                        </svg>
+                      </div>
+                    </button>
+                    <div
+                      aria-labelledby="downshift-0-label"
+                      className="bx--list-box__menu"
+                      id="downshift-0-menu"
+                      onBlur={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseLeave={[Function]}
+                      role="listbox"
+                      tabIndex={-1}
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--card-edit-form--input"
+              >
+                <div
+                  className="bx--dropdown__wrapper bx--list-box__wrapper"
+                  title="Select a time range"
+                >
+                  <label
+                    className="bx--label"
+                    htmlFor="downshift-1-toggle-button"
+                    id="downshift-1-label"
+                  >
+                    Time range
+                  </label>
+                  <div
+                    className="bx--dropdown bx--dropdown--light bx--list-box bx--list-box--light"
+                    id="calculated_time_range"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                  >
+                    <button
+                      aria-disabled={false}
+                      aria-expanded={false}
+                      aria-haspopup="listbox"
+                      aria-labelledby="downshift-1-label downshift-1-toggle-button"
+                      className="bx--list-box__field"
+                      disabled={false}
+                      id="downshift-1-toggle-button"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--list-box__label"
+                      >
+                        Select a time range
+                      </span>
+                      <div
+                        className="bx--list-box__menu-icon"
+                      >
+                        <svg
+                          aria-label="Open menu"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          name="chevron--down"
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                          />
+                          <title>
+                            Open menu
+                          </title>
+                        </svg>
+                      </div>
+                    </button>
+                    <div
+                      aria-labelledby="downshift-1-label"
+                      className="bx--list-box__menu"
+                      id="downshift-1-menu"
+                      onBlur={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseLeave={[Function]}
+                      role="listbox"
+                      tabIndex={-1}
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--card-edit-form--form-section"
+              >
+                <div>
+                  Data
+                </div>
+                <div>
+                  <div
+                    className="bx--tooltip__label"
+                    id="card-edit-form-Data"
+                  >
+                    <div
+                      aria-describedby={null}
+                      className="bx--tooltip__trigger"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onContextMenu={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseOut={[Function]}
+                      onMouseOver={[Function]}
+                      role="button"
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-hidden={true}
+                        description={null}
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role={null}
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
+                        />
+                        <path
+                          d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--card-edit-form--input"
+              >
+                <div
+                  className="iot--combobox"
+                  data-edit-option-text="Create"
+                  data-testid="combo-wrapper"
+                  onBlur={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  <div
+                    className="bx--list-box__wrapper"
+                  >
+                    <label
+                      className="bx--label"
+                      htmlFor="calculated_dataSourceIds-combobox"
+                      id="downshift-2-label"
+                    >
+                      Data item
+                    </label>
+                    <div
+                      className="bx--combo-box iot--combobox-input bx--list-box bx--list-box--light"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                    >
+                      <div
+                        className="bx--list-box__field"
+                      >
+                        <input
+                          aria-activedescendant={null}
+                          aria-autocomplete="list"
+                          aria-controls={null}
+                          aria-expanded={false}
+                          aria-haspopup="listbox"
+                          aria-labelledby={null}
+                          autoComplete="off"
+                          className="bx--text-input bx--text-input--empty"
+                          data-testid="editor--data-series--combobox"
+                          disabled={false}
+                          id="calculated_dataSourceIds-combobox"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          placeholder="Filter"
+                          role="combobox"
+                          tabIndex="0"
+                          type="text"
+                          value=""
+                        />
+                        
+                        <button
+                          aria-haspopup={true}
+                          aria-label="Open menu"
+                          className="bx--list-box__menu-icon"
+                          data-toggle={true}
+                          disabled={false}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseUp={[Function]}
+                          role="button"
+                          tabIndex="-1"
+                          title="Open menu"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden={true}
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                      <div
+                        aria-label="Choose an item"
+                        aria-labelledby={null}
+                        className="bx--list-box__menu"
+                        id="downshift-2-menu"
+                        role="listbox"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--list iot--card-edit-form--data-item-list"
+              >
+                <div
+                  className="iot--list-header-container"
+                />
+                <div
+                  className="iot--list--content"
+                >
+                  <div />
+                </div>
+              </div>
+              <div
+                className="iot--card-edit-form--form-section"
+              >
+                <div>
+                  customTitle
+                </div>
+                <div>
+                  <div
+                    className="bx--tooltip__label"
+                    id="card-edit-form-customTitle"
+                  >
+                    <div
+                      aria-describedby={null}
+                      className="bx--tooltip__trigger"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onContextMenu={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseOut={[Function]}
+                      onMouseOver={[Function]}
+                      role="button"
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-hidden={true}
+                        description={null}
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role={null}
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
+                        />
+                        <path
+                          d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="bx--form-item bx--text-input-wrapper"
+              >
+                <label
+                  className="bx--label"
+                >
+                  Title
+                </label>
+                <div
+                  className="bx--text-input__field-outer-wrapper"
+                >
+                  <div
+                    className="bx--text-input__field-wrapper"
+                    data-invalid={null}
+                  >
+                    <input
+                      className="bx--text-input bx--text__input"
+                      disabled={false}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      type="text"
+                      value="Calculated"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="bx--tab-content"
+              hidden={true}
+              role="tabpanel"
+              selected={false}
+              tabIndex={0}
+            >
+              <div
+                className="iot--card-edit-form--input"
+              >
+                <div
+                  className="bx--form-item bx--text-input-wrapper bx--text-input-wrapper--light"
+                >
+                  <label
+                    className="bx--label"
+                    htmlFor="calculated_title"
+                  >
+                    X-axis label
+                  </label>
+                  <div
+                    className="bx--text-input__field-outer-wrapper"
+                  >
+                    <div
+                      className="bx--text-input__field-wrapper"
+                      data-invalid={null}
+                    >
+                      <input
+                        className="bx--text-input bx--text__input bx--text-input--light"
+                        disabled={false}
+                        id="calculated_title"
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        type="text"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--card-edit-form--input"
+              >
+                <div
+                  className="bx--form-item bx--text-input-wrapper bx--text-input-wrapper--light"
+                >
+                  <label
+                    className="bx--label"
+                    htmlFor="calculated_y-axis-label"
+                  >
+                    Y-axis label
+                  </label>
+                  <div
+                    className="bx--text-input__field-outer-wrapper"
+                  >
+                    <div
+                      className="bx--text-input__field-wrapper"
+                      data-invalid={null}
+                    >
+                      <input
+                        className="bx--text-input bx--text__input bx--text-input--light"
+                        disabled={false}
+                        id="calculated_y-axis-label"
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        type="text"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--card-edit-form--input"
+              >
+                <div
+                  className="bx--form-item bx--text-input-wrapper bx--text-input-wrapper--light"
+                >
+                  <label
+                    className="bx--label"
+                    htmlFor="calculated_unit-selection"
+                  >
+                    Unit
+                  </label>
+                  <div
+                    className="bx--text-input__field-outer-wrapper"
+                  >
+                    <div
+                      className="bx--text-input__field-wrapper"
+                      data-invalid={null}
+                    >
+                      <input
+                        className="bx--text-input bx--text__input bx--text-input--light"
+                        disabled={false}
+                        id="calculated_unit-selection"
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        type="text"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--card-edit-form--input"
+              >
+                <div
+                  className="bx--form-item bx--text-input-wrapper bx--text-input-wrapper--light"
+                >
+                  <label
+                    className="bx--label"
+                    htmlFor="calculated_decimal-precision"
+                  >
+                    Decimal precision
+                  </label>
+                  <div
+                    className="bx--text-input__field-outer-wrapper"
+                  >
+                    <div
+                      className="bx--text-input__field-wrapper"
+                      data-invalid={null}
+                    >
+                      <input
+                        className="bx--text-input bx--text__input bx--text-input--light"
+                        disabled={false}
+                        id="calculated_decimal-precision"
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        type="text"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--card-edit-form--input--toggle-field iot--card-edit-form--input"
+              >
+                <span>
+                  Include zero on x-axis
+                </span>
+                <div
+                  className="bx--form-item"
+                >
+                  <input
+                    aria-label={null}
+                    className="bx--toggle-input bx--toggle-input--small"
+                    data-testid="includeZeroOnXaxis-toggle"
+                    defaultChecked={false}
+                    id="includeZeroOnXaxis-toggle"
+                    onChange={[Function]}
+                    onKeyUp={[Function]}
+                    type="checkbox"
+                  />
+                  <label
+                    aria-label="Include zero on x-axis"
+                    className="bx--toggle-input__label"
+                    htmlFor="includeZeroOnXaxis-toggle"
+                  >
+                    <span
+                      className="bx--toggle__switch"
+                    >
+                      <svg
+                        className="bx--toggle__check"
+                        height="5px"
+                        viewBox="0 0 6 5"
+                        width="6px"
+                      >
+                        <path
+                          d="M2.2 2.7L5 0 6 1 2.2 5 0 2.7 1 1.5z"
+                        />
+                      </svg>
+                      <span
+                        aria-hidden="true"
+                        className="bx--toggle__text--off"
+                      >
+                        
+                      </span>
+                      <span
+                        aria-hidden="true"
+                        className="bx--toggle__text--on"
+                      >
+                        
+                      </span>
+                    </span>
+                  </label>
+                </div>
+              </div>
+              <div
+                className="iot--card-edit-form--input--toggle-field iot--card-edit-form--input"
+              >
+                <span>
+                  Include zero on y-axis
+                </span>
+                <div
+                  className="bx--form-item"
+                >
+                  <input
+                    aria-label={null}
+                    className="bx--toggle-input bx--toggle-input--small"
+                    data-testid="includeZeroOnYaxis-toggle"
+                    defaultChecked={false}
+                    id="includeZeroOnYaxis-toggle"
+                    onChange={[Function]}
+                    onKeyUp={[Function]}
+                    type="checkbox"
+                  />
+                  <label
+                    aria-label="Include zero on y-axis"
+                    className="bx--toggle-input__label"
+                    htmlFor="includeZeroOnYaxis-toggle"
+                  >
+                    <span
+                      className="bx--toggle__switch"
+                    >
+                      <svg
+                        className="bx--toggle__check"
+                        height="5px"
+                        viewBox="0 0 6 5"
+                        width="6px"
+                      >
+                        <path
+                          d="M2.2 2.7L5 0 6 1 2.2 5 0 2.7 1 1.5z"
+                        />
+                      </svg>
+                      <span
+                        aria-hidden="true"
+                        className="bx--toggle__text--off"
+                      >
+                        
+                      </span>
+                      <span
+                        aria-hidden="true"
+                        className="bx--toggle__text--on"
+                      >
+                        
+                      </span>
+                    </span>
+                  </label>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--card-edit-form--footer"
+            >
+              <button
+                aria-pressed={null}
+                className="iot--btn bx--btn bx--btn--sm bx--btn--tertiary"
+                data-testid="card-edit-form-open-editor-button"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Open JSON editor
+                <svg
+                  aria-hidden={true}
+                  className="bx--btn__icon"
+                  fill="currentColor"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M31 16L24 23 22.59 21.59 28.17 16 22.59 10.41 24 9 31 16zM1 16L8 9 9.41 10.41 3.83 16 9.41 21.59 8 23 1 16z"
+                  />
+                  <path
+                    d="M5.91 15H26.080000000000002V17H5.91z"
+                    transform="rotate(-75 15.996 16)"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT Experimental/☢️ CardEditor default 1`] = `
 <div
   className="storybook-container"

--- a/packages/react/src/components/CardEditor/__snapshots__/CardEditor.story.storyshot
+++ b/packages/react/src/components/CardEditor/__snapshots__/CardEditor.story.storyshot
@@ -1713,6 +1713,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
               >
                 <label
                   className="bx--label"
+                  htmlFor="custom-content-textinput"
                 >
                   Title
                 </label>
@@ -1726,6 +1727,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     <input
                       className="bx--text-input bx--text__input"
                       disabled={false}
+                      id="custom-content-textinput"
                       onChange={[Function]}
                       onClick={[Function]}
                       type="text"

--- a/packages/react/src/components/ComboBox/__snapshots__/ComboBox.story.storyshot
+++ b/packages/react/src/components/ComboBox/__snapshots__/ComboBox.story.storyshot
@@ -133,7 +133,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
           </div>
           <div
             className="bx--form__helper-text"
-            id="combobox-helper-text-7"
+            id="combobox-helper-text-8"
           >
             Optional helper text here
           </div>
@@ -293,7 +293,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
           </div>
           <div
             className="bx--form__helper-text"
-            id="combobox-helper-text-2"
+            id="combobox-helper-text-3"
           >
             Optional helper text here
           </div>
@@ -437,7 +437,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
           </div>
           <div
             className="bx--form__helper-text"
-            id="combobox-helper-text-3"
+            id="combobox-helper-text-4"
           >
             Optional helper text here
           </div>
@@ -581,7 +581,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
           </div>
           <div
             className="bx--form__helper-text"
-            id="combobox-helper-text-6"
+            id="combobox-helper-text-7"
           >
             Optional helper text here
           </div>
@@ -740,7 +740,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
         </div>
         <div
           className="bx--form__helper-text"
-          id="combobox-helper-text-4"
+          id="combobox-helper-text-5"
         >
           Optional helper text here
         </div>
@@ -899,7 +899,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
           </div>
           <div
             className="bx--form__helper-text"
-            id="combobox-helper-text-5"
+            id="combobox-helper-text-6"
           >
             Optional helper text here
           </div>

--- a/packages/react/src/components/HotspotEditorModal/__snapshots__/HotspotEditorModal.story.storyshot
+++ b/packages/react/src/components/HotspotEditorModal/__snapshots__/HotspotEditorModal.story.storyshot
@@ -333,11 +333,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                   role="presentation"
                 >
                   <button
-                    aria-controls="tab-11__panel"
+                    aria-controls="tab-13__panel"
                     aria-selected={true}
                     className="bx--tabs--scrollable__nav-link"
                     href="#"
-                    id="tab-11"
+                    id="tab-13"
                     role="tab"
                     tabIndex={0}
                     type="button"
@@ -352,11 +352,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                   role="presentation"
                 >
                   <button
-                    aria-controls="tab-12__panel"
+                    aria-controls="tab-14__panel"
                     aria-selected={false}
                     className="bx--tabs--scrollable__nav-link"
                     href="#"
-                    id="tab-12"
+                    id="tab-14"
                     role="tab"
                     tabIndex={-1}
                     type="button"
@@ -832,11 +832,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                   role="presentation"
                 >
                   <button
-                    aria-controls="tab-13__panel"
+                    aria-controls="tab-15__panel"
                     aria-selected={true}
                     className="bx--tabs--scrollable__nav-link"
                     href="#"
-                    id="tab-13"
+                    id="tab-15"
                     role="tab"
                     tabIndex={0}
                     type="button"
@@ -851,11 +851,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                   role="presentation"
                 >
                   <button
-                    aria-controls="tab-14__panel"
+                    aria-controls="tab-16__panel"
                     aria-selected={false}
                     className="bx--tabs--scrollable__nav-link"
                     href="#"
-                    id="tab-14"
+                    id="tab-16"
                     role="tab"
                     tabIndex={-1}
                     type="button"
@@ -1801,11 +1801,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                   role="presentation"
                 >
                   <button
-                    aria-controls="tab-15__panel"
+                    aria-controls="tab-17__panel"
                     aria-selected={true}
                     className="bx--tabs--scrollable__nav-link"
                     href="#"
-                    id="tab-15"
+                    id="tab-17"
                     role="tab"
                     tabIndex={0}
                     type="button"
@@ -1820,11 +1820,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                   role="presentation"
                 >
                   <button
-                    aria-controls="tab-16__panel"
+                    aria-controls="tab-18__panel"
                     aria-selected={false}
                     className="bx--tabs--scrollable__nav-link"
                     href="#"
-                    id="tab-16"
+                    id="tab-18"
                     role="tab"
                     tabIndex={-1}
                     type="button"

--- a/packages/react/src/components/NavigationBar/__snapshots__/NavigationBar.story.storyshot
+++ b/packages/react/src/components/NavigationBar/__snapshots__/NavigationBar.story.storyshot
@@ -108,11 +108,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/N
               role="presentation"
             >
               <button
-                aria-controls="tab-25__panel"
+                aria-controls="tab-27__panel"
                 aria-selected={true}
                 className="bx--tabs--scrollable__nav-link"
                 href="#"
-                id="tab-25"
+                id="tab-27"
                 role="tab"
                 tabIndex={0}
                 type="button"
@@ -127,11 +127,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/N
               role="presentation"
             >
               <button
-                aria-controls="tab-26__panel"
+                aria-controls="tab-28__panel"
                 aria-selected={false}
                 className="bx--tabs--scrollable__nav-link"
                 href="#"
-                id="tab-26"
+                id="tab-28"
                 role="tab"
                 tabIndex={-1}
                 type="button"
@@ -346,11 +346,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/N
               role="presentation"
             >
               <button
-                aria-controls="tab-19__panel"
+                aria-controls="tab-21__panel"
                 aria-selected={true}
                 className="bx--tabs--scrollable__nav-link"
                 href="#"
-                id="tab-19"
+                id="tab-21"
                 role="tab"
                 tabIndex={0}
                 type="button"
@@ -365,11 +365,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/N
               role="presentation"
             >
               <button
-                aria-controls="tab-20__panel"
+                aria-controls="tab-22__panel"
                 aria-selected={false}
                 className="bx--tabs--scrollable__nav-link"
                 href="#"
-                id="tab-20"
+                id="tab-22"
                 role="tab"
                 tabIndex={-1}
                 type="button"
@@ -570,11 +570,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/N
               role="presentation"
             >
               <button
-                aria-controls="tab-21__panel"
+                aria-controls="tab-23__panel"
                 aria-selected={false}
                 className="bx--tabs--scrollable__nav-link"
                 href="#"
-                id="tab-21"
+                id="tab-23"
                 role="tab"
                 tabIndex={-1}
                 type="button"
@@ -589,11 +589,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/N
               role="presentation"
             >
               <button
-                aria-controls="tab-22__panel"
+                aria-controls="tab-24__panel"
                 aria-selected={true}
                 className="bx--tabs--scrollable__nav-link"
                 href="#"
-                id="tab-22"
+                id="tab-24"
                 role="tab"
                 tabIndex={0}
                 type="button"
@@ -794,11 +794,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/N
               role="presentation"
             >
               <button
-                aria-controls="tab-23__panel"
+                aria-controls="tab-25__panel"
                 aria-selected={true}
                 className="bx--tabs--scrollable__nav-link"
                 href="#"
-                id="tab-23"
+                id="tab-25"
                 role="tab"
                 tabIndex={0}
                 type="button"
@@ -813,11 +813,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/N
               role="presentation"
             >
               <button
-                aria-controls="tab-24__panel"
+                aria-controls="tab-26__panel"
                 aria-selected={false}
                 className="bx--tabs--scrollable__nav-link"
                 href="#"
-                id="tab-24"
+                id="tab-26"
                 role="tab"
                 tabIndex={-1}
                 type="button"

--- a/packages/react/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
+++ b/packages/react/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
@@ -621,11 +621,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                     role="presentation"
                   >
                     <button
-                      aria-controls="tab-30__panel"
+                      aria-controls="tab-32__panel"
                       aria-selected={true}
                       className="bx--tabs--scrollable__nav-link"
                       href="#"
-                      id="tab-30"
+                      id="tab-32"
                       role="tab"
                       tabIndex={0}
                       type="button"
@@ -640,11 +640,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                     role="presentation"
                   >
                     <button
-                      aria-controls="tab-31__panel"
+                      aria-controls="tab-33__panel"
                       aria-selected={false}
                       className="bx--tabs--scrollable__nav-link"
                       href="#"
-                      id="tab-31"
+                      id="tab-33"
                       role="tab"
                       tabIndex={-1}
                       type="button"
@@ -659,11 +659,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                     role="presentation"
                   >
                     <button
-                      aria-controls="tab-32__panel"
+                      aria-controls="tab-34__panel"
                       aria-selected={false}
                       className="bx--tabs--scrollable__nav-link"
                       href="#"
-                      id="tab-32"
+                      id="tab-34"
                       role="tab"
                       tabIndex={-1}
                       type="button"
@@ -1961,11 +1961,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                     role="presentation"
                   >
                     <button
-                      aria-controls="tab-33__panel"
+                      aria-controls="tab-35__panel"
                       aria-selected={true}
                       className="bx--tabs--scrollable__nav-link"
                       href="#"
-                      id="tab-33"
+                      id="tab-35"
                       role="tab"
                       tabIndex={0}
                       type="button"
@@ -1980,11 +1980,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                     role="presentation"
                   >
                     <button
-                      aria-controls="tab-34__panel"
+                      aria-controls="tab-36__panel"
                       aria-selected={false}
                       className="bx--tabs--scrollable__nav-link"
                       href="#"
-                      id="tab-34"
+                      id="tab-36"
                       role="tab"
                       tabIndex={-1}
                       type="button"
@@ -1999,11 +1999,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                     role="presentation"
                   >
                     <button
-                      aria-controls="tab-35__panel"
+                      aria-controls="tab-37__panel"
                       aria-selected={false}
                       className="bx--tabs--scrollable__nav-link"
                       href="#"
-                      id="tab-35"
+                      id="tab-37"
                       role="tab"
                       tabIndex={-1}
                       type="button"
@@ -3665,11 +3665,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                     role="presentation"
                   >
                     <button
-                      aria-controls="tab-27__panel"
+                      aria-controls="tab-29__panel"
                       aria-selected={true}
                       className="bx--tabs--scrollable__nav-link"
                       href="#"
-                      id="tab-27"
+                      id="tab-29"
                       role="tab"
                       tabIndex={0}
                       type="button"
@@ -3684,11 +3684,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                     role="presentation"
                   >
                     <button
-                      aria-controls="tab-28__panel"
+                      aria-controls="tab-30__panel"
                       aria-selected={false}
                       className="bx--tabs--scrollable__nav-link"
                       href="#"
-                      id="tab-28"
+                      id="tab-30"
                       role="tab"
                       tabIndex={-1}
                       type="button"
@@ -3703,11 +3703,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                     role="presentation"
                   >
                     <button
-                      aria-controls="tab-29__panel"
+                      aria-controls="tab-31__panel"
                       aria-selected={false}
                       className="bx--tabs--scrollable__nav-link"
                       href="#"
-                      id="tab-29"
+                      id="tab-31"
                       role="tab"
                       tabIndex={-1}
                       type="button"

--- a/packages/react/src/components/RuleBuilder/__snapshots__/RuleBuilder.story.storyshot
+++ b/packages/react/src/components/RuleBuilder/__snapshots__/RuleBuilder.story.storyshot
@@ -182,11 +182,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                 role="presentation"
               >
                 <button
-                  aria-controls="tab-36__panel"
+                  aria-controls="tab-38__panel"
                   aria-selected={true}
                   className="bx--tabs--scrollable__nav-link"
                   href="#"
-                  id="tab-36"
+                  id="tab-38"
                   role="tab"
                   tabIndex={0}
                   type="button"
@@ -201,11 +201,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                 role="presentation"
               >
                 <button
-                  aria-controls="tab-37__panel"
+                  aria-controls="tab-39__panel"
                   aria-selected={false}
                   className="bx--tabs--scrollable__nav-link"
                   href="#"
-                  id="tab-37"
+                  id="tab-39"
                   role="tab"
                   tabIndex={-1}
                   type="button"
@@ -2748,11 +2748,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                 role="presentation"
               >
                 <button
-                  aria-controls="tab-38__panel"
+                  aria-controls="tab-40__panel"
                   aria-selected={true}
                   className="bx--tabs--scrollable__nav-link"
                   href="#"
-                  id="tab-38"
+                  id="tab-40"
                   role="tab"
                   tabIndex={0}
                   type="button"
@@ -2767,11 +2767,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                 role="presentation"
               >
                 <button
-                  aria-controls="tab-39__panel"
+                  aria-controls="tab-41__panel"
                   aria-selected={false}
                   className="bx--tabs--scrollable__nav-link"
                   href="#"
-                  id="tab-39"
+                  id="tab-41"
                   role="tab"
                   tabIndex={-1}
                   type="button"

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -107,7 +107,7 @@ const TimeSeriesCardPropTypes = {
     /** set of thresholds these render dotted lines on the graph to indicate that the line values might be crossing logical thresholds */
     thresholds: PropTypes.arrayOf(
       PropTypes.shape({
-        axis: PropTypes.oneOf('x', 'y'),
+        axis: PropTypes.oneOf(['x', 'y']),
         value: PropTypes.number,
         label: PropTypes.string,
         fillColor: PropTypes.string,
@@ -401,7 +401,9 @@ const TimeSeriesCard = ({
             number: maxTicksPerSize,
             formatter: formatTick,
           },
-          thresholds: thresholds?.filter((threshold) => threshold.axis === 'x'),
+          ...(thresholds?.some((threshold) => threshold.axis === 'x')
+            ? { thresholds: thresholds?.filter((threshold) => threshold.axis === 'x') }
+            : {}),
           includeZero: includeZeroOnXaxis,
           ...(domainRange ? { domain: domainRange } : {}),
         },
@@ -412,7 +414,9 @@ const TimeSeriesCard = ({
             formatter: (axisValue) =>
               chartValueFormatter(axisValue, newSize, null, locale, decimalPrecision),
           },
-          thresholds: thresholds?.filter((threshold) => threshold.axis === 'y'),
+          ...(thresholds?.some((threshold) => threshold.axis === 'y')
+            ? { thresholds: thresholds?.filter((threshold) => threshold.axis === 'y') }
+            : {}),
           ...(chartType !== TIME_SERIES_TYPES.BAR
             ? { yMaxAdjuster: (yMaxValue) => yMaxValue * 1.3 }
             : {}),

--- a/packages/react/src/constants/CardPropTypes.js
+++ b/packages/react/src/constants/CardPropTypes.js
@@ -688,4 +688,8 @@ export const CardPropTypes = {
   locale: PropTypes.string,
   /** a way to pass down dashboard grid resize handles, only used by other card types */
   resizeHandles: PropTypes.array,
+  /** Optional callback function that is passed an onChange function and the original cardConfig function.
+   * This allows additional information to be passed to be used in the Card Editor for this type.
+   * You need to return an array of child objects with a header: {title, tooltip: {tooltipText: PropTypes.string}} and content element to render * */
+  renderEditContent: PropTypes.func,
 };

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -5659,6 +5659,9 @@ Map {
       "onTouchStart": Object {
         "type": "func",
       },
+      "renderEditContent": Object {
+        "type": "func",
+      },
       "renderExpandIcon": Object {
         "args": Array [
           Array [
@@ -11094,6 +11097,9 @@ Map {
       "onTouchStart": Object {
         "type": "func",
       },
+      "renderEditContent": Object {
+        "type": "func",
+      },
       "renderExpandIcon": Object {
         "args": Array [
           Array [
@@ -11959,6 +11965,9 @@ Map {
           },
         ],
         "type": "shape",
+      },
+      "renderEditContent": Object {
+        "type": "func",
       },
       "renderExpandIcon": Object {
         "args": Array [
@@ -12908,6 +12917,9 @@ Map {
       "onTouchStart": Object {
         "type": "func",
       },
+      "renderEditContent": Object {
+        "type": "func",
+      },
       "renderExpandIcon": Object {
         "args": Array [
           Array [
@@ -13635,8 +13647,10 @@ Map {
                     Object {
                       "axis": Object {
                         "args": Array [
-                          "x",
-                          "y",
+                          Array [
+                            "x",
+                            "y",
+                          ],
                         ],
                         "type": "oneOf",
                       },
@@ -13883,6 +13897,9 @@ Map {
         "type": "func",
       },
       "onTouchStart": Object {
+        "type": "func",
+      },
+      "renderEditContent": Object {
         "type": "func",
       },
       "renderExpandIcon": Object {
@@ -14698,6 +14715,9 @@ Map {
         "type": "func",
       },
       "onUpload": Object {
+        "type": "func",
+      },
+      "renderEditContent": Object {
         "type": "func",
       },
       "renderExpandIcon": Object {
@@ -15616,6 +15636,9 @@ Map {
         "type": "func",
       },
       "onTouchStart": Object {
+        "type": "func",
+      },
+      "renderEditContent": Object {
         "type": "func",
       },
       "renderExpandIcon": Object {
@@ -16539,6 +16562,9 @@ Map {
       "onTouchStart": Object {
         "type": "func",
       },
+      "renderEditContent": Object {
+        "type": "func",
+      },
       "renderExpandIcon": Object {
         "args": Array [
           Array [
@@ -17375,6 +17401,9 @@ Map {
         "type": "func",
       },
       "onTouchStart": Object {
+        "type": "func",
+      },
+      "renderEditContent": Object {
         "type": "func",
       },
       "renderExpandIcon": Object {
@@ -20614,6 +20643,9 @@ Map {
         "type": "func",
       },
       "onTouchStart": Object {
+        "type": "func",
+      },
+      "renderEditContent": Object {
         "type": "func",
       },
       "renderExpandIcon": Object {

--- a/yarn.lock
+++ b/yarn.lock
@@ -732,6 +732,14 @@
     "@babel/helper-explode-assignable-expression" "^7.12.13"
     "@babel/types" "^7.12.13"
 
+"@babel/helper-builder-react-jsx@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.12.13.tgz#df6a76fb83feb6b8e6dcfb46bb49010098cb51f0"
+  integrity sha512-QN7Z5FByIOFESQXxoNYVPU7xONzrDW2fv7oKKVkj+62N3Dx1IZaVu/RF9QhV9XyCZE/xiYNfuQ1JsiL1jduT1A==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.12.13"
+    "@babel/types" "^7.12.13"
+
 "@babel/helper-compilation-targets@^7.12.5":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.13.tgz#d689cdef88810aa74e15a7a94186f26a3d773c98"
@@ -8907,21 +8915,6 @@ cheerio@^1.0.0-rc.2:
     htmlparser2 "^3.9.1"
     lodash "^4.15.0"
     parse5 "^3.0.1"
-
-chokidar@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.1.tgz#c84e5b3d18d9a4d77558fef466b1bf16bbeb3450"
-  integrity sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==
-  dependencies:
-    anymatch "~3.1.1"
-    braces "~3.0.2"
-    glob-parent "~5.1.0"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.3.0"
-  optionalDependencies:
-    fsevents "~2.1.2"
 
 "chokidar@>=2.0.0 <4.0.0", "chokidar@>=3.0.0 <4.0.0", chokidar@^3.0.0, chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.5.1:
   version "3.5.1"
@@ -19646,11 +19639,6 @@ picomatch@^2.0.5:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.1.1.tgz#ecdfbea7704adb5fe6fb47f9866c4c0e15e905c5"
   integrity sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==
 
-picomatch@^2.0.7:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.3.tgz#465547f359ccc206d3c48e46a1bcb89bf7ee619d"
-  integrity sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==
-
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -21258,7 +21246,7 @@ react-syntax-highlighter@^13.5.3:
     prismjs "^1.21.0"
     refractor "^3.1.0"
 
-react-test-renderer@16.14.0, react-test-renderer@^16.0.0-0, "react-test-renderer@^16.8.0 || ^17.0.0", react-test-renderer@^16.8.6:
+react-test-renderer@^16.0.0-0, "react-test-renderer@^16.8.0 || ^17.0.0", react-test-renderer@^16.8.6:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.14.0.tgz#e98360087348e260c56d4fe2315e970480c228ae"
   integrity sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==
@@ -21518,13 +21506,6 @@ readdirp@^2.2.1:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
-
-readdirp@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.3.0.tgz#984458d13a1e42e2e9f5841b129e162f369aff17"
-  integrity sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==
-  dependencies:
-    picomatch "^2.0.7"
 
 readdirp@~3.5.0:
   version "3.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8916,6 +8916,21 @@ cheerio@^1.0.0-rc.2:
     lodash "^4.15.0"
     parse5 "^3.0.1"
 
+chokidar@3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.1.tgz#c84e5b3d18d9a4d77558fef466b1bf16bbeb3450"
+  integrity sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.3.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
+
 "chokidar@>=2.0.0 <4.0.0", "chokidar@>=3.0.0 <4.0.0", chokidar@^3.0.0, chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
@@ -19639,6 +19654,11 @@ picomatch@^2.0.5:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.1.1.tgz#ecdfbea7704adb5fe6fb47f9866c4c0e15e905c5"
   integrity sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==
 
+picomatch@^2.0.7:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.3.tgz#465547f359ccc206d3c48e46a1bcb89bf7ee619d"
+  integrity sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==
+
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -21246,7 +21266,7 @@ react-syntax-highlighter@^13.5.3:
     prismjs "^1.21.0"
     refractor "^3.1.0"
 
-react-test-renderer@^16.0.0-0, "react-test-renderer@^16.8.0 || ^17.0.0", react-test-renderer@^16.8.6:
+react-test-renderer@16.14.0, react-test-renderer@^16.0.0-0, "react-test-renderer@^16.8.0 || ^17.0.0", react-test-renderer@^16.8.6:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.14.0.tgz#e98360087348e260c56d4fe2315e970480c228ae"
   integrity sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==
@@ -21506,6 +21526,13 @@ readdirp@^2.2.1:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
+
+readdirp@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.3.0.tgz#984458d13a1e42e2e9f5841b129e162f369aff17"
+  integrity sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==
+  dependencies:
+    picomatch "^2.0.7"
 
 readdirp@~3.5.0:
   version "3.5.0"


### PR DESCRIPTION
Closes #

**Summary**

- Previously only the Custom card types could render custom EditSettingsForm sections.  This adds the capability for all card types

**Change List (commits, features, bugs, etc)**

- feat(CardEditFormContent): show any custom sections if they are included
- fix(TimeSeriesCard): PropTypes for oneOf were incorrect
- fix(CardPropTypes): document the existing renderEditContent prop

**Acceptance Test (how to verify the PR)**

- Verify the new CardEditor story and make sure the custom section shows for the TimeSeriesCard

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Verify that other card types in the CardEditor stories do not render custom content sections
