### PR TITLE
fix(side-nav): remove bad props from story and component

### DIFF
--- a/packages/react/src/components/SideNav/SideNav.jsx
+++ b/packages/react/src/components/SideNav/SideNav.jsx
@@ -58,21 +58,20 @@ export const SideNavPropTypes = {
     })
   ).isRequired,
   isSideNavExpanded: PropTypes.bool,
-  /** An array of strings which will be options of switcher */
-  // switcherProps: PropTypes.obj,
   i18n: PropTypes.shape({
     closeText: PropTypes.string,
     openText: PropTypes.string,
+    sideNavLabelText: PropTypes.string,
   }),
 };
 
 const defaultProps = {
   defaultExpanded: false,
   isSideNavExpanded: false,
-  // switcherProps: null,
   i18n: {
     closeText: 'Close',
     openText: 'Open',
+    sideNavLabelText: 'Side navigation',
   },
 };
 
@@ -130,8 +129,10 @@ const SideNav = ({ links, defaultExpanded, isSideNavExpanded, i18n, ...props }) 
     })
     .filter((i) => i);
 
-  const translateById = (id) =>
-    id !== 'carbon.sidenav.state.closed' ? i18n.closeText : i18n.openText;
+  // TODO: Will be added back in when footer is added for rails.
+  // see: https://github.com/carbon-design-system/carbon/blob/main/packages/react/src/components/UIShell/SideNav.js#L143
+  // const translateById = (id) =>
+  //   id !== 'carbon.sidenav.state.closed' ? i18n.closeText : i18n.openText;
 
   return (
     <CarbonSideNav
@@ -140,13 +141,14 @@ const SideNav = ({ links, defaultExpanded, isSideNavExpanded, i18n, ...props }) 
         [`${prefix}--side-nav--expanded`]: isSideNavExpanded,
       })}
       expanded={isSideNavExpanded}
-      translateById={translateById}
-      aria-label="Side navigation"
+      // TODO: Will be added back in when footer is added for rails.
+      // see: https://github.com/carbon-design-system/carbon/blob/main/packages/react/src/components/UIShell/SideNav.js#L143
+      // translateById={translateById}
+      aria-label={i18n.sideNavLabelText}
       defaultExpanded={defaultExpanded}
       isRail
       {...props} // spreading here as base component does not pass to DOM element.
     >
-      {/* {switcherProps && <SideNavSwitcher {...switcherProps} />} */}
       <SideNavItems>{nav}</SideNavItems>
     </CarbonSideNav>
   );

--- a/packages/react/src/components/SideNav/SideNav.story.jsx
+++ b/packages/react/src/components/SideNav/SideNav.story.jsx
@@ -109,15 +109,6 @@ const links = [
   },
 ];
 
-const switcherProps = {
-  options: ['ExampleOne', 'ExampleTwo'],
-  labelText: 'ExampleOne',
-  onChange: () => {},
-  className: 'class',
-  switcherTitle: 'Applications',
-};
-
-// const link = <Icon name="header--help" fill="white" description="Icon" />;
 const HeaderProps = {
   user: 'JohnDoe@ibm.com',
   tenant: 'TenantId: Acme',
@@ -156,12 +147,7 @@ export const SideNavComponent = () => (
             isSideNavExpanded={isSideNavExpanded}
             onClickSideNavExpand={onClickSideNavExpand}
           />
-          <SideNav
-            links={links}
-            isSideNavExpanded={isSideNavExpanded}
-            onClickSideNavExpand={onClickSideNavExpand}
-            switcherProps={switcherProps}
-          />
+          <SideNav links={links} isSideNavExpanded={isSideNavExpanded} />
           <div className={`${iotPrefix}--main-content`}>
             <PageTitleBar title="Title" description="Description" />
           </div>
@@ -193,7 +179,6 @@ SideNavComponent.story = {
         <SideNav
           links={links}
           isSideNavExpanded={isSideNavExpanded}
-          onClickSideNavExpand={onClickSideNavExpand}
         />
       </>
     )}

--- a/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
+++ b/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
@@ -125,23 +125,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
         aria-label="Side navigation"
         className="bx--side-nav__navigation bx--side-nav bx--side-nav--rail iot--side-nav bx--side-nav--ux"
         onBlur={[Function]}
-        onClickSideNavExpand={[Function]}
         onFocus={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
-        switcherProps={
-          Object {
-            "className": "class",
-            "labelText": "ExampleOne",
-            "onChange": [Function],
-            "options": Array [
-              "ExampleOne",
-              "ExampleTwo",
-            ],
-            "switcherTitle": "Applications",
-          }
-        }
-        translateById={[Function]}
       >
         <ul
           className="bx--side-nav__items"

--- a/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
@@ -3093,7 +3093,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
       onFocus={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
-      translateById={[Function]}
     >
       <ul
         className="bx--side-nav__items"

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -7394,6 +7394,7 @@ Map {
       "i18n": Object {
         "closeText": "Close",
         "openText": "Open",
+        "sideNavLabelText": "Side navigation",
       },
       "isSideNavExpanded": false,
     },
@@ -7408,6 +7409,9 @@ Map {
               "type": "string",
             },
             "openText": Object {
+              "type": "string",
+            },
+            "sideNavLabelText": Object {
               "type": "string",
             },
           },
@@ -7857,6 +7861,9 @@ Map {
                     "type": "string",
                   },
                   "openText": Object {
+                    "type": "string",
+                  },
+                  "sideNavLabelText": Object {
                     "type": "string",
                   },
                 },


### PR DESCRIPTION
Closes #2352 

**Summary**

- translateById was removed from the carbon SideNav, but we were still passing it.

**Change List (commits, features, bugs, etc)**

- comment out translateById and link to comment in carbon about re-adding it at some point
- stop passing `onClickSideNavExpand` to SideNav in SideNav stories
- add i18n prop for for the SideNav aria-label

**Acceptance Test (how to verify the PR)**

- the SideNav story should show no warnings in the console

**Regression Test (how to make sure this PR doesn't break old functionality)**

- The SideNav should continue to work as expected
