### PR TITLE
fix(tablecard): allow row-specific and cardVariables prop

### DIFF
--- a/packages/react/src/components/TableCard/TableCard.jsx
+++ b/packages/react/src/components/TableCard/TableCard.jsx
@@ -179,11 +179,12 @@ const TableCard = ({
   // Set the locale
   dayjs.locale(locale);
   /** Searches for variables and updates the card if it is passed the cardVariables prop */
+  // Need to skip the linkTemplate variable for now because we will handle it at render time per row
   const {
     title,
     content: { columns = [], showHeader, expandedRows, sort, thresholds, emptyMessage },
     values: data,
-  } = handleCardVariables(titleProp, contentProp, valuesProp, others);
+  } = handleCardVariables(titleProp, contentProp, valuesProp, others, ['href']);
 
   // Checks size property against new size naming convention and reassigns to closest supported size if necessary.
   const newSize = getUpdatedCardSize(size);
@@ -288,7 +289,8 @@ const TableCard = ({
 
   const hasActionColumn = data.filter((i) => i.actions).length > 0;
 
-  // If a column has a linkTemplate, format the column to render a link
+  // If a column has a linkTemplate, format the column to render a link,
+  // we need a special case here because this is the only card where we examine the actual data to replace variables in each
   const columnsWithFormattedLinks = createColumnsWithFormattedLinks(columns, others.cardVariables);
 
   // filter to get the indexes for each one

--- a/packages/react/src/components/TableCard/TableCard.jsx
+++ b/packages/react/src/components/TableCard/TableCard.jsx
@@ -291,7 +291,7 @@ const TableCard = ({
 
   // If a column has a linkTemplate, format the column to render a link,
   // we need a special case here because this is the only card where we examine the actual data to replace variables in each
-  const columnsWithFormattedLinks = createColumnsWithFormattedLinks(columns, others.cardVariables);
+  const columnsWithFormattedLinks = createColumnsWithFormattedLinks(columns);
 
   // filter to get the indexes for each one
   const columnsUpdated = cloneDeep(columnsWithFormattedLinks);

--- a/packages/react/src/components/TableCard/TableCard.story.jsx
+++ b/packages/react/src/components/TableCard/TableCard.story.jsx
@@ -54,73 +54,6 @@ WithMultipleActions.story = {
   name: 'with multiple actions',
 };
 
-export const WithLinks = () => {
-  const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGE);
-  const cardVariables = object('Dynamic link variable', {
-    assetId: '11112',
-    company: 'ibm',
-  });
-  const tableLinkColumns = [
-    {
-      dataSourceId: 'pressure',
-      label: 'Pressure',
-    },
-    {
-      dataSourceId: 'deviceId',
-      label: 'Link',
-      linkTemplate: {
-        href: text('href', 'https://{company}.com/{assetId}'),
-        target: select('target', ['_blank', null], '_blank'),
-      },
-    },
-  ];
-
-  const tableLinkData = tableData.slice(0);
-  // eslint-disable-next-line no-return-assign, no-param-reassign
-  tableLinkData.forEach((row) => (row.values.deviceId = 'Link'));
-
-  return (
-    <div
-      style={{
-        width: `${getCardMinSize('lg', size).x}px`,
-        margin: spacing05 + 4,
-      }}
-    >
-      <TableCard
-        title={text('title', 'Open Alerts {assetId}')}
-        id="table-list"
-        tooltip={text('Tooltip text', "Here's a Tooltip")}
-        content={{
-          columns: tableLinkColumns,
-        }}
-        values={tableLinkData}
-        onCardAction={(id, type, payload) => action('onCardAction', id, type, payload)}
-        size={size}
-        isLoading={boolean('isLoading', false)}
-        cardVariables={cardVariables}
-      />
-    </div>
-  );
-};
-
-WithLinks.story = {
-  name: 'With links',
-
-  parameters: {
-    info: {
-      text: `<p>Links can added by providing a linkTemplate prop to the content.columns[i] property.
-                2 additional properties can be configured within the linkTemplate object: href and target</p>
-            <p>href is the url the link will use. This property is required.</p>
-            <p>target is whether you would like to open the link in a new window or not.
-                This property defaults to opening in the current window. Use '_blank' to open in a new window
-            </p>
-            <p> Note: if using row-specific variables in a TableCard href (ie a variable that has a different value per row),
-            do NOT pass the cardVariables prop and be sure that your table has reference to the proper value in another column</p>
-  `,
-    },
-  },
-};
-
 export const WithRowSpecificLinkVariables = () => {
   const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGEWIDE);
 
@@ -182,7 +115,7 @@ export const WithRowSpecificLinkVariables = () => {
       }}
     >
       <TableCard
-        title={text('title', 'Asset Open Alerts')}
+        title={text('title', '{assetId} Open Alerts')}
         id="table-list"
         tooltip={text('Tooltip text', "Here's a Tooltip")}
         content={{
@@ -193,6 +126,9 @@ export const WithRowSpecificLinkVariables = () => {
         onCardAction={(id, type, payload) => action('onCardAction', id, type, payload)}
         size={size}
         isLoading={boolean('isLoading', false)}
+        cardVariables={{
+          assetId: '11112',
+        }}
       />
     </div>
   );
@@ -203,10 +139,15 @@ WithRowSpecificLinkVariables.story = {
 
   parameters: {
     info: {
-      text: ` # Passing variables
-      To pass row-specific variables in a TableCard href (ie a variable that has a different value per row),
-            do NOT pass the cardVariables prop and be sure that your table has reference to the proper value in another column
-      `,
+      text: `<p>Links can added by providing a linkTemplate prop to the content.columns[i] property.
+                2 additional properties can be configured within the linkTemplate object: href and target</p>
+            <p>href is the url the link will use. This property is required.</p>
+            <p>target is whether you would like to open the link in a new window or not.
+                This property defaults to opening in the current window. Use '_blank' to open in a new window
+            </p>
+            <p> Note: if using row-specific variables in a TableCard href (ie a variable that has a different value per row),
+            be sure that your table has reference to the proper value in another column</p>
+  `,
     },
   },
 };

--- a/packages/react/src/components/TableCard/TableCard.test.jsx
+++ b/packages/react/src/components/TableCard/TableCard.test.jsx
@@ -3,77 +3,11 @@ import { mount } from 'enzyme';
 import { render, within, screen } from '@testing-library/react';
 
 import { CARD_SIZES } from '../../constants/LayoutConstants';
-import { tableColumns, tableData, actions2, tableColumnsWithLinks } from '../../utils/sample';
+import { tableColumns, tableData, actions2 } from '../../utils/sample';
 
 import TableCard from './TableCard';
-import { createColumnsWithFormattedLinks, handleExpandedItemLinks } from './tableCardUtils';
 
 describe('TableCard', () => {
-  it('createColumnsWithFormattedLinks adds renderDataFunction to columns with links', () => {
-    const columnsWithFormattedLinks = createColumnsWithFormattedLinks(tableColumnsWithLinks);
-    const columnsWithlinks = columnsWithFormattedLinks.filter(
-      (column) => column.renderDataFunction
-    );
-    expect(columnsWithlinks).toHaveLength(1);
-  });
-  it('handleExpandedItemLinks correctly applies linkTemplates and variables', () => {
-    const row = {
-      alert: 'some-alert',
-      count: 6,
-      hour: 126432112000,
-      pressure: 3,
-      deviceId: 73000,
-    };
-    const expandedRow = [
-      {
-        id: 'count',
-        label: 'Count',
-      },
-      {
-        id: 'deviceId',
-        label: 'Device link',
-        linkTemplate: {
-          href: 'http://ibm.com/{deviceId}',
-        },
-      },
-      {
-        id: 'alert',
-        label: 'Alert Description',
-        linkTemplate: {
-          href: 'http://ibm.com/',
-        },
-      },
-    ];
-    const cardVariables = {
-      variable: 'variable-value',
-    };
-
-    // with row specific variables
-    const updatedRowSpecificExpandedItems = handleExpandedItemLinks(row, expandedRow);
-    expect(updatedRowSpecificExpandedItems).toEqual([
-      {
-        id: 'count',
-        label: 'Count',
-      },
-      {
-        id: 'deviceId',
-        label: 'Device link',
-        linkTemplate: {
-          href: 'http://ibm.com/73000',
-        },
-      },
-      {
-        id: 'alert',
-        label: 'Alert Description',
-        linkTemplate: {
-          href: 'http://ibm.com/',
-        },
-      },
-    ]);
-    // if cardVariables are given, then this function should return its original data
-    const updatedExpandedItems = handleExpandedItemLinks(row, expandedRow, cardVariables);
-    expect(updatedExpandedItems).toEqual(expandedRow);
-  });
   it('Row specific link variables populate correctly', () => {
     const tableLinkColumns = [
       ...tableColumns,
@@ -131,7 +65,7 @@ describe('TableCard', () => {
 
     render(
       <TableCard
-        title="Asset Open Alerts"
+        title="{assetId} Open Alerts"
         id="table-list"
         tooltip="Here's a Tooltip"
         content={{
@@ -140,11 +74,13 @@ describe('TableCard', () => {
         }}
         values={tableLinkData}
         size={CARD_SIZES.LARGE}
+        cardVariables={{ assetId: 'the best asset' }}
       />
     );
     expect(screen.getAllByText('Link').length).toEqual(11);
     expect(document.querySelector('a').getAttribute('href')).toEqual('https://ibm.com/73003');
   });
+
   it('Clicked row actions', () => {
     const onCardAction = jest.fn();
 
@@ -170,56 +106,65 @@ describe('TableCard', () => {
     wrapper.find('.iot--table-card--action-icon').first().simulate('click');
     expect(onCardAction.mock.calls).toHaveLength(1);
   });
-  it('Columns displayed XLarge', () => {
-    const wrapper = mount(
-      <TableCard
-        title="Open Alerts"
-        content={{
-          columns: tableColumns,
-        }}
-        values={tableData}
-        size={CARD_SIZES.LARGEWIDE}
-      />
-    );
-    expect(wrapper.find('TableHeader').length).toBe(tableColumns.length);
-  });
-  it('Columns displayed Large', () => {
-    const wrapper = mount(
-      <TableCard
-        title="Open Alerts"
-        content={{
-          columns: tableColumns,
-        }}
-        values={tableData}
-        size={CARD_SIZES.LARGE}
-      />
-    );
 
-    const totalColumns = tableColumns.filter((item) => item.priority === 1 || item.priority === 2);
-    expect(wrapper.find('TableHeader').length).toBe(totalColumns.length);
-  });
-  it('Columns displayed Large with actions', () => {
-    const tableDataWithActions = tableData.map((item) => {
-      return {
-        ...item,
-        actions: actions2,
-      };
+  describe('Columns displayed', () => {
+    it('XLarge', () => {
+      const wrapper = mount(
+        <TableCard
+          title="Open Alerts"
+          content={{
+            columns: tableColumns,
+          }}
+          values={tableData}
+          size={CARD_SIZES.LARGEWIDE}
+        />
+      );
+      expect(wrapper.find('TableHeader').length).toBe(tableColumns.length);
     });
 
-    const wrapper = mount(
-      <TableCard
-        title="Open Alerts"
-        content={{
-          columns: tableColumns,
-        }}
-        values={tableDataWithActions}
-        size={CARD_SIZES.LARGE}
-      />
-    );
+    it('Large', () => {
+      const wrapper = mount(
+        <TableCard
+          title="Open Alerts"
+          content={{
+            columns: tableColumns,
+          }}
+          values={tableData}
+          size={CARD_SIZES.LARGE}
+        />
+      );
 
-    const totalColumns = tableColumns.filter((item) => item.priority === 1 || item.priority === 2);
-    expect(wrapper.find('TableHeader').length).toBe(totalColumns.length + 1); // +1 for action column
+      const totalColumns = tableColumns.filter(
+        (item) => item.priority === 1 || item.priority === 2
+      );
+      expect(wrapper.find('TableHeader').length).toBe(totalColumns.length);
+    });
+    it('Large with actions', () => {
+      const tableDataWithActions = tableData.map((item) => {
+        return {
+          ...item,
+          actions: actions2,
+        };
+      });
+
+      const wrapper = mount(
+        <TableCard
+          title="Open Alerts"
+          content={{
+            columns: tableColumns,
+          }}
+          values={tableDataWithActions}
+          size={CARD_SIZES.LARGE}
+        />
+      );
+
+      const totalColumns = tableColumns.filter(
+        (item) => item.priority === 1 || item.priority === 2
+      );
+      expect(wrapper.find('TableHeader').length).toBe(totalColumns.length + 1); // +1 for action column
+    });
   });
+
   it('Columns should use custom render fuction when present', () => {
     const mockRenderFunc = jest.fn(() => {
       return <p className="myCustomRenderedCell" />;
@@ -275,253 +220,259 @@ describe('TableCard', () => {
     );
     expect(wrapper2.find('TableCell .myCustomRenderedCell').length).toBe(0);
   });
-  it('threshold columns should render in correct column regardless of order', () => {
-    // The pressure header comes after the count header, but the ordering should not matter when
-    // it comes to rendering the threshold columns
-    const customThresholds = [
-      {
-        dataSourceId: 'pressure',
-        comparison: '>=',
-        value: 10,
-        severity: 1,
-        icon: 'bee',
-        color: 'black',
-        label: 'Pressure Sev',
-      },
-      {
-        dataSourceId: 'count',
-        comparison: '<',
-        value: 5,
-        severity: 3,
-      },
-      {
-        dataSourceId: 'count',
-        comparison: '>=',
-        value: 10,
-        severity: 1,
-      },
-      {
-        dataSourceId: 'count',
-        comparison: '=',
-        value: 7,
-        severity: 2,
-      },
-    ];
-    render(
-      <TableCard
-        id="table-list"
-        title="Open Alerts"
-        content={{
-          columns: tableColumns,
-          thresholds: customThresholds,
-        }}
-        values={tableData}
-        size={CARD_SIZES.LARGEWIDE}
-      />
-    );
 
-    // If the ordering was being affected, Count Severity would not appear. Instead, Pressure Severity would appear
-    expect(screen.getByTitle('Count Severity')).toBeInTheDocument();
-    expect(screen.queryByTitle('Pressure Severity')).not.toBeInTheDocument();
-    expect(screen.getByTitle('Pressure Sev')).toBeInTheDocument();
-  });
-  it('threshold columns should render in correct column regardless of quantity', () => {
-    // If there are more than 2 thresholds, they should still render to the left of the datasource column
-    const customThresholds = [
-      {
-        dataSourceId: 'pressure',
-        comparison: '>=',
-        value: 10,
-        severity: 1,
-      },
-      {
-        dataSourceId: 'count',
-        comparison: '<',
-        value: 5,
-        severity: 3,
-      },
-      {
-        dataSourceId: 'count',
-        comparison: '>=',
-        value: 10,
-        severity: 1,
-      },
-      {
-        dataSourceId: 'count',
-        comparison: '=',
-        value: 7,
-        severity: 2,
-      },
-      {
-        dataSourceId: 'hour',
-        comparison: '<',
-        value: 1563877570000,
-        severity: 1, // High threshold, medium, or low used for sorting and defined filtration
-      },
-    ];
-    // First the component needs to be rendered. getByTitle doesn't need to be used
-    // eslint-disable-next-line no-unused-vars
-    const { getByTitle } = render(
-      <TableCard
-        id="table-list"
-        title="Open Alerts"
-        content={{
-          columns: tableColumns,
-          thresholds: customThresholds,
-        }}
-        values={tableData}
-        size={CARD_SIZES.LARGEWIDE}
-      />
-    );
+  describe('thresholds', () => {
+    it('threshold columns should render in correct column regardless of order', () => {
+      // The pressure header comes after the count header, but the ordering should not matter when
+      // it comes to rendering the threshold columns
+      const customThresholds = [
+        {
+          dataSourceId: 'pressure',
+          comparison: '>=',
+          value: 10,
+          severity: 1,
+          icon: 'bee',
+          color: 'black',
+          label: 'Pressure Sev',
+        },
+        {
+          dataSourceId: 'count',
+          comparison: '<',
+          value: 5,
+          severity: 3,
+        },
+        {
+          dataSourceId: 'count',
+          comparison: '>=',
+          value: 10,
+          severity: 1,
+        },
+        {
+          dataSourceId: 'count',
+          comparison: '=',
+          value: 7,
+          severity: 2,
+        },
+      ];
+      render(
+        <TableCard
+          id="table-list"
+          title="Open Alerts"
+          content={{
+            columns: tableColumns,
+            thresholds: customThresholds,
+          }}
+          values={tableData}
+          size={CARD_SIZES.LARGEWIDE}
+        />
+      );
 
-    // Then get all of the th elements. This is how the ordering will be determined
-    const tableHeader = document.getElementsByTagName('th');
-    // The within function comes in SUPER handy here
-    const countSeverityIndex = 1;
-    const { getByText } = within(tableHeader[countSeverityIndex]);
-    expect(getByText('Count Severity')).toBeTruthy();
+      // If the ordering was being affected, Count Severity would not appear. Instead, Pressure Severity would appear
+      expect(screen.getByTitle('Count Severity')).toBeInTheDocument();
+      expect(screen.queryByTitle('Pressure Severity')).not.toBeInTheDocument();
+      expect(screen.getByTitle('Pressure Sev')).toBeInTheDocument();
+    });
 
-    const hourSeverityIndex = 3;
-    within(tableHeader[hourSeverityIndex]);
-    // expect(screen.getByTextHour('Hour Severity')).toBeTruthy();
-    expect(screen.getByText('Hour Severity')).toBeTruthy();
+    it('threshold columns should render in correct column regardless of quantity', () => {
+      // If there are more than 2 thresholds, they should still render to the left of the datasource column
+      const customThresholds = [
+        {
+          dataSourceId: 'pressure',
+          comparison: '>=',
+          value: 10,
+          severity: 1,
+        },
+        {
+          dataSourceId: 'count',
+          comparison: '<',
+          value: 5,
+          severity: 3,
+        },
+        {
+          dataSourceId: 'count',
+          comparison: '>=',
+          value: 10,
+          severity: 1,
+        },
+        {
+          dataSourceId: 'count',
+          comparison: '=',
+          value: 7,
+          severity: 2,
+        },
+        {
+          dataSourceId: 'hour',
+          comparison: '<',
+          value: 1563877570000,
+          severity: 1, // High threshold, medium, or low used for sorting and defined filtration
+        },
+      ];
+      // First the component needs to be rendered. getByTitle doesn't need to be used
+      // eslint-disable-next-line no-unused-vars
+      const { getByTitle } = render(
+        <TableCard
+          id="table-list"
+          title="Open Alerts"
+          content={{
+            columns: tableColumns,
+            thresholds: customThresholds,
+          }}
+          values={tableData}
+          size={CARD_SIZES.LARGEWIDE}
+        />
+      );
 
-    const pressureSeverityIndex = 5;
-    within(tableHeader[pressureSeverityIndex]);
-    // expect(screen.getByTextPressure('Pressure Severity')).toBeTruthy();
-    expect(screen.getByText('Pressure Severity')).toBeTruthy();
-  });
-  it('threshold icon labels should not display when showSeverityLabel is false', () => {
-    const customThresholds = [
-      {
-        dataSourceId: 'pressure',
-        comparison: '>=',
-        value: 10,
-        severity: 1,
-      },
-      {
-        dataSourceId: 'count',
-        comparison: '<',
-        value: 5,
-        severity: 3,
-        showSeverityLabel: false,
-      },
-      {
-        dataSourceId: 'count',
-        comparison: '=',
-        value: 7,
-        severity: 2,
-        showSeverityLabel: false,
-      },
-    ];
-    render(
-      <TableCard
-        id="table-list"
-        title="Open Alerts"
-        content={{
-          columns: tableColumns,
-          thresholds: customThresholds,
-          expandedRows: [
-            {
-              id: 'pressure',
-              label: 'Pressure',
-            },
-          ],
-        }}
-        values={tableData}
-        size={CARD_SIZES.LARGEWIDE}
-      />
-    );
+      // Then get all of the th elements. This is how the ordering will be determined
+      const tableHeader = document.getElementsByTagName('th');
+      // The within function comes in SUPER handy here
+      const countSeverityIndex = 1;
+      const { getByText } = within(tableHeader[countSeverityIndex]);
+      expect(getByText('Count Severity')).toBeTruthy();
 
-    // The Pressure threshold is the only threshold that has a 'Critical' severity
-    // and doesn't have showSeverityLabel: false, so it should be the only severity text to appear
-    expect(screen.queryAllByText(/Critical/g)).toHaveLength(3);
-    expect(screen.queryByText(/Moderate/g)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Low/g)).not.toBeInTheDocument();
-  });
-  it('threshold icon label should not display default strings', () => {
-    const customThresholds = [
-      {
-        dataSourceId: 'pressure',
-        comparison: '>=',
-        value: 10,
-        severity: 1,
-      },
-      {
-        dataSourceId: 'count',
-        comparison: '<',
-        value: 5,
-        severity: 3,
-        severityLabel: 'Lowest',
-      },
-      {
-        dataSourceId: 'count',
-        comparison: '=',
-        value: 7,
-        severity: 2,
-        severityLabel: 'Medium',
-      },
-    ];
-    render(
-      <TableCard
-        id="table-list"
-        title="Open Alerts"
-        content={{
-          columns: tableColumns,
-          thresholds: customThresholds,
-        }}
-        values={tableData}
-        size={CARD_SIZES.LARGE}
-      />
-    );
+      const hourSeverityIndex = 3;
+      within(tableHeader[hourSeverityIndex]);
+      // expect(screen.getByTextHour('Hour Severity')).toBeTruthy();
+      expect(screen.getByText('Hour Severity')).toBeTruthy();
 
-    // Critical should exist as that is the only threshold that doesn't have custom label text
-    expect(screen.queryAllByText(/^Critical$/g)).toHaveLength(3);
-    // These are default labels, so they should not exist
-    expect(screen.queryByText(/^Moderate$/g)).not.toBeInTheDocument();
-    expect(screen.queryByText(/^Low$/g)).not.toBeInTheDocument();
-    // These are the custom labels that should appear instead of the defaults above
-    expect(screen.queryAllByText(/^Medium$/g)).toHaveLength(1);
-    expect(screen.queryAllByText(/^Lowest$/g)).toHaveLength(5);
-  });
-  it('can be resized without crashing', () => {
-    const { rerender } = render(
-      <TableCard
-        id="table-list"
-        title="Testing resize"
-        content={{
-          columns: tableColumns,
-        }}
-        values={tableData}
-        size={CARD_SIZES.LARGE}
-      />
-    );
+      const pressureSeverityIndex = 5;
+      within(tableHeader[pressureSeverityIndex]);
+      // expect(screen.getByTextPressure('Pressure Severity')).toBeTruthy();
+      expect(screen.getByText('Pressure Severity')).toBeTruthy();
+    });
 
-    rerender(
-      <TableCard
-        id="table-list"
-        title="Testing resize"
-        content={{
-          columns: tableColumns,
-        }}
-        values={tableData}
-        size={CARD_SIZES.LARGEWIDE}
-      />
-    );
+    it('threshold icon labels should not display when showSeverityLabel is false', () => {
+      const customThresholds = [
+        {
+          dataSourceId: 'pressure',
+          comparison: '>=',
+          value: 10,
+          severity: 1,
+        },
+        {
+          dataSourceId: 'count',
+          comparison: '<',
+          value: 5,
+          severity: 3,
+          showSeverityLabel: false,
+        },
+        {
+          dataSourceId: 'count',
+          comparison: '=',
+          value: 7,
+          severity: 2,
+          showSeverityLabel: false,
+        },
+      ];
+      render(
+        <TableCard
+          id="table-list"
+          title="Open Alerts"
+          content={{
+            columns: tableColumns,
+            thresholds: customThresholds,
+            expandedRows: [
+              {
+                id: 'pressure',
+                label: 'Pressure',
+              },
+            ],
+          }}
+          values={tableData}
+          size={CARD_SIZES.LARGEWIDE}
+        />
+      );
 
-    rerender(
-      <TableCard
-        id="table-list"
-        title="Testing resize"
-        content={{
-          columns: tableColumns,
-        }}
-        values={tableData}
-        size={CARD_SIZES.LARGE}
-      />
-    );
+      // The Pressure threshold is the only threshold that has a 'Critical' severity
+      // and doesn't have showSeverityLabel: false, so it should be the only severity text to appear
+      expect(screen.queryAllByText(/Critical/g)).toHaveLength(3);
+      expect(screen.queryByText(/Moderate/g)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Low/g)).not.toBeInTheDocument();
+    });
+    it('threshold icon label should not display default strings', () => {
+      const customThresholds = [
+        {
+          dataSourceId: 'pressure',
+          comparison: '>=',
+          value: 10,
+          severity: 1,
+        },
+        {
+          dataSourceId: 'count',
+          comparison: '<',
+          value: 5,
+          severity: 3,
+          severityLabel: 'Lowest',
+        },
+        {
+          dataSourceId: 'count',
+          comparison: '=',
+          value: 7,
+          severity: 2,
+          severityLabel: 'Medium',
+        },
+      ];
+      render(
+        <TableCard
+          id="table-list"
+          title="Open Alerts"
+          content={{
+            columns: tableColumns,
+            thresholds: customThresholds,
+          }}
+          values={tableData}
+          size={CARD_SIZES.LARGE}
+        />
+      );
 
-    expect(screen.getByText('Testing resize')).toBeInTheDocument();
+      // Critical should exist as that is the only threshold that doesn't have custom label text
+      expect(screen.queryAllByText(/^Critical$/g)).toHaveLength(3);
+      // These are default labels, so they should not exist
+      expect(screen.queryByText(/^Moderate$/g)).not.toBeInTheDocument();
+      expect(screen.queryByText(/^Low$/g)).not.toBeInTheDocument();
+      // These are the custom labels that should appear instead of the defaults above
+      expect(screen.queryAllByText(/^Medium$/g)).toHaveLength(1);
+      expect(screen.queryAllByText(/^Lowest$/g)).toHaveLength(5);
+    });
+
+    it('can be resized without crashing', () => {
+      const { rerender } = render(
+        <TableCard
+          id="table-list"
+          title="Testing resize"
+          content={{
+            columns: tableColumns,
+          }}
+          values={tableData}
+          size={CARD_SIZES.LARGE}
+        />
+      );
+
+      rerender(
+        <TableCard
+          id="table-list"
+          title="Testing resize"
+          content={{
+            columns: tableColumns,
+          }}
+          values={tableData}
+          size={CARD_SIZES.LARGEWIDE}
+        />
+      );
+
+      rerender(
+        <TableCard
+          id="table-list"
+          title="Testing resize"
+          content={{
+            columns: tableColumns,
+          }}
+          values={tableData}
+          size={CARD_SIZES.LARGE}
+        />
+      );
+
+      expect(screen.getByText('Testing resize')).toBeInTheDocument();
+    });
   });
 
   it('last column is not dublicated when changeing sizes', () => {

--- a/packages/react/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/packages/react/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -2275,8 +2275,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-38"
-                  id="bx-pagination-select-38-count-label"
+                  htmlFor="bx-pagination-select-37"
+                  id="bx-pagination-select-37-count-label"
                 >
                   Items per page:
                 </label>
@@ -2295,7 +2295,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-38"
+                          id="bx-pagination-select-37"
                           onChange={[Function]}
                           value={10}
                         >
@@ -2360,7 +2360,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-38-right"
+                      htmlFor="bx-pagination-select-37-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -2373,1247 +2373,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-38-right"
-                          onChange={[Function]}
-                          value={1}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={1}
-                          >
-                            1
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={2}
-                          >
-                            2
-                          </option>
-                        </select>
-                        <svg
-                          aria-hidden={true}
-                          className="bx--select__arrow"
-                          fill="currentColor"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1 of 2 pages
-                </span>
-                <div
-                  className="bx--pagination__control-buttons"
-                >
-                  <button
-                    className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index bx--btn bx--btn--ghost bx--btn--disabled bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
-                    disabled={true}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    type="button"
-                  >
-                    <span
-                      className="bx--assistive-text"
-                    >
-                      Previous page
-                    </span>
-                    <svg
-                      aria-hidden="true"
-                      aria-label="Previous page"
-                      className="bx--btn__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      viewBox="0 0 32 32"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M20 24L10 16 20 8z"
-                      />
-                    </svg>
-                  </button>
-                  <button
-                    className="bx--pagination__button bx--pagination__button--forward bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-end"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    type="button"
-                  >
-                    <span
-                      className="bx--assistive-text"
-                    >
-                      Next page
-                    </span>
-                    <svg
-                      aria-hidden="true"
-                      aria-label="Next page"
-                      className="bx--btn__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      viewBox="0 0 32 32"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M12 8L22 16 12 24z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <button
-    className="info__show-button"
-    onClick={[Function]}
-    style={
-      Object {
-        "background": "#027ac5",
-        "border": "none",
-        "borderRadius": "0 0 0 5px",
-        "color": "#fff",
-        "cursor": "pointer",
-        "display": "block",
-        "fontFamily": "sans-serif",
-        "fontSize": 12,
-        "padding": "5px 15px",
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
-    type="button"
-  >
-    Show Info
-  </button>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/TableCard With links 1`] = `
-<div
-  className="storybook-container"
->
-  <div
-    style={
-      Object {
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "margin": "1rem4",
-          "width": "520px",
-        }
-      }
-    >
-      <div
-        className="iot--card iot--card--wrapper"
-        data-testid="Card"
-        id="table-list"
-        role="presentation"
-        style={
-          Object {
-            "--card-default-height": "624px",
-          }
-        }
-      >
-        <div
-          className="iot--card--content"
-          style={
-            Object {
-              "--card-content-height": "576px",
-            }
-          }
-        >
-          <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
-            data-testid="table-for-card-table-list-table-container"
-          >
-            <section
-              aria-label="data table toolbar"
-              className="bx--table-toolbar"
-              data-testid="table-for-card-table-list-table-toolbar"
-            >
-              <div
-                aria-hidden={true}
-                className="bx--batch-actions iot--table-batch-actions"
-                data-testid="table-for-card-table-list-table-toolbar-batch-actions"
-              >
-                <div
-                  className="bx--batch-summary"
-                >
-                  <p
-                    className="bx--batch-summary__para"
-                  >
-                    <span>
-                      0 items selected
-                    </span>
-                  </p>
-                </div>
-                <div
-                  className="bx--action-list"
-                >
-                  <button
-                    aria-pressed={null}
-                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </div>
-              <label
-                className="iot--table-toolbar-secondary-title"
-              >
-                Open Alerts 11112
-              </label>
-              <div
-                className="iot--table-tooltip-container"
-              >
-                <div
-                  className="bx--tooltip__label"
-                  id="card-tooltip-trigger-table-for-card-table-list"
-                >
-                  
-                  <div
-                    aria-describedby={null}
-                    className="bx--tooltip__trigger"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onContextMenu={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
-                    <svg
-                      aria-hidden={true}
-                      description={null}
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role={null}
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
-                      />
-                      <path
-                        d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-content iot--table-toolbar-content"
-                data-testid="table-for-card-table-list-table-toolbar-content"
-              >
-                <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  tabIndex="0"
-                >
-                  <div
-                    aria-labelledby="table-for-card-table-list-toolbar-search-search"
-                    className="bx--search bx--search--sm table-toolbar-search"
-                    role="search"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="bx--search-magnifier"
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                      />
-                    </svg>
-                    <label
-                      className="bx--label"
-                      htmlFor="table-for-card-table-list-toolbar-search"
-                      id="table-for-card-table-list-toolbar-search-search"
-                    >
-                      Search
-                    </label>
-                    <input
-                      autoComplete="off"
-                      className="bx--search-input"
-                      data-testid="table-for-card-table-list-table-toolbar-search"
-                      id="table-for-card-table-list-toolbar-search"
-                      onChange={[Function]}
-                      onKeyDown={[Function]}
-                      placeholder="Search"
-                      role="searchbox"
-                      tabIndex="-1"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Clear search input"
-                      className="bx--search-close bx--search-close--hidden"
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-                <button
-                  aria-pressed={null}
-                  className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
-                  data-testid="download-button"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Download table content"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Download table content"
-                    className="bx--btn__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M26 24v4H6V24H4v4H4a2 2 0 002 2H26a2 2 0 002-2h0V24zM26 14L24.59 12.59 17 20.17 17 2 15 2 15 20.17 7.41 12.59 6 14 16 24 26 14z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  aria-pressed={null}
-                  className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
-                  data-testid="filter-button"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Filters"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Filters"
-                    className="bx--btn__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M18,28H14a2,2,0,0,1-2-2V18.41L4.59,11A2,2,0,0,1,4,9.59V6A2,2,0,0,1,6,4H26a2,2,0,0,1,2,2V9.59A2,2,0,0,1,27.41,11L20,18.41V26A2,2,0,0,1,18,28ZM6,6V9.59l8,8V26h4V17.59l8-8V6Z"
-                    />
-                  </svg>
-                </button>
-                <div
-                  className="iot--card--toolbar"
-                >
-                  <div
-                    className="iot--card--toolbar-date-range-wrapper"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="open and close list of options"
-                      className="iot--card--toolbar-date-range-action bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      title="Select time range"
-                      type="button"
-                    >
-                      <svg
-                        aria-label="Select time range"
-                        className="bx--overflow-menu__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        onClick={[Function]}
-                        onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
-                        />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
-                        />
-                        <path
-                          d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
-                        />
-                        <title>
-                          Select time range
-                        </title>
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </section>
-            <div
-              className="addons-iot-table-container"
-            >
-              <div
-                className="bx--data-table-content"
-              >
-                <table
-                  className="bx--data-table bx--data-table--no-border"
-                  data-testid="table-for-card-table-list"
-                  id="table-for-card-table-list"
-                  title={null}
-                >
-                  <thead
-                    data-testid="table-for-card-table-list-table-head"
-                    onMouseMove={null}
-                    onMouseUp={null}
-                  >
-                    <tr>
-                      <th
-                        aria-sort="none"
-                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
-                        data-testid="table-for-card-table-list-table-head-column-pressure"
-                        scope="col"
-                        style={
-                          Object {
-                            "width": undefined,
-                          }
-                        }
-                        width=""
-                      >
-                        <button
-                          align="start"
-                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
-                          data-column="pressure"
-                          data-floating-menu-container={true}
-                          id="column-pressure"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "--table-header-width": "",
-                            }
-                          }
-                          width=""
-                        >
-                          <span
-                            className="bx--table-header-label"
-                          >
-                            <span
-                              className=""
-                              title="Pressure"
-                            >
-                              Pressure
-                            </span>
-                          </span>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                            />
-                          </svg>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon-unsorted"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                            />
-                          </svg>
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="none"
-                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
-                        data-testid="table-for-card-table-list-table-head-column-deviceId"
-                        scope="col"
-                        style={
-                          Object {
-                            "width": undefined,
-                          }
-                        }
-                        width=""
-                      >
-                        <button
-                          align="start"
-                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
-                          data-column="deviceId"
-                          data-floating-menu-container={true}
-                          id="column-deviceId"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "--table-header-width": "",
-                            }
-                          }
-                          width=""
-                        >
-                          <span
-                            className="bx--table-header-label"
-                          >
-                            <span
-                              className=""
-                              title="Link"
-                            >
-                              Link
-                            </span>
-                          </span>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                            />
-                          </svg>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon-unsorted"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                            />
-                          </svg>
-                        </button>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody
-                    aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
-                  >
-                    <tr
-                      className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"
-                      onClick={[Function]}
-                    >
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-1-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="0"
-                          >
-                            0
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="deviceId"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-1-deviceId"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                          >
-                            <a
-                              className="bx--link"
-                              href="https://ibm.com/11112"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Link
-                            </a>
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"
-                      onClick={[Function]}
-                    >
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-2-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="2"
-                          >
-                            2
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="deviceId"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-2-deviceId"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                          >
-                            <a
-                              className="bx--link"
-                              href="https://ibm.com/11112"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Link
-                            </a>
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"
-                      onClick={[Function]}
-                    >
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-3-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="10"
-                          >
-                            10
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="deviceId"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-3-deviceId"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                          >
-                            <a
-                              className="bx--link"
-                              href="https://ibm.com/11112"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Link
-                            </a>
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"
-                      onClick={[Function]}
-                    >
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-4-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="0"
-                          >
-                            0
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="deviceId"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-4-deviceId"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                          >
-                            <a
-                              className="bx--link"
-                              href="https://ibm.com/11112"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Link
-                            </a>
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"
-                      onClick={[Function]}
-                    >
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-5-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="10"
-                          >
-                            10
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="deviceId"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-5-deviceId"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                          >
-                            <a
-                              className="bx--link"
-                              href="https://ibm.com/11112"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Link
-                            </a>
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"
-                      onClick={[Function]}
-                    >
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-6-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="68"
-                          >
-                            68
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="deviceId"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-6-deviceId"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                          >
-                            <a
-                              className="bx--link"
-                              href="https://ibm.com/11112"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Link
-                            </a>
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"
-                      onClick={[Function]}
-                    >
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-7-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="0"
-                          >
-                            0
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="deviceId"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-7-deviceId"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                          >
-                            <a
-                              className="bx--link"
-                              href="https://ibm.com/11112"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Link
-                            </a>
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"
-                      onClick={[Function]}
-                    >
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-8-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="0"
-                          >
-                            0
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="deviceId"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-8-deviceId"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                          >
-                            <a
-                              className="bx--link"
-                              href="https://ibm.com/11112"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Link
-                            </a>
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"
-                      onClick={[Function]}
-                    >
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-9-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="0"
-                          >
-                            0
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="deviceId"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-9-deviceId"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                          >
-                            <a
-                              className="bx--link"
-                              href="https://ibm.com/11112"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Link
-                            </a>
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="TableBodyRow__StyledTableRow-sc-103itxu-0 fNIOnc"
-                      onClick={[Function]}
-                    >
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-10-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="0"
-                          >
-                            0
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="deviceId"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-10-deviceId"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                          >
-                            <a
-                              className="bx--link"
-                              href="https://ibm.com/11112"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Link
-                            </a>
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-            </div>
-            <div
-              className="bx--pagination iot--pagination iot--pagination--hide-page"
-              data-testid="table-for-card-table-list-table-pagination"
-              style={
-                Object {
-                  "--pagination-text-display": "flex",
-                }
-              }
-            >
-              <div
-                className="bx--pagination__left"
-              >
-                <label
-                  className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-34"
-                  id="bx-pagination-select-34-count-label"
-                >
-                  Items per page:
-                </label>
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__item-count"
-                  >
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-34"
-                          onChange={[Function]}
-                          value={10}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={10}
-                          >
-                            10
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={25}
-                          >
-                            25
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={100}
-                          >
-                            100
-                          </option>
-                        </select>
-                        <svg
-                          aria-hidden={true}
-                          className="bx--select__arrow"
-                          fill="currentColor"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text bx--pagination__items-count"
-                >
-                  1–10 of 11 items
-                </span>
-              </div>
-              <div
-                className="bx--pagination__right"
-              >
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__page-number"
-                  >
-                    <label
-                      className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-34-right"
-                    >
-                      Page number, of 2 pages
-                    </label>
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-34-right"
+                          id="bx-pagination-select-37-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -3837,7 +2597,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               <label
                 className="iot--table-toolbar-secondary-title"
               >
-                Asset Open Alerts
+                11112 Open Alerts
               </label>
               <div
                 className="iot--table-tooltip-container"
@@ -6300,8 +5060,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-35"
-                  id="bx-pagination-select-35-count-label"
+                  htmlFor="bx-pagination-select-34"
+                  id="bx-pagination-select-34-count-label"
                 >
                   Items per page:
                 </label>
@@ -6320,7 +5080,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-35"
+                          id="bx-pagination-select-34"
                           onChange={[Function]}
                           value={10}
                         >
@@ -6385,7 +5145,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-35-right"
+                      htmlFor="bx-pagination-select-34-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -6398,7 +5158,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-35-right"
+                          id="bx-pagination-select-34-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -7681,8 +6441,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-49"
-                  id="bx-pagination-select-49-count-label"
+                  htmlFor="bx-pagination-select-48"
+                  id="bx-pagination-select-48-count-label"
                 >
                   Items per page:
                 </label>
@@ -7701,7 +6461,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-49"
+                          id="bx-pagination-select-48"
                           onChange={[Function]}
                           value={10}
                         >
@@ -7766,7 +6526,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-49-right"
+                      htmlFor="bx-pagination-select-48-right"
                     >
                       Page number, of 10 pages
                     </label>
@@ -7779,7 +6539,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-49-right"
+                          id="bx-pagination-select-48-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -9461,8 +8221,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-50"
-                  id="bx-pagination-select-50-count-label"
+                  htmlFor="bx-pagination-select-49"
+                  id="bx-pagination-select-49-count-label"
                 >
                   Items per page:
                 </label>
@@ -9481,7 +8241,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-50"
+                          id="bx-pagination-select-49"
                           onChange={[Function]}
                           value={10}
                         >
@@ -9546,7 +8306,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-50-right"
+                      htmlFor="bx-pagination-select-49-right"
                     >
                       Page number, of 10 pages
                     </label>
@@ -9559,7 +8319,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-50-right"
+                          id="bx-pagination-select-49-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -13116,8 +11876,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-52"
-                  id="bx-pagination-select-52-count-label"
+                  htmlFor="bx-pagination-select-51"
+                  id="bx-pagination-select-51-count-label"
                 >
                   Items per page:
                 </label>
@@ -13136,7 +11896,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-52"
+                          id="bx-pagination-select-51"
                           onChange={[Function]}
                           value={10}
                         >
@@ -13201,7 +11961,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-52-right"
+                      htmlFor="bx-pagination-select-51-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -13214,7 +11974,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-52-right"
+                          id="bx-pagination-select-51-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -14596,8 +13356,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-48"
-                  id="bx-pagination-select-48-count-label"
+                  htmlFor="bx-pagination-select-47"
+                  id="bx-pagination-select-47-count-label"
                 >
                   Items per page:
                 </label>
@@ -14616,7 +13376,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-48"
+                          id="bx-pagination-select-47"
                           onChange={[Function]}
                           value={10}
                         >
@@ -14681,7 +13441,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-48-right"
+                      htmlFor="bx-pagination-select-47-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -14694,7 +13454,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-48-right"
+                          id="bx-pagination-select-47-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -16316,8 +15076,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-42"
-                  id="bx-pagination-select-42-count-label"
+                  htmlFor="bx-pagination-select-41"
+                  id="bx-pagination-select-41-count-label"
                 >
                   Items per page:
                 </label>
@@ -16336,7 +15096,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-42"
+                          id="bx-pagination-select-41"
                           onChange={[Function]}
                           value={10}
                         >
@@ -16401,7 +15161,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-42-right"
+                      htmlFor="bx-pagination-select-41-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -16414,7 +15174,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-42-right"
+                          id="bx-pagination-select-41-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -17177,8 +15937,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-51"
-                  id="bx-pagination-select-51-count-label"
+                  htmlFor="bx-pagination-select-50"
+                  id="bx-pagination-select-50-count-label"
                 >
                   Items per page:
                 </label>
@@ -17197,7 +15957,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-51"
+                          id="bx-pagination-select-50"
                           onChange={[Function]}
                           value={10}
                         >
@@ -17262,7 +16022,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-51-right"
+                      htmlFor="bx-pagination-select-50-right"
                     >
                       Page number, of 1 pages
                     </label>
@@ -17275,7 +16035,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-51-right"
+                          id="bx-pagination-select-50-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -18649,8 +17409,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-43"
-                  id="bx-pagination-select-43-count-label"
+                  htmlFor="bx-pagination-select-42"
+                  id="bx-pagination-select-42-count-label"
                 >
                   Items per page:
                 </label>
@@ -18669,7 +17429,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-43"
+                          id="bx-pagination-select-42"
                           onChange={[Function]}
                           value={10}
                         >
@@ -18734,7 +17494,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-43-right"
+                      htmlFor="bx-pagination-select-42-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -18747,7 +17507,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-43-right"
+                          id="bx-pagination-select-42-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -21798,8 +20558,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-41"
-                  id="bx-pagination-select-41-count-label"
+                  htmlFor="bx-pagination-select-40"
+                  id="bx-pagination-select-40-count-label"
                 >
                   Items per page:
                 </label>
@@ -21818,7 +20578,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-41"
+                          id="bx-pagination-select-40"
                           onChange={[Function]}
                           value={10}
                         >
@@ -21883,7 +20643,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-41-right"
+                      htmlFor="bx-pagination-select-40-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -21896,7 +20656,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-41-right"
+                          id="bx-pagination-select-40-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -25679,8 +24439,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-44"
-                  id="bx-pagination-select-44-count-label"
+                  htmlFor="bx-pagination-select-43"
+                  id="bx-pagination-select-43-count-label"
                 >
                   Items per page:
                 </label>
@@ -25699,7 +24459,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-44"
+                          id="bx-pagination-select-43"
                           onChange={[Function]}
                           value={10}
                         >
@@ -25764,7 +24524,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-44-right"
+                      htmlFor="bx-pagination-select-43-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -25777,7 +24537,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-44-right"
+                          id="bx-pagination-select-43-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -25920,3636 +24680,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
 `;
 
 exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/TableCard with row expansion and link variables 1`] = `
-<div
-  className="storybook-container"
->
-  <div
-    style={
-      Object {
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "margin": "1rem4",
-          "width": "520px",
-        }
-      }
-    >
-      <div
-        className="iot--card iot--card--wrapper"
-        data-testid="Card"
-        id="table-list"
-        role="presentation"
-        style={
-          Object {
-            "--card-default-height": "624px",
-          }
-        }
-      >
-        <div
-          className="iot--card--content"
-          style={
-            Object {
-              "--card-content-height": "576px",
-            }
-          }
-        >
-          <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
-            data-testid="table-for-card-table-list-table-container"
-          >
-            <section
-              aria-label="data table toolbar"
-              className="bx--table-toolbar"
-              data-testid="table-for-card-table-list-table-toolbar"
-            >
-              <div
-                aria-hidden={true}
-                className="bx--batch-actions iot--table-batch-actions"
-                data-testid="table-for-card-table-list-table-toolbar-batch-actions"
-              >
-                <div
-                  className="bx--batch-summary"
-                >
-                  <p
-                    className="bx--batch-summary__para"
-                  >
-                    <span>
-                      0 items selected
-                    </span>
-                  </p>
-                </div>
-                <div
-                  className="bx--action-list"
-                >
-                  <button
-                    aria-pressed={null}
-                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </div>
-              <label
-                className="iot--table-toolbar-secondary-title"
-              >
-                Open Alerts
-              </label>
-              <div
-                className="iot--table-tooltip-container"
-              >
-                <div
-                  className="bx--tooltip__label"
-                  id="card-tooltip-trigger-table-for-card-table-list"
-                >
-                  
-                  <div
-                    aria-describedby={null}
-                    className="bx--tooltip__trigger"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onContextMenu={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
-                    <svg
-                      aria-hidden={true}
-                      description={null}
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role={null}
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
-                      />
-                      <path
-                        d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-content iot--table-toolbar-content"
-                data-testid="table-for-card-table-list-table-toolbar-content"
-              >
-                <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  tabIndex="0"
-                >
-                  <div
-                    aria-labelledby="table-for-card-table-list-toolbar-search-search"
-                    className="bx--search bx--search--sm table-toolbar-search"
-                    role="search"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="bx--search-magnifier"
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                      />
-                    </svg>
-                    <label
-                      className="bx--label"
-                      htmlFor="table-for-card-table-list-toolbar-search"
-                      id="table-for-card-table-list-toolbar-search-search"
-                    >
-                      Search
-                    </label>
-                    <input
-                      autoComplete="off"
-                      className="bx--search-input"
-                      data-testid="table-for-card-table-list-table-toolbar-search"
-                      id="table-for-card-table-list-toolbar-search"
-                      onChange={[Function]}
-                      onKeyDown={[Function]}
-                      placeholder="Search"
-                      role="searchbox"
-                      tabIndex="-1"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Clear search input"
-                      className="bx--search-close bx--search-close--hidden"
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-                <button
-                  aria-pressed={null}
-                  className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
-                  data-testid="download-button"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Download table content"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Download table content"
-                    className="bx--btn__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M26 24v4H6V24H4v4H4a2 2 0 002 2H26a2 2 0 002-2h0V24zM26 14L24.59 12.59 17 20.17 17 2 15 2 15 20.17 7.41 12.59 6 14 16 24 26 14z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  aria-pressed={null}
-                  className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
-                  data-testid="filter-button"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Filters"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Filters"
-                    className="bx--btn__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M18,28H14a2,2,0,0,1-2-2V18.41L4.59,11A2,2,0,0,1,4,9.59V6A2,2,0,0,1,6,4H26a2,2,0,0,1,2,2V9.59A2,2,0,0,1,27.41,11L20,18.41V26A2,2,0,0,1,18,28ZM6,6V9.59l8,8V26h4V17.59l8-8V6Z"
-                    />
-                  </svg>
-                </button>
-                <div
-                  className="iot--card--toolbar"
-                >
-                  <div
-                    className="iot--card--toolbar-date-range-wrapper"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="open and close list of options"
-                      className="iot--card--toolbar-date-range-action bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      title="Select time range"
-                      type="button"
-                    >
-                      <svg
-                        aria-label="Select time range"
-                        className="bx--overflow-menu__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        onClick={[Function]}
-                        onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
-                        />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
-                        />
-                        <path
-                          d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
-                        />
-                        <title>
-                          Select time range
-                        </title>
-                      </svg>
-                    </button>
-                  </div>
-                  <button
-                    aria-pressed={null}
-                    className="iot--card--toolbar-action iot--card--toolbar-svg-wrapper bx--btn--icon-only bx--btn bx--btn--ghost"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    title="Expand to fullscreen"
-                    type="button"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      aria-label="Expand to fullscreen"
-                      className="bx--btn__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      viewBox="0 0 32 32"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M28,4H10A2.0059,2.0059,0,0,0,8,6V20a2.0059,2.0059,0,0,0,2,2H28a2.0059,2.0059,0,0,0,2-2V6A2.0059,2.0059,0,0,0,28,4Zm0,16H10V6H28Z"
-                      />
-                      <path
-                        d="M18,26H4V16H6V14H4a2.0059,2.0059,0,0,0-2,2V26a2.0059,2.0059,0,0,0,2,2H18a2.0059,2.0059,0,0,0,2-2V24H18Z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-            </section>
-            <div
-              className="addons-iot-table-container"
-            >
-              <div
-                className="bx--data-table-content"
-              >
-                <table
-                  className="bx--data-table bx--data-table--no-border"
-                  data-testid="table-for-card-table-list"
-                  id="table-for-card-table-list"
-                  title={null}
-                >
-                  <thead
-                    data-testid="table-for-card-table-list-table-head"
-                    onMouseMove={null}
-                    onMouseUp={null}
-                  >
-                    <tr>
-                      <th
-                        className="bx--table-expand"
-                        scope="col"
-                        testID="table-for-card-table-list-table-head-row-expansion-column"
-                      />
-                      <th
-                        aria-sort="none"
-                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
-                        data-testid="table-for-card-table-list-table-head-column-alert"
-                        scope="col"
-                        style={
-                          Object {
-                            "width": undefined,
-                          }
-                        }
-                        width=""
-                      >
-                        <button
-                          align="start"
-                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
-                          data-column="alert"
-                          data-floating-menu-container={true}
-                          id="column-alert"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "--table-header-width": "",
-                            }
-                          }
-                          width=""
-                        >
-                          <span
-                            className="bx--table-header-label"
-                          >
-                            <span
-                              className=""
-                              title="Alert"
-                            >
-                              Alert
-                            </span>
-                          </span>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                            />
-                          </svg>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon-unsorted"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                            />
-                          </svg>
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="none"
-                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
-                        data-testid="table-for-card-table-list-table-head-column-hour"
-                        scope="col"
-                        style={
-                          Object {
-                            "width": undefined,
-                          }
-                        }
-                        width=""
-                      >
-                        <button
-                          align="start"
-                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
-                          data-column="hour"
-                          data-floating-menu-container={true}
-                          id="column-hour"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "--table-header-width": "",
-                            }
-                          }
-                          width=""
-                        >
-                          <span
-                            className="bx--table-header-label"
-                          >
-                            <span
-                              className=""
-                              title="Hour"
-                            >
-                              Hour
-                            </span>
-                          </span>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                            />
-                          </svg>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon-unsorted"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                            />
-                          </svg>
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="none"
-                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
-                        data-testid="table-for-card-table-list-table-head-column-pressure"
-                        scope="col"
-                        style={
-                          Object {
-                            "width": undefined,
-                          }
-                        }
-                        width=""
-                      >
-                        <button
-                          align="start"
-                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
-                          data-column="pressure"
-                          data-floating-menu-container={true}
-                          id="column-pressure"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "--table-header-width": "",
-                            }
-                          }
-                          width=""
-                        >
-                          <span
-                            className="bx--table-header-label"
-                          >
-                            <span
-                              className=""
-                              title="Pressure"
-                            >
-                              Pressure
-                            </span>
-                          </span>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                            />
-                          </svg>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon-unsorted"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                            />
-                          </svg>
-                        </button>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody
-                    aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
-                  >
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-10-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI010 proccess need to optimize adjust Y variables"
-                          >
-                            AHI010 proccess need to optimize adjust Y variables
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-10-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="07/23/2019 04:26"
-                          >
-                            07/23/2019 04:26
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-10-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="0"
-                          >
-                            0
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-11-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI010 proccess need to optimize adjust Y variables"
-                          >
-                            AHI010 proccess need to optimize adjust Y variables
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-11-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="07/23/2019 05:26"
-                          >
-                            07/23/2019 05:26
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-11-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="1"
-                          >
-                            1
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-1-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI005 Asset failure"
-                          >
-                            AHI005 Asset failure
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-1-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="07/23/2019 05:26"
-                          >
-                            07/23/2019 05:26
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-1-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="0"
-                          >
-                            0
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-2-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI003 process need to optimize adjust X variables"
-                          >
-                            AHI003 process need to optimize adjust X variables
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-2-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="07/23/2019 04:26"
-                          >
-                            07/23/2019 04:26
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-2-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="2"
-                          >
-                            2
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-6-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI001 proccess need to optimize."
-                          >
-                            AHI001 proccess need to optimize.
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-6-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="07/23/2019 04:30"
-                          >
-                            07/23/2019 04:30
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-6-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="68"
-                          >
-                            68
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-3-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI001 proccess need to optimize adjust Y variables"
-                          >
-                            AHI001 proccess need to optimize adjust Y variables
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-3-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="08/02/2019 09:42"
-                          >
-                            08/02/2019 09:42
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-3-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="10"
-                          >
-                            10
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-4-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI001 proccess need to optimize adjust Y variables"
-                          >
-                            AHI001 proccess need to optimize adjust Y variables
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-4-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="07/23/2019 05:26"
-                          >
-                            07/23/2019 05:26
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-4-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="0"
-                          >
-                            0
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-8-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI001 proccess need to optimize adjust Y variables"
-                          >
-                            AHI001 proccess need to optimize adjust Y variables
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-8-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="07/23/2019 03:30"
-                          >
-                            07/23/2019 03:30
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-8-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="0"
-                          >
-                            0
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-9-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI001 proccess need to optimize adjust Y variables"
-                          >
-                            AHI001 proccess need to optimize adjust Y variables
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-9-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="07/23/2019 04:26"
-                          >
-                            07/23/2019 04:26
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-9-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="0"
-                          >
-                            0
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-5-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI001 proccess need to optimize"
-                          >
-                            AHI001 proccess need to optimize
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-5-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="07/23/2019 04:30"
-                          >
-                            07/23/2019 04:30
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-5-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="10"
-                          >
-                            10
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-            </div>
-            <div
-              className="bx--pagination iot--pagination iot--pagination--hide-page"
-              data-testid="table-for-card-table-list-table-pagination"
-              style={
-                Object {
-                  "--pagination-text-display": "flex",
-                }
-              }
-            >
-              <div
-                className="bx--pagination__left"
-              >
-                <label
-                  className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-46"
-                  id="bx-pagination-select-46-count-label"
-                >
-                  Items per page:
-                </label>
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__item-count"
-                  >
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-46"
-                          onChange={[Function]}
-                          value={10}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={10}
-                          >
-                            10
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={25}
-                          >
-                            25
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={100}
-                          >
-                            100
-                          </option>
-                        </select>
-                        <svg
-                          aria-hidden={true}
-                          className="bx--select__arrow"
-                          fill="currentColor"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text bx--pagination__items-count"
-                >
-                  1–10 of 11 items
-                </span>
-              </div>
-              <div
-                className="bx--pagination__right"
-              >
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__page-number"
-                  >
-                    <label
-                      className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-46-right"
-                    >
-                      Page number, of 2 pages
-                    </label>
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-46-right"
-                          onChange={[Function]}
-                          value={1}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={1}
-                          >
-                            1
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={2}
-                          >
-                            2
-                          </option>
-                        </select>
-                        <svg
-                          aria-hidden={true}
-                          className="bx--select__arrow"
-                          fill="currentColor"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1 of 2 pages
-                </span>
-                <div
-                  className="bx--pagination__control-buttons"
-                >
-                  <button
-                    className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index bx--btn bx--btn--ghost bx--btn--disabled bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
-                    disabled={true}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    type="button"
-                  >
-                    <span
-                      className="bx--assistive-text"
-                    >
-                      Previous page
-                    </span>
-                    <svg
-                      aria-hidden="true"
-                      aria-label="Previous page"
-                      className="bx--btn__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      viewBox="0 0 32 32"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M20 24L10 16 20 8z"
-                      />
-                    </svg>
-                  </button>
-                  <button
-                    className="bx--pagination__button bx--pagination__button--forward bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-end"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    type="button"
-                  >
-                    <span
-                      className="bx--assistive-text"
-                    >
-                      Next page
-                    </span>
-                    <svg
-                      aria-hidden="true"
-                      aria-label="Next page"
-                      className="bx--btn__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      viewBox="0 0 32 32"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M12 8L22 16 12 24z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <button
-    className="info__show-button"
-    onClick={[Function]}
-    style={
-      Object {
-        "background": "#027ac5",
-        "border": "none",
-        "borderRadius": "0 0 0 5px",
-        "color": "#fff",
-        "cursor": "pointer",
-        "display": "block",
-        "fontFamily": "sans-serif",
-        "fontSize": 12,
-        "padding": "5px 15px",
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
-    type="button"
-  >
-    Show Info
-  </button>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/TableCard with row expansion and row specific link variables 1`] = `
-<div
-  className="storybook-container"
->
-  <div
-    style={
-      Object {
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "margin": "1rem4",
-          "width": "520px",
-        }
-      }
-    >
-      <div
-        className="iot--card iot--card--wrapper"
-        data-testid="Card"
-        id="table-list"
-        role="presentation"
-        style={
-          Object {
-            "--card-default-height": "624px",
-          }
-        }
-      >
-        <div
-          className="iot--card--content"
-          style={
-            Object {
-              "--card-content-height": "576px",
-            }
-          }
-        >
-          <div
-            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
-            data-testid="table-for-card-table-list-table-container"
-          >
-            <section
-              aria-label="data table toolbar"
-              className="bx--table-toolbar"
-              data-testid="table-for-card-table-list-table-toolbar"
-            >
-              <div
-                aria-hidden={true}
-                className="bx--batch-actions iot--table-batch-actions"
-                data-testid="table-for-card-table-list-table-toolbar-batch-actions"
-              >
-                <div
-                  className="bx--batch-summary"
-                >
-                  <p
-                    className="bx--batch-summary__para"
-                  >
-                    <span>
-                      0 items selected
-                    </span>
-                  </p>
-                </div>
-                <div
-                  className="bx--action-list"
-                >
-                  <button
-                    aria-pressed={null}
-                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    type="button"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </div>
-              <label
-                className="iot--table-toolbar-secondary-title"
-              >
-                Open Alerts
-              </label>
-              <div
-                className="iot--table-tooltip-container"
-              >
-                <div
-                  className="bx--tooltip__label"
-                  id="card-tooltip-trigger-table-for-card-table-list"
-                >
-                  
-                  <div
-                    aria-describedby={null}
-                    className="bx--tooltip__trigger"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onContextMenu={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
-                    <svg
-                      aria-hidden={true}
-                      description={null}
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role={null}
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
-                      />
-                      <path
-                        d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-content iot--table-toolbar-content"
-                data-testid="table-for-card-table-list-table-toolbar-content"
-              >
-                <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  tabIndex="0"
-                >
-                  <div
-                    aria-labelledby="table-for-card-table-list-toolbar-search-search"
-                    className="bx--search bx--search--sm table-toolbar-search"
-                    role="search"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="bx--search-magnifier"
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                      />
-                    </svg>
-                    <label
-                      className="bx--label"
-                      htmlFor="table-for-card-table-list-toolbar-search"
-                      id="table-for-card-table-list-toolbar-search-search"
-                    >
-                      Search
-                    </label>
-                    <input
-                      autoComplete="off"
-                      className="bx--search-input"
-                      data-testid="table-for-card-table-list-table-toolbar-search"
-                      id="table-for-card-table-list-toolbar-search"
-                      onChange={[Function]}
-                      onKeyDown={[Function]}
-                      placeholder="Search"
-                      role="searchbox"
-                      tabIndex="-1"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Clear search input"
-                      className="bx--search-close bx--search-close--hidden"
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-                <button
-                  aria-pressed={null}
-                  className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
-                  data-testid="download-button"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Download table content"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Download table content"
-                    className="bx--btn__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M26 24v4H6V24H4v4H4a2 2 0 002 2H26a2 2 0 002-2h0V24zM26 14L24.59 12.59 17 20.17 17 2 15 2 15 20.17 7.41 12.59 6 14 16 24 26 14z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  aria-pressed={null}
-                  className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
-                  data-testid="filter-button"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Filters"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Filters"
-                    className="bx--btn__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M18,28H14a2,2,0,0,1-2-2V18.41L4.59,11A2,2,0,0,1,4,9.59V6A2,2,0,0,1,6,4H26a2,2,0,0,1,2,2V9.59A2,2,0,0,1,27.41,11L20,18.41V26A2,2,0,0,1,18,28ZM6,6V9.59l8,8V26h4V17.59l8-8V6Z"
-                    />
-                  </svg>
-                </button>
-                <div
-                  className="iot--card--toolbar"
-                >
-                  <div
-                    className="iot--card--toolbar-date-range-wrapper"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="open and close list of options"
-                      className="iot--card--toolbar-date-range-action bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      title="Select time range"
-                      type="button"
-                    >
-                      <svg
-                        aria-label="Select time range"
-                        className="bx--overflow-menu__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height={16}
-                        onClick={[Function]}
-                        onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        viewBox="0 0 32 32"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
-                        />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
-                        />
-                        <path
-                          d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
-                        />
-                        <title>
-                          Select time range
-                        </title>
-                      </svg>
-                    </button>
-                  </div>
-                  <button
-                    aria-pressed={null}
-                    className="iot--card--toolbar-action iot--card--toolbar-svg-wrapper bx--btn--icon-only bx--btn bx--btn--ghost"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    title="Expand to fullscreen"
-                    type="button"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      aria-label="Expand to fullscreen"
-                      className="bx--btn__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      viewBox="0 0 32 32"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M28,4H10A2.0059,2.0059,0,0,0,8,6V20a2.0059,2.0059,0,0,0,2,2H28a2.0059,2.0059,0,0,0,2-2V6A2.0059,2.0059,0,0,0,28,4Zm0,16H10V6H28Z"
-                      />
-                      <path
-                        d="M18,26H4V16H6V14H4a2.0059,2.0059,0,0,0-2,2V26a2.0059,2.0059,0,0,0,2,2H18a2.0059,2.0059,0,0,0,2-2V24H18Z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-            </section>
-            <div
-              className="addons-iot-table-container"
-            >
-              <div
-                className="bx--data-table-content"
-              >
-                <table
-                  className="bx--data-table bx--data-table--no-border"
-                  data-testid="table-for-card-table-list"
-                  id="table-for-card-table-list"
-                  title={null}
-                >
-                  <thead
-                    data-testid="table-for-card-table-list-table-head"
-                    onMouseMove={null}
-                    onMouseUp={null}
-                  >
-                    <tr>
-                      <th
-                        className="bx--table-expand"
-                        scope="col"
-                        testID="table-for-card-table-list-table-head-row-expansion-column"
-                      />
-                      <th
-                        aria-sort="none"
-                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
-                        data-testid="table-for-card-table-list-table-head-column-alert"
-                        scope="col"
-                        style={
-                          Object {
-                            "width": undefined,
-                          }
-                        }
-                        width=""
-                      >
-                        <button
-                          align="start"
-                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
-                          data-column="alert"
-                          data-floating-menu-container={true}
-                          id="column-alert"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "--table-header-width": "",
-                            }
-                          }
-                          width=""
-                        >
-                          <span
-                            className="bx--table-header-label"
-                          >
-                            <span
-                              className=""
-                              title="Alert"
-                            >
-                              Alert
-                            </span>
-                          </span>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                            />
-                          </svg>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon-unsorted"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                            />
-                          </svg>
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="none"
-                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
-                        data-testid="table-for-card-table-list-table-head-column-hour"
-                        scope="col"
-                        style={
-                          Object {
-                            "width": undefined,
-                          }
-                        }
-                        width=""
-                      >
-                        <button
-                          align="start"
-                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
-                          data-column="hour"
-                          data-floating-menu-container={true}
-                          id="column-hour"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "--table-header-width": "",
-                            }
-                          }
-                          width=""
-                        >
-                          <span
-                            className="bx--table-header-label"
-                          >
-                            <span
-                              className=""
-                              title="Hour"
-                            >
-                              Hour
-                            </span>
-                          </span>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                            />
-                          </svg>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon-unsorted"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                            />
-                          </svg>
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="none"
-                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
-                        data-testid="table-for-card-table-list-table-head-column-pressure"
-                        scope="col"
-                        style={
-                          Object {
-                            "width": undefined,
-                          }
-                        }
-                        width=""
-                      >
-                        <button
-                          align="start"
-                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
-                          data-column="pressure"
-                          data-floating-menu-container={true}
-                          id="column-pressure"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "--table-header-width": "",
-                            }
-                          }
-                          width=""
-                        >
-                          <span
-                            className="bx--table-header-label"
-                          >
-                            <span
-                              className=""
-                              title="Pressure"
-                            >
-                              Pressure
-                            </span>
-                          </span>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                            />
-                          </svg>
-                          <svg
-                            aria-label="Sort rows by this header in ascending order"
-                            className="bx--table-sort__icon-unsorted"
-                            fill="currentColor"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                            />
-                          </svg>
-                        </button>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody
-                    aria-live="polite"
-                    data-testID="table-for-card-table-list-table-body"
-                  >
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-10-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI010 proccess need to optimize adjust Y variables"
-                          >
-                            AHI010 proccess need to optimize adjust Y variables
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-10-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="07/23/2019 04:26"
-                          >
-                            07/23/2019 04:26
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-10-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="0"
-                          >
-                            0
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-11-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI010 proccess need to optimize adjust Y variables"
-                          >
-                            AHI010 proccess need to optimize adjust Y variables
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-11-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="07/23/2019 05:26"
-                          >
-                            07/23/2019 05:26
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-11-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="1"
-                          >
-                            1
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-1-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI005 Asset failure"
-                          >
-                            AHI005 Asset failure
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-1-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="07/23/2019 05:26"
-                          >
-                            07/23/2019 05:26
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-1-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="0"
-                          >
-                            0
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-2-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI003 process need to optimize adjust X variables"
-                          >
-                            AHI003 process need to optimize adjust X variables
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-2-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="07/23/2019 04:26"
-                          >
-                            07/23/2019 04:26
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-2-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="2"
-                          >
-                            2
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-6-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI001 proccess need to optimize."
-                          >
-                            AHI001 proccess need to optimize.
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-6-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="07/23/2019 04:30"
-                          >
-                            07/23/2019 04:30
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-6-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="68"
-                          >
-                            68
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-3-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI001 proccess need to optimize adjust Y variables"
-                          >
-                            AHI001 proccess need to optimize adjust Y variables
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-3-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="08/02/2019 09:42"
-                          >
-                            08/02/2019 09:42
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-3-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="10"
-                          >
-                            10
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-4-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI001 proccess need to optimize adjust Y variables"
-                          >
-                            AHI001 proccess need to optimize adjust Y variables
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-4-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="07/23/2019 05:26"
-                          >
-                            07/23/2019 05:26
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-4-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="0"
-                          >
-                            0
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-8-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI001 proccess need to optimize adjust Y variables"
-                          >
-                            AHI001 proccess need to optimize adjust Y variables
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-8-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="07/23/2019 03:30"
-                          >
-                            07/23/2019 03:30
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-8-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="0"
-                          >
-                            0
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-9-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI001 proccess need to optimize adjust Y variables"
-                          >
-                            AHI001 proccess need to optimize adjust Y variables
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-9-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="07/23/2019 04:26"
-                          >
-                            07/23/2019 04:26
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-9-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="0"
-                          >
-                            0
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr
-                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
-                      data-child-count={0}
-                      data-nesting-offset={0}
-                      data-parent-row={true}
-                      data-row-nesting={false}
-                      onClick={[Function]}
-                    >
-                      <td
-                        className="bx--table-expand"
-                        headers="expand"
-                      >
-                        <button
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__button"
-                          onClick={[Function]}
-                          title="Click to expand content"
-                          type="button"
-                        >
-                          <svg
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__svg"
-                            fill="currentColor"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                            />
-                          </svg>
-                        </button>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="alert"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-5-alert"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="AHI001 proccess need to optimize"
-                          >
-                            AHI001 proccess need to optimize
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="hour"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-5-hour"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="07/23/2019 04:30"
-                          >
-                            07/23/2019 04:30
-                          </span>
-                        </span>
-                      </td>
-                      <td
-                        align="start"
-                        className="data-table-start iot--table__cell--sortable"
-                        data-column="pressure"
-                        data-offset={0}
-                        id="cell-table-for-card-table-list-row-5-pressure"
-                        offset={0}
-                        width=""
-                      >
-                        <span
-                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                        >
-                          <span
-                            className=""
-                            title="10"
-                          >
-                            10
-                          </span>
-                        </span>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-            </div>
-            <div
-              className="bx--pagination iot--pagination iot--pagination--hide-page"
-              data-testid="table-for-card-table-list-table-pagination"
-              style={
-                Object {
-                  "--pagination-text-display": "flex",
-                }
-              }
-            >
-              <div
-                className="bx--pagination__left"
-              >
-                <label
-                  className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-47"
-                  id="bx-pagination-select-47-count-label"
-                >
-                  Items per page:
-                </label>
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__item-count"
-                  >
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-47"
-                          onChange={[Function]}
-                          value={10}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={10}
-                          >
-                            10
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={25}
-                          >
-                            25
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={100}
-                          >
-                            100
-                          </option>
-                        </select>
-                        <svg
-                          aria-hidden={true}
-                          className="bx--select__arrow"
-                          fill="currentColor"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text bx--pagination__items-count"
-                >
-                  1–10 of 11 items
-                </span>
-              </div>
-              <div
-                className="bx--pagination__right"
-              >
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__page-number"
-                  >
-                    <label
-                      className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-47-right"
-                    >
-                      Page number, of 2 pages
-                    </label>
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-47-right"
-                          onChange={[Function]}
-                          value={1}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={1}
-                          >
-                            1
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={2}
-                          >
-                            2
-                          </option>
-                        </select>
-                        <svg
-                          aria-hidden={true}
-                          className="bx--select__arrow"
-                          fill="currentColor"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1 of 2 pages
-                </span>
-                <div
-                  className="bx--pagination__control-buttons"
-                >
-                  <button
-                    className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index bx--btn bx--btn--ghost bx--btn--disabled bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
-                    disabled={true}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    type="button"
-                  >
-                    <span
-                      className="bx--assistive-text"
-                    >
-                      Previous page
-                    </span>
-                    <svg
-                      aria-hidden="true"
-                      aria-label="Previous page"
-                      className="bx--btn__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      viewBox="0 0 32 32"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M20 24L10 16 20 8z"
-                      />
-                    </svg>
-                  </button>
-                  <button
-                    className="bx--pagination__button bx--pagination__button--forward bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-end"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    type="button"
-                  >
-                    <span
-                      className="bx--assistive-text"
-                    >
-                      Next page
-                    </span>
-                    <svg
-                      aria-hidden="true"
-                      aria-label="Next page"
-                      className="bx--btn__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      viewBox="0 0 32 32"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M12 8L22 16 12 24z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <button
-    className="info__show-button"
-    onClick={[Function]}
-    style={
-      Object {
-        "background": "#027ac5",
-        "border": "none",
-        "borderRadius": "0 0 0 5px",
-        "color": "#fff",
-        "cursor": "pointer",
-        "display": "block",
-        "fontFamily": "sans-serif",
-        "fontSize": 12,
-        "padding": "5px 15px",
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
-    type="button"
-  >
-    Show Info
-  </button>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/TableCard with row expansion and timestamp 1`] = `
 <div
   className="storybook-container"
 >
@@ -31364,6 +26494,3636 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/TableCard with row expansion and row specific link variables 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": "1rem4",
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="iot--card iot--card--wrapper"
+        data-testid="Card"
+        id="table-list"
+        role="presentation"
+        style={
+          Object {
+            "--card-default-height": "624px",
+          }
+        }
+      >
+        <div
+          className="iot--card--content"
+          style={
+            Object {
+              "--card-content-height": "576px",
+            }
+          }
+        >
+          <div
+            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
+            data-testid="table-for-card-table-list-table-container"
+          >
+            <section
+              aria-label="data table toolbar"
+              className="bx--table-toolbar"
+              data-testid="table-for-card-table-list-table-toolbar"
+            >
+              <div
+                aria-hidden={true}
+                className="bx--batch-actions iot--table-batch-actions"
+                data-testid="table-for-card-table-list-table-toolbar-batch-actions"
+              >
+                <div
+                  className="bx--batch-summary"
+                >
+                  <p
+                    className="bx--batch-summary__para"
+                  >
+                    <span>
+                      0 items selected
+                    </span>
+                  </p>
+                </div>
+                <div
+                  className="bx--action-list"
+                >
+                  <button
+                    aria-pressed={null}
+                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={-1}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+              <label
+                className="iot--table-toolbar-secondary-title"
+              >
+                Open Alerts
+              </label>
+              <div
+                className="iot--table-tooltip-container"
+              >
+                <div
+                  className="bx--tooltip__label"
+                  id="card-tooltip-trigger-table-for-card-table-list"
+                >
+                  
+                  <div
+                    aria-describedby={null}
+                    className="bx--tooltip__trigger"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onContextMenu={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      description={null}
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role={null}
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
+                      />
+                      <path
+                        d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="bx--toolbar-content iot--table-toolbar-content"
+                data-testid="table-for-card-table-list-table-toolbar-content"
+              >
+                <div
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  tabIndex="0"
+                >
+                  <div
+                    aria-labelledby="table-for-card-table-list-toolbar-search-search"
+                    className="bx--search bx--search--sm table-toolbar-search"
+                    role="search"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="bx--search-magnifier"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                      />
+                    </svg>
+                    <label
+                      className="bx--label"
+                      htmlFor="table-for-card-table-list-toolbar-search"
+                      id="table-for-card-table-list-toolbar-search-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      autoComplete="off"
+                      className="bx--search-input"
+                      data-testid="table-for-card-table-list-table-toolbar-search"
+                      id="table-for-card-table-list-toolbar-search"
+                      onChange={[Function]}
+                      onKeyDown={[Function]}
+                      placeholder="Search"
+                      role="searchbox"
+                      tabIndex="-1"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <button
+                  aria-pressed={null}
+                  className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
+                  data-testid="download-button"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  title="Download table content"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Download table content"
+                    className="bx--btn__icon"
+                    fill="currentColor"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M26 24v4H6V24H4v4H4a2 2 0 002 2H26a2 2 0 002-2h0V24zM26 14L24.59 12.59 17 20.17 17 2 15 2 15 20.17 7.41 12.59 6 14 16 24 26 14z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-pressed={null}
+                  className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
+                  data-testid="filter-button"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  title="Filters"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Filters"
+                    className="bx--btn__icon"
+                    fill="currentColor"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M18,28H14a2,2,0,0,1-2-2V18.41L4.59,11A2,2,0,0,1,4,9.59V6A2,2,0,0,1,6,4H26a2,2,0,0,1,2,2V9.59A2,2,0,0,1,27.41,11L20,18.41V26A2,2,0,0,1,18,28ZM6,6V9.59l8,8V26h4V17.59l8-8V6Z"
+                    />
+                  </svg>
+                </button>
+                <div
+                  className="iot--card--toolbar"
+                >
+                  <div
+                    className="iot--card--toolbar-date-range-wrapper"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="open and close list of options"
+                      className="iot--card--toolbar-date-range-action bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      title="Select time range"
+                      type="button"
+                    >
+                      <svg
+                        aria-label="Select time range"
+                        className="bx--overflow-menu__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
+                        />
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        />
+                        <path
+                          d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
+                        />
+                        <title>
+                          Select time range
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                  <button
+                    aria-pressed={null}
+                    className="iot--card--toolbar-action iot--card--toolbar-svg-wrapper bx--btn--icon-only bx--btn bx--btn--ghost"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    title="Expand to fullscreen"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Expand to fullscreen"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M28,4H10A2.0059,2.0059,0,0,0,8,6V20a2.0059,2.0059,0,0,0,2,2H28a2.0059,2.0059,0,0,0,2-2V6A2.0059,2.0059,0,0,0,28,4Zm0,16H10V6H28Z"
+                      />
+                      <path
+                        d="M18,26H4V16H6V14H4a2.0059,2.0059,0,0,0-2,2V26a2.0059,2.0059,0,0,0,2,2H18a2.0059,2.0059,0,0,0,2-2V24H18Z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </section>
+            <div
+              className="addons-iot-table-container"
+            >
+              <div
+                className="bx--data-table-content"
+              >
+                <table
+                  className="bx--data-table bx--data-table--no-border"
+                  data-testid="table-for-card-table-list"
+                  id="table-for-card-table-list"
+                  title={null}
+                >
+                  <thead
+                    data-testid="table-for-card-table-list-table-head"
+                    onMouseMove={null}
+                    onMouseUp={null}
+                  >
+                    <tr>
+                      <th
+                        className="bx--table-expand"
+                        scope="col"
+                        testID="table-for-card-table-list-table-head-row-expansion-column"
+                      />
+                      <th
+                        aria-sort="none"
+                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
+                        data-testid="table-for-card-table-list-table-head-column-alert"
+                        scope="col"
+                        style={
+                          Object {
+                            "width": undefined,
+                          }
+                        }
+                        width=""
+                      >
+                        <button
+                          align="start"
+                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
+                          data-column="alert"
+                          data-floating-menu-container={true}
+                          id="column-alert"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "--table-header-width": "",
+                            }
+                          }
+                          width=""
+                        >
+                          <span
+                            className="bx--table-header-label"
+                          >
+                            <span
+                              className=""
+                              title="Alert"
+                            >
+                              Alert
+                            </span>
+                          </span>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                            />
+                          </svg>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon-unsorted"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                            />
+                          </svg>
+                        </button>
+                      </th>
+                      <th
+                        aria-sort="none"
+                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
+                        data-testid="table-for-card-table-list-table-head-column-hour"
+                        scope="col"
+                        style={
+                          Object {
+                            "width": undefined,
+                          }
+                        }
+                        width=""
+                      >
+                        <button
+                          align="start"
+                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
+                          data-column="hour"
+                          data-floating-menu-container={true}
+                          id="column-hour"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "--table-header-width": "",
+                            }
+                          }
+                          width=""
+                        >
+                          <span
+                            className="bx--table-header-label"
+                          >
+                            <span
+                              className=""
+                              title="Hour"
+                            >
+                              Hour
+                            </span>
+                          </span>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                            />
+                          </svg>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon-unsorted"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                            />
+                          </svg>
+                        </button>
+                      </th>
+                      <th
+                        aria-sort="none"
+                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
+                        data-testid="table-for-card-table-list-table-head-column-pressure"
+                        scope="col"
+                        style={
+                          Object {
+                            "width": undefined,
+                          }
+                        }
+                        width=""
+                      >
+                        <button
+                          align="start"
+                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
+                          data-column="pressure"
+                          data-floating-menu-container={true}
+                          id="column-pressure"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "--table-header-width": "",
+                            }
+                          }
+                          width=""
+                        >
+                          <span
+                            className="bx--table-header-label"
+                          >
+                            <span
+                              className=""
+                              title="Pressure"
+                            >
+                              Pressure
+                            </span>
+                          </span>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                            />
+                          </svg>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon-unsorted"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                            />
+                          </svg>
+                        </button>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    aria-live="polite"
+                    data-testID="table-for-card-table-list-table-body"
+                  >
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-10-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI010 proccess need to optimize adjust Y variables"
+                          >
+                            AHI010 proccess need to optimize adjust Y variables
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-10-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="07/23/2019 04:26"
+                          >
+                            07/23/2019 04:26
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-10-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="0"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-11-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI010 proccess need to optimize adjust Y variables"
+                          >
+                            AHI010 proccess need to optimize adjust Y variables
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-11-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="07/23/2019 05:26"
+                          >
+                            07/23/2019 05:26
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-11-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="1"
+                          >
+                            1
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-1-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI005 Asset failure"
+                          >
+                            AHI005 Asset failure
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-1-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="07/23/2019 05:26"
+                          >
+                            07/23/2019 05:26
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-1-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="0"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-2-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI003 process need to optimize adjust X variables"
+                          >
+                            AHI003 process need to optimize adjust X variables
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-2-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="07/23/2019 04:26"
+                          >
+                            07/23/2019 04:26
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-2-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="2"
+                          >
+                            2
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-6-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI001 proccess need to optimize."
+                          >
+                            AHI001 proccess need to optimize.
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-6-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="07/23/2019 04:30"
+                          >
+                            07/23/2019 04:30
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-6-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="68"
+                          >
+                            68
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-3-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI001 proccess need to optimize adjust Y variables"
+                          >
+                            AHI001 proccess need to optimize adjust Y variables
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-3-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="08/02/2019 09:42"
+                          >
+                            08/02/2019 09:42
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-3-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="10"
+                          >
+                            10
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-4-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI001 proccess need to optimize adjust Y variables"
+                          >
+                            AHI001 proccess need to optimize adjust Y variables
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-4-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="07/23/2019 05:26"
+                          >
+                            07/23/2019 05:26
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-4-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="0"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-8-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI001 proccess need to optimize adjust Y variables"
+                          >
+                            AHI001 proccess need to optimize adjust Y variables
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-8-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="07/23/2019 03:30"
+                          >
+                            07/23/2019 03:30
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-8-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="0"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-9-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI001 proccess need to optimize adjust Y variables"
+                          >
+                            AHI001 proccess need to optimize adjust Y variables
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-9-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="07/23/2019 04:26"
+                          >
+                            07/23/2019 04:26
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-9-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="0"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-5-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI001 proccess need to optimize"
+                          >
+                            AHI001 proccess need to optimize
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-5-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="07/23/2019 04:30"
+                          >
+                            07/23/2019 04:30
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-5-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="10"
+                          >
+                            10
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div
+              className="bx--pagination iot--pagination iot--pagination--hide-page"
+              data-testid="table-for-card-table-list-table-pagination"
+              style={
+                Object {
+                  "--pagination-text-display": "flex",
+                }
+              }
+            >
+              <div
+                className="bx--pagination__left"
+              >
+                <label
+                  className="bx--pagination__text"
+                  htmlFor="bx-pagination-select-46"
+                  id="bx-pagination-select-46-count-label"
+                >
+                  Items per page:
+                </label>
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__item-count"
+                  >
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-46"
+                          onChange={[Function]}
+                          value={10}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={10}
+                          >
+                            10
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={25}
+                          >
+                            25
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={100}
+                          >
+                            100
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden={true}
+                          className="bx--select__arrow"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text bx--pagination__items-count"
+                >
+                  1–10 of 11 items
+                </span>
+              </div>
+              <div
+                className="bx--pagination__right"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__page-number"
+                  >
+                    <label
+                      className="bx--label bx--visually-hidden"
+                      htmlFor="bx-pagination-select-46-right"
+                    >
+                      Page number, of 2 pages
+                    </label>
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-46-right"
+                          onChange={[Function]}
+                          value={1}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={1}
+                          >
+                            1
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={2}
+                          >
+                            2
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden={true}
+                          className="bx--select__arrow"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1 of 2 pages
+                </span>
+                <div
+                  className="bx--pagination__control-buttons"
+                >
+                  <button
+                    className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index bx--btn bx--btn--ghost bx--btn--disabled bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                    disabled={true}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Previous page
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Previous page"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M20 24L10 16 20 8z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="bx--pagination__button bx--pagination__button--forward bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-end"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Next page
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Next page"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M12 8L22 16 12 24z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/TableCard with row expansion and timestamp 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": "1rem4",
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="iot--card iot--card--wrapper"
+        data-testid="Card"
+        id="table-list"
+        role="presentation"
+        style={
+          Object {
+            "--card-default-height": "624px",
+          }
+        }
+      >
+        <div
+          className="iot--card--content"
+          style={
+            Object {
+              "--card-content-height": "576px",
+            }
+          }
+        >
+          <div
+            className="TableCard__StyledStatefulTable-q9l5bz-0 rxvQn iot--table-container bx--data-table-container"
+            data-testid="table-for-card-table-list-table-container"
+          >
+            <section
+              aria-label="data table toolbar"
+              className="bx--table-toolbar"
+              data-testid="table-for-card-table-list-table-toolbar"
+            >
+              <div
+                aria-hidden={true}
+                className="bx--batch-actions iot--table-batch-actions"
+                data-testid="table-for-card-table-list-table-toolbar-batch-actions"
+              >
+                <div
+                  className="bx--batch-summary"
+                >
+                  <p
+                    className="bx--batch-summary__para"
+                  >
+                    <span>
+                      0 items selected
+                    </span>
+                  </p>
+                </div>
+                <div
+                  className="bx--action-list"
+                >
+                  <button
+                    aria-pressed={null}
+                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={-1}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+              <label
+                className="iot--table-toolbar-secondary-title"
+              >
+                Open Alerts
+              </label>
+              <div
+                className="iot--table-tooltip-container"
+              >
+                <div
+                  className="bx--tooltip__label"
+                  id="card-tooltip-trigger-table-for-card-table-list"
+                >
+                  
+                  <div
+                    aria-describedby={null}
+                    className="bx--tooltip__trigger"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onContextMenu={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      description={null}
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role={null}
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
+                      />
+                      <path
+                        d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="bx--toolbar-content iot--table-toolbar-content"
+                data-testid="table-for-card-table-list-table-toolbar-content"
+              >
+                <div
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  tabIndex="0"
+                >
+                  <div
+                    aria-labelledby="table-for-card-table-list-toolbar-search-search"
+                    className="bx--search bx--search--sm table-toolbar-search"
+                    role="search"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="bx--search-magnifier"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                      />
+                    </svg>
+                    <label
+                      className="bx--label"
+                      htmlFor="table-for-card-table-list-toolbar-search"
+                      id="table-for-card-table-list-toolbar-search-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      autoComplete="off"
+                      className="bx--search-input"
+                      data-testid="table-for-card-table-list-table-toolbar-search"
+                      id="table-for-card-table-list-toolbar-search"
+                      onChange={[Function]}
+                      onKeyDown={[Function]}
+                      placeholder="Search"
+                      role="searchbox"
+                      tabIndex="-1"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <button
+                  aria-pressed={null}
+                  className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
+                  data-testid="download-button"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  title="Download table content"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Download table content"
+                    className="bx--btn__icon"
+                    fill="currentColor"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M26 24v4H6V24H4v4H4a2 2 0 002 2H26a2 2 0 002-2h0V24zM26 14L24.59 12.59 17 20.17 17 2 15 2 15 20.17 7.41 12.59 6 14 16 24 26 14z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-pressed={null}
+                  className="bx--btn--icon-only iot--tooltip-svg-wrapper bx--btn bx--btn--ghost"
+                  data-testid="filter-button"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  title="Filters"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Filters"
+                    className="bx--btn__icon"
+                    fill="currentColor"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M18,28H14a2,2,0,0,1-2-2V18.41L4.59,11A2,2,0,0,1,4,9.59V6A2,2,0,0,1,6,4H26a2,2,0,0,1,2,2V9.59A2,2,0,0,1,27.41,11L20,18.41V26A2,2,0,0,1,18,28ZM6,6V9.59l8,8V26h4V17.59l8-8V6Z"
+                    />
+                  </svg>
+                </button>
+                <div
+                  className="iot--card--toolbar"
+                >
+                  <div
+                    className="iot--card--toolbar-date-range-wrapper"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="open and close list of options"
+                      className="iot--card--toolbar-date-range-action bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      title="Select time range"
+                      type="button"
+                    >
+                      <svg
+                        aria-label="Select time range"
+                        className="bx--overflow-menu__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
+                        />
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        />
+                        <path
+                          d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
+                        />
+                        <title>
+                          Select time range
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                  <button
+                    aria-pressed={null}
+                    className="iot--card--toolbar-action iot--card--toolbar-svg-wrapper bx--btn--icon-only bx--btn bx--btn--ghost"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    title="Expand to fullscreen"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Expand to fullscreen"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M28,4H10A2.0059,2.0059,0,0,0,8,6V20a2.0059,2.0059,0,0,0,2,2H28a2.0059,2.0059,0,0,0,2-2V6A2.0059,2.0059,0,0,0,28,4Zm0,16H10V6H28Z"
+                      />
+                      <path
+                        d="M18,26H4V16H6V14H4a2.0059,2.0059,0,0,0-2,2V26a2.0059,2.0059,0,0,0,2,2H18a2.0059,2.0059,0,0,0,2-2V24H18Z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </section>
+            <div
+              className="addons-iot-table-container"
+            >
+              <div
+                className="bx--data-table-content"
+              >
+                <table
+                  className="bx--data-table bx--data-table--no-border"
+                  data-testid="table-for-card-table-list"
+                  id="table-for-card-table-list"
+                  title={null}
+                >
+                  <thead
+                    data-testid="table-for-card-table-list-table-head"
+                    onMouseMove={null}
+                    onMouseUp={null}
+                  >
+                    <tr>
+                      <th
+                        className="bx--table-expand"
+                        scope="col"
+                        testID="table-for-card-table-list-table-head-row-expansion-column"
+                      />
+                      <th
+                        aria-sort="none"
+                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
+                        data-testid="table-for-card-table-list-table-head-column-alert"
+                        scope="col"
+                        style={
+                          Object {
+                            "width": undefined,
+                          }
+                        }
+                        width=""
+                      >
+                        <button
+                          align="start"
+                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
+                          data-column="alert"
+                          data-floating-menu-container={true}
+                          id="column-alert"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "--table-header-width": "",
+                            }
+                          }
+                          width=""
+                        >
+                          <span
+                            className="bx--table-header-label"
+                          >
+                            <span
+                              className=""
+                              title="Alert"
+                            >
+                              Alert
+                            </span>
+                          </span>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                            />
+                          </svg>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon-unsorted"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                            />
+                          </svg>
+                        </button>
+                      </th>
+                      <th
+                        aria-sort="none"
+                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
+                        data-testid="table-for-card-table-list-table-head-column-hour"
+                        scope="col"
+                        style={
+                          Object {
+                            "width": undefined,
+                          }
+                        }
+                        width=""
+                      >
+                        <button
+                          align="start"
+                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
+                          data-column="hour"
+                          data-floating-menu-container={true}
+                          id="column-hour"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "--table-header-width": "",
+                            }
+                          }
+                          width=""
+                        >
+                          <span
+                            className="bx--table-header-label"
+                          >
+                            <span
+                              className=""
+                              title="Hour"
+                            >
+                              Hour
+                            </span>
+                          </span>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                            />
+                          </svg>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon-unsorted"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                            />
+                          </svg>
+                        </button>
+                      </th>
+                      <th
+                        aria-sort="none"
+                        className="table-header-label-start iot--table-head--table-header table-header-sortable"
+                        data-testid="table-for-card-table-list-table-head-column-pressure"
+                        scope="col"
+                        style={
+                          Object {
+                            "width": undefined,
+                          }
+                        }
+                        width=""
+                      >
+                        <button
+                          align="start"
+                          className="table-header-label-start iot--table-head--table-header table-header-sortable bx--table-sort"
+                          data-column="pressure"
+                          data-floating-menu-container={true}
+                          id="column-pressure"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "--table-header-width": "",
+                            }
+                          }
+                          width=""
+                        >
+                          <span
+                            className="bx--table-header-label"
+                          >
+                            <span
+                              className=""
+                              title="Pressure"
+                            >
+                              Pressure
+                            </span>
+                          </span>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                            />
+                          </svg>
+                          <svg
+                            aria-label="Sort rows by this header in ascending order"
+                            className="bx--table-sort__icon-unsorted"
+                            fill="currentColor"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                            />
+                          </svg>
+                        </button>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    aria-live="polite"
+                    data-testID="table-for-card-table-list-table-body"
+                  >
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-10-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI010 proccess need to optimize adjust Y variables"
+                          >
+                            AHI010 proccess need to optimize adjust Y variables
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-10-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="07/23/2019 04:26"
+                          >
+                            07/23/2019 04:26
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-10-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="0"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-11-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI010 proccess need to optimize adjust Y variables"
+                          >
+                            AHI010 proccess need to optimize adjust Y variables
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-11-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="07/23/2019 05:26"
+                          >
+                            07/23/2019 05:26
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-11-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="1"
+                          >
+                            1
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-1-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI005 Asset failure"
+                          >
+                            AHI005 Asset failure
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-1-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="07/23/2019 05:26"
+                          >
+                            07/23/2019 05:26
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-1-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="0"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-2-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI003 process need to optimize adjust X variables"
+                          >
+                            AHI003 process need to optimize adjust X variables
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-2-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="07/23/2019 04:26"
+                          >
+                            07/23/2019 04:26
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-2-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="2"
+                          >
+                            2
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-6-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI001 proccess need to optimize."
+                          >
+                            AHI001 proccess need to optimize.
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-6-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="07/23/2019 04:30"
+                          >
+                            07/23/2019 04:30
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-6-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="68"
+                          >
+                            68
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-3-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI001 proccess need to optimize adjust Y variables"
+                          >
+                            AHI001 proccess need to optimize adjust Y variables
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-3-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="08/02/2019 09:42"
+                          >
+                            08/02/2019 09:42
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-3-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="10"
+                          >
+                            10
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-4-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI001 proccess need to optimize adjust Y variables"
+                          >
+                            AHI001 proccess need to optimize adjust Y variables
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-4-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="07/23/2019 05:26"
+                          >
+                            07/23/2019 05:26
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-4-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="0"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-8-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI001 proccess need to optimize adjust Y variables"
+                          >
+                            AHI001 proccess need to optimize adjust Y variables
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-8-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="07/23/2019 03:30"
+                          >
+                            07/23/2019 03:30
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-8-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="0"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-9-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI001 proccess need to optimize adjust Y variables"
+                          >
+                            AHI001 proccess need to optimize adjust Y variables
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-9-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="07/23/2019 04:26"
+                          >
+                            07/23/2019 04:26
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-9-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="0"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr
+                      className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 cTiOFn"
+                      data-child-count={0}
+                      data-nesting-offset={0}
+                      data-parent-row={true}
+                      data-row-nesting={false}
+                      onClick={[Function]}
+                    >
+                      <td
+                        className="bx--table-expand"
+                        headers="expand"
+                      >
+                        <button
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__button"
+                          onClick={[Function]}
+                          title="Click to expand content"
+                          type="button"
+                        >
+                          <svg
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__svg"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="alert"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-5-alert"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="AHI001 proccess need to optimize"
+                          >
+                            AHI001 proccess need to optimize
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="hour"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-5-hour"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="07/23/2019 04:30"
+                          >
+                            07/23/2019 04:30
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start iot--table__cell--sortable"
+                        data-column="pressure"
+                        data-offset={0}
+                        id="cell-table-for-card-table-list-row-5-pressure"
+                        offset={0}
+                        width=""
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                        >
+                          <span
+                            className=""
+                            title="10"
+                          >
+                            10
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div
+              className="bx--pagination iot--pagination iot--pagination--hide-page"
+              data-testid="table-for-card-table-list-table-pagination"
+              style={
+                Object {
+                  "--pagination-text-display": "flex",
+                }
+              }
+            >
+              <div
+                className="bx--pagination__left"
+              >
+                <label
+                  className="bx--pagination__text"
+                  htmlFor="bx-pagination-select-44"
+                  id="bx-pagination-select-44-count-label"
+                >
+                  Items per page:
+                </label>
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__item-count"
+                  >
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-44"
+                          onChange={[Function]}
+                          value={10}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={10}
+                          >
+                            10
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={25}
+                          >
+                            25
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={100}
+                          >
+                            100
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden={true}
+                          className="bx--select__arrow"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text bx--pagination__items-count"
+                >
+                  1–10 of 11 items
+                </span>
+              </div>
+              <div
+                className="bx--pagination__right"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__page-number"
+                  >
+                    <label
+                      className="bx--label bx--visually-hidden"
+                      htmlFor="bx-pagination-select-44-right"
+                    >
+                      Page number, of 2 pages
+                    </label>
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-44-right"
+                          onChange={[Function]}
+                          value={1}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={1}
+                          >
+                            1
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={2}
+                          >
+                            2
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden={true}
+                          className="bx--select__arrow"
+                          fill="currentColor"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1 of 2 pages
+                </span>
+                <div
+                  className="bx--pagination__control-buttons"
+                >
+                  <button
+                    className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index bx--btn bx--btn--ghost bx--btn--disabled bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                    disabled={true}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Previous page
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Previous page"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M20 24L10 16 20 8z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="bx--pagination__button bx--pagination__button--forward bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-end"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Next page
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Next page"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M12 8L22 16 12 24z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/TableCard with single actions 1`] = `
 <div
   className="storybook-container"
@@ -32980,8 +31740,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-36"
-                  id="bx-pagination-select-36-count-label"
+                  htmlFor="bx-pagination-select-35"
+                  id="bx-pagination-select-35-count-label"
                 >
                   Items per page:
                 </label>
@@ -33000,7 +31760,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-36"
+                          id="bx-pagination-select-35"
                           onChange={[Function]}
                           value={10}
                         >
@@ -33065,7 +31825,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-36-right"
+                      htmlFor="bx-pagination-select-35-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -33078,7 +31838,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-36-right"
+                          id="bx-pagination-select-35-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -35685,8 +34445,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-39"
-                  id="bx-pagination-select-39-count-label"
+                  htmlFor="bx-pagination-select-38"
+                  id="bx-pagination-select-38-count-label"
                 >
                   Items per page:
                 </label>
@@ -35705,7 +34465,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-39"
+                          id="bx-pagination-select-38"
                           onChange={[Function]}
                           value={10}
                         >
@@ -35770,7 +34530,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-39-right"
+                      htmlFor="bx-pagination-select-38-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -35783,7 +34543,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-39-right"
+                          id="bx-pagination-select-38-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -37850,8 +36610,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-40"
-                  id="bx-pagination-select-40-count-label"
+                  htmlFor="bx-pagination-select-39"
+                  id="bx-pagination-select-39-count-label"
                 >
                   Items per page:
                 </label>
@@ -37870,7 +36630,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-40"
+                          id="bx-pagination-select-39"
                           onChange={[Function]}
                           value={10}
                         >
@@ -37935,7 +36695,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-40-right"
+                      htmlFor="bx-pagination-select-39-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -37948,7 +36708,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-40-right"
+                          id="bx-pagination-select-39-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -40610,8 +39370,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-37"
-                  id="bx-pagination-select-37-count-label"
+                  htmlFor="bx-pagination-select-36"
+                  id="bx-pagination-select-36-count-label"
                 >
                   Items per page:
                 </label>
@@ -40630,7 +39390,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-37"
+                          id="bx-pagination-select-36"
                           onChange={[Function]}
                           value={10}
                         >
@@ -40695,7 +39455,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-37-right"
+                      htmlFor="bx-pagination-select-36-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -40708,7 +39468,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-37-right"
+                          id="bx-pagination-select-36-right"
                           onChange={[Function]}
                           value={1}
                         >

--- a/packages/react/src/components/TableCard/tableCardUtils.jsx
+++ b/packages/react/src/components/TableCard/tableCardUtils.jsx
@@ -21,18 +21,14 @@ export const determinePrecisionAndValue = (precision = 0, value, locale) => {
  * Updates the hrefs in each column to be us-able links. If href variables are on a table that has row specific values, the user
  * should not pass in a cardVariables object as each variable with have multiple values.
  * @param {Array<Object>} columns - Array of TableCard columns
- * @param {object} cardVariables - object of cardVariables
  * @return {array} array of columns with formatted links and updated variable values
  */
-export const createColumnsWithFormattedLinks = (columns, cardVariables) => {
+export const createColumnsWithFormattedLinks = (columns) => {
   return columns.map((column) => {
     const { linkTemplate } = column;
     if (linkTemplate) {
-      let variables;
-      if (!cardVariables) {
-        // fetch variables on the href
-        variables = linkTemplate.href ? getVariables(linkTemplate.href) : [];
-      }
+      // get the variable names from the href
+      const variables = linkTemplate.href ? getVariables(linkTemplate.href) : [];
       return {
         ...column,
         // eslint-disable-next-line react/prop-types

--- a/packages/react/src/components/TableCard/tableCardUtils.test.jsx
+++ b/packages/react/src/components/TableCard/tableCardUtils.test.jsx
@@ -1,32 +1,99 @@
 import { render, screen } from '@testing-library/react';
 
-import { createColumnsWithFormattedLinks } from './tableCardUtils';
+import { createColumnsWithFormattedLinks, handleExpandedItemLinks } from './tableCardUtils';
 
 describe('tableCardUtils', () => {
-  it('createColumnsWithFormattedLinks skip encoding', () => {
-    const columns = createColumnsWithFormattedLinks([{ linkTemplate: { href: '{myurl}' } }]);
-    render(columns[0].renderDataFunction({ value: 'Link', row: { myurl: 'https://www.ibm.com' } }));
-    expect(screen.getByText('Link').parentNode.innerHTML).toEqual(
-      expect.stringContaining('https://www.ibm.com')
-    );
+  describe('createColumnsWithFormattedLinks', () => {
+    it('skip encoding', () => {
+      const columns = createColumnsWithFormattedLinks([{ linkTemplate: { href: '{myurl}' } }]);
+      render(
+        columns[0].renderDataFunction({ value: 'Link', row: { myurl: 'https://www.ibm.com' } })
+      );
+      expect(screen.getByText('Link').parentNode.innerHTML).toEqual(
+        expect.stringContaining('https://www.ibm.com')
+      );
+    });
+
+    it('encode value', () => {
+      const columns = createColumnsWithFormattedLinks([
+        { linkTemplate: { href: 'https://www.ibm.com?{asset}' } },
+      ]);
+      render(columns[0].renderDataFunction({ value: 'Link', row: { asset: 'asset with spaces' } }));
+      expect(screen.getByText('Link').parentNode.innerHTML).toEqual(
+        expect.stringContaining('https://www.ibm.com?asset%20with%20spaces')
+      );
+    });
+
+    it('encode timestamp value', () => {
+      const columns = createColumnsWithFormattedLinks([
+        { linkTemplate: { href: 'https://www.ibm.com?{time}' } },
+        { dataSourceId: 'time', type: 'TIMESTAMP' },
+      ]);
+      render(columns[0].renderDataFunction({ value: 'Link', row: { time: 1618431426000 } }));
+      expect(screen.getByText('Link').parentNode.innerHTML).toEqual(
+        expect.stringContaining('https://www.ibm.com?04%2F14%2F2021%2015%3A17')
+      );
+    });
   });
-  it('createColumnsWithFormattedLinks encode value', () => {
-    const columns = createColumnsWithFormattedLinks([
-      { linkTemplate: { href: 'https://www.ibm.com?{asset}' } },
-    ]);
-    render(columns[0].renderDataFunction({ value: 'Link', row: { asset: 'asset with spaces' } }));
-    expect(screen.getByText('Link').parentNode.innerHTML).toEqual(
-      expect.stringContaining('https://www.ibm.com?asset%20with%20spaces')
-    );
-  });
-  it('createColumnsWithFormattedLinks encode timestamp value', () => {
-    const columns = createColumnsWithFormattedLinks([
-      { linkTemplate: { href: 'https://www.ibm.com?{time}' } },
-      { dataSourceId: 'time', type: 'TIMESTAMP' },
-    ]);
-    render(columns[0].renderDataFunction({ value: 'Link', row: { time: 1618431426000 } }));
-    expect(screen.getByText('Link').parentNode.innerHTML).toEqual(
-      expect.stringContaining('https://www.ibm.com?04%2F14%2F2021%2015%3A17')
-    );
+
+  describe('handleExpandedItemLinks', () => {
+    it('handleExpandedItemLinks correctly applies linkTemplates and variables', () => {
+      const row = {
+        alert: 'some-alert',
+        count: 6,
+        hour: 126432112000,
+        pressure: 3,
+        deviceId: 73000,
+      };
+      const expandedRow = [
+        {
+          id: 'count',
+          label: 'Count',
+        },
+        {
+          id: 'deviceId',
+          label: 'Device link',
+          linkTemplate: {
+            href: 'http://ibm.com/{deviceId}',
+          },
+        },
+        {
+          id: 'alert',
+          label: 'Alert Description',
+          linkTemplate: {
+            href: 'http://ibm.com/',
+          },
+        },
+      ];
+      const cardVariables = {
+        variable: 'variable-value',
+      };
+
+      // with row specific variables
+      const updatedRowSpecificExpandedItems = handleExpandedItemLinks(row, expandedRow);
+      expect(updatedRowSpecificExpandedItems).toEqual([
+        {
+          id: 'count',
+          label: 'Count',
+        },
+        {
+          id: 'deviceId',
+          label: 'Device link',
+          linkTemplate: {
+            href: 'http://ibm.com/73000',
+          },
+        },
+        {
+          id: 'alert',
+          label: 'Alert Description',
+          linkTemplate: {
+            href: 'http://ibm.com/',
+          },
+        },
+      ]);
+      // if cardVariables are given, then this function should return its original data
+      const updatedExpandedItems = handleExpandedItemLinks(row, expandedRow, cardVariables);
+      expect(updatedExpandedItems).toEqual(expandedRow);
+    });
   });
 });

--- a/packages/react/src/components/TileCatalogNew/__snapshots__/TileCatalogNew.story.storyshot
+++ b/packages/react/src/components/TileCatalogNew/__snapshots__/TileCatalogNew.story.storyshot
@@ -43,7 +43,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 tabIndex="0"
               >
                 <div
-                  aria-labelledby="44-search"
+                  aria-labelledby="43-search"
                   className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
                   role="search"
                 >
@@ -64,15 +64,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </svg>
                   <label
                     className="bx--label"
-                    htmlFor="44"
-                    id="44-search"
+                    htmlFor="43"
+                    id="43-search"
                   >
                     Filter table
                   </label>
                   <input
                     autoComplete="off"
                     className="bx--search-input"
-                    id="44"
+                    id="43"
                     onChange={[Function]}
                     onKeyDown={[Function]}
                     placeholder="Enter a value"
@@ -412,7 +412,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 tabIndex="0"
               >
                 <div
-                  aria-labelledby="45-search"
+                  aria-labelledby="44-search"
                   className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
                   role="search"
                 >
@@ -433,15 +433,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </svg>
                   <label
                     className="bx--label"
-                    htmlFor="45"
-                    id="45-search"
+                    htmlFor="44"
+                    id="44-search"
                   >
                     Filter table
                   </label>
                   <input
                     autoComplete="off"
                     className="bx--search-input"
-                    id="45"
+                    id="44"
                     onChange={[Function]}
                     onKeyDown={[Function]}
                     placeholder="Enter a value"
@@ -688,7 +688,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 tabIndex="0"
               >
                 <div
-                  aria-labelledby="47-search"
+                  aria-labelledby="46-search"
                   className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
                   role="search"
                 >
@@ -709,15 +709,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </svg>
                   <label
                     className="bx--label"
-                    htmlFor="47"
-                    id="47-search"
+                    htmlFor="46"
+                    id="46-search"
                   >
                     Filter table
                   </label>
                   <input
                     autoComplete="off"
                     className="bx--search-input"
-                    id="47"
+                    id="46"
                     onChange={[Function]}
                     onKeyDown={[Function]}
                     placeholder="Enter a value"
@@ -945,7 +945,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 tabIndex="0"
               >
                 <div
-                  aria-labelledby="46-search"
+                  aria-labelledby="45-search"
                   className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
                   role="search"
                 >
@@ -966,15 +966,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </svg>
                   <label
                     className="bx--label"
-                    htmlFor="46"
-                    id="46-search"
+                    htmlFor="45"
+                    id="45-search"
                   >
                     Filter table
                   </label>
                   <input
                     autoComplete="off"
                     className="bx--search-input"
-                    id="46"
+                    id="45"
                     onChange={[Function]}
                     onKeyDown={[Function]}
                     placeholder="Enter a value"
@@ -1173,7 +1173,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 tabIndex="0"
               >
                 <div
-                  aria-labelledby="50-search"
+                  aria-labelledby="49-search"
                   className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
                   role="search"
                 >
@@ -1194,15 +1194,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </svg>
                   <label
                     className="bx--label"
-                    htmlFor="50"
-                    id="50-search"
+                    htmlFor="49"
+                    id="49-search"
                   >
                     Filter table
                   </label>
                   <input
                     autoComplete="off"
                     className="bx--search-input"
-                    id="50"
+                    id="49"
                     onChange={[Function]}
                     onKeyDown={[Function]}
                     placeholder="Enter a value"
@@ -1655,7 +1655,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 tabIndex="0"
               >
                 <div
-                  aria-labelledby="48-search"
+                  aria-labelledby="47-search"
                   className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
                   role="search"
                 >
@@ -1676,15 +1676,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </svg>
                   <label
                     className="bx--label"
-                    htmlFor="48"
-                    id="48-search"
+                    htmlFor="47"
+                    id="47-search"
                   >
                     Filter table
                   </label>
                   <input
                     autoComplete="off"
                     className="bx--search-input"
-                    id="48"
+                    id="47"
                     onChange={[Function]}
                     onKeyDown={[Function]}
                     placeholder="Enter a value"
@@ -2258,7 +2258,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 tabIndex="0"
               >
                 <div
-                  aria-labelledby="49-search"
+                  aria-labelledby="48-search"
                   className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
                   role="search"
                 >
@@ -2279,15 +2279,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </svg>
                   <label
                     className="bx--label"
-                    htmlFor="49"
-                    id="49-search"
+                    htmlFor="48"
+                    id="48-search"
                   >
                     Filter table
                   </label>
                   <input
                     autoComplete="off"
                     className="bx--search-input"
-                    id="49"
+                    id="48"
                     onChange={[Function]}
                     onKeyDown={[Function]}
                     placeholder="Enter a value"

--- a/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -2898,8 +2898,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 >
                   <label
                     className="bx--pagination__text"
-                    htmlFor="bx-pagination-select-53"
-                    id="bx-pagination-select-53-count-label"
+                    htmlFor="bx-pagination-select-52"
+                    id="bx-pagination-select-52-count-label"
                   >
                     Items per page:
                   </label>
@@ -2918,7 +2918,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                         >
                           <select
                             className="bx--select-input"
-                            id="bx-pagination-select-53"
+                            id="bx-pagination-select-52"
                             onChange={[Function]}
                             value={10}
                           >
@@ -2983,7 +2983,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     >
                       <label
                         className="bx--label bx--visually-hidden"
-                        htmlFor="bx-pagination-select-53-right"
+                        htmlFor="bx-pagination-select-52-right"
                       >
                         Page number, of 1 pages
                       </label>
@@ -2996,7 +2996,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                         >
                           <select
                             className="bx--select-input"
-                            id="bx-pagination-select-53-right"
+                            id="bx-pagination-select-52-right"
                             onChange={[Function]}
                             value={1}
                           >

--- a/packages/react/src/utils/__tests__/cardUtilityFunctions.test.jsx
+++ b/packages/react/src/utils/__tests__/cardUtilityFunctions.test.jsx
@@ -17,7 +17,7 @@ import {
 import { CARD_SIZES } from '../../constants/LayoutConstants';
 
 describe('cardUtilityFunctions', () => {
-  it('determine precision', () => {
+  it('determinePrecision', () => {
     // default precisions
     expect(determinePrecision(CARD_SIZES.SMALL, 11.45)).toEqual(0);
     expect(determinePrecision(CARD_SIZES.SMALL, 0.125)).toBeUndefined();
@@ -57,1041 +57,1299 @@ describe('cardUtilityFunctions', () => {
       expect(formatNumberWithPrecision(35000, null, 'en', true)).toEqual('35K');
     });
   });
-  it('handleCardVariables updates value cards with variables', () => {
-    const valueCardPropsWithVariables = {
-      title: 'Fuel {variable} flow',
-      content: {
-        attributes: [
-          {
-            dataSourceId: 'fuel_flow_rate',
-            dataFilter: {
-              deviceid: '73000',
-            },
-            label: 'Latest - 73000',
-            precision: 3,
-            thresholds: [
+  describe('card variables', () => {
+    describe('handleCardVariables', () => {
+      it('updates value cards with variables', () => {
+        const valueCardPropsWithVariables = {
+          title: 'Fuel {variable} flow',
+          content: {
+            attributes: [
               {
-                color: '#F00',
-                comparison: '>',
-                icon: 'Warning',
-                value: 2,
+                dataSourceId: 'fuel_flow_rate',
+                dataFilter: {
+                  deviceid: '73000',
+                },
+                label: 'Latest - 73000',
+                precision: 3,
+                thresholds: [
+                  {
+                    color: '#F00',
+                    comparison: '>',
+                    icon: 'Warning',
+                    value: 2,
+                  },
+                ],
+              },
+              {
+                dataSourceId: 'fuel_flow_rate2',
+                dataFilter: {
+                  deviceid: '73001',
+                },
+                label: 'Latest - 73001',
+                precision: 3,
+                thresholds: [
+                  {
+                    color: '#F00',
+                    comparison: '>',
+                    icon: 'Warning',
+                    value: '{unitVariable}',
+                  },
+                ],
+              },
+              {
+                dataSourceId: 'fuel_flow_rate_min',
+                label: 'Minimum {otherVariable}',
+                precision: 3,
+                thresholds: [
+                  {
+                    color: '#5aa700',
+                    comparison: '>',
+                    icon: 'Checkmark outline',
+                    value: -2,
+                  },
+                ],
+              },
+              {
+                dataSourceId: 'fuel_flow_rate_max',
+                label: 'Maximum',
+                precision: 3,
+                thresholds: [
+                  {
+                    color: '#5aa700',
+                    comparison: '<',
+                    icon: 'Checkmark outline',
+                    value: 5,
+                  },
+                ],
               },
             ],
           },
-          {
-            dataSourceId: 'fuel_flow_rate2',
-            dataFilter: {
-              deviceid: '73001',
+          values: [],
+          others: {
+            cardVariables: {
+              variable: 'big',
+              otherVariable: 'small',
+              unitVariable: 'F',
             },
-            label: 'Latest - 73001',
-            precision: 3,
-            thresholds: [
-              {
-                color: '#F00',
-                comparison: '>',
-                icon: 'Warning',
-                value: '{unitVariable}',
+            dataSource: {
+              range: {
+                type: 'periodToDate',
+                count: -24,
+                interval: 'hour',
               },
-            ],
-          },
-          {
-            dataSourceId: 'fuel_flow_rate_min',
-            label: 'Minimum {otherVariable}',
-            precision: 3,
-            thresholds: [
-              {
-                color: '#5aa700',
-                comparison: '>',
-                icon: 'Checkmark outline',
-                value: -2,
-              },
-            ],
-          },
-          {
-            dataSourceId: 'fuel_flow_rate_max',
-            label: 'Maximum',
-            precision: 3,
-            thresholds: [
-              {
-                color: '#5aa700',
-                comparison: '<',
-                icon: 'Checkmark outline',
-                value: 5,
-              },
-            ],
-          },
-        ],
-      },
-      values: [],
-      others: {
-        cardVariables: {
-          variable: 'big',
-          otherVariable: 'small',
-          unitVariable: 'F',
-        },
-        dataSource: {
-          range: {
-            type: 'periodToDate',
-            count: -24,
-            interval: 'hour',
-          },
-          attributes: [
-            {
-              aggregator: 'last',
-              attribute: 'fuel_flow_rate',
-              id: 'fuel_flow_rate',
-            },
-            {
-              aggregator: 'last',
-              attribute: 'fuel_flow_rate',
-              id: 'fuel_flow_rate2',
-            },
-            {
-              aggregator: 'min',
-              attribute: 'fuel_flow_rate',
-              id: 'fuel_flow_rate_min',
-            },
-            {
-              aggregator: 'max',
-              attribute: 'fuel_flow_rate',
-              id: 'fuel_flow_rate_max',
-            },
-          ],
-          groupBy: ['deviceid'],
-        },
-      },
-    };
-    const updatedContent = {
-      attributes: [
-        {
-          dataSourceId: 'fuel_flow_rate',
-          dataFilter: {
-            deviceid: '73000',
-          },
-          label: 'Latest - 73000',
-          precision: 3,
-          thresholds: [
-            {
-              color: '#F00',
-              comparison: '>',
-              icon: 'Warning',
-              value: 2,
-            },
-          ],
-        },
-        {
-          dataSourceId: 'fuel_flow_rate2',
-          dataFilter: {
-            deviceid: '73001',
-          },
-          label: 'Latest - 73001',
-          precision: 3,
-          thresholds: [
-            {
-              color: '#F00',
-              comparison: '>',
-              icon: 'Warning',
-              value: 'F',
-            },
-          ],
-        },
-        {
-          dataSourceId: 'fuel_flow_rate_min',
-          label: 'Minimum small',
-          precision: 3,
-          thresholds: [
-            {
-              color: '#5aa700',
-              comparison: '>',
-              icon: 'Checkmark outline',
-              value: -2,
-            },
-          ],
-        },
-        {
-          dataSourceId: 'fuel_flow_rate_max',
-          label: 'Maximum',
-          precision: 3,
-          thresholds: [
-            {
-              color: '#5aa700',
-              comparison: '<',
-              icon: 'Checkmark outline',
-              value: 5,
-            },
-          ],
-        },
-      ],
-    };
-    const updatedTitle = 'Fuel big flow';
-    const updatedValues = [];
-    const { title, content, values, others } = valueCardPropsWithVariables;
-    expect(handleCardVariables(title, content, values, others)).toEqual({
-      title: updatedTitle,
-      content: updatedContent,
-      values: updatedValues,
-      ...others,
-    });
-  });
-  it('handleCardVariables updates table cards with variables', () => {
-    const tableCardPropsWithVariables = {
-      title: 'Max and {minimum} speed',
-      content: {
-        columns: [
-          {
-            dataSourceId: 'abnormal_stop_id',
-            label: 'Abnormal Stop Count',
-          },
-          {
-            dataSourceId: 'speed_id_mean',
-            label: 'Mean Speed',
-          },
-          {
-            dataSourceId: 'speed_id_max',
-            label: 'Max Speed',
-          },
-          {
-            dataSourceId: 'deviceid',
-            linkTemplate: {
-              href: 'www.{url}.com',
-            },
-          },
-          {
-            dataSourceId: 'timestamp',
-            label: 'Time stamp',
-            type: 'TIMESTAMP',
-          },
-        ],
-        thresholds: [
-          {
-            dataSourceId: 'abnormal_stop_id',
-            comparison: '>=',
-            severity: 1,
-            value: 75,
-            label: '{level} Severity',
-            severityLabel: '{size} severity',
-            icon: 'Stop filled',
-            color: '#008000',
-          },
-        ],
-        expandedRows: [
-          {
-            dataSourceId: 'travel_time_id',
-            label: 'Mean travel time',
-          },
-        ],
-        sort: 'DESC',
-      },
-      values: [],
-      others: {
-        cardVariables: {
-          minimum: 1.24,
-          url: 'google',
-          level: 'high',
-          size: 'large',
-        },
-        dataSource: {
-          attributes: [
-            {
-              aggregator: 'mean',
-              attribute: 'speed',
-              id: 'speed_id_mean',
-            },
-            {
-              aggregator: 'count',
-              attribute: 'abnormal_stop_count',
-              id: 'abnormal_stop_id',
-            },
-            {
-              aggregator: 'max',
-              attribute: 'speed',
-              id: 'speed_id_max',
-            },
-            {
-              aggregator: 'mean',
-              attribute: 'travel_time',
-              id: 'travel_time_id',
-            },
-          ],
-          range: {
-            count: -7,
-            interval: 'day',
-          },
-          timeGrain: 'day',
-          groupBy: ['deviceid'],
-        },
-      },
-    };
-    const updatedTitle = 'Max and 1.24 speed';
-    const updatedContent = {
-      columns: [
-        {
-          dataSourceId: 'abnormal_stop_id',
-          label: 'Abnormal Stop Count',
-        },
-        {
-          dataSourceId: 'speed_id_mean',
-          label: 'Mean Speed',
-        },
-        {
-          dataSourceId: 'speed_id_max',
-          label: 'Max Speed',
-        },
-        {
-          dataSourceId: 'deviceid',
-          linkTemplate: {
-            href: 'www.google.com',
-          },
-        },
-        {
-          dataSourceId: 'timestamp',
-          label: 'Time stamp',
-          type: 'TIMESTAMP',
-        },
-      ],
-      thresholds: [
-        {
-          dataSourceId: 'abnormal_stop_id',
-          comparison: '>=',
-          severity: 1,
-          value: 75,
-          label: 'high Severity',
-          severityLabel: 'large severity',
-          icon: 'Stop filled',
-          color: '#008000',
-        },
-      ],
-      expandedRows: [
-        {
-          dataSourceId: 'travel_time_id',
-          label: 'Mean travel time',
-        },
-      ],
-      sort: 'DESC',
-    };
-    const updatedValues = [];
-    const { title, content, values, others } = tableCardPropsWithVariables;
-    expect(handleCardVariables(title, content, values, others)).toEqual({
-      title: updatedTitle,
-      content: updatedContent,
-      values: updatedValues,
-      ...others,
-    });
-  });
-  it('handleCardVariables returns original card when no value cardVariables are specified', () => {
-    const valueCardProps = {
-      id: 'fuel_flow',
-      size: 'SMALL',
-      title: 'Fuel flow',
-      content: {
-        attributes: [
-          {
-            dataSourceId: 'fuel_flow_rate',
-            dataFilter: {
-              deviceid: '73000',
-            },
-            label: 'Latest - 73000',
-            precision: 3,
-            thresholds: [
-              {
-                color: '#F00',
-                comparison: '>',
-                icon: 'Warning',
-                value: 2,
-              },
-            ],
-          },
-          {
-            dataSourceId: 'fuel_flow_rate2',
-            dataFilter: {
-              deviceid: '73001',
-            },
-            label: 'Latest - 73001',
-            precision: 3,
-            thresholds: [
-              {
-                color: '#F00',
-                comparison: '>',
-                icon: 'Warning',
-                value: '%',
-              },
-            ],
-          },
-          {
-            dataSourceId: 'fuel_flow_rate_min',
-            label: 'Minimum',
-            precision: 3,
-            thresholds: [
-              {
-                color: '#5aa700',
-                comparison: '>',
-                icon: 'Checkmark outline',
-                value: -2,
-              },
-            ],
-          },
-          {
-            dataSourceId: 'fuel_flow_rate_max',
-            label: 'Maximum',
-            precision: 3,
-            thresholds: [
-              {
-                color: '#5aa700',
-                comparison: '<',
-                icon: 'Checkmark outline',
-                value: 5,
-              },
-            ],
-          },
-        ],
-      },
-      values: [],
-      others: {
-        dataSource: {
-          range: {
-            type: 'periodToDate',
-            count: -24,
-            interval: 'hour',
-          },
-          attributes: [
-            {
-              aggregator: 'last',
-              attribute: 'fuel_flow_rate',
-              id: 'fuel_flow_rate',
-            },
-            {
-              aggregator: 'last',
-              attribute: 'fuel_flow_rate',
-              id: 'fuel_flow_rate2',
-            },
-            {
-              aggregator: 'min',
-              attribute: 'fuel_flow_rate',
-              id: 'fuel_flow_rate_min',
-            },
-            {
-              aggregator: 'max',
-              attribute: 'fuel_flow_rate',
-              id: 'fuel_flow_rate_max',
-            },
-          ],
-          groupBy: ['deviceid'],
-        },
-      },
-    };
-    const { title, content, values, others } = valueCardProps;
-    expect(handleCardVariables(title, content, [], others)).toEqual({
-      title,
-      content,
-      values,
-      ...others,
-    });
-  });
-  it('handleCardVariables returns original card when no table cardVariables are specified', () => {
-    const tableCardProps = {
-      title: 'Max and min speed',
-      content: {
-        columns: [
-          {
-            dataSourceId: 'abnormal_stop_id',
-            label: 'Abnormal Stop Count',
-          },
-          {
-            dataSourceId: 'speed_id_mean',
-            label: 'Mean Speed',
-          },
-          {
-            dataSourceId: 'speed_id_max',
-            label: 'Max Speed',
-          },
-          {
-            dataSourceId: 'timestamp',
-            label: 'Time stamp',
-            type: 'TIMESTAMP',
-          },
-        ],
-        thresholds: [
-          {
-            dataSourceId: 'abnormal_stop_id',
-            comparison: '>=',
-            severity: 1,
-            value: 75,
-            label: 'Low Severity',
-            severityLabel: 'Low severity',
-            icon: 'Stop filled',
-            color: '#008000',
-          },
-        ],
-        expandedRows: [
-          {
-            dataSourceId: 'travel_time_id',
-            label: 'Mean travel time',
-          },
-        ],
-        sort: 'DESC',
-      },
-      values: [],
-      others: {
-        dataSource: {
-          attributes: [
-            {
-              aggregator: 'mean',
-              attribute: 'speed',
-              id: 'speed_id_mean',
-            },
-            {
-              aggregator: 'count',
-              attribute: 'abnormal_stop_count',
-              id: 'abnormal_stop_id',
-            },
-            {
-              aggregator: 'max',
-              attribute: 'speed',
-              id: 'speed_id_max',
-            },
-            {
-              aggregator: 'mean',
-              attribute: 'travel_time',
-              id: 'travel_time_id',
-            },
-          ],
-          range: {
-            count: -7,
-            interval: 'day',
-          },
-          timeGrain: 'day',
-          groupBy: ['deviceid'],
-        },
-      },
-    };
-    const { title, content, values, others } = tableCardProps;
-    expect(handleCardVariables(title, content, values, others)).toEqual({
-      title,
-      content,
-      values,
-      ...others,
-    });
-  });
-  it('handleCardVariables updates cards with variables when there are case discrepancies in cardVariables', () => {
-    const timeSeriesCardPropsWithVariables = {
-      title: 'timeSeries {device}',
-      content: {
-        xLabel: '{x_label}',
-        yLabel: '{y_label}',
-        unit: '{unit}',
-        series: [
-          {
-            dataSourceId: 'airflow_mean',
-            label: '{label}',
-          },
-        ],
-      },
-      values: [],
-      others: {
-        cardVariables: {
-          x_labEL: 'x-axis',
-          y_label: 'y-axis',
-          deVice: 'air',
-          unit: 'F',
-          Label: 'Airflow Mean',
-        },
-      },
-    };
-    const updatedTitle = 'timeSeries air';
-    const updatedContent = {
-      xLabel: 'x-axis',
-      yLabel: 'y-axis',
-      unit: 'F',
-      series: [
-        {
-          dataSourceId: 'airflow_mean',
-          label: 'Airflow Mean',
-        },
-      ],
-    };
-    const updatedValues = [];
-    const { title, content, values, others } = timeSeriesCardPropsWithVariables;
-    expect(handleCardVariables(title, content, values, others)).toEqual({
-      title: updatedTitle,
-      content: updatedContent,
-      values: updatedValues,
-      ...others,
-    });
-  });
-  it('handleCardVariables updates timeseries cards with variables', () => {
-    const timeSeriesCardPropsWithVariables = {
-      title: 'timeSeries {device}',
-      content: {
-        xLabel: '{x_label}',
-        yLabel: '{y_label}',
-        unit: '{unit}',
-        series: [
-          {
-            dataSourceId: 'airflow_mean',
-            label: '{label}',
-          },
-        ],
-      },
-      values: [],
-      others: {
-        cardVariables: {
-          x_label: 'x-axis',
-          y_label: 'y-axis',
-          device: 'air',
-          unit: 'F',
-          label: 'Airflow Mean',
-        },
-      },
-    };
-    const updatedTitle = 'timeSeries air';
-    const updatedContent = {
-      xLabel: 'x-axis',
-      yLabel: 'y-axis',
-      unit: 'F',
-      series: [
-        {
-          dataSourceId: 'airflow_mean',
-          label: 'Airflow Mean',
-        },
-      ],
-    };
-    const updatedValues = [];
-    const { title, content, values, others } = timeSeriesCardPropsWithVariables;
-    expect(handleCardVariables(title, content, values, others)).toEqual({
-      title: updatedTitle,
-      content: updatedContent,
-      values: updatedValues,
-      ...others,
-    });
-  });
-  it('handleCardVariables returns original card when no cardVariables are specified', () => {
-    const timeSeriesCardProps = {
-      title: 'timeSeries',
-      content: {
-        xLabel: 'x-axis',
-        yLabel: 'y-axis',
-        unit: 'F',
-        series: [
-          {
-            dataSourceId: 'airflow_mean',
-            label: 'Airflow Mean',
-          },
-        ],
-      },
-      values: [],
-      others: {},
-    };
-    const { title, content, values, others } = timeSeriesCardProps;
-    expect(handleCardVariables(title, content, values, others)).toEqual({
-      title,
-      content,
-      values,
-      ...others,
-    });
-  });
-  it('getVariables should return a list of variables from a string', () => {
-    const titleWithVariables = '{variable} in a title with {variables}';
-    const title = 'A title without variables';
-    expect(getVariables(titleWithVariables)).toEqual(['variable', 'variables']);
-    expect(getVariables(title)).toEqual(undefined);
-  });
-  it('getCardVariables returns variables in ValueCards', () => {
-    const valueCardWithVariables = {
-      id: 'fuel_flow',
-      size: 'SMALL',
-      title: 'Fuel {variable} flow',
-      type: 'VALUE',
-      content: {
-        attributes: [
-          {
-            dataSourceId: 'fuel_flow_rate',
-            dataFilter: {
-              deviceid: '73000',
-            },
-            label: 'Latest - 73000',
-            precision: 3,
-            thresholds: [
-              {
-                color: '#F00',
-                comparison: '>',
-                icon: 'Warning',
-                value: 2,
-              },
-            ],
-          },
-          {
-            dataSourceId: 'fuel_flow_rate2',
-            dataFilter: {
-              deviceid: '73001',
-            },
-            label: 'Latest - 73001',
-            precision: 3,
-            thresholds: [
-              {
-                color: '#F00',
-                comparison: '>',
-                icon: 'Warning',
-                value: '{unitVariable}',
-              },
-            ],
-          },
-          {
-            dataSourceId: 'fuel_flow_rate_min',
-            label: 'Minimum {otherVariable}',
-            precision: 3,
-            thresholds: [
-              {
-                color: '#5aa700',
-                comparison: '>',
-                icon: 'Checkmark outline',
-                value: -2,
-              },
-            ],
-          },
-          {
-            dataSourceId: 'fuel_flow_rate_max',
-            label: 'Maximum',
-            precision: 3,
-            thresholds: [
-              {
-                color: '#5aa700',
-                comparison: '<',
-                icon: 'Checkmark outline',
-                value: 5,
-              },
-            ],
-          },
-        ],
-      },
-      dataSource: {
-        range: {
-          type: 'periodToDate',
-          count: -24,
-          interval: 'hour',
-        },
-        attributes: [
-          {
-            aggregator: 'last',
-            attribute: 'fuel_flow_rate',
-            id: 'fuel_flow_rate',
-          },
-          {
-            aggregator: 'last',
-            attribute: 'fuel_flow_rate',
-            id: 'fuel_flow_rate2',
-          },
-          {
-            aggregator: 'min',
-            attribute: 'fuel_flow_rate',
-            id: 'fuel_flow_rate_min',
-          },
-          {
-            aggregator: 'max',
-            attribute: 'fuel_flow_rate',
-            id: 'fuel_flow_rate_max',
-          },
-        ],
-        groupBy: ['deviceid'],
-      },
-    };
-    expect(getCardVariables(valueCardWithVariables)).toEqual([
-      'variable',
-      'unitVariable',
-      'otherVariable',
-    ]);
-  });
-  it('getCardVariables returns variables for an ImageCard', () => {
-    const imageCardWithVariables = {
-      content: {
-        alt: 'Sample image',
-        src: 'static/media/landscape.69143f06.jpg',
-        zoomMax: 10,
-        hotspots: [
-          {
-            icon: 'carbon-icon',
-            color: 'blue',
-            content: {
-              title: 'sensor readings',
               attributes: [
                 {
-                  dataSourceId: 'temp_last',
-                  label: '{high} temp',
-                  unit: '{unitVar}',
+                  aggregator: 'last',
+                  attribute: 'fuel_flow_rate',
+                  id: 'fuel_flow_rate',
+                },
+                {
+                  aggregator: 'last',
+                  attribute: 'fuel_flow_rate',
+                  id: 'fuel_flow_rate2',
+                },
+                {
+                  aggregator: 'min',
+                  attribute: 'fuel_flow_rate',
+                  id: 'fuel_flow_rate_min',
+                },
+                {
+                  aggregator: 'max',
+                  attribute: 'fuel_flow_rate',
+                  id: 'fuel_flow_rate_max',
+                },
+              ],
+              groupBy: ['deviceid'],
+            },
+          },
+        };
+        const updatedContent = {
+          attributes: [
+            {
+              dataSourceId: 'fuel_flow_rate',
+              dataFilter: {
+                deviceid: '73000',
+              },
+              label: 'Latest - 73000',
+              precision: 3,
+              thresholds: [
+                {
+                  color: '#F00',
+                  comparison: '>',
+                  icon: 'Warning',
+                  value: 2,
                 },
               ],
             },
-            thresholds: [
-              {
-                dataSourceId: 'temp_last',
-                comparison: '>=',
-                value: '{thresVar}',
+            {
+              dataSourceId: 'fuel_flow_rate2',
+              dataFilter: {
+                deviceid: '73001',
               },
-            ],
-          },
-        ],
-      },
-      size: 'LARGE',
-      title: 'Expanded {large} card',
-      type: 'IMAGE',
-    };
-    expect(getCardVariables(imageCardWithVariables)).toEqual([
-      'high',
-      'unitVar',
-      'thresVar',
-      'large',
-    ]);
-  });
-  it('getCardVariables returns variables for a TableCard', () => {
-    const tableCardWithVariables = {
-      id: 'speed_mean_and_max_threshold',
-      size: 'LARGE',
-      title: 'Max and {minimum} speed',
-      type: 'TABLE',
-      content: {
-        columns: [
-          {
-            dataSourceId: 'abnormal_stop_id',
-            label: 'Abnormal Stop Count',
-          },
-          {
-            dataSourceId: 'speed_id_mean',
-            label: 'Mean Speed',
-          },
-          {
-            dataSourceId: 'speed_id_max',
-            label: 'Max Speed',
-          },
-          {
-            dataSourceId: 'deviceid',
-            linkTemplate: {
-              href: 'www.{url}.com',
-              displayValue: '{url}',
-            },
-          },
-          {
-            dataSourceId: 'timestamp',
-            label: 'Time stamp',
-            type: 'TIMESTAMP',
-          },
-        ],
-        thresholds: [
-          {
-            dataSourceId: 'abnormal_stop_id',
-            comparison: '>=',
-            severity: 1,
-            value: 75,
-            label: '{high} Severity',
-            severityLabel: '{large} severity',
-            icon: 'Stop filled',
-            color: '#008000',
-          },
-        ],
-        expandedRows: [
-          {
-            dataSourceId: 'travel_time_id',
-            label: 'Mean travel time',
-          },
-        ],
-        sort: 'DESC',
-      },
-      dataSource: {
-        attributes: [
-          {
-            aggregator: 'mean',
-            attribute: 'speed',
-            id: 'speed_id_mean',
-          },
-          {
-            aggregator: 'count',
-            attribute: 'abnormal_stop_count',
-            id: 'abnormal_stop_id',
-          },
-          {
-            aggregator: 'max',
-            attribute: 'speed',
-            id: 'speed_id_max',
-          },
-          {
-            aggregator: 'mean',
-            attribute: 'travel_time',
-            id: 'travel_time_id',
-          },
-        ],
-        range: {
-          count: -7,
-          interval: 'day',
-        },
-        timeGrain: 'day',
-        groupBy: ['deviceid'],
-      },
-    };
-    expect(getCardVariables(tableCardWithVariables)).toEqual(['minimum', 'url', 'high', 'large']);
-  });
-  it('getCardVariables returns variables for a TimeSeriesCard', () => {
-    const timeSeriesCardWithVariables = {
-      id: 'air_flow_mean',
-      size: 'LARGE',
-      title: 'Air flow {deviceId} mean vs max',
-      type: 'TIMESERIES',
-      content: {
-        series: [
-          {
-            dataSourceId: 'airflow_mean',
-            label: 'Airflow Mean',
-          },
-          {
-            dataSourceId: 'airflow_max',
-            label: '{airflow_max}',
-          },
-        ],
-        xLabel: '{x_axis}',
-        yLabel: '{y_axis}',
-        unit: '{unit}',
-        timeDataSourceId: 'timestamp',
-      },
-      dataSource: {
-        attributes: [
-          {
-            aggregator: 'mean',
-            attribute: 'air_flow_rate',
-            id: 'airflow_mean',
-          },
-          {
-            aggregator: 'max',
-            attribute: 'air_flow_rate',
-            id: 'airflow_max',
-          },
-        ],
-        range: {
-          type: 'periodToDate',
-          count: -7,
-          interval: 'day',
-        },
-        additionalData: {
-          type: 'alert',
-          dataFilter: {
-            name: 'alert_air_flow_rate_greater_than_1',
-          },
-        },
-        timeGrain: 'day',
-      },
-    };
-    expect(getCardVariables(timeSeriesCardWithVariables)).toEqual([
-      'deviceId',
-      'airflow_max',
-      'x_axis',
-      'y_axis',
-      'unit',
-    ]);
-  });
-  it('getCardVariables does not blow up on null or react symbols', () => {
-    const timeSeriesCardWithVariables = {
-      id: 'air_flow_mean',
-      size: 'LARGE',
-      title: 'Air flow {deviceId} mean vs max',
-      type: 'TIMESERIES',
-      content: {
-        series: [
-          {
-            dataSourceId: 'airflow_max',
-            label: '{airflow_max}',
-          },
-        ],
-        xLabel: '{x_axis}',
-        yLabel: '{y_axis}',
-        unit: '{unit}',
-        timeDataSourceId: 'timestamp',
-      },
-      dataSource: {
-        attributes: [
-          {
-            aggregator: 'max',
-            attribute: 'air_flow_rate',
-            id: 'airflow_max',
-          },
-        ],
-        range: {
-          type: 'periodToDate',
-          count: -7,
-          interval: 'day',
-        },
-        timeGrain: 'day',
-      },
-      someNullProperty: null,
-      someReactSymbolProperty: <p>Hi I am a React symbol</p>,
-    };
-    expect(getCardVariables(timeSeriesCardWithVariables)).toEqual([
-      'deviceId',
-      'airflow_max',
-      'x_axis',
-      'y_axis',
-      'unit',
-    ]);
-  });
-  it('getCardVariables returns empty array when no variables are given', () => {
-    const imageCard = {
-      content: {
-        alt: 'Sample image',
-        src: 'static/media/landscape.69143f06.jpg',
-        zoomMax: 10,
-        hotspots: [
-          {
-            icon: 'carbon-icon',
-            color: 'blue',
-            content: {
-              title: 'sensor readings',
-              attributes: [
+              label: 'Latest - 73001',
+              precision: 3,
+              thresholds: [
                 {
-                  dataSourceId: 'temp_last',
-                  label: 'temp',
-                  unit: 'F',
+                  color: '#F00',
+                  comparison: '>',
+                  icon: 'Warning',
+                  value: 'F',
                 },
               ],
             },
+            {
+              dataSourceId: 'fuel_flow_rate_min',
+              label: 'Minimum small',
+              precision: 3,
+              thresholds: [
+                {
+                  color: '#5aa700',
+                  comparison: '>',
+                  icon: 'Checkmark outline',
+                  value: -2,
+                },
+              ],
+            },
+            {
+              dataSourceId: 'fuel_flow_rate_max',
+              label: 'Maximum',
+              precision: 3,
+              thresholds: [
+                {
+                  color: '#5aa700',
+                  comparison: '<',
+                  icon: 'Checkmark outline',
+                  value: 5,
+                },
+              ],
+            },
+          ],
+        };
+        const updatedTitle = 'Fuel big flow';
+        const updatedValues = [];
+        const { title, content, values, others } = valueCardPropsWithVariables;
+        expect(handleCardVariables(title, content, values, others)).toEqual({
+          title: updatedTitle,
+          content: updatedContent,
+          values: updatedValues,
+          ...others,
+        });
+      });
+
+      it('updates table cards with variables', () => {
+        const tableCardPropsWithVariables = {
+          title: 'Max and {minimum} speed',
+          content: {
+            columns: [
+              {
+                dataSourceId: 'abnormal_stop_id',
+                label: 'Abnormal Stop Count',
+              },
+              {
+                dataSourceId: 'speed_id_mean',
+                label: 'Mean Speed',
+              },
+              {
+                dataSourceId: 'speed_id_max',
+                label: 'Max Speed',
+              },
+              {
+                dataSourceId: 'deviceid',
+                linkTemplate: {
+                  href: 'www.{url}.com',
+                },
+              },
+              {
+                dataSourceId: 'timestamp',
+                label: 'Time stamp',
+                type: 'TIMESTAMP',
+              },
+            ],
             thresholds: [
               {
-                dataSourceId: 'temp_last',
+                dataSourceId: 'abnormal_stop_id',
                 comparison: '>=',
-                value: '300',
+                severity: 1,
+                value: 75,
+                label: '{level} Severity',
+                severityLabel: '{size} severity',
+                icon: 'Stop filled',
+                color: '#008000',
+              },
+            ],
+            expandedRows: [
+              {
+                dataSourceId: 'travel_time_id',
+                label: 'Mean travel time',
+              },
+            ],
+            sort: 'DESC',
+          },
+          values: [],
+          others: {
+            cardVariables: {
+              minimum: 1.24,
+              url: 'google',
+              level: 'high',
+              size: 'large',
+            },
+            dataSource: {
+              attributes: [
+                {
+                  aggregator: 'mean',
+                  attribute: 'speed',
+                  id: 'speed_id_mean',
+                },
+                {
+                  aggregator: 'count',
+                  attribute: 'abnormal_stop_count',
+                  id: 'abnormal_stop_id',
+                },
+                {
+                  aggregator: 'max',
+                  attribute: 'speed',
+                  id: 'speed_id_max',
+                },
+                {
+                  aggregator: 'mean',
+                  attribute: 'travel_time',
+                  id: 'travel_time_id',
+                },
+              ],
+              range: {
+                count: -7,
+                interval: 'day',
+              },
+              timeGrain: 'day',
+              groupBy: ['deviceid'],
+            },
+          },
+        };
+        const updatedTitle = 'Max and 1.24 speed';
+        const updatedContent = {
+          columns: [
+            {
+              dataSourceId: 'abnormal_stop_id',
+              label: 'Abnormal Stop Count',
+            },
+            {
+              dataSourceId: 'speed_id_mean',
+              label: 'Mean Speed',
+            },
+            {
+              dataSourceId: 'speed_id_max',
+              label: 'Max Speed',
+            },
+            {
+              dataSourceId: 'deviceid',
+              linkTemplate: {
+                href: 'www.google.com',
+              },
+            },
+            {
+              dataSourceId: 'timestamp',
+              label: 'Time stamp',
+              type: 'TIMESTAMP',
+            },
+          ],
+          thresholds: [
+            {
+              dataSourceId: 'abnormal_stop_id',
+              comparison: '>=',
+              severity: 1,
+              value: 75,
+              label: 'high Severity',
+              severityLabel: 'large severity',
+              icon: 'Stop filled',
+              color: '#008000',
+            },
+          ],
+          expandedRows: [
+            {
+              dataSourceId: 'travel_time_id',
+              label: 'Mean travel time',
+            },
+          ],
+          sort: 'DESC',
+        };
+        const updatedValues = [];
+        const { title, content, values, others } = tableCardPropsWithVariables;
+        expect(handleCardVariables(title, content, values, others)).toEqual({
+          title: updatedTitle,
+          content: updatedContent,
+          values: updatedValues,
+          ...others,
+        });
+      });
+
+      it('returns original card when no value cardVariables are specified', () => {
+        const valueCardProps = {
+          id: 'fuel_flow',
+          size: 'SMALL',
+          title: 'Fuel flow',
+          content: {
+            attributes: [
+              {
+                dataSourceId: 'fuel_flow_rate',
+                dataFilter: {
+                  deviceid: '73000',
+                },
+                label: 'Latest - 73000',
+                precision: 3,
+                thresholds: [
+                  {
+                    color: '#F00',
+                    comparison: '>',
+                    icon: 'Warning',
+                    value: 2,
+                  },
+                ],
+              },
+              {
+                dataSourceId: 'fuel_flow_rate2',
+                dataFilter: {
+                  deviceid: '73001',
+                },
+                label: 'Latest - 73001',
+                precision: 3,
+                thresholds: [
+                  {
+                    color: '#F00',
+                    comparison: '>',
+                    icon: 'Warning',
+                    value: '%',
+                  },
+                ],
+              },
+              {
+                dataSourceId: 'fuel_flow_rate_min',
+                label: 'Minimum',
+                precision: 3,
+                thresholds: [
+                  {
+                    color: '#5aa700',
+                    comparison: '>',
+                    icon: 'Checkmark outline',
+                    value: -2,
+                  },
+                ],
+              },
+              {
+                dataSourceId: 'fuel_flow_rate_max',
+                label: 'Maximum',
+                precision: 3,
+                thresholds: [
+                  {
+                    color: '#5aa700',
+                    comparison: '<',
+                    icon: 'Checkmark outline',
+                    value: 5,
+                  },
+                ],
               },
             ],
           },
-        ],
-      },
-      size: 'LARGE',
-      title: 'Expanded card',
-      type: 'IMAGE',
-    };
-    expect(getCardVariables(imageCard)).toEqual([]);
+          values: [],
+          others: {
+            dataSource: {
+              range: {
+                type: 'periodToDate',
+                count: -24,
+                interval: 'hour',
+              },
+              attributes: [
+                {
+                  aggregator: 'last',
+                  attribute: 'fuel_flow_rate',
+                  id: 'fuel_flow_rate',
+                },
+                {
+                  aggregator: 'last',
+                  attribute: 'fuel_flow_rate',
+                  id: 'fuel_flow_rate2',
+                },
+                {
+                  aggregator: 'min',
+                  attribute: 'fuel_flow_rate',
+                  id: 'fuel_flow_rate_min',
+                },
+                {
+                  aggregator: 'max',
+                  attribute: 'fuel_flow_rate',
+                  id: 'fuel_flow_rate_max',
+                },
+              ],
+              groupBy: ['deviceid'],
+            },
+          },
+        };
+        const { title, content, values, others } = valueCardProps;
+        expect(handleCardVariables(title, content, [], others)).toEqual({
+          title,
+          content,
+          values,
+          ...others,
+        });
+      });
+
+      it('returns original card when no table cardVariables are specified', () => {
+        const tableCardProps = {
+          title: 'Max and min speed',
+          content: {
+            columns: [
+              {
+                dataSourceId: 'abnormal_stop_id',
+                label: 'Abnormal Stop Count',
+              },
+              {
+                dataSourceId: 'speed_id_mean',
+                label: 'Mean Speed',
+              },
+              {
+                dataSourceId: 'speed_id_max',
+                label: 'Max Speed',
+              },
+              {
+                dataSourceId: 'timestamp',
+                label: 'Time stamp',
+                type: 'TIMESTAMP',
+              },
+            ],
+            thresholds: [
+              {
+                dataSourceId: 'abnormal_stop_id',
+                comparison: '>=',
+                severity: 1,
+                value: 75,
+                label: 'Low Severity',
+                severityLabel: 'Low severity',
+                icon: 'Stop filled',
+                color: '#008000',
+              },
+            ],
+            expandedRows: [
+              {
+                dataSourceId: 'travel_time_id',
+                label: 'Mean travel time',
+              },
+            ],
+            sort: 'DESC',
+          },
+          values: [],
+          others: {
+            dataSource: {
+              attributes: [
+                {
+                  aggregator: 'mean',
+                  attribute: 'speed',
+                  id: 'speed_id_mean',
+                },
+                {
+                  aggregator: 'count',
+                  attribute: 'abnormal_stop_count',
+                  id: 'abnormal_stop_id',
+                },
+                {
+                  aggregator: 'max',
+                  attribute: 'speed',
+                  id: 'speed_id_max',
+                },
+                {
+                  aggregator: 'mean',
+                  attribute: 'travel_time',
+                  id: 'travel_time_id',
+                },
+              ],
+              range: {
+                count: -7,
+                interval: 'day',
+              },
+              timeGrain: 'day',
+              groupBy: ['deviceid'],
+            },
+          },
+        };
+        const { title, content, values, others } = tableCardProps;
+        expect(handleCardVariables(title, content, values, others)).toEqual({
+          title,
+          content,
+          values,
+          ...others,
+        });
+      });
+
+      it('updates cards with variables when there are case discrepancies in cardVariables', () => {
+        const timeSeriesCardPropsWithVariables = {
+          title: 'timeSeries {device}',
+          content: {
+            xLabel: '{x_label}',
+            yLabel: '{y_label}',
+            unit: '{unit}',
+            series: [
+              {
+                dataSourceId: 'airflow_mean',
+                label: '{label}',
+              },
+            ],
+          },
+          values: [],
+          others: {
+            cardVariables: {
+              x_labEL: 'x-axis',
+              y_label: 'y-axis',
+              deVice: 'air',
+              unit: 'F',
+              Label: 'Airflow Mean',
+            },
+          },
+        };
+        const updatedTitle = 'timeSeries air';
+        const updatedContent = {
+          xLabel: 'x-axis',
+          yLabel: 'y-axis',
+          unit: 'F',
+          series: [
+            {
+              dataSourceId: 'airflow_mean',
+              label: 'Airflow Mean',
+            },
+          ],
+        };
+        const updatedValues = [];
+        const { title, content, values, others } = timeSeriesCardPropsWithVariables;
+        expect(handleCardVariables(title, content, values, others)).toEqual({
+          title: updatedTitle,
+          content: updatedContent,
+          values: updatedValues,
+          ...others,
+        });
+      });
+
+      it('updates timeseries cards with variables', () => {
+        const timeSeriesCardPropsWithVariables = {
+          title: 'timeSeries {device}',
+          content: {
+            xLabel: '{x_label}',
+            yLabel: '{y_label}',
+            unit: '{unit}',
+            series: [
+              {
+                dataSourceId: 'airflow_mean',
+                label: '{label}',
+              },
+            ],
+          },
+          values: [],
+          others: {
+            cardVariables: {
+              x_label: 'x-axis',
+              y_label: 'y-axis',
+              device: 'air',
+              unit: 'F',
+              label: 'Airflow Mean',
+            },
+          },
+        };
+        const updatedTitle = 'timeSeries air';
+        const updatedContent = {
+          xLabel: 'x-axis',
+          yLabel: 'y-axis',
+          unit: 'F',
+          series: [
+            {
+              dataSourceId: 'airflow_mean',
+              label: 'Airflow Mean',
+            },
+          ],
+        };
+        const updatedValues = [];
+        const { title, content, values, others } = timeSeriesCardPropsWithVariables;
+        expect(handleCardVariables(title, content, values, others)).toEqual({
+          title: updatedTitle,
+          content: updatedContent,
+          values: updatedValues,
+          ...others,
+        });
+      });
+
+      it('returns original card when no timeseries cardVariables are specified', () => {
+        const timeSeriesCardProps = {
+          title: 'timeSeries',
+          content: {
+            xLabel: 'x-axis',
+            yLabel: 'y-axis',
+            unit: 'F',
+            series: [
+              {
+                dataSourceId: 'airflow_mean',
+                label: 'Airflow Mean',
+              },
+            ],
+          },
+          values: [],
+          others: {},
+        };
+        const { title, content, values, others } = timeSeriesCardProps;
+        expect(handleCardVariables(title, content, values, others)).toEqual({
+          title,
+          content,
+          values,
+          ...others,
+        });
+      });
+
+      it('should not replace href since its being skipped', () => {
+        const tableCardPropsWithVariables = {
+          title: 'Max and {minimum} speed',
+          content: {
+            columns: [
+              {
+                dataSourceId: 'abnormal_stop_id',
+                label: 'Abnormal Stop Count',
+              },
+              {
+                dataSourceId: 'speed_id_mean',
+                label: 'Mean Speed',
+              },
+              {
+                dataSourceId: 'speed_id_max',
+                label: 'Max Speed',
+              },
+              {
+                dataSourceId: 'deviceid',
+                linkTemplate: {
+                  href: 'www.{url}.com',
+                },
+              },
+              {
+                dataSourceId: 'timestamp',
+                label: 'Time stamp',
+                type: 'TIMESTAMP',
+              },
+            ],
+            thresholds: [
+              {
+                dataSourceId: 'abnormal_stop_id',
+                comparison: '>=',
+                severity: 1,
+                value: 75,
+                label: '{level} Severity',
+                severityLabel: '{size} severity',
+                icon: 'Stop filled',
+                color: '#008000',
+              },
+            ],
+            expandedRows: [
+              {
+                dataSourceId: 'travel_time_id',
+                label: 'Mean travel time',
+              },
+            ],
+            sort: 'DESC',
+          },
+          values: [],
+          others: {
+            cardVariables: {
+              minimum: 1.24,
+              url: 'google',
+              level: 'high',
+              size: 'large',
+            },
+            dataSource: {
+              attributes: [
+                {
+                  aggregator: 'mean',
+                  attribute: 'speed',
+                  id: 'speed_id_mean',
+                },
+                {
+                  aggregator: 'count',
+                  attribute: 'abnormal_stop_count',
+                  id: 'abnormal_stop_id',
+                },
+                {
+                  aggregator: 'max',
+                  attribute: 'speed',
+                  id: 'speed_id_max',
+                },
+                {
+                  aggregator: 'mean',
+                  attribute: 'travel_time',
+                  id: 'travel_time_id',
+                },
+              ],
+              range: {
+                count: -7,
+                interval: 'day',
+              },
+              timeGrain: 'day',
+              groupBy: ['deviceid'],
+            },
+          },
+        };
+        const updatedTitle = 'Max and 1.24 speed';
+        const updatedContent = {
+          columns: [
+            {
+              dataSourceId: 'abnormal_stop_id',
+              label: 'Abnormal Stop Count',
+            },
+            {
+              dataSourceId: 'speed_id_mean',
+              label: 'Mean Speed',
+            },
+            {
+              dataSourceId: 'speed_id_max',
+              label: 'Max Speed',
+            },
+            {
+              dataSourceId: 'deviceid',
+              linkTemplate: {
+                href: 'www.{url}.com',
+              },
+            },
+            {
+              dataSourceId: 'timestamp',
+              label: 'Time stamp',
+              type: 'TIMESTAMP',
+            },
+          ],
+          thresholds: [
+            {
+              dataSourceId: 'abnormal_stop_id',
+              comparison: '>=',
+              severity: 1,
+              value: 75,
+              label: 'high Severity',
+              severityLabel: 'large severity',
+              icon: 'Stop filled',
+              color: '#008000',
+            },
+          ],
+          expandedRows: [
+            {
+              dataSourceId: 'travel_time_id',
+              label: 'Mean travel time',
+            },
+          ],
+          sort: 'DESC',
+        };
+        const updatedValues = [];
+        const { title, content, values, others } = tableCardPropsWithVariables;
+        expect(handleCardVariables(title, content, values, others, ['href'])).toEqual({
+          title: updatedTitle,
+          content: updatedContent,
+          values: updatedValues,
+          ...others,
+        });
+      });
+    });
+
+    it('getVariables should return a list of variables from a string', () => {
+      const titleWithVariables = '{variable} in a title with {variables}';
+      const title = 'A title without variables';
+      expect(getVariables(titleWithVariables)).toEqual(['variable', 'variables']);
+      expect(getVariables(title)).toEqual(undefined);
+    });
+
+    describe('getCardVariables', () => {
+      it('returns variables in ValueCards', () => {
+        const valueCardWithVariables = {
+          id: 'fuel_flow',
+          size: 'SMALL',
+          title: 'Fuel {variable} flow',
+          type: 'VALUE',
+          content: {
+            attributes: [
+              {
+                dataSourceId: 'fuel_flow_rate',
+                dataFilter: {
+                  deviceid: '73000',
+                },
+                label: 'Latest - 73000',
+                precision: 3,
+                thresholds: [
+                  {
+                    color: '#F00',
+                    comparison: '>',
+                    icon: 'Warning',
+                    value: 2,
+                  },
+                ],
+              },
+              {
+                dataSourceId: 'fuel_flow_rate2',
+                dataFilter: {
+                  deviceid: '73001',
+                },
+                label: 'Latest - 73001',
+                precision: 3,
+                thresholds: [
+                  {
+                    color: '#F00',
+                    comparison: '>',
+                    icon: 'Warning',
+                    value: '{unitVariable}',
+                  },
+                ],
+              },
+              {
+                dataSourceId: 'fuel_flow_rate_min',
+                label: 'Minimum {otherVariable}',
+                precision: 3,
+                thresholds: [
+                  {
+                    color: '#5aa700',
+                    comparison: '>',
+                    icon: 'Checkmark outline',
+                    value: -2,
+                  },
+                ],
+              },
+              {
+                dataSourceId: 'fuel_flow_rate_max',
+                label: 'Maximum',
+                precision: 3,
+                thresholds: [
+                  {
+                    color: '#5aa700',
+                    comparison: '<',
+                    icon: 'Checkmark outline',
+                    value: 5,
+                  },
+                ],
+              },
+            ],
+          },
+          dataSource: {
+            range: {
+              type: 'periodToDate',
+              count: -24,
+              interval: 'hour',
+            },
+            attributes: [
+              {
+                aggregator: 'last',
+                attribute: 'fuel_flow_rate',
+                id: 'fuel_flow_rate',
+              },
+              {
+                aggregator: 'last',
+                attribute: 'fuel_flow_rate',
+                id: 'fuel_flow_rate2',
+              },
+              {
+                aggregator: 'min',
+                attribute: 'fuel_flow_rate',
+                id: 'fuel_flow_rate_min',
+              },
+              {
+                aggregator: 'max',
+                attribute: 'fuel_flow_rate',
+                id: 'fuel_flow_rate_max',
+              },
+            ],
+            groupBy: ['deviceid'],
+          },
+        };
+        expect(getCardVariables(valueCardWithVariables)).toEqual([
+          'variable',
+          'unitVariable',
+          'otherVariable',
+        ]);
+      });
+
+      it('returns variables for an ImageCard', () => {
+        const imageCardWithVariables = {
+          content: {
+            alt: 'Sample image',
+            src: 'static/media/landscape.69143f06.jpg',
+            zoomMax: 10,
+            hotspots: [
+              {
+                icon: 'carbon-icon',
+                color: 'blue',
+                content: {
+                  title: 'sensor readings',
+                  attributes: [
+                    {
+                      dataSourceId: 'temp_last',
+                      label: '{high} temp',
+                      unit: '{unitVar}',
+                    },
+                  ],
+                },
+                thresholds: [
+                  {
+                    dataSourceId: 'temp_last',
+                    comparison: '>=',
+                    value: '{thresVar}',
+                  },
+                ],
+              },
+            ],
+          },
+          size: 'LARGE',
+          title: 'Expanded {large} card',
+          type: 'IMAGE',
+        };
+        expect(getCardVariables(imageCardWithVariables)).toEqual([
+          'high',
+          'unitVar',
+          'thresVar',
+          'large',
+        ]);
+      });
+
+      it('returns variables for a TableCard', () => {
+        const tableCardWithVariables = {
+          id: 'speed_mean_and_max_threshold',
+          size: 'LARGE',
+          title: 'Max and {minimum} speed',
+          type: 'TABLE',
+          content: {
+            columns: [
+              {
+                dataSourceId: 'abnormal_stop_id',
+                label: 'Abnormal Stop Count',
+              },
+              {
+                dataSourceId: 'speed_id_mean',
+                label: 'Mean Speed',
+              },
+              {
+                dataSourceId: 'speed_id_max',
+                label: 'Max Speed',
+              },
+              {
+                dataSourceId: 'deviceid',
+                linkTemplate: {
+                  href: 'www.{url}.com',
+                  displayValue: '{url}',
+                },
+              },
+              {
+                dataSourceId: 'timestamp',
+                label: 'Time stamp',
+                type: 'TIMESTAMP',
+              },
+            ],
+            thresholds: [
+              {
+                dataSourceId: 'abnormal_stop_id',
+                comparison: '>=',
+                severity: 1,
+                value: 75,
+                label: '{high} Severity',
+                severityLabel: '{large} severity',
+                icon: 'Stop filled',
+                color: '#008000',
+              },
+            ],
+            expandedRows: [
+              {
+                dataSourceId: 'travel_time_id',
+                label: 'Mean travel time',
+              },
+            ],
+            sort: 'DESC',
+          },
+          dataSource: {
+            attributes: [
+              {
+                aggregator: 'mean',
+                attribute: 'speed',
+                id: 'speed_id_mean',
+              },
+              {
+                aggregator: 'count',
+                attribute: 'abnormal_stop_count',
+                id: 'abnormal_stop_id',
+              },
+              {
+                aggregator: 'max',
+                attribute: 'speed',
+                id: 'speed_id_max',
+              },
+              {
+                aggregator: 'mean',
+                attribute: 'travel_time',
+                id: 'travel_time_id',
+              },
+            ],
+            range: {
+              count: -7,
+              interval: 'day',
+            },
+            timeGrain: 'day',
+            groupBy: ['deviceid'],
+          },
+        };
+        expect(getCardVariables(tableCardWithVariables)).toEqual([
+          'minimum',
+          'url',
+          'high',
+          'large',
+        ]);
+      });
+
+      it('returns variables for a TimeSeriesCard', () => {
+        const timeSeriesCardWithVariables = {
+          id: 'air_flow_mean',
+          size: 'LARGE',
+          title: 'Air flow {deviceId} mean vs max',
+          type: 'TIMESERIES',
+          content: {
+            series: [
+              {
+                dataSourceId: 'airflow_mean',
+                label: 'Airflow Mean',
+              },
+              {
+                dataSourceId: 'airflow_max',
+                label: '{airflow_max}',
+              },
+            ],
+            xLabel: '{x_axis}',
+            yLabel: '{y_axis}',
+            unit: '{unit}',
+            timeDataSourceId: 'timestamp',
+          },
+          dataSource: {
+            attributes: [
+              {
+                aggregator: 'mean',
+                attribute: 'air_flow_rate',
+                id: 'airflow_mean',
+              },
+              {
+                aggregator: 'max',
+                attribute: 'air_flow_rate',
+                id: 'airflow_max',
+              },
+            ],
+            range: {
+              type: 'periodToDate',
+              count: -7,
+              interval: 'day',
+            },
+            additionalData: {
+              type: 'alert',
+              dataFilter: {
+                name: 'alert_air_flow_rate_greater_than_1',
+              },
+            },
+            timeGrain: 'day',
+          },
+        };
+        expect(getCardVariables(timeSeriesCardWithVariables)).toEqual([
+          'deviceId',
+          'airflow_max',
+          'x_axis',
+          'y_axis',
+          'unit',
+        ]);
+      });
+
+      it('does not blow up on null or react symbols', () => {
+        const timeSeriesCardWithVariables = {
+          id: 'air_flow_mean',
+          size: 'LARGE',
+          title: 'Air flow {deviceId} mean vs max',
+          type: 'TIMESERIES',
+          content: {
+            series: [
+              {
+                dataSourceId: 'airflow_max',
+                label: '{airflow_max}',
+              },
+            ],
+            xLabel: '{x_axis}',
+            yLabel: '{y_axis}',
+            unit: '{unit}',
+            timeDataSourceId: 'timestamp',
+          },
+          dataSource: {
+            attributes: [
+              {
+                aggregator: 'max',
+                attribute: 'air_flow_rate',
+                id: 'airflow_max',
+              },
+            ],
+            range: {
+              type: 'periodToDate',
+              count: -7,
+              interval: 'day',
+            },
+            timeGrain: 'day',
+          },
+          someNullProperty: null,
+          someReactSymbolProperty: <p>Hi I am a React symbol</p>,
+        };
+        expect(getCardVariables(timeSeriesCardWithVariables)).toEqual([
+          'deviceId',
+          'airflow_max',
+          'x_axis',
+          'y_axis',
+          'unit',
+        ]);
+      });
+
+      it('returns empty array when no variables are given', () => {
+        const imageCard = {
+          content: {
+            alt: 'Sample image',
+            src: 'static/media/landscape.69143f06.jpg',
+            zoomMax: 10,
+            hotspots: [
+              {
+                icon: 'carbon-icon',
+                color: 'blue',
+                content: {
+                  title: 'sensor readings',
+                  attributes: [
+                    {
+                      dataSourceId: 'temp_last',
+                      label: 'temp',
+                      unit: 'F',
+                    },
+                  ],
+                },
+                thresholds: [
+                  {
+                    dataSourceId: 'temp_last',
+                    comparison: '>=',
+                    value: '300',
+                  },
+                ],
+              },
+            ],
+          },
+          size: 'LARGE',
+          title: 'Expanded card',
+          type: 'IMAGE',
+        };
+        expect(getCardVariables(imageCard)).toEqual([]);
+      });
+
+      it('does not return variables for skipped properties', () => {
+        const tableCardWithVariables = {
+          id: 'speed_mean_and_max_threshold',
+          size: 'LARGE',
+          title: 'Max and {minimum} speed',
+          type: 'TABLE',
+          content: {
+            columns: [
+              {
+                dataSourceId: 'abnormal_stop_id',
+                label: 'Abnormal Stop Count',
+              },
+              {
+                dataSourceId: 'deviceid',
+                linkTemplate: {
+                  href: 'www.{url}.com',
+                  target: '_blank',
+                },
+              },
+              {
+                dataSourceId: 'timestamp',
+                label: 'Time stamp',
+                type: 'TIMESTAMP',
+              },
+            ],
+            thresholds: [
+              {
+                dataSourceId: 'abnormal_stop_id',
+                comparison: '>=',
+                severity: 1,
+                value: 75,
+                label: '{high} Severity',
+                severityLabel: '{large} severity',
+                icon: 'Stop filled',
+                color: '#008000',
+              },
+            ],
+            expandedRows: [
+              {
+                dataSourceId: 'travel_time_id',
+                label: 'Mean travel time',
+              },
+            ],
+            sort: 'DESC',
+          },
+          dataSource: {
+            attributes: [
+              {
+                aggregator: 'mean',
+                attribute: 'speed',
+                id: 'speed_id_mean',
+              },
+              {
+                aggregator: 'count',
+                attribute: 'abnormal_stop_count',
+                id: 'abnormal_stop_id',
+              },
+              {
+                aggregator: 'max',
+                attribute: 'speed',
+                id: 'speed_id_max',
+              },
+              {
+                aggregator: 'mean',
+                attribute: 'travel_time',
+                id: 'travel_time_id',
+              },
+            ],
+            range: {
+              count: -7,
+              interval: 'day',
+            },
+            timeGrain: 'day',
+            groupBy: ['deviceid'],
+          },
+        };
+        expect(getCardVariables(tableCardWithVariables, ['href'])).toEqual([
+          'minimum',
+          'high',
+          'large',
+        ]);
+      });
+    });
+
+    describe('replaceVariables', () => {
+      it('replaceVariables', () => {
+        const card = {
+          title: 'my {number_variable} {string_variable}',
+          thresholds: [{ value: '{number_variable}' }, { value: '{string_variable}' }],
+        };
+        const updatedCard = replaceVariables(
+          ['number_variable', 'string_variable'],
+          { number_variable: 100, string_variable: 'mystring' },
+          card
+        );
+        expect(updatedCard.title).toEqual('my 100 mystring');
+        expect(updatedCard.thresholds[0].value).toEqual(100);
+        expect(updatedCard.thresholds[1].value).toEqual('mystring');
+      });
+
+      it('replaceVariables handles nodes correctly', () => {
+        const card = {
+          title: <p>my default</p>,
+          thresholds: [{ value: '{number_variable}' }, { value: '{string_variable}' }],
+        };
+        const updatedCard = replaceVariables(
+          ['number_variable', 'string_variable'],
+          { number_variable: 100, string_variable: 'mystring' },
+          card
+        );
+        expect(React.isValidElement(updatedCard.title)).toEqual(true);
+        expect(updatedCard.thresholds[0].value).toEqual(100);
+        expect(updatedCard.thresholds[1].value).toEqual('mystring');
+      });
+    });
   });
-  it('replaceVariables', () => {
-    const card = {
-      title: 'my {number_variable} {string_variable}',
-      thresholds: [{ value: '{number_variable}' }, { value: '{string_variable}' }],
-    };
-    const updatedCard = replaceVariables(
-      ['number_variable', 'string_variable'],
-      { number_variable: 100, string_variable: 'mystring' },
-      card
-    );
-    expect(updatedCard.title).toEqual('my 100 mystring');
-    expect(updatedCard.thresholds[0].value).toEqual(100);
-    expect(updatedCard.thresholds[1].value).toEqual('mystring');
-  });
-  it('replaceVariables handles nodes correctly', () => {
-    const card = {
-      title: <p>my default</p>,
-      thresholds: [{ value: '{number_variable}' }, { value: '{string_variable}' }],
-    };
-    const updatedCard = replaceVariables(
-      ['number_variable', 'string_variable'],
-      { number_variable: 100, string_variable: 'mystring' },
-      card
-    );
-    expect(React.isValidElement(updatedCard.title)).toEqual(true);
-    expect(updatedCard.thresholds[0].value).toEqual(100);
-    expect(updatedCard.thresholds[1].value).toEqual('mystring');
-  });
+
   it('chartValueFormatter', () => {
     // Small should get 3 precision
     expect(chartValueFormatter(0.23456, CARD_SIZES.LARGE, null)).toEqual('0.235');
@@ -1107,6 +1365,7 @@ describe('cardUtilityFunctions', () => {
     // nil
     expect(chartValueFormatter(null, CARD_SIZES.LARGE, null)).toEqual('--');
   });
+
   describe('Card sizes', () => {
     const consoleSpy = jest.spyOn(global.console, 'error').mockImplementation(() => {});
     let originalDev;
@@ -1149,6 +1408,7 @@ describe('cardUtilityFunctions', () => {
       expect(increaseSmallCardSize(CARD_SIZES.LARGEWIDE)).toEqual(CARD_SIZES.LARGEWIDE);
     });
   });
+
   describe('findMatchingThresholds', () => {
     const thresholds = [
       { comparison: '>', dataSourceId: 'airflow_mean', severity: 3, value: 2 },

--- a/packages/react/src/utils/cardUtilityFunctions.js
+++ b/packages/react/src/utils/cardUtilityFunctions.js
@@ -211,24 +211,28 @@ export const replaceVariables = (variables, cardVariables, target) => {
 };
 
 /**
- * @param {Object} cardProperty
+ * This function recurses across all of the card properties to find templatted variable
+ * strings that need to be replaced
+ * @param {Object} cardProperty i.e. title, content
+ * @param {Array<string>} keysToSkip if present, do not attempt to retrieve variables
+ * i.e. in table cards, there is unique cases in which it retrieves its only variables
  * @returns {Array<String>} an array of unique variable values
  */
-export const getCardVariables = (cardProperty) => {
-  const propertyVariables = Object.values(cardProperty).reduce((acc, property) => {
-    if (typeof property === 'object' && !React.isValidElement(property) && !isNil(property)) {
+export const getCardVariables = (cardProperty, keysToSkip = []) => {
+  const cardVariables = Object.entries(cardProperty).reduce((acc, [key, value]) => {
+    if (typeof value === 'object' && !React.isValidElement(value) && !isNil(value)) {
       // recursively search any objects for additional string properties
-      acc.push(...getCardVariables(property));
-    } else if (typeof property === 'string') {
+      acc.push(...getCardVariables(value, keysToSkip));
+    } else if (typeof value === 'string' && !keysToSkip.includes(key)) {
       // if it's a string, look for variables
-      const detectedVariables = getVariables(property);
+      const detectedVariables = getVariables(value);
       if (detectedVariables) {
         acc.push(...detectedVariables);
       }
     }
     return acc;
   }, []);
-  return [...new Set(propertyVariables)];
+  return [...new Set(cardVariables)];
 };
 
 /**
@@ -237,9 +241,11 @@ export const getCardVariables = (cardProperty) => {
  * @param {object} content - Contents for the card
  * @param {string} values - Values for the card
  * @param {object} card - The rest of the card
+ * @param {Array<string>} keysToSkip if present, do not attempt to retrieve variables
+ * i.e. in table cards, there is unique cases in which it retrieves its only variables
  * @return {object} updatedCard - card with any found variables replaced by their coresponding values, or the original card if no variables
  */
-export const handleCardVariables = (title, content, values, card) => {
+export const handleCardVariables = (title, content, values, card, keysToSkip = []) => {
   const updatedCard = {
     title,
     content,
@@ -252,7 +258,7 @@ export const handleCardVariables = (title, content, values, card) => {
   }
   const { cardVariables } = updatedCard;
 
-  const variablesArray = getCardVariables(updatedCard);
+  const variablesArray = getCardVariables(updatedCard, keysToSkip);
   return replaceVariables(variablesArray, cardVariables, updatedCard);
 };
 


### PR DESCRIPTION
**Summary**

- If `cardVariables` was provided to TableCard, row-specific variables were no longer working correctly. This fix splits the two and assumes that all variables within the table rows are row-specific

**Change List (commits, features, bugs, etc)**

- Remove the `with links` story in favor of the `row-specific links` story to avoid confusion
- Added a `keysToSkip` argument to `handleCardVariables` and `getCardVariables` to skip over specific keys such as the TableCard `href`
  - also sets up the ability to get better and/or fix this issue: https://github.com/carbon-design-system/carbon-addons-iot-react/issues/1527
- Moved all tableCardUtil tests to the tableCardUtils test file
- Added describe blocks to groups of tests based on the same function and/or topic
- Renamed `propertyVariables` variable in `getCardVariables` to `cardVariables` to better reflect its purpose

**Acceptance Test (how to verify the PR)**

- Go to /?path=/story/1-watson-iot-tablecard--with-row-specific-link-variables and check each link's href to ensure that the device id and timestamp is specific to that row's values
- Also check that the title is substituted (the bug here was that these 2 types of variables could not co-exist properly)

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Should be covered by the above tests
