### PR TITLE
fix(dashboardtemplateeditor): fix approach for editing title

### DIFF
--- a/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
@@ -65,8 +65,8 @@ const propTypes = {
   headerBreadcrumbs: PropTypes.arrayOf(PropTypes.element),
   /** if provided, renders node underneath the header and above the dashboard grid */
   notification: PropTypes.node,
-  /** if provided, renders edit button next to title linked to this callback */
-  onEditTitle: PropTypes.func,
+  /** if provided, renders edit button next to title */
+  isTitleEditable: PropTypes.bool,
   /** if provided, returns an array of strings which are the dataItems to be allowed
    * on each card
    * getValidDataItems(card, selectedTimeRange)
@@ -300,7 +300,7 @@ const defaultProps = {
   headerBreadcrumbs: null,
   notification: null,
   title: '',
-  onEditTitle: null,
+  isTitleEditable: null,
   getValidDataItems: null,
   getValidTimeRanges: null,
   availableImages: [],
@@ -379,7 +379,6 @@ const DashboardEditor = ({
   onCardChange,
   onLayoutChange,
   onCardJsonPreview,
-  onEditTitle,
   onImport,
   onExport,
   onDelete,
@@ -395,6 +394,7 @@ const DashboardEditor = ({
   i18n,
   locale,
   dataSeriesItemLinks,
+  isTitleEditable,
   icons,
   // eslint-disable-next-line react/prop-types
   onFetchDynamicDemoHotspots, // needed for the HotspotEditorModal, see the proptypes for more details
@@ -573,6 +573,10 @@ const DashboardEditor = ({
     },
     [dashboardJson.cards, handleOnCardChange, selectedCardId]
   );
+  const handleEditTitle = useCallback(
+    (newTitle) => setDashboardJson((oldJSON) => ({ ...oldJSON, title: newTitle })),
+    []
+  );
 
   return isLoading ? (
     <div className={baseClassName}>
@@ -591,9 +595,8 @@ const DashboardEditor = ({
           renderHeader()
         ) : (
           <DashboardEditorHeader
-            title={title}
+            title={dashboardJson?.title || title}
             breadcrumbs={headerBreadcrumbs}
-            onEditTitle={onEditTitle}
             onImport={onImport}
             onExport={() => onExport(dashboardJson, imagesToUpload)}
             onDelete={onDelete}
@@ -602,6 +605,7 @@ const DashboardEditor = ({
             isSubmitDisabled={isSubmitDisabled}
             isSubmitLoading={isSubmitLoading}
             i18n={mergedI18n}
+            onEditTitle={isTitleEditable && handleEditTitle}
             dashboardJson={dashboardJson}
             selectedBreakpointIndex={selectedBreakpointIndex}
             setSelectedBreakpointIndex={setSelectedBreakpointIndex}

--- a/packages/react/src/components/DashboardEditor/DashboardEditor.story.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.story.jsx
@@ -177,7 +177,6 @@ export const Default = () => (
       headerEditTitleButton: 'Edit title updated',
     }}
     onAddImage={action('onAddImage')}
-    onEditTitle={action('onEditTitle')}
     onImport={action('onImport')}
     onExport={action('onExport')}
     onDelete={action('onDelete')}
@@ -380,7 +379,6 @@ export const WithInitialValue = () => (
         ],
       },
     }}
-    onEditTitle={action('onEditTitle')}
     onImport={action('onImport')}
     onExport={action('onExport')}
     onDelete={action('onDelete')}
@@ -411,6 +409,12 @@ export const WithInitialValue = () => (
 
 WithInitialValue.story = {
   name: 'with initialValue',
+};
+
+export const WithEditableTitle = () => <DashboardEditor title="Custom dashboard" isTitleEditable />;
+
+WithEditableTitle.story = {
+  namd: 'with editable title',
 };
 
 export const SummaryDashboardWithInitialValue = () => (
@@ -581,7 +585,6 @@ export const SummaryDashboardWithInitialValue = () => (
           ],
         },
       }}
-      onEditTitle={action('onEditTitle')}
       onImport={action('onImport')}
       onExport={action('onExport')}
       onDelete={action('onDelete')}
@@ -651,7 +654,6 @@ export const WithCustomOnCardChange = () => (
       ],
       layouts: {},
     }}
-    onEditTitle={action('onEditTitle')}
     onImport={action('onImport')}
     onExport={action('onExport')}
     onDelete={action('onDelete')}
@@ -691,7 +693,6 @@ export const WithNotifications = () => (
     isSubmitDisabled={boolean('isSubmitDisabled', false)}
     isSubmitLoading={boolean('isSubmitLoading', false)}
     title={text('title', 'My dashboard')}
-    onEditTitle={action('onEditTitle')}
     onImport={action('onImport')}
     onExport={action('onExport')}
     onDelete={action('onDelete')}
@@ -748,7 +749,6 @@ export const WithBreakpointSwitcher = () => (
       isSubmitLoading={boolean('isSubmitLoading', false)}
       title={text('title', 'My dashboard')}
       onAddImage={action('onAddImage')}
-      onEditTitle={action('onEditTitle')}
       onImport={action('onImport')}
       onExport={action('onExport')}
       onDelete={action('onDelete')}
@@ -815,7 +815,6 @@ export const CustomCardPreviewRenderer = () => (
       ],
       layouts: {},
     })}
-    onEditTitle={action('onEditTitle')}
     onImport={action('onImport')}
     onExport={action('onExport')}
     onDelete={action('onDelete')}
@@ -908,7 +907,6 @@ export const I18N = () => (
     dataItems={mockDataItems}
     availableImages={images}
     onAddImage={action('onAddImage')}
-    onEditTitle={action('onEditTitle')}
     onImport={action('onImport')}
     onExport={action('onExport')}
     onDelete={action('onDelete')}
@@ -1349,7 +1347,6 @@ export const WithCustomCards = () => {
       }}
       icons={{ CUSTOM1: <DataScientistIcon />, CUSTOM2: <EmptystateDefaultIcon /> }}
       onAddImage={action('onAddImage')}
-      onEditTitle={action('onEditTitle')}
       onImport={action('onImport')}
       onExport={action('onExport')}
       onDelete={action('onDelete')}

--- a/packages/react/src/components/DashboardEditor/DashboardEditor.test.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { Link } from '../..';
 
@@ -71,6 +72,16 @@ describe('DashboardEditor', () => {
     ],
   };
 
+  it('edit title', () => {
+    render(
+      <DashboardEditor {...commonProps} isTitleEditable initialValue={{ cards: [mockValueCard] }} />
+    );
+    userEvent.click(screen.getByRole('button', { name: 'Edit title' }));
+    userEvent.type(screen.getByRole('textbox', { name: 'Dashboard title' }), '25');
+    userEvent.click(screen.getByRole('button', { name: 'Save title' }));
+    // updates the title on screen
+    expect(screen.getByRole('heading', { name: 'My dashboard25' })).not.toBeNull();
+  });
   it('verify icon renders in editor', () => {
     render(<DashboardEditor {...commonProps} initialValue={{ cards: [mockValueCard] }} />);
     // no card should be selected, meaning the gallery should be open

--- a/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -85,38 +85,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                   >
                     Custom dashboard
                   </h2>
-                  <button
-                    className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                    data-testid="Button"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    title="Edit title"
-                    type="button"
-                  >
-                    <span
-                      className="bx--assistive-text"
-                    >
-                      Edit title
-                    </span>
-                    <svg
-                      aria-hidden="true"
-                      aria-label="Edit title"
-                      className="bx--btn__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      viewBox="0 0 32 32"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                      />
-                    </svg>
-                  </button>
                 </div>
               </div>
               <div
@@ -2894,6 +2862,1199 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT Experimental/☢️ DashboardEditor With Editable Title 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="iot--dashboard-editor"
+    >
+      <div
+        className="iot--dashboard-editor--content"
+      >
+        <div
+          className="page-title-bar"
+          style={
+            Object {
+              "--header-offset": "48px",
+              "--scroll-transition-progress": 1,
+            }
+          }
+        >
+          <div
+            className="page-title-bar-header"
+          >
+            <div
+              className="page-title-bar-breadcrumb-bg"
+            />
+            <div
+              className="page-title-bar-title"
+            >
+              <div
+                className="page-title-bar-title--text"
+              >
+                <h2
+                  title="Custom dashboard"
+                >
+                  Custom dashboard
+                </h2>
+                <button
+                  className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                  data-testid="Button"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  title="Edit title"
+                  type="button"
+                >
+                  <span
+                    className="bx--assistive-text"
+                  >
+                    Edit title
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Edit title"
+                    className="bx--btn__icon"
+                    fill="currentColor"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 32 32"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              className="page-title-bar-header-right"
+            >
+              <div
+                className="iot--dashboard-editor-header--right"
+              >
+                <div
+                  className="iot--dashboard-editor-header--top"
+                />
+                <div
+                  className="iot--dashboard-editor-header--bottom"
+                >
+                  <button
+                    className="iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                    data-testid="Button"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Export
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Export"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M13 21L26.17 21 23.59 23.59 25 25 30 20 25 15 23.59 16.41 26.17 19 13 19 13 21z"
+                      />
+                      <path
+                        d="M22,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,14,2H4A2,2,0,0,0,2,4V28a2,2,0,0,0,2,2H20a2,2,0,0,0,2-2V26H20v2H4V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L19.59,10Z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    aria-pressed={null}
+                    className="iot--btn bx--btn bx--btn--field bx--btn--primary"
+                    data-testid="Button"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Save and close
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--dashboard-editor--preview"
+        >
+          <div
+            className=""
+          >
+            <div
+              className="iot--dashboard-editor--preview__grid-container"
+            >
+              <div
+                className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
+                data-floating-menu-container={true}
+                data-testid="ComposedModal"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onClose={[Function]}
+                onKeyDown={[Function]}
+                open={false}
+                role="presentation"
+              >
+                <span
+                  className="bx--visually-hidden"
+                  role="link"
+                  tabIndex="0"
+                >
+                  Focus sentinel
+                </span>
+                <div
+                  aria-label="New image card"
+                  aria-modal="true"
+                  className="bx--modal-container"
+                  role="dialog"
+                >
+                  <div
+                    className="bx--modal-header"
+                  >
+                    <h2
+                      className="bx--modal-header__label bx--type-delta"
+                    >
+                      New image card
+                    </h2>
+                    <h3
+                      className="bx--modal-header__heading bx--type-beta"
+                    >
+                      Image gallery
+                    </h3>
+                    <button
+                      aria-label="Close"
+                      className="bx--modal-close"
+                      onClick={[Function]}
+                      title="Close"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="bx--modal-close__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                  <div
+                    className="bx--modal-content"
+                  >
+                    <div
+                      className="iot--image-gallery-modal__top-section"
+                    >
+                      <p
+                        alt="Select the image that you want to display on this card."
+                        className="iot--image-gallery-modal__instruction-text"
+                      >
+                        Select the image that you want to display on this card.
+                      </p>
+                      <div
+                        className="iot--image-gallery-modal__search-list-view-container"
+                      >
+                        <div
+                          aria-labelledby="iot--image-gallery-modal--search-search"
+                          className="bx--search bx--search--xl bx--search--light"
+                          role="search"
+                        >
+                          <svg
+                            aria-hidden={true}
+                            className="bx--search-magnifier"
+                            fill="currentColor"
+                            focusable="false"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                            />
+                          </svg>
+                          <label
+                            className="bx--label"
+                            htmlFor="iot--image-gallery-modal--search"
+                            id="iot--image-gallery-modal--search-search"
+                          >
+                            
+                          </label>
+                          <input
+                            autoComplete="off"
+                            className="bx--search-input"
+                            id="iot--image-gallery-modal--search"
+                            onChange={[Function]}
+                            onKeyDown={[Function]}
+                            placeholder="Search image by file name"
+                            role="searchbox"
+                            type="text"
+                          />
+                          <button
+                            aria-label="Clear search input"
+                            className="bx--search-close bx--search-close--hidden"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <div
+                          className="bx--content-switcher iot--image-gallery-modal__content-switcher"
+                          onChange={[Function]}
+                          role="tablist"
+                        >
+                          <button
+                            aria-pressed={null}
+                            className="iot--icon-switch iot--icon-switch--large bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                            disabled={false}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            tabIndex={0}
+                            type="button"
+                          >
+                            <span
+                              className="bx--assistive-text"
+                            >
+                              Grid
+                            </span>
+                            <svg
+                              aria-hidden="true"
+                              aria-label="Grid"
+                              className="bx--btn__icon"
+                              fill="currentColor"
+                              focusable="false"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M12 4H6A2 2 0 004 6v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0012 4zm0 8H6V6h6zM26 4H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V6A2 2 0 0026 4zm0 8H20V6h6zM12 18H6a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0012 18zm0 8H6V20h6zM26 18H20a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2V20A2 2 0 0026 18zm0 8H20V20h6z"
+                              />
+                            </svg>
+                          </button>
+                          <button
+                            aria-pressed={null}
+                            className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center"
+                            disabled={false}
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            tabIndex={0}
+                            type="button"
+                          >
+                            <span
+                              className="bx--assistive-text"
+                            >
+                              List
+                            </span>
+                            <svg
+                              aria-hidden="true"
+                              aria-label="List"
+                              className="bx--btn__icon"
+                              fill="currentColor"
+                              focusable="false"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M10 6H28V8H10zM10 24H28V26H10zM10 15H28V17H10zM4 15H6V17H4zM4 6H6V8H4zM4 24H6V26H4z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="iot--image-gallery-modal__flex-wrapper"
+                    >
+                      <div
+                        className="iot--image-gallery-modal__scroll-panel iot--image-gallery-modal__scroll-panel--grid"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="bx--modal-footer iot--composed-modal-footer bx--btn-set"
+                  >
+                    <button
+                      aria-pressed={null}
+                      className="iot--btn bx--btn bx--btn--secondary"
+                      data-testid="ComposedModal-modal-secondary-button"
+                      disabled={false}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      aria-pressed={null}
+                      className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
+                      data-testid="ComposedModal-modal-primary-button"
+                      disabled={true}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      Select
+                    </button>
+                  </div>
+                </div>
+                <span
+                  className="bx--visually-hidden"
+                  role="link"
+                  tabIndex="0"
+                >
+                  Focus sentinel
+                </span>
+              </div>
+              <div
+                style={
+                  Object {
+                    "flex": 1,
+                  }
+                }
+              >
+                <div
+                  className="react-grid-layout iot--dashboard-grid"
+                  onDragEnter={[Function]}
+                  onDragLeave={[Function]}
+                  onDragOver={[Function]}
+                  onDrop={[Function]}
+                  style={
+                    Object {
+                      "height": "-16px",
+                    }
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="iot--dashboard-editor--sidebar"
+      >
+        <div
+          className="iot--card-editor"
+          data-testid="card-editor"
+        >
+          <div
+            className="iot--card-editor--header"
+          >
+            <h2
+              className="iot--card-editor--header--title"
+            >
+              Gallery
+            </h2>
+          </div>
+          <div
+            className="iot--card-editor--content"
+          >
+            <div
+              className="iot--list iot--list__full-height"
+            >
+              <div
+                className="iot--list-header-container"
+              >
+                <div
+                  className="iot--list-header--search"
+                >
+                  <div
+                    aria-labelledby="iot--list-header--search-search"
+                    className="bx--search bx--search--sm"
+                    role="search"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="bx--search-magnifier"
+                      fill="currentColor"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                      />
+                    </svg>
+                    <label
+                      className="bx--label"
+                      htmlFor="iot--list-header--search"
+                      id="iot--list-header--search-search"
+                    >
+                      Enter a value
+                    </label>
+                    <input
+                      autoComplete="off"
+                      className="bx--search-input"
+                      id="iot--list-header--search"
+                      onChange={[Function]}
+                      onKeyDown={[Function]}
+                      placeholder="Enter a value"
+                      role="searchbox"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="iot--list--content__full-height iot--list--content"
+              >
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
+                  <div
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <div
+                      className="iot--list-item--content"
+                    >
+                      <div
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                      >
+                        <div
+                          className="iot--card-gallery-list__icon"
+                        >
+                          <svg
+                            height={32}
+                            width={40}
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                            >
+                              <path
+                                d="M.5.5h38.752v31H.5z"
+                                stroke="#2160F8"
+                              />
+                              <path
+                                d="M4.969 21.714h21.863v4.571H4.969zm26.832 0l1.988 4.572h-3.975z"
+                                fill="#8EC1FF"
+                              />
+                              <text
+                                fill="#2160F8"
+                                fontFamily="IBMPlexSans, IBM Plex Sans"
+                                fontSize={10}
+                              >
+                                <tspan
+                                  x={4.969}
+                                  y={15.5}
+                                >
+                                  25%
+                                </tspan>
+                              </text>
+                            </g>
+                          </svg>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
+                        <div
+                          className="iot--list-item--content--values--main"
+                        >
+                          <div
+                            className="iot--list-item--content--values--value"
+                            title="Value / KPI"
+                          >
+                            Value / KPI
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
+                  <div
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <div
+                      className="iot--list-item--content"
+                    >
+                      <div
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                      >
+                        <div
+                          className="iot--card-gallery-list__icon"
+                        >
+                          <svg
+                            height={34}
+                            width={40}
+                          >
+                            <g
+                              fill="none"
+                              fillRule="nonzero"
+                              transform="translate(0 1)"
+                            >
+                              <path
+                                d="M20.556 1.233L32.28 7.368l.033.013 7.299 1.68v-.453l-7.193-1.675L20.376.63 7.546 30.883.519 28.516l-.002.483 7.23 2.436z"
+                                fill="#0062FF"
+                              />
+                              <circle
+                                cx={7.382}
+                                cy={31.154}
+                                fill="#FFF"
+                                r={1}
+                                stroke="#0062FF"
+                                strokeWidth={1.5}
+                              />
+                              <circle
+                                cx={20.455}
+                                cy={0.966}
+                                fill="#FFF"
+                                r={1}
+                                stroke="#0062FF"
+                                strokeWidth={1.5}
+                              />
+                              <circle
+                                cx={32.904}
+                                cy={7.365}
+                                fill="#FFF"
+                                r={1}
+                                stroke="#0062FF"
+                                strokeWidth={1.5}
+                              />
+                              <path
+                                d="M.13 13.592h.776v-.155H.13zM1.424 13.592H2.2v-.155h-.777zM2.718 13.592h.777v-.155h-.777zM4.013 13.592h.777v-.155h-.777zM5.307 13.592h.777v-.155h-.777zM6.602 13.592h.777v-.155h-.777zM7.896 13.592h.777v-.155h-.777zM9.19 13.592h.778v-.155H9.19zM10.485 13.592h.777v-.155h-.777zM11.78 13.592h.777v-.155h-.777zM13.074 13.592h.777v-.155h-.777zM14.369 13.592h.777v-.155h-.777zM15.663 13.592h.777v-.155h-.777zM16.958 13.592h.777v-.155h-.777zM18.252 13.592h.777v-.155h-.777zM19.547 13.592h.777v-.155h-.777zM20.841 13.592h.777v-.155h-.777zM22.136 13.592h.777v-.155h-.777zM23.43 13.592h.777v-.155h-.777zM24.725 13.592h.777v-.155h-.777zM26.02 13.592h.776v-.155h-.777zM27.314 13.592h.777v-.155h-.777zM28.608 13.592h.777v-.155h-.777zM29.903 13.592h.777v-.155h-.777zM31.197 13.592h.777v-.155h-.777zM32.492 13.592h.777v-.155h-.777zM33.786 13.592h.777v-.155h-.777zM35.08 13.592h.778v-.155h-.777zM36.375 13.592h.777v-.155h-.777zM37.67 13.592h.777v-.155h-.777zM38.964 13.592h.389v-.155h-.389z"
+                                fill="#0062FF"
+                              />
+                            </g>
+                          </svg>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
+                        <div
+                          className="iot--list-item--content--values--main"
+                        >
+                          <div
+                            className="iot--list-item--content--values--value"
+                            title="Time series line"
+                          >
+                            Time series line
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
+                  <div
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <div
+                      className="iot--list-item--content"
+                    >
+                      <div
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                      >
+                        <div
+                          className="iot--card-gallery-list__icon"
+                        >
+                          <svg
+                            height={32}
+                            width={40}
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                            >
+                              <path
+                                d="M1.29 21.57L13 10.477l11.2 12.347L30.5 16l8.21 9.6"
+                                stroke="#0062FF"
+                              />
+                              <ellipse
+                                cx={25.835}
+                                cy={7.62}
+                                rx={3.19}
+                                ry={3.5}
+                                stroke="#005BFF"
+                              />
+                              <path
+                                d="M.5.5h39v31H.5z"
+                                stroke="#2160F8"
+                              />
+                            </g>
+                          </svg>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
+                        <div
+                          className="iot--list-item--content--values--main"
+                        >
+                          <div
+                            className="iot--list-item--content--values--value"
+                            title="Image"
+                          >
+                            Image
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
+                  <div
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <div
+                      className="iot--list-item--content"
+                    >
+                      <div
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                      >
+                        <div
+                          className="iot--card-gallery-list__icon"
+                        >
+                          <svg
+                            height={32}
+                            width={40}
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                            >
+                              <path
+                                d="M0 0h40v2.759H0z"
+                                fill="#0058FF"
+                              />
+                              <path
+                                d="M.5 3.259h39V31.5H.5z"
+                                stroke="#005BFF"
+                              />
+                              <path
+                                d="M3.5 6.621h19V9.38h-19zm21.5 0h11V9.38H25zM3.5 18.759h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 12.69h19v2.759h-19zm21.5 0h11v2.759H25zM3.5 24.828h19v2.759h-19zm21.5 0h11v2.759H25z"
+                                fill="#D8D8D8"
+                              />
+                            </g>
+                          </svg>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
+                        <div
+                          className="iot--list-item--content--values--main"
+                        >
+                          <div
+                            className="iot--list-item--content--values--value"
+                            title="Data table"
+                          >
+                            Data table
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
+                  <div
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <div
+                      className="iot--list-item--content"
+                    >
+                      <div
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                      >
+                        <div
+                          className="iot--card-gallery-list__icon"
+                        >
+                          <svg
+                            height={32}
+                            width={40}
+                          >
+                            <path
+                              d="M0 0h1.111v32H0zm31.111 2.963h1.111V32h-1.111zM7.778 19.259h1.111V32H7.778zm7.778-7.407h1.111V32h-1.111zM38.889 26.37H40V32h-1.111zM23.333 14.222h1.111V32h-1.111z"
+                              fill="#0062FF"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
+                        <div
+                          className="iot--list-item--content--values--main"
+                        >
+                          <div
+                            className="iot--list-item--content--values--value"
+                            title="Simple bar"
+                          >
+                            Simple bar
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
+                  <div
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <div
+                      className="iot--list-item--content"
+                    >
+                      <div
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                      >
+                        <div
+                          className="iot--card-gallery-list__icon"
+                        >
+                          <svg
+                            height={32}
+                            width={40}
+                          >
+                            <g
+                              fill="none"
+                            >
+                              <path
+                                d="M38.926 7.822H40V32h-1.074z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M37.584 17.422h1.074V32h-1.074z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M31.41 3.2h1.073V32H31.41z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M30.067 9.956h1.074V32h-1.074z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M23.893 14.578h1.073V32h-1.073z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M22.55 21.333h1.074V32H22.55z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M16.644 12.089h1.074V32h-1.074z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M15.302 25.6h1.074V32h-1.074z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M8.86 20.267h1.073V32H8.859z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M7.517 23.111h1.074V32H7.517z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M1.342 0h1.074v32H1.342z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M0 14.222h1.074V32H0z"
+                                fill="#0062FF"
+                              />
+                            </g>
+                          </svg>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
+                        <div
+                          className="iot--list-item--content--values--main"
+                        >
+                          <div
+                            className="iot--list-item--content--values--value"
+                            title="Grouped bar"
+                          >
+                            Grouped bar
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
+                  <div
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <div
+                      className="iot--list-item--content"
+                    >
+                      <div
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                      >
+                        <div
+                          className="iot--card-gallery-list__icon"
+                        >
+                          <svg
+                            height={32}
+                            width={40}
+                          >
+                            <g
+                              fill="none"
+                            >
+                              <path
+                                d="M38.108 7.467H40v24.178h-1.892z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M38.108 17.067H40v14.578h-1.892z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M38.108 16.711H40v1h-1.892z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M30.27 2.844h1.892v28.8H30.27z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M30.27 9.956h1.892V32H30.27z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M30.27 9.6h1.892v1H30.27z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M22.703 14.578h1.892V32h-1.892z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M22.703 21.333h1.892V32h-1.892z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M22.703 20.978h1.892v1h-1.892z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M15.405 12.089h1.892V32h-1.892z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M15.405 25.6h1.892V32h-1.892z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M15.405 25.244h1.892v1h-1.892z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M7.838 20.267H9.73V32H7.838z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M7.838 23.111H9.73V32H7.838z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M7.838 22.756H9.73v1H7.838z"
+                                fill="#FFF"
+                              />
+                              <path
+                                d="M0 0h1.892v32H0z"
+                                fill="#97C1FF"
+                              />
+                              <path
+                                d="M0 14.222h1.892V32H0z"
+                                fill="#0062FF"
+                              />
+                              <path
+                                d="M0 13.867h1.892v1H0z"
+                                fill="#FFF"
+                              />
+                            </g>
+                          </svg>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
+                        <div
+                          className="iot--list-item--content--values--main"
+                        >
+                          <div
+                            className="iot--list-item--content--values--value"
+                            title="Stacked bar"
+                          >
+                            Stacked bar
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
+                  <div
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <div
+                      className="iot--list-item--content"
+                    >
+                      <div
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                      >
+                        <div
+                          className="iot--card-gallery-list__icon"
+                        >
+                          <svg
+                            height={32}
+                            width={40}
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                            >
+                              <path
+                                d="M3.636 0H40v4.174H3.636zm0 6.957H40v4.174H3.636zm0 6.956H40v4.174H3.636zm0 6.957H40v4.174H3.636zm0 6.956H40V32H3.636z"
+                                fill="#D8D8D8"
+                              />
+                              <path
+                                d="M0 1.391h1.212v1.391H0zm0 6.957h1.212v1.391H0zm0 6.956h1.212v1.391H0zm0 6.957h1.212v1.391H0zm0 6.956h1.212v1.391H0z"
+                                fill="#171717"
+                              />
+                            </g>
+                          </svg>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
+                        <div
+                          className="iot--list-item--content--values--main"
+                        >
+                          <div
+                            className="iot--list-item--content--values--value"
+                            title="List"
+                          >
+                            List
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item-parent"
+                  data-floating-menu-container={true}
+                >
+                  <div
+                    className="iot--list-item iot--list-item__selectable"
+                    data_testid={null}
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <div
+                      className="iot--list-item--content"
+                    >
+                      <div
+                        className="iot--list-item--content--icon iot--list-item--content--icon__left"
+                      >
+                        <div
+                          className="iot--card-gallery-list__icon"
+                        />
+                      </div>
+                      <div
+                        className="iot--list-item--content--values"
+                      >
+                        <div
+                          className="iot--list-item--content--values--main"
+                        >
+                          <div
+                            className="iot--list-item--content--values--value"
+                            title="ALERT"
+                          >
+                            ALERT
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT Experimental/☢️ DashboardEditor With custom cards 1`] = `
 <div
   className="storybook-container"
@@ -2972,38 +4133,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                 >
                   My dashboard
                 </h2>
-                <button
-                  className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                  data-testid="Button"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Edit title updated"
-                  type="button"
-                >
-                  <span
-                    className="bx--assistive-text"
-                  >
-                    Edit title updated
-                  </span>
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Edit title updated"
-                    className="bx--btn__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    viewBox="0 0 32 32"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                    />
-                  </svg>
-                </button>
               </div>
             </div>
             <div
@@ -6050,38 +7179,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                 >
                   Custom dashboard
                 </h2>
-                <button
-                  className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                  data-testid="Button"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Edit title"
-                  type="button"
-                >
-                  <span
-                    className="bx--assistive-text"
-                  >
-                    Edit title
-                  </span>
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Edit title"
-                    className="bx--btn__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    viewBox="0 0 32 32"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                    />
-                  </svg>
-                </button>
               </div>
             </div>
             <div
@@ -8784,38 +9881,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                 >
                   My dashboard
                 </h2>
-                <button
-                  className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                  data-testid="Button"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Edit title updated"
-                  type="button"
-                >
-                  <span
-                    className="bx--assistive-text"
-                  >
-                    Edit title updated
-                  </span>
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Edit title updated"
-                    className="bx--btn__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    viewBox="0 0 32 32"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                    />
-                  </svg>
-                </button>
               </div>
             </div>
             <div
@@ -10929,38 +11994,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                 >
                   My dashboard
                 </h2>
-                <button
-                  className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                  data-testid="Button"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="headerEditTitleButton"
-                  type="button"
-                >
-                  <span
-                    className="bx--assistive-text"
-                  >
-                    headerEditTitleButton
-                  </span>
-                  <svg
-                    aria-hidden="true"
-                    aria-label="headerEditTitleButton"
-                    className="bx--btn__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    viewBox="0 0 32 32"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                    />
-                  </svg>
-                </button>
               </div>
             </div>
             <div
@@ -13283,38 +14316,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                   >
                     My dashboard
                   </h2>
-                  <button
-                    className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                    data-testid="Button"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    title="Edit title"
-                    type="button"
-                  >
-                    <span
-                      className="bx--assistive-text"
-                    >
-                      Edit title
-                    </span>
-                    <svg
-                      aria-hidden="true"
-                      aria-label="Edit title"
-                      className="bx--btn__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      viewBox="0 0 32 32"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                      />
-                    </svg>
-                  </button>
                 </div>
               </div>
               <div
@@ -14659,38 +15660,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                 >
                   Custom dashboard
                 </h2>
-                <button
-                  className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                  data-testid="Button"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Edit title"
-                  type="button"
-                >
-                  <span
-                    className="bx--assistive-text"
-                  >
-                    Edit title
-                  </span>
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Edit title"
-                    className="bx--btn__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    viewBox="0 0 32 32"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                    />
-                  </svg>
-                </button>
               </div>
             </div>
             <div
@@ -16011,38 +16980,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                 >
                   Custom dashboard
                 </h2>
-                <button
-                  className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                  data-testid="Button"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Edit title"
-                  type="button"
-                >
-                  <span
-                    className="bx--assistive-text"
-                  >
-                    Edit title
-                  </span>
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Edit title"
-                    className="bx--btn__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    viewBox="0 0 32 32"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                    />
-                  </svg>
-                </button>
               </div>
             </div>
             <div
@@ -18935,38 +19872,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                 >
                   My dashboard
                 </h2>
-                <button
-                  className="page-title-bar-title--edit iot--btn bx--btn bx--btn--field bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-                  data-testid="Button"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Edit title"
-                  type="button"
-                >
-                  <span
-                    className="bx--assistive-text"
-                  >
-                    Edit title
-                  </span>
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Edit title"
-                    className="bx--btn__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    viewBox="0 0 32 32"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                    />
-                  </svg>
-                </button>
               </div>
             </div>
             <div

--- a/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
@@ -68,7 +68,7 @@ const PageTitleBarPropTypes = {
   /** Content rendered beneath title bar */
   content: PropTypes.node,
   /** Callback to allow custom rendering of the title, it is called back with the title property */
-  renderTitleFunction: PropTypes.function,
+  renderTitleFunction: PropTypes.func,
 };
 
 const defaultProps = {

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -4671,7 +4671,9 @@ Map {
       "onEdit": Object {
         "type": "func",
       },
-      "renderTitleFunction": undefined,
+      "renderTitleFunction": Object {
+        "type": "func",
+      },
       "rightContent": [Function],
       "stickyHeaderOffset": Object {
         "type": "number",
@@ -9163,13 +9165,13 @@ Map {
       "isSubmitDisabled": false,
       "isSubmitLoading": false,
       "isSummaryDashboard": false,
+      "isTitleEditable": null,
       "locale": "en",
       "notification": null,
       "onCancel": null,
       "onCardChange": null,
       "onCardJsonPreview": null,
       "onDelete": null,
-      "onEditTitle": null,
       "onExport": null,
       "onFetchDynamicDemoHotspots": [Function],
       "onImageDelete": null,
@@ -9717,6 +9719,9 @@ Map {
       "isSummaryDashboard": Object {
         "type": "bool",
       },
+      "isTitleEditable": Object {
+        "type": "bool",
+      },
       "locale": Object {
         "type": "string",
       },
@@ -9733,9 +9738,6 @@ Map {
         "type": "func",
       },
       "onDelete": Object {
-        "type": "func",
-      },
-      "onEditTitle": Object {
         "type": "func",
       },
       "onExport": Object {


### PR DESCRIPTION
Closes #

**Summary**

- There was a pretty serious issue with the DashboardEditor onEditTitle implementation.  Since the DashboardEditor is the component saving the draft state of the template in it's local state, we can't allow the parent component to change the template title or any new draft changes to the template will be lost

**Change List (commits, features, bugs, etc)**

- fix(DashboardEditor): don't allow parents to change the title, only allow them to control whether the title is editable or not.   The DashboardEditor needs to change it's local draft state of the template to have the new title
- fix(PageTitleBar): fix the proptype of the PageTitleBar so that it's valid

**Acceptance Test (how to verify the PR)**

- Verify the new isEditable DashboardEditor story actually updates the title

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Verify normal DashboardEditor stories
