### PR TITLE
chore(carbon-chart): upgrade carbon charts

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -122,7 +122,7 @@
   "dependencies": {
     "@babel/runtime": "^7.10.2",
     "@carbon/charts": "^0.41.11",
-    "@carbon/charts-react": "^0.41.11",
+    "@carbon/charts-react": "^0.41.66",
     "@carbon/colors": "10.22.0",
     "@carbon/icons-react": "10.28.0",
     "@carbon/layout": "10.21.0",

--- a/packages/react/src/components/ComboChartCard/comboChartHelpers.js
+++ b/packages/react/src/components/ComboChartCard/comboChartHelpers.js
@@ -119,9 +119,6 @@ const configureAxes = (content) => {
         formatter: (axisValue) =>
           chartValueFormatter(axisValue, newSize, null, locale, decimalPrecision),
       },
-      ...(chartType !== TIME_SERIES_TYPES.BAR
-        ? { yMaxAdjuster: (yMaxValue) => yMaxValue * 1.3 }
-        : {}),
       stacked: chartType === TIME_SERIES_TYPES.BAR && series.length > 1,
       includeZero: includeZeroOnYaxis,
       scaleType: 'linear',

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -422,9 +422,6 @@ const TimeSeriesCard = ({
           ...(thresholds?.some((threshold) => threshold.axis === 'y')
             ? { thresholds: thresholds?.filter((threshold) => threshold.axis === 'y') }
             : {}),
-          // ...(chartType !== TIME_SERIES_TYPES.BAR
-          //   ? { yMaxAdjuster: (yMaxValue) => yMaxValue * 1.3 }
-          //   : {}),
           stacked: chartType === TIME_SERIES_TYPES.BAR && series.length > 1,
           includeZero: includeZeroOnYaxis,
           scaleType: 'linear',

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -230,12 +230,11 @@ const TimeSeriesCard = ({
 
   // Workaround since downstream consumers might keep regenerating the series object and useMemo does a direct in-memory comparison for the object
   const objectAgnosticSeries = JSON.stringify(series);
-  const objectAgnosticThresholds = JSON.stringify(thresholds);
 
   const sampleValues = useMemo(
     () => generateSampleValues(series, timeDataSourceId, interval, timeRange),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [objectAgnosticSeries, timeDataSourceId, interval, timeRange, objectAgnosticThresholds]
+    [objectAgnosticSeries, timeDataSourceId, interval, timeRange]
   );
 
   const values = useMemo(() => (isEditable ? sampleValues : valuesProp), [

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -228,9 +228,13 @@ const TimeSeriesCard = ({
   const previousTick = useRef();
   dayjs.locale(locale);
 
+  // Workaround since downstream consumers might keep regenerating the series object and useMemo does a direct in-memory comparison for the object
+  const objectAgnosticSeries = JSON.stringify(series);
+
   const sampleValues = useMemo(
     () => generateSampleValues(series, timeDataSourceId, interval, timeRange),
-    [series, timeDataSourceId, interval, timeRange]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [objectAgnosticSeries, timeDataSourceId, interval, timeRange]
   );
 
   const values = useMemo(() => (isEditable ? sampleValues : valuesProp), [

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -233,7 +233,7 @@ const TimeSeriesCard = ({
   const objectAgnosticThresholds = JSON.stringify(thresholds);
 
   const sampleValues = useMemo(
-    () => generateSampleValues(series, timeDataSourceId, interval, timeRange, thresholds),
+    () => generateSampleValues(series, timeDataSourceId, interval, timeRange),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [objectAgnosticSeries, timeDataSourceId, interval, timeRange, objectAgnosticThresholds]
   );
@@ -534,7 +534,6 @@ const TimeSeriesCard = ({
               options={options}
               width="100%"
               height="100%"
-              key={`thresholds-key${thresholds?.length ? JSON.stringify(thresholds) : ''}`} // have to regen the component if thresholds change
             />
           </div>
           {isExpanded ? (

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -532,6 +532,7 @@ const TimeSeriesCard = ({
               options={options}
               width="100%"
               height="100%"
+              key={`thresholds-key${thresholds?.length}`} // have to regen the component if thresholds change
             />
           </div>
           {isExpanded ? (

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -230,11 +230,12 @@ const TimeSeriesCard = ({
 
   // Workaround since downstream consumers might keep regenerating the series object and useMemo does a direct in-memory comparison for the object
   const objectAgnosticSeries = JSON.stringify(series);
+  const objectAgnosticThresholds = JSON.stringify(thresholds);
 
   const sampleValues = useMemo(
-    () => generateSampleValues(series, timeDataSourceId, interval, timeRange),
+    () => generateSampleValues(series, timeDataSourceId, interval, timeRange, thresholds),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [objectAgnosticSeries, timeDataSourceId, interval, timeRange]
+    [objectAgnosticSeries, timeDataSourceId, interval, timeRange, objectAgnosticThresholds]
   );
 
   const values = useMemo(() => (isEditable ? sampleValues : valuesProp), [
@@ -421,9 +422,9 @@ const TimeSeriesCard = ({
           ...(thresholds?.some((threshold) => threshold.axis === 'y')
             ? { thresholds: thresholds?.filter((threshold) => threshold.axis === 'y') }
             : {}),
-          ...(chartType !== TIME_SERIES_TYPES.BAR
-            ? { yMaxAdjuster: (yMaxValue) => yMaxValue * 1.3 }
-            : {}),
+          // ...(chartType !== TIME_SERIES_TYPES.BAR
+          //   ? { yMaxAdjuster: (yMaxValue) => yMaxValue * 1.3 }
+          //   : {}),
           stacked: chartType === TIME_SERIES_TYPES.BAR && series.length > 1,
           includeZero: includeZeroOnYaxis,
           scaleType: 'linear',
@@ -536,7 +537,7 @@ const TimeSeriesCard = ({
               options={options}
               width="100%"
               height="100%"
-              key={`thresholds-key${thresholds?.length}`} // have to regen the component if thresholds change
+              key={`thresholds-key${thresholds?.length ? JSON.stringify(thresholds) : ''}`} // have to regen the component if thresholds change
             />
           </div>
           {isExpanded ? (

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
@@ -1296,6 +1296,9 @@ Locale.story = {
 
 export const Thresholds = () => {
   const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGE);
+  const interval = select('interval', ['hour', 'day', 'week', 'quarter', 'month', 'year'], 'hour');
+
+  const values = getIntervalChartData(interval, 20, { min: 10, max: 100 }, 100, 1572824320000);
   return (
     <div
       style={{
@@ -1308,13 +1311,13 @@ export const Thresholds = () => {
         title={text('title', 'Pressure')}
         isLoading={boolean('isLoading', false)}
         isExpanded={boolean('isExpanded', false)}
-        isEditable
+        isEditable={boolean('isEditable', true)}
         content={object('content-thresholds', {
           series: [
             {
               label: 'Pressure',
               dataSourceId: 'pressure',
-              color: text('color', COLORS.MAGENTA),
+              color: text('color', COLORS.PURPLE),
             },
           ],
           unit: 'm/sec',
@@ -1324,16 +1327,31 @@ export const Thresholds = () => {
           includeZeroOnYaxis: true,
           timeDataSourceId: 'timestamp',
           addSpaceOnEdges: 1,
+          alertRanges: [
+            {
+              startTimestamp: 1,
+              endTimestamp: 2572486422000,
+              color: '#FF0000',
+              details: 'Alert name',
+            },
+          ],
           thresholds: [
             {
               axis: 'y',
-              value: 100,
+              value: 300,
               fillColor: 'red',
               label: 'Alert 1',
             },
-            { axis: 'y', value: -1, fillColor: 'yellow', label: 'Alert 2' },
+            {
+              axis: 'y',
+              value: 4,
+              fillColor: 'red',
+              label: 'Alert 3',
+            },
+            { axis: 'y', value: -100, fillColor: 'yellow', label: 'Alert 2' },
           ],
         })}
+        values={values}
         interval="day"
         breakpoint="lg"
         showTimeInGMT={boolean('showTimeInGMT', false)}

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
@@ -1296,8 +1296,6 @@ Locale.story = {
 
 export const Thresholds = () => {
   const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGE);
-  const interval = select('interval', ['hour', 'day', 'week', 'quarter', 'month', 'year'], 'hour');
-  const values = getIntervalChartData(interval, 20, { min: 10, max: 100 }, 100);
   return (
     <div
       style={{
@@ -1310,6 +1308,7 @@ export const Thresholds = () => {
         title={text('title', 'Pressure')}
         isLoading={boolean('isLoading', false)}
         isExpanded={boolean('isExpanded', false)}
+        isEditable
         content={object('content-thresholds', {
           series: [
             {
@@ -1326,11 +1325,15 @@ export const Thresholds = () => {
           timeDataSourceId: 'timestamp',
           addSpaceOnEdges: 1,
           thresholds: [
-            { axis: 'y', value: values[0].pressure, fillColor: 'red', label: 'Alert 1' },
-            { axis: 'x', value: values[0].timestamp, fillColor: 'yellow', label: 'Alert 2' },
+            {
+              axis: 'y',
+              value: 100,
+              fillColor: 'red',
+              label: 'Alert 1',
+            },
+            { axis: 'y', value: -1, fillColor: 'yellow', label: 'Alert 2' },
           ],
         })}
-        values={values}
         interval="day"
         breakpoint="lg"
         showTimeInGMT={boolean('showTimeInGMT', false)}

--- a/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -5859,82 +5859,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           </span>
           <div
             className="iot--card--toolbar"
-          >
-            <div
-              className="iot--card--toolbar-date-range-wrapper"
-            >
-              <button
-                aria-expanded={false}
-                aria-haspopup={true}
-                aria-label="open and close list of options"
-                className="iot--card--toolbar-date-range-action bx--overflow-menu"
-                onClick={[Function]}
-                onClose={[Function]}
-                onKeyDown={[Function]}
-                open={false}
-                title="Select time range"
-                type="button"
-              >
-                <svg
-                  aria-label="Select time range"
-                  className="bx--overflow-menu__icon"
-                  fill="currentColor"
-                  focusable="false"
-                  height={16}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  preserveAspectRatio="xMidYMid meet"
-                  role="img"
-                  viewBox="0 0 32 32"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
-                  />
-                  <path
-                    d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
-                  />
-                  <path
-                    d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
-                  />
-                  <title>
-                    Select time range
-                  </title>
-                </svg>
-              </button>
-            </div>
-            <button
-              aria-pressed={null}
-              className="iot--card--toolbar-action iot--card--toolbar-svg-wrapper bx--btn--icon-only bx--btn bx--btn--ghost"
-              disabled={false}
-              onClick={[Function]}
-              tabIndex={0}
-              title="Expand to fullscreen"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                aria-label="Expand to fullscreen"
-                className="bx--btn__icon"
-                fill="currentColor"
-                focusable="false"
-                height={16}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                viewBox="0 0 32 32"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M28,4H10A2.0059,2.0059,0,0,0,8,6V20a2.0059,2.0059,0,0,0,2,2H28a2.0059,2.0059,0,0,0,2-2V6A2.0059,2.0059,0,0,0,28,4Zm0,16H10V6H28Z"
-                />
-                <path
-                  d="M18,26H4V16H6V14H4a2.0059,2.0059,0,0,0-2,2V26a2.0059,2.0059,0,0,0,2,2H18a2.0059,2.0059,0,0,0,2-2V24H18Z"
-                />
-              </svg>
-            </button>
-          </div>
+          />
         </div>
         <div
           className="iot--card--content"
@@ -5945,7 +5870,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           }
         >
           <div
-            className="iot--time-series-card--wrapper"
+            className="iot--time-series-card--wrapper iot--time-series-card--wrapper__editable"
           >
             <div
               id="mock-line-chart"

--- a/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.js
+++ b/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.js
@@ -2,13 +2,26 @@ import isNil from 'lodash/isNil';
 import isEmpty from 'lodash/isEmpty';
 import filter from 'lodash/filter';
 import find from 'lodash/find';
+import orderBy from 'lodash/orderBy';
 
 import { CHART_COLORS } from '../../constants/CardPropTypes';
 import { findMatchingAlertRange } from '../../utils/cardUtilityFunctions';
 import dayjs from '../../utils/dayjs';
 
-/** Generate fake values for my line chart */
-export const generateSampleValues = (series, timeDataSourceId, timeGrain = 'day', timeRange) => {
+/**
+ * Generate fake values for my line chart
+ * thresholds:  axis: PropTypes.oneOf(['x', 'y']),
+        value: PropTypes.number,
+        label: PropTypes.string,
+        fillColor: PropTypes.string,
+ * */
+export const generateSampleValues = (
+  series,
+  timeDataSourceId,
+  timeGrain = 'day',
+  timeRange,
+  thresholds = []
+) => {
   // determine interval type
   const timeRangeType = timeRange?.includes('this') ? 'periodToDate' : 'rolling';
   // for month timeGrains, we need to determine whether to show 3 for a quarter or 12 for a year
@@ -38,6 +51,26 @@ export const generateSampleValues = (series, timeDataSourceId, timeGrain = 'day'
       break;
   }
 
+  const highestThresholdValue =
+    orderBy(
+      thresholds.filter((threshold) => threshold.axis === 'y'),
+      'value',
+      'desc'
+    )?.[0]?.value || 0;
+
+  const lowestThresholdValue =
+    orderBy(
+      thresholds.filter((threshold) => threshold.axis === 'y'),
+      'value',
+      'acc'
+    )?.[0]?.value || 0;
+
+  const generateDatapoint = (index) =>
+    isEmpty(thresholds)
+      ? Math.random() * 100
+      : index % 2 === 0
+      ? highestThresholdValue + Math.random() * 10
+      : lowestThresholdValue - Math.random() * 10;
   // number of each record to define
   const sampleValues = Array(count).fill(1);
   // ensure the series is actually an array since it can also be an object
@@ -49,13 +82,13 @@ export const generateSampleValues = (series, timeDataSourceId, timeGrain = 'day'
         : dayjs().subtract(count, timeGrain);
 
     let nextTimeStamp = now;
-    sampleValues.forEach(() => {
+    sampleValues.forEach((value, index) => {
       nextTimeStamp = nextTimeStamp.add(1, timeGrain);
       if (!isEmpty(dataFilter)) {
         // if we have a data filter, then we need a specific row for every filter
         sampleData.push({
           [timeDataSourceId]: nextTimeStamp.valueOf(),
-          [dataSourceId]: Math.random() * 100,
+          [dataSourceId]: generateDatapoint(index),
           ...dataFilter,
         });
       } else {
@@ -64,12 +97,12 @@ export const generateSampleValues = (series, timeDataSourceId, timeGrain = 'day'
         });
         if (existingData) {
           // add the additional dataSource to the existing datapoint
-          existingData[dataSourceId] = Math.random() * 100;
+          existingData[dataSourceId] = generateDatapoint(index);
         } else {
           // otherwise we need explicit row
           sampleData.push({
             [timeDataSourceId]: nextTimeStamp.valueOf(),
-            [dataSourceId]: Math.random() * 100,
+            [dataSourceId]: generateDatapoint(index),
           });
         }
       }

--- a/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.js
+++ b/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.js
@@ -51,6 +51,7 @@ export const generateSampleValues = (
       break;
   }
 
+  // This is a bit of a workaround for carbon-design-system/carbon-charts#1034 as they don't adjust the graph axes to include thresholds
   const highestThresholdValue =
     orderBy(
       thresholds.filter((threshold) => threshold.axis === 'y'),

--- a/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.test.js
+++ b/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.test.js
@@ -42,6 +42,30 @@ describe('timeSeriesUtils', () => {
       expect(sampleValues[7].temperature).toBeDefined();
       expect(sampleValues[7].severity).toEqual(3);
     });
+    it('generateSampleValues with thresholds', () => {
+      const sampleValues = generateSampleValues(
+        [{ dataSourceId: 'temperature' }, { dataSourceId: 'temperature' }],
+        'timestamp',
+        'day',
+        undefined,
+        [
+          {
+            axis: 'y',
+            value: 100,
+            fillColor: 'red',
+            label: 'Alert 1',
+          },
+          {
+            axis: 'y',
+            value: 5,
+            fillColor: 'red',
+            label: 'Alert 1',
+          },
+        ]
+      );
+      expect(sampleValues.some((value) => value.temperature > 100)).toEqual(true);
+      expect(sampleValues.some((value) => value.temperature < 5)).toEqual(true);
+    });
     it('generateSampleValues hour', () => {
       const sampleValues = generateSampleValues(
         [{ dataSourceId: 'temperature' }, { dataSourceId: 'pressure' }],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2968,12 +2968,13 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@carbon/charts-react@^0.41.11":
-  version "0.41.11"
-  resolved "https://registry.yarnpkg.com/@carbon/charts-react/-/charts-react-0.41.11.tgz#60fa7044dfbae9c4a94679ab290aadbf34a5c069"
-  integrity sha512-WRsfO+X5NQhhKzyevY8MQAWlL+SKOlvPm+WK1vaKnD5VuFMrdnLB2OG6esJmrF7taAC5qeY5mTlAfJ0ZE97p5Q==
+"@carbon/charts-react@^0.41.66":
+  version "0.41.66"
+  resolved "https://registry.yarnpkg.com/@carbon/charts-react/-/charts-react-0.41.66.tgz#dae5061ffd92ee27633ba2b3f4469028cd2b3301"
+  integrity sha512-HN8mOlM+MsZ2J1gYBU8DSCf3L/Kvs6p/COgn4r9nnj0LASU9UdXlPYDPZjSlH+B/sdEwUFUtZ8uIgejYTdIlKw==
   dependencies:
-    "@carbon/charts" "^0.41.11"
+    "@carbon/charts" "^0.41.66"
+    "@carbon/telemetry" "0.0.0-alpha.6"
 
 "@carbon/charts@0.41.31":
   version "0.41.31"
@@ -2996,6 +2997,19 @@
     "@carbon/utils-position" "1.1.1"
     date-fns "2.8.1"
     lodash-es "4.17.15"
+    resize-observer-polyfill "1.5.0"
+
+"@carbon/charts@^0.41.66":
+  version "0.41.66"
+  resolved "https://registry.yarnpkg.com/@carbon/charts/-/charts-0.41.66.tgz#2fc937b616bd47233c3360558d67821d5769791a"
+  integrity sha512-LirAW331K7CIXeqqnzkXwnMdXzh66SjudkKuRFWiXrK8NkRqjUqKrWYe+opCsOnSnQ/xbTkYiTspHVZVIBP97w==
+  dependencies:
+    "@carbon/colors" "10.15.0"
+    "@carbon/telemetry" "0.0.0-alpha.6"
+    "@carbon/utils-position" "1.1.1"
+    d3-cloud "1.2.5"
+    date-fns "2.8.1"
+    lodash-es "4.17.21"
     resize-observer-polyfill "1.5.0"
 
 "@carbon/colors@10.15.0":
@@ -8916,21 +8930,6 @@ cheerio@^1.0.0-rc.2:
     lodash "^4.15.0"
     parse5 "^3.0.1"
 
-chokidar@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.1.tgz#c84e5b3d18d9a4d77558fef466b1bf16bbeb3450"
-  integrity sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==
-  dependencies:
-    anymatch "~3.1.1"
-    braces "~3.0.2"
-    glob-parent "~5.1.0"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.3.0"
-  optionalDependencies:
-    fsevents "~2.1.2"
-
 "chokidar@>=2.0.0 <4.0.0", "chokidar@>=3.0.0 <4.0.0", chokidar@^3.0.0, chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
@@ -10511,6 +10510,13 @@ d3-chord@1:
     d3-array "1"
     d3-path "1"
 
+d3-cloud@1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/d3-cloud/-/d3-cloud-1.2.5.tgz#3e91564f2d27fba47fcc7d812eb5081ea24c603d"
+  integrity sha512-4s2hXZgvs0CoUIw31oBAGrHt9Kt/7P9Ik5HIVzISFiWkD0Ga2VLAuO/emO/z1tYIpE7KG2smB4PhMPfFMJpahw==
+  dependencies:
+    d3-dispatch "^1.0.3"
+
 d3-collection@1:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
@@ -10528,6 +10534,11 @@ d3-contour@1:
 d3-dispatch@1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.5.tgz#e25c10a186517cd6c82dd19ea018f07e01e39015"
+
+d3-dispatch@^1.0.3:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.6.tgz#00d37bcee4dd8cd97729dd893a0ac29caaba5d58"
+  integrity sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==
 
 d3-drag@1:
   version "1.2.3"
@@ -16888,6 +16899,11 @@ lodash-es@4.17.15, lodash-es@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
   integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
 
+lodash-es@4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -19629,11 +19645,6 @@ picomatch@^2.0.5:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.1.1.tgz#ecdfbea7704adb5fe6fb47f9866c4c0e15e905c5"
   integrity sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==
 
-picomatch@^2.0.7:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.3.tgz#465547f359ccc206d3c48e46a1bcb89bf7ee619d"
-  integrity sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==
-
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -21237,7 +21248,7 @@ react-syntax-highlighter@^13.5.3:
     prismjs "^1.21.0"
     refractor "^3.1.0"
 
-react-test-renderer@16.14.0, react-test-renderer@^16.0.0-0, "react-test-renderer@^16.8.0 || ^17.0.0", react-test-renderer@^16.8.6:
+react-test-renderer@^16.0.0-0, "react-test-renderer@^16.8.0 || ^17.0.0", react-test-renderer@^16.8.6:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.14.0.tgz#e98360087348e260c56d4fe2315e970480c228ae"
   integrity sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==
@@ -21497,13 +21508,6 @@ readdirp@^2.2.1:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
-
-readdirp@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.3.0.tgz#984458d13a1e42e2e9f5841b129e162f369aff17"
-  integrity sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==
-  dependencies:
-    picomatch "^2.0.7"
 
 readdirp@~3.5.0:
   version "3.5.0"


### PR DESCRIPTION
Closes #

**Summary**

- Trying out the latest version of carbon charts

**Change List (commits, features, bugs, etc)**

- Intentionally removing some previous workarounds to see if carbon-charts has fixed the bugs in the newest version
- refactor(TimeSeriesCard): remove the workaround to regen the chart if the thresholds change
- refactor(TimeSeriesCard): remove the workaround to generate sample data outside the thresholds so they're not offscreen

**Acceptance Test (how to verify the PR)**

- Verify that removing a threshold from a TimeSeriesCard actually updates the LineChart
- Verify that no threshold shows offscreen and the y-axis should be updated to contain them
- Verify that mousing over a data point keeps the same look and feel of the old charts

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Sniff test of the other charts
