### PR TITLE
fix(timeseries): card with thresholds should generate sample values between the thresholds

### DIFF
--- a/packages/react/src/components/ComboChartCard/comboChartHelpers.js
+++ b/packages/react/src/components/ComboChartCard/comboChartHelpers.js
@@ -119,9 +119,6 @@ const configureAxes = (content) => {
         formatter: (axisValue) =>
           chartValueFormatter(axisValue, newSize, null, locale, decimalPrecision),
       },
-      ...(chartType !== TIME_SERIES_TYPES.BAR
-        ? { yMaxAdjuster: (yMaxValue) => yMaxValue * 1.3 }
-        : {}),
       stacked: chartType === TIME_SERIES_TYPES.BAR && series.length > 1,
       includeZero: includeZeroOnYaxis,
       scaleType: 'linear',

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -422,9 +422,6 @@ const TimeSeriesCard = ({
           ...(thresholds?.some((threshold) => threshold.axis === 'y')
             ? { thresholds: thresholds?.filter((threshold) => threshold.axis === 'y') }
             : {}),
-          // ...(chartType !== TIME_SERIES_TYPES.BAR
-          //   ? { yMaxAdjuster: (yMaxValue) => yMaxValue * 1.3 }
-          //   : {}),
           stacked: chartType === TIME_SERIES_TYPES.BAR && series.length > 1,
           includeZero: includeZeroOnYaxis,
           scaleType: 'linear',

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -228,9 +228,13 @@ const TimeSeriesCard = ({
   const previousTick = useRef();
   dayjs.locale(locale);
 
+  // Workaround since downstream consumers might keep regenerating the series object and useMemo does a direct in-memory comparison for the object
+  const objectAgnosticSeries = JSON.stringify(series);
+
   const sampleValues = useMemo(
     () => generateSampleValues(series, timeDataSourceId, interval, timeRange),
-    [series, timeDataSourceId, interval, timeRange]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [objectAgnosticSeries, timeDataSourceId, interval, timeRange]
   );
 
   const values = useMemo(() => (isEditable ? sampleValues : valuesProp), [

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -534,7 +534,7 @@ const TimeSeriesCard = ({
               options={options}
               width="100%"
               height="100%"
-              key={`thresholds-key${thresholds?.length ? JSON.stringify(thresholds) : ''}`} // have to regen the component if thresholds change
+              key={`thresholds-key${thresholds?.length ? objectAgnosticThresholds : ''}`} // have to regen the component if thresholds change
             />
           </div>
           {isExpanded ? (

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -532,6 +532,7 @@ const TimeSeriesCard = ({
               options={options}
               width="100%"
               height="100%"
+              key={`thresholds-key${thresholds?.length}`} // have to regen the component if thresholds change
             />
           </div>
           {isExpanded ? (

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -230,11 +230,12 @@ const TimeSeriesCard = ({
 
   // Workaround since downstream consumers might keep regenerating the series object and useMemo does a direct in-memory comparison for the object
   const objectAgnosticSeries = JSON.stringify(series);
+  const objectAgnosticThresholds = JSON.stringify(thresholds);
 
   const sampleValues = useMemo(
-    () => generateSampleValues(series, timeDataSourceId, interval, timeRange),
+    () => generateSampleValues(series, timeDataSourceId, interval, timeRange, thresholds),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [objectAgnosticSeries, timeDataSourceId, interval, timeRange]
+    [objectAgnosticSeries, timeDataSourceId, interval, timeRange, objectAgnosticThresholds]
   );
 
   const values = useMemo(() => (isEditable ? sampleValues : valuesProp), [
@@ -421,9 +422,9 @@ const TimeSeriesCard = ({
           ...(thresholds?.some((threshold) => threshold.axis === 'y')
             ? { thresholds: thresholds?.filter((threshold) => threshold.axis === 'y') }
             : {}),
-          ...(chartType !== TIME_SERIES_TYPES.BAR
-            ? { yMaxAdjuster: (yMaxValue) => yMaxValue * 1.3 }
-            : {}),
+          // ...(chartType !== TIME_SERIES_TYPES.BAR
+          //   ? { yMaxAdjuster: (yMaxValue) => yMaxValue * 1.3 }
+          //   : {}),
           stacked: chartType === TIME_SERIES_TYPES.BAR && series.length > 1,
           includeZero: includeZeroOnYaxis,
           scaleType: 'linear',
@@ -536,7 +537,7 @@ const TimeSeriesCard = ({
               options={options}
               width="100%"
               height="100%"
-              key={`thresholds-key${thresholds?.length}`} // have to regen the component if thresholds change
+              key={`thresholds-key${thresholds?.length ? JSON.stringify(thresholds) : ''}`} // have to regen the component if thresholds change
             />
           </div>
           {isExpanded ? (

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
@@ -1296,8 +1296,6 @@ Locale.story = {
 
 export const Thresholds = () => {
   const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGE);
-  const interval = select('interval', ['hour', 'day', 'week', 'quarter', 'month', 'year'], 'hour');
-  const values = getIntervalChartData(interval, 20, { min: 10, max: 100 }, 100);
   return (
     <div
       style={{
@@ -1310,6 +1308,7 @@ export const Thresholds = () => {
         title={text('title', 'Pressure')}
         isLoading={boolean('isLoading', false)}
         isExpanded={boolean('isExpanded', false)}
+        isEditable
         content={object('content-thresholds', {
           series: [
             {
@@ -1326,11 +1325,15 @@ export const Thresholds = () => {
           timeDataSourceId: 'timestamp',
           addSpaceOnEdges: 1,
           thresholds: [
-            { axis: 'y', value: values[0].pressure, fillColor: 'red', label: 'Alert 1' },
-            { axis: 'x', value: values[0].timestamp, fillColor: 'yellow', label: 'Alert 2' },
+            {
+              axis: 'y',
+              value: 100,
+              fillColor: 'red',
+              label: 'Alert 1',
+            },
+            { axis: 'y', value: -1, fillColor: 'yellow', label: 'Alert 2' },
           ],
         })}
-        values={values}
         interval="day"
         breakpoint="lg"
         showTimeInGMT={boolean('showTimeInGMT', false)}

--- a/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -5859,82 +5859,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           </span>
           <div
             className="iot--card--toolbar"
-          >
-            <div
-              className="iot--card--toolbar-date-range-wrapper"
-            >
-              <button
-                aria-expanded={false}
-                aria-haspopup={true}
-                aria-label="open and close list of options"
-                className="iot--card--toolbar-date-range-action bx--overflow-menu"
-                onClick={[Function]}
-                onClose={[Function]}
-                onKeyDown={[Function]}
-                open={false}
-                title="Select time range"
-                type="button"
-              >
-                <svg
-                  aria-label="Select time range"
-                  className="bx--overflow-menu__icon"
-                  fill="currentColor"
-                  focusable="false"
-                  height={16}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  preserveAspectRatio="xMidYMid meet"
-                  role="img"
-                  viewBox="0 0 32 32"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
-                  />
-                  <path
-                    d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
-                  />
-                  <path
-                    d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
-                  />
-                  <title>
-                    Select time range
-                  </title>
-                </svg>
-              </button>
-            </div>
-            <button
-              aria-pressed={null}
-              className="iot--card--toolbar-action iot--card--toolbar-svg-wrapper bx--btn--icon-only bx--btn bx--btn--ghost"
-              disabled={false}
-              onClick={[Function]}
-              tabIndex={0}
-              title="Expand to fullscreen"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                aria-label="Expand to fullscreen"
-                className="bx--btn__icon"
-                fill="currentColor"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 32 32"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M28,4H10A2.0059,2.0059,0,0,0,8,6V20a2.0059,2.0059,0,0,0,2,2H28a2.0059,2.0059,0,0,0,2-2V6A2.0059,2.0059,0,0,0,28,4Zm0,16H10V6H28Z"
-                />
-                <path
-                  d="M18,26H4V16H6V14H4a2.0059,2.0059,0,0,0-2,2V26a2.0059,2.0059,0,0,0,2,2H18a2.0059,2.0059,0,0,0,2-2V24H18Z"
-                />
-              </svg>
-            </button>
-          </div>
+          />
         </div>
         <div
           className="iot--card--content"
@@ -5945,7 +5870,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           }
         >
           <div
-            className="iot--time-series-card--wrapper"
+            className="iot--time-series-card--wrapper iot--time-series-card--wrapper__editable"
           >
             <div
               id="mock-line-chart"

--- a/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.js
+++ b/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.js
@@ -2,13 +2,26 @@ import isNil from 'lodash/isNil';
 import isEmpty from 'lodash/isEmpty';
 import filter from 'lodash/filter';
 import find from 'lodash/find';
+import orderBy from 'lodash/orderBy';
 
 import { CHART_COLORS } from '../../constants/CardPropTypes';
 import { findMatchingAlertRange } from '../../utils/cardUtilityFunctions';
 import dayjs from '../../utils/dayjs';
 
-/** Generate fake values for my line chart */
-export const generateSampleValues = (series, timeDataSourceId, timeGrain = 'day', timeRange) => {
+/**
+ * Generate fake values for my line chart
+ * thresholds:  axis: PropTypes.oneOf(['x', 'y']),
+        value: PropTypes.number,
+        label: PropTypes.string,
+        fillColor: PropTypes.string,
+ * */
+export const generateSampleValues = (
+  series,
+  timeDataSourceId,
+  timeGrain = 'day',
+  timeRange,
+  thresholds = []
+) => {
   // determine interval type
   const timeRangeType = timeRange?.includes('this') ? 'periodToDate' : 'rolling';
   // for month timeGrains, we need to determine whether to show 3 for a quarter or 12 for a year
@@ -38,6 +51,26 @@ export const generateSampleValues = (series, timeDataSourceId, timeGrain = 'day'
       break;
   }
 
+  const highestThresholdValue =
+    orderBy(
+      thresholds.filter((threshold) => threshold.axis === 'y'),
+      'value',
+      'desc'
+    )?.[0]?.value || 0;
+
+  const lowestThresholdValue =
+    orderBy(
+      thresholds.filter((threshold) => threshold.axis === 'y'),
+      'value',
+      'acc'
+    )?.[0]?.value || 0;
+
+  const generateDatapoint = (index) =>
+    isEmpty(thresholds)
+      ? Math.random() * 100
+      : index % 2 === 0
+      ? highestThresholdValue + Math.random() * 10
+      : lowestThresholdValue - Math.random() * 10;
   // number of each record to define
   const sampleValues = Array(count).fill(1);
   // ensure the series is actually an array since it can also be an object
@@ -49,13 +82,13 @@ export const generateSampleValues = (series, timeDataSourceId, timeGrain = 'day'
         : dayjs().subtract(count, timeGrain);
 
     let nextTimeStamp = now;
-    sampleValues.forEach(() => {
+    sampleValues.forEach((value, index) => {
       nextTimeStamp = nextTimeStamp.add(1, timeGrain);
       if (!isEmpty(dataFilter)) {
         // if we have a data filter, then we need a specific row for every filter
         sampleData.push({
           [timeDataSourceId]: nextTimeStamp.valueOf(),
-          [dataSourceId]: Math.random() * 100,
+          [dataSourceId]: generateDatapoint(index),
           ...dataFilter,
         });
       } else {
@@ -64,12 +97,12 @@ export const generateSampleValues = (series, timeDataSourceId, timeGrain = 'day'
         });
         if (existingData) {
           // add the additional dataSource to the existing datapoint
-          existingData[dataSourceId] = Math.random() * 100;
+          existingData[dataSourceId] = generateDatapoint(index);
         } else {
           // otherwise we need explicit row
           sampleData.push({
             [timeDataSourceId]: nextTimeStamp.valueOf(),
-            [dataSourceId]: Math.random() * 100,
+            [dataSourceId]: generateDatapoint(index),
           });
         }
       }

--- a/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.js
+++ b/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.js
@@ -51,6 +51,7 @@ export const generateSampleValues = (
       break;
   }
 
+  // This is a bit of a workaround for carbon-design-system/carbon-charts#1034 as they don't adjust the graph axes to include thresholds
   const highestThresholdValue =
     orderBy(
       thresholds.filter((threshold) => threshold.axis === 'y'),

--- a/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.test.js
+++ b/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.test.js
@@ -42,6 +42,30 @@ describe('timeSeriesUtils', () => {
       expect(sampleValues[7].temperature).toBeDefined();
       expect(sampleValues[7].severity).toEqual(3);
     });
+    it('generateSampleValues with thresholds', () => {
+      const sampleValues = generateSampleValues(
+        [{ dataSourceId: 'temperature' }, { dataSourceId: 'temperature' }],
+        'timestamp',
+        'day',
+        undefined,
+        [
+          {
+            axis: 'y',
+            value: 100,
+            fillColor: 'red',
+            label: 'Alert 1',
+          },
+          {
+            axis: 'y',
+            value: 5,
+            fillColor: 'red',
+            label: 'Alert 1',
+          },
+        ]
+      );
+      expect(sampleValues.some((value) => value.temperature > 100)).toEqual(true);
+      expect(sampleValues.some((value) => value.temperature < 5)).toEqual(true);
+    });
     it('generateSampleValues hour', () => {
       const sampleValues = generateSampleValues(
         [{ dataSourceId: 'temperature' }, { dataSourceId: 'pressure' }],


### PR DESCRIPTION
This is a little bit of a workaround for a carbon charts bug, they don't render thresholds if they're off the y-axis graph:
https://github.com/carbon-design-system/carbon-charts/issues/1034

**Summary**

- Set of fixes to the TimeSeriesCard so support the edit/preview case with thresholds

**Change List (commits, features, bugs, etc)**

- fix(TimeSeriesCard): sample values generation should not regenerate if the series and thresholds really don't change (do a json comparison). 
- refactor(TimeSeriesCard): remove unused yMaxAdjuster property in options
- workaround(TimeSeriesCard): regenerate the LineChart if the thresholds change. (this is to workaround an opened bug on carbon-charts
- feat(timeSeriesUtils): add thresholds to the generateSampleData function so we can make sure that all the sample data values are close to the threshold values (so the thresholds actually show on the graph)

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here
