### PR TITLE
Add getDefaultCard prop to editor

### DIFF
--- a/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
@@ -77,6 +77,10 @@ const propTypes = {
    * getValidTimeRanges(card, selectedDataItems)
    */
   getValidTimeRanges: PropTypes.func,
+  /** if provided, determines the default cardConfig for a new card when it is added
+   * getDefaultCard(cardType)
+   */
+  getDefaultCard: PropTypes.func,
   /** an array of dataItems to be included on each card
    * this prop will be ignored if getValidDataItems is defined
    */
@@ -300,6 +304,7 @@ const defaultProps = {
   onEditTitle: null,
   getValidDataItems: null,
   getValidTimeRanges: null,
+  getDefaultCard: null,
   availableImages: [],
   dataItems: [],
   availableDimensions: {},
@@ -365,6 +370,7 @@ const DashboardEditor = ({
   renderIconByName,
   getValidDataItems,
   getValidTimeRanges,
+  getDefaultCard: customGetDefaultCard,
   dataItems,
   availableImages,
   headerBreadcrumbs,
@@ -453,10 +459,15 @@ const DashboardEditor = ({
    */
   const addCard = useCallback(
     (type) => {
-      // notify consumers that the card has been added if they're listening (they might want to tweak the card defaults)
-      const cardConfig = onCardChange
-        ? onCardChange(getDefaultCard(type, mergedI18n), dashboardJson)
+      const defaultCard = customGetDefaultCard // Use the default card specified by the consumer if it exists
+        ? customGetDefaultCard(type)
         : getDefaultCard(type, mergedI18n);
+
+      // notify consumers that the card has been added if they're listening (they might want to tweak the card defaults here)
+      const cardConfig =
+        onCardChange && !customGetDefaultCard
+          ? onCardChange(defaultCard, dashboardJson)
+          : defaultCard;
 
       // eslint-disable-next-line no-shadow
       setDashboardJson((dashboardJson) => ({
@@ -466,7 +477,7 @@ const DashboardEditor = ({
       setSelectedCardId(cardConfig.id);
       setNeedsScroll(true);
     },
-    [dashboardJson, mergedI18n, onCardChange]
+    [customGetDefaultCard, dashboardJson, mergedI18n, onCardChange]
   );
 
   /**

--- a/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
@@ -469,7 +469,7 @@ const DashboardEditor = ({
         ? customGetDefaultCard(type)
         : getDefaultCard(type, mergedI18n);
 
-      // notify consumers that the card has been added if they're listening (they might want to tweak the card defaults here)
+      // notify consumers that the card has been added in onCardChange if we don't have an explicit customGetDefaultCard passed
       const cardConfig =
         onCardChange && !customGetDefaultCard
           ? onCardChange(defaultCard, dashboardJson)

--- a/packages/react/src/components/DashboardEditor/DashboardEditor.story.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.story.jsx
@@ -1394,3 +1394,88 @@ export const WithCustomCards = () => {
 WithCustomCards.story = {
   name: 'With custom cards',
 };
+
+export const withGetDefaultCard = () => {
+  const renderDefaultCard = ({ cardContent }) => <h5>{cardContent || 'My custom 1 content'}</h5>;
+
+  return (
+    <DashboardEditor
+      title={text('title', 'My dashboard')}
+      getValidDataItems={() => mockDataItems}
+      dataItems={mockDataItems}
+      availableImages={images}
+      onAddImage={action('onAddImage')}
+      onEditTitle={action('onEditTitle')}
+      onImport={action('onImport')}
+      onExport={action('onExport')}
+      onDelete={action('onDelete')}
+      onCancel={action('onCancel')}
+      onSubmit={action('onSubmit')}
+      onImageDelete={action('onImageDelete')}
+      onLayoutChange={action('onLayoutChange')}
+      isSubmitDisabled={boolean('isSubmitDisabled', false)}
+      isSubmitLoading={boolean('isSubmitLoading', false)}
+      availableDimensions={{
+        deviceid: ['73000', '73001', '73002'],
+        manufacturer: ['rentech', 'GHI Industries'],
+      }}
+      onCardChange={(cardConfig) => {
+        if (cardConfig.type === 'MYCUSTOMCARD') {
+          return {
+            ...cardConfig,
+            content: renderDefaultCard(cardConfig),
+          };
+        }
+        return cardConfig;
+      }}
+      getDefaultCard={(type) => {
+        switch (type) {
+          case 'MYCUSTOMCARD':
+            return {
+              id: 'custom1Id',
+              type: 'MYCUSTOMCARD',
+              title: 'My custom 1',
+              size: 'MEDIUM',
+              content: renderDefaultCard,
+              renderEditContent: (onChange, cardConfig) => [
+                {
+                  header: { title: 'Edit custom 1', tooltip: { tooltipText: 'tooltip' } },
+                  content: (
+                    <TextInput
+                      onChange={(e) => onChange({ ...cardConfig, cardContent: e.target.value })}
+                    />
+                  ),
+                },
+              ],
+            };
+          case 'MYCUSTOMCARD2':
+            return {
+              id: 'custom2Id',
+              type: 'MYCUSTOMCARD2',
+              title: 'My custom 2',
+              size: 'MEDIUMTHIN',
+              content: () => <h5>My custom 2 content</h5>,
+            };
+          default:
+            return {
+              id: 'defaultId',
+              title: 'defaultCard',
+              size: 'MEDIUM',
+              content: () => <h5>Default card</h5>,
+            };
+        }
+      }}
+      supportedCardTypes={array('supportedCardTypes', ['MYCUSTOMCARD', 'MYCUSTOMCARD2'])}
+      breakpointSwitcher={{ enabled: true }}
+      headerBreadcrumbs={[
+        <Link href="www.ibm.com">Dashboard library</Link>,
+        <Link href="www.ibm.com">Favorites</Link>,
+      ]}
+      isLoading={boolean('isLoading', false)}
+    />
+  );
+};
+
+withGetDefaultCard.story = {
+  name: 'With get default card',
+};

--- a/packages/react/src/components/DashboardEditor/DashboardEditorHeader/__snapshots__/DashboardEditorHeader.story.storyshot
+++ b/packages/react/src/components/DashboardEditor/DashboardEditorHeader/__snapshots__/DashboardEditorHeader.story.storyshot
@@ -94,7 +94,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                 className="iot--dashboard-editor-header--bottom"
               >
                 <button
-                  aria-describedby="icon-tooltip-10"
+                  aria-describedby="icon-tooltip-11"
                   className="bx--tooltip__trigger bx--tooltip--a11y iot--dashboard-editor-header--bottom__import bx--tooltip--bottom bx--tooltip--align-center"
                   onFocus={[Function]}
                   onMouseEnter={[Function]}
@@ -102,7 +102,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                 >
                   <span
                     className="bx--assistive-text"
-                    id="icon-tooltip-10"
+                    id="icon-tooltip-11"
                   >
                     Import
                   </span>
@@ -114,7 +114,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     }
                     aria-disabled={false}
                     className="bx--btn bx--btn--ghost bx--btn--field"
-                    htmlFor="id10"
+                    htmlFor="id11"
                     onKeyDown={[Function]}
                     tabIndex={0}
                   >
@@ -143,7 +143,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                   <input
                     className="bx--visually-hidden"
                     disabled={false}
-                    id="id10"
+                    id="id11"
                     multiple={false}
                     onChange={[Function]}
                     onClick={[Function]}

--- a/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -6056,6 +6056,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                   disabled={false}
                   onClick={[Function]}
                   tabIndex={0}
+                  title="Edit title"
                   type="button"
                 >
                   <span

--- a/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -7179,38 +7179,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                 >
                   My dashboard
                 </h2>
-                <button
-                  className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                  data-testid="Button"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Edit title"
-                  type="button"
-                >
-                  <span
-                    className="bx--assistive-text"
-                  >
-                    Edit title
-                  </span>
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Edit title"
-                    className="bx--btn__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    viewBox="0 0 32 32"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                    />
-                  </svg>
-                </button>
               </div>
             </div>
             <div

--- a/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -5970,6 +5970,1761 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT Experimental/☢️ DashboardEditor With get default card 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="iot--dashboard-editor"
+    >
+      <div
+        className="iot--dashboard-editor--content"
+      >
+        <div
+          className="page-title-bar"
+          style={
+            Object {
+              "--header-offset": "48px",
+              "--scroll-transition-progress": 1,
+            }
+          }
+        >
+          <div
+            className="page-title-bar-header"
+          >
+            <div
+              className="page-title-bar-breadcrumb-bg"
+            />
+            <div
+              className="page-title-bar-breadcrumb breadcrumb--container"
+            >
+              <nav
+                aria-label="Breadcrumb"
+              >
+                <ol
+                  className="bx--breadcrumb"
+                >
+                  <li
+                    className="bx--breadcrumb-item"
+                  >
+                    <a
+                      className="bx--link bx--link"
+                      href="www.ibm.com"
+                      rel={null}
+                    >
+                      Dashboard library
+                    </a>
+                  </li>
+                  <li
+                    className="bx--breadcrumb-item"
+                  >
+                    <a
+                      className="bx--link bx--link"
+                      href="www.ibm.com"
+                      rel={null}
+                    >
+                      Favorites
+                    </a>
+                  </li>
+                </ol>
+              </nav>
+            </div>
+            <div
+              className="page-title-bar-title"
+            >
+              <div
+                className="page-title-bar-title--text"
+              >
+                <h2
+                  title="My dashboard"
+                >
+                  My dashboard
+                </h2>
+                <button
+                  className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                  data-testid="Button"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  type="button"
+                >
+                  <span
+                    className="bx--assistive-text"
+                  >
+                    Edit title
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Edit title"
+                    className="bx--btn__icon"
+                    fill="currentColor"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 32 32"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              className="page-title-bar-header-right"
+            >
+              <div
+                className="iot--dashboard-editor-header--right"
+              >
+                <div
+                  className="iot--dashboard-editor-header--top"
+                />
+                <div
+                  className="iot--dashboard-editor-header--bottom"
+                >
+                  <div
+                    className="bx--content-switcher iot--dashboard-editor-header--bottom__switcher"
+                    onChange={[Function]}
+                    role="tablist"
+                  >
+                    <button
+                      aria-pressed={null}
+                      className="iot--icon-switch iot--icon-switch--default bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                      disabled={false}
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="bx--assistive-text"
+                      >
+                        Fit to screen
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="Fit to screen"
+                        className="bx--btn__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M6 15L6 14 2.7 14 7 9.7 6.3 9 2 13.3 2 10 1 10 1 15zM10 1L10 2 13.3 2 9 6.3 9.7 7 14 2.7 14 6 15 6 15 1z"
+                        />
+                      </svg>
+                    </button>
+                    <button
+                      aria-pressed={null}
+                      className="iot--icon-switch iot--icon-switch--default iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                      disabled={false}
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="bx--assistive-text"
+                      >
+                        Large view
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="Large view"
+                        className="bx--btn__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M28,4H4A2,2,0,0,0,2,6V22a2,2,0,0,0,2,2h8v4H8v2H24V28H20V24h8a2,2,0,0,0,2-2V6A2,2,0,0,0,28,4ZM18,28H14V24h4Zm10-6H4V6H28Z"
+                        />
+                      </svg>
+                    </button>
+                    <button
+                      aria-pressed={null}
+                      className="iot--icon-switch iot--icon-switch--default iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                      disabled={false}
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="bx--assistive-text"
+                      >
+                        Medium view
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="Medium view"
+                        className="bx--btn__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M26,24H6a2.0023,2.0023,0,0,1-2-2V8A2.002,2.002,0,0,1,6,6H26a2.0023,2.0023,0,0,1,2,2V22A2.0027,2.0027,0,0,1,26,24ZM6,8V22H26V8Z"
+                          transform="translate(0 .005)"
+                        />
+                        <path
+                          d="M2 26.005H30V28.005H2z"
+                        />
+                      </svg>
+                    </button>
+                    <button
+                      aria-pressed={null}
+                      className="iot--icon-switch iot--icon-switch--default iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                      disabled={false}
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="bx--assistive-text"
+                      >
+                        Small view
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="Small view"
+                        className="bx--btn__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M15 22H17V28H15z"
+                          transform="rotate(90 16 25)"
+                        />
+                        <path
+                          d="M25,30H7a2.0023,2.0023,0,0,1-2-2V4A2.002,2.002,0,0,1,7,2H25a2.0023,2.0023,0,0,1,2,2V28A2.0027,2.0027,0,0,1,25,30ZM7,4V28H25V4Z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                  <button
+                    aria-describedby="icon-tooltip-10"
+                    className="bx--tooltip__trigger bx--tooltip--a11y iot--dashboard-editor-header--bottom__import bx--tooltip--bottom bx--tooltip--align-center"
+                    onFocus={[Function]}
+                    onMouseEnter={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                      id="icon-tooltip-10"
+                    >
+                      Import
+                    </span>
+                    <label
+                      accepts={
+                        Array [
+                          ".json",
+                        ]
+                      }
+                      aria-disabled={false}
+                      className="bx--btn bx--btn--ghost bx--btn--field"
+                      htmlFor="id10"
+                      onKeyDown={[Function]}
+                      tabIndex={0}
+                    >
+                      <span
+                        role="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          fill="#161616"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M28 19L14.83 19 17.41 16.41 16 15 11 20 16 25 17.41 23.59 14.83 21 28 21 28 19z"
+                          />
+                          <path
+                            d="M24,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,16,2H6A2,2,0,0,0,4,4V28a2,2,0,0,0,2,2H22a2,2,0,0,0,2-2V26H22v2H6V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L21.59,10Z"
+                          />
+                        </svg>
+                      </span>
+                    </label>
+                    <input
+                      className="bx--visually-hidden"
+                      disabled={false}
+                      id="id10"
+                      multiple={false}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      tabIndex="-1"
+                      type="file"
+                    />
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                    data-testid="Button"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Export
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Export"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M13 21L26.17 21 23.59 23.59 25 25 30 20 25 15 23.59 16.41 26.17 19 13 19 13 21z"
+                      />
+                      <path
+                        d="M22,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,14,2H4A2,2,0,0,0,2,4V28a2,2,0,0,0,2,2H20a2,2,0,0,0,2-2V26H20v2H4V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L19.59,10Z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                    data-testid="Button"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Delete
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Delete"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M12 12H14V24H12zM18 12H20V24H18z"
+                      />
+                      <path
+                        d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    aria-pressed={null}
+                    className="iot--btn bx--btn bx--btn--field bx--btn--secondary"
+                    data-testid="Button"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    aria-pressed={null}
+                    className="iot--btn bx--btn bx--btn--field bx--btn--primary"
+                    data-testid="Button"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Save and close
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--dashboard-editor--preview"
+        >
+          <div
+            className=""
+          >
+            <div
+              className="iot--dashboard-editor--preview__grid-container"
+            >
+              <div
+                className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
+                data-floating-menu-container={true}
+                data-testid="ComposedModal"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onClose={[Function]}
+                onKeyDown={[Function]}
+                open={false}
+                role="presentation"
+              >
+                <span
+                  className="bx--visually-hidden"
+                  role="link"
+                  tabIndex="0"
+                >
+                  Focus sentinel
+                </span>
+                <div
+                  aria-label="New image card"
+                  aria-modal="true"
+                  className="bx--modal-container"
+                  role="dialog"
+                >
+                  <div
+                    className="bx--modal-header"
+                  >
+                    <h2
+                      className="bx--modal-header__label bx--type-delta"
+                    >
+                      New image card
+                    </h2>
+                    <h3
+                      className="bx--modal-header__heading bx--type-beta"
+                    >
+                      Image gallery
+                    </h3>
+                    <button
+                      aria-label="Close"
+                      className="bx--modal-close"
+                      onClick={[Function]}
+                      title="Close"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="bx--modal-close__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                  <div
+                    className="bx--modal-content"
+                  >
+                    <div
+                      className="iot--image-gallery-modal__top-section"
+                    >
+                      <p
+                        alt="Select the image that you want to display on this card."
+                        className="iot--image-gallery-modal__instruction-text"
+                      >
+                        Select the image that you want to display on this card.
+                      </p>
+                      <div
+                        className="iot--image-gallery-modal__search-list-view-container"
+                      >
+                        <div
+                          aria-labelledby="iot--image-gallery-modal--search-search"
+                          className="bx--search bx--search--xl bx--search--light"
+                          role="search"
+                        >
+                          <svg
+                            aria-hidden={true}
+                            className="bx--search-magnifier"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                            />
+                          </svg>
+                          <label
+                            className="bx--label"
+                            htmlFor="iot--image-gallery-modal--search"
+                            id="iot--image-gallery-modal--search-search"
+                          >
+                            
+                          </label>
+                          <input
+                            autoComplete="off"
+                            className="bx--search-input"
+                            id="iot--image-gallery-modal--search"
+                            onChange={[Function]}
+                            onKeyDown={[Function]}
+                            placeholder="Search image by file name"
+                            role="searchbox"
+                            type="text"
+                          />
+                          <button
+                            aria-label="Clear search input"
+                            className="bx--search-close bx--search-close--hidden"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <div
+                          className="bx--content-switcher iot--image-gallery-modal__content-switcher"
+                          onChange={[Function]}
+                          role="tablist"
+                        >
+                          <button
+                            aria-pressed={null}
+                            className="iot--icon-switch iot--icon-switch--large bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                            disabled={false}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            tabIndex={0}
+                            type="button"
+                          >
+                            <span
+                              className="bx--assistive-text"
+                            >
+                              Grid
+                            </span>
+                            <svg
+                              aria-hidden="true"
+                              aria-label="Grid"
+                              className="bx--btn__icon"
+                              fill="currentColor"
+                              focusable="false"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M12 4H6A2 2 0 004 6v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0012 4zm0 8H6V6h6zM26 4H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0026 4zm0 8H20V6h6zM12 18H6a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0012 18zm0 8H6V20h6zM26 18H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0026 18zm0 8H20V20h6z"
+                              />
+                            </svg>
+                          </button>
+                          <button
+                            aria-pressed={null}
+                            className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                            disabled={false}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            tabIndex={0}
+                            type="button"
+                          >
+                            <span
+                              className="bx--assistive-text"
+                            >
+                              List
+                            </span>
+                            <svg
+                              aria-hidden="true"
+                              aria-label="List"
+                              className="bx--btn__icon"
+                              fill="currentColor"
+                              focusable="false"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M10 6H28V8H10zM10 24H28V26H10zM10 15H28V17H10zM4 15H6V17H4zM4 6H6V8H4zM4 24H6V26H4z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="iot--image-gallery-modal__flex-wrapper"
+                    >
+                      <div
+                        className="iot--image-gallery-modal__scroll-panel iot--image-gallery-modal__scroll-panel--grid"
+                      >
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="assemblyline"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="assemblyline"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
+                          >
+                            <div
+                              className="iot--image-tile__title"
+                            >
+                              <span>
+                                custom title assemblyline that is very long a and must be managed.
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+      eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+      ad minim veniam.
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
+                            >
+                              <img
+                                alt="assemblyline"
+                                src="assemblyline.jpg"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--assistive-text"
+                                >
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="floow_plan"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="floow_plan"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
+                          >
+                            <div
+                              className="iot--image-tile__title"
+                            >
+                              <span>
+                                floow_plan
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
+                            >
+                              <img
+                                alt="floow plan"
+                                src="floow_plan.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--assistive-text"
+                                >
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="manufacturing_plant"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="manufacturing_plant"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
+                          >
+                            <div
+                              className="iot--image-tile__title"
+                            >
+                              <span>
+                                Manufacturing_plant
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
+                            >
+                              <img
+                                alt="manufacturing plant"
+                                src="Manufacturing_plant.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--assistive-text"
+                                >
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="robot_arm"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="robot_arm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
+                          >
+                            <div
+                              className="iot--image-tile__title"
+                            >
+                              <span>
+                                robot_arm
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
+                            >
+                              <img
+                                alt="robot arm"
+                                src="robot_arm.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--assistive-text"
+                                >
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="tankmodal"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="tankmodal"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
+                          >
+                            <div
+                              className="iot--image-tile__title"
+                            >
+                              <span>
+                                tankmodal
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
+                            >
+                              <img
+                                alt="tankmodal"
+                                src="tankmodal.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--assistive-text"
+                                >
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="turbines"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="turbines"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
+                          >
+                            <div
+                              className="iot--image-tile__title"
+                            >
+                              <span>
+                                turbines
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
+                            >
+                              <img
+                                alt="turbines"
+                                src="turbines.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--assistive-text"
+                                >
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="extra-wide-image"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="extra-wide-image"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
+                          >
+                            <div
+                              className="iot--image-tile__title"
+                            >
+                              <span>
+                                extra-wide-image
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
+                            >
+                              <img
+                                alt="extra wide image"
+                                src="extra-wide-image.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--assistive-text"
+                                >
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="large"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="large"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
+                          >
+                            <div
+                              className="iot--image-tile__title"
+                            >
+                              <span>
+                                large
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
+                            >
+                              <img
+                                alt="large image"
+                                src="large.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--assistive-text"
+                                >
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                        <input
+                          checked={false}
+                          className="bx--tile-input"
+                          id="large_portrait"
+                          onChange={[Function]}
+                          tabIndex={-1}
+                          title="title"
+                          type="checkbox"
+                          value="value"
+                        />
+                        <label
+                          className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
+                          htmlFor="large_portrait"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          selected={false}
+                          tabIndex={0}
+                        >
+                          <span
+                            className="bx--tile__checkmark"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              />
+                              <path
+                                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                                data-icon-path="inner-path"
+                                opacity="0"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            className="bx--tile-content"
+                          >
+                            <div
+                              className="iot--image-tile__title"
+                            >
+                              <span>
+                                large_portrait
+                              </span>
+                            </div>
+                            <div
+                              className="iot--image-tile__image-container"
+                            >
+                              <img
+                                alt="large image portrait"
+                                src="large_portrait.png"
+                              />
+                              <button
+                                className="iot--image-tile__title__delete bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                                disabled={false}
+                                onClick={[Function]}
+                                tabIndex={0}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--assistive-text"
+                                >
+                                  Delete
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  aria-label="Delete"
+                                  className="bx--btn__icon"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 12H14V24H12zM18 12H20V24H18z"
+                                  />
+                                  <path
+                                    d="M4 6V8H6V28a2 2 0 002 2H24a2 2 0 002-2V8h2V6zM8 28V8H24V28zM12 2H20V4H12z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="bx--modal-footer iot--composed-modal-footer bx--btn-set"
+                  >
+                    <button
+                      aria-pressed={null}
+                      className="iot--btn bx--btn bx--btn--secondary"
+                      data-testid="ComposedModal-modal-secondary-button"
+                      disabled={false}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      aria-pressed={null}
+                      className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                      data-testid="ComposedModal-modal-primary-button"
+                      disabled={true}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      Select
+                    </button>
+                  </div>
+                </div>
+                <span
+                  className="bx--visually-hidden"
+                  role="link"
+                  tabIndex="0"
+                >
+                  Focus sentinel
+                </span>
+              </div>
+              <div
+                style={
+                  Object {
+                    "flex": 1,
+                  }
+                }
+              >
+                <div
+                  className="react-grid-layout iot--dashboard-grid"
+                  onDragEnter={[Function]}
+                  onDragLeave={[Function]}
+                  onDragOver={[Function]}
+                  onDrop={[Function]}
+                  style={
+                    Object {
+                      "height": "-16px",
+                    }
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="iot--dashboard-editor--sidebar"
+      >
+        <div
+          className="iot--card-editor"
+          data-testid="card-editor"
+        >
+          <div
+            className="iot--card-editor--header"
+          >
+            <h2
+              className="iot--card-editor--header--title"
+            >
+              Gallery
+            </h2>
+          </div>
+          <div
+            className="iot--card-editor--content"
+          >
+            <div
+              className="iot--list iot--list__full-height"
+            >
+              <div
+                className="iot--list-header-container"
+              >
+                <div
+                  className="iot--list-header--search"
+                >
+                  <div
+                    aria-labelledby="iot--list-header--search-search"
+                    className="bx--search bx--search--sm"
+                    role="search"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="bx--search-magnifier"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                      />
+                    </svg>
+                    <label
+                      className="bx--label"
+                      htmlFor="iot--list-header--search"
+                      id="iot--list-header--search-search"
+                    >
+                      Enter a value
+                    </label>
+                    <input
+                      autoComplete="off"
+                      className="bx--search-input"
+                      id="iot--list-header--search"
+                      onChange={[Function]}
+                      onKeyDown={[Function]}
+                      placeholder="Enter a value"
+                      role="searchbox"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--list--content__full-height iot--list--content"
+              >
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
+                  <div
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <div
+                      className="iot--list-item--content"
+                    >
+                      <div
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                      >
+                        <div
+                          className="iot--card-gallery-list__icon"
+                        />
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
+                        <div
+                          className="iot--list-item--content--values--main"
+                        >
+                          <div
+                            className="iot--list-item--content--values--value"
+                            title="MYCUSTOMCARD"
+                          >
+                            MYCUSTOMCARD
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
+                  <div
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <div
+                      className="iot--list-item--content"
+                    >
+                      <div
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                      >
+                        <div
+                          className="iot--card-gallery-list__icon"
+                        />
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
+                        <div
+                          className="iot--list-item--content--values--main"
+                        >
+                          <div
+                            className="iot--list-item--content--values--value"
+                            title="MYCUSTOMCARD2"
+                          >
+                            MYCUSTOMCARD2
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT Experimental/☢️ DashboardEditor custom card preview renderer 1`] = `
 <div
   className="storybook-container"

--- a/packages/react/src/components/FileDrop/__snapshots__/FileDrop.story.storyshot
+++ b/packages/react/src/components/FileDrop/__snapshots__/FileDrop.story.storyshot
@@ -122,7 +122,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/F
       <label
         aria-disabled={false}
         className="bx--btn bx--btn--secondary"
-        htmlFor="id11"
+        htmlFor="id12"
         onKeyDown={[Function]}
         tabIndex={0}
       >
@@ -136,7 +136,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/F
         accept={Array []}
         className="bx--visually-hidden"
         disabled={false}
-        id="id11"
+        id="id12"
         multiple={true}
         onChange={[Function]}
         onClick={[Function]}
@@ -203,7 +203,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/F
       <label
         aria-disabled={false}
         className="bx--btn bx--btn--secondary"
-        htmlFor="id12"
+        htmlFor="id13"
         onKeyDown={[Function]}
         tabIndex={0}
       >
@@ -217,7 +217,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/F
         accept={Array []}
         className="bx--visually-hidden"
         disabled={false}
-        id="id12"
+        id="id13"
         multiple={false}
         onChange={[Function]}
         onClick={[Function]}

--- a/packages/react/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
+++ b/packages/react/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
@@ -1323,7 +1323,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/I
               >
                 <label
                   className="bx--file-browse-btn"
-                  htmlFor="id14"
+                  htmlFor="id15"
                   onKeyDown={[Function]}
                   size="field"
                   tabIndex={0}
@@ -1336,7 +1336,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/I
                     <input
                       accept={Array []}
                       className="bx--file-input"
-                      id="id14"
+                      id="id15"
                       multiple={false}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -1506,7 +1506,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/I
               >
                 <label
                   className="bx--file-browse-btn"
-                  htmlFor="id13"
+                  htmlFor="id14"
                   onKeyDown={[Function]}
                   size="field"
                   tabIndex={0}
@@ -1519,7 +1519,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/I
                     <input
                       accept={Array []}
                       className="bx--file-input"
-                      id="id13"
+                      id="id14"
                       multiple={false}
                       onChange={[Function]}
                       onClick={[Function]}

--- a/packages/react/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
+++ b/packages/react/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
@@ -624,7 +624,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                   <input
                     checked={false}
                     className="bx--radio-button"
-                    id="id15"
+                    id="id16"
                     name="Chicago White Sox"
                     onChange={[Function]}
                     tabIndex={0}
@@ -633,7 +633,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                   />
                   <label
                     className="bx--radio-button__label"
-                    htmlFor="id15"
+                    htmlFor="id16"
                   >
                     <span
                       className="bx--radio-button__appearance"
@@ -668,7 +668,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                   <input
                     checked={false}
                     className="bx--radio-button"
-                    id="id16"
+                    id="id17"
                     name="New York Yankees"
                     onChange={[Function]}
                     tabIndex={0}
@@ -677,7 +677,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                   />
                   <label
                     className="bx--radio-button__label"
-                    htmlFor="id16"
+                    htmlFor="id17"
                   >
                     <span
                       className="bx--radio-button__appearance"
@@ -712,7 +712,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                   <input
                     checked={false}
                     className="bx--radio-button"
-                    id="id17"
+                    id="id18"
                     name="Houston Astros"
                     onChange={[Function]}
                     tabIndex={0}
@@ -721,7 +721,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                   />
                   <label
                     className="bx--radio-button__label"
-                    htmlFor="id17"
+                    htmlFor="id18"
                   >
                     <span
                       className="bx--radio-button__appearance"
@@ -756,7 +756,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                   <input
                     checked={false}
                     className="bx--radio-button"
-                    id="id18"
+                    id="id19"
                     name="Atlanta Braves"
                     onChange={[Function]}
                     tabIndex={0}
@@ -765,7 +765,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                   />
                   <label
                     className="bx--radio-button__label"
-                    htmlFor="id18"
+                    htmlFor="id19"
                   >
                     <span
                       className="bx--radio-button__appearance"
@@ -800,7 +800,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                   <input
                     checked={false}
                     className="bx--radio-button"
-                    id="id19"
+                    id="id20"
                     name="New York Mets"
                     onChange={[Function]}
                     tabIndex={0}
@@ -809,7 +809,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                   />
                   <label
                     className="bx--radio-button__label"
-                    htmlFor="id19"
+                    htmlFor="id20"
                   >
                     <span
                       className="bx--radio-button__appearance"
@@ -844,7 +844,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                   <input
                     checked={false}
                     className="bx--radio-button"
-                    id="id20"
+                    id="id21"
                     name="Washington Nationals"
                     onChange={[Function]}
                     tabIndex={0}
@@ -853,7 +853,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                   />
                   <label
                     className="bx--radio-button__label"
-                    htmlFor="id20"
+                    htmlFor="id21"
                   >
                     <span
                       className="bx--radio-button__appearance"

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -9117,6 +9117,7 @@ Map {
       "breakpointSwitcher": null,
       "dataItems": Array [],
       "dataSeriesItemLinks": null,
+      "getDefaultCard": null,
       "getValidDataItems": null,
       "getValidTimeRanges": null,
       "headerBreadcrumbs": null,
@@ -9307,6 +9308,9 @@ Map {
           },
         ],
         "type": "shape",
+      },
+      "getDefaultCard": Object {
+        "type": "func",
       },
       "getValidDataItems": Object {
         "type": "func",


### PR DESCRIPTION
Closes #

**Summary**
Need to give the consumer the ability to create their own default card configs.

**Change List (commits, features, bugs, etc)**
Add `getDefaultCard` prop to editor

**Acceptance Test (how to verify the PR)**
Go to the `With get default card` story and see that the card properly renders a custom default config

**Regression Test (how to make sure this PR doesn't break old functionality)**
Make sure that the card configs (found in the json editor modal) are still the correct defaults for mainstream cards.
