### PR TITLE
fix(hotspoteditormodal): fixed broken stories

### DIFF
--- a/packages/react/src/components/HotspotEditorModal/DynamicHotspotSourcePicker/DynamicHotspotSourcePicker.story.jsx
+++ b/packages/react/src/components/HotspotEditorModal/DynamicHotspotSourcePicker/DynamicHotspotSourcePicker.story.jsx
@@ -47,7 +47,7 @@ export const WithStateInStory = () => {
             setXSourceId(undefined);
             setYSourceId(undefined);
           }}
-          translateWithId={jest.fn()}
+          translateWithId={() => {}}
         />
       </div>
     );

--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/HotspotEditorDataSourceTab.test.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/HotspotEditorDataSourceTab.test.jsx
@@ -81,6 +81,7 @@ describe('HotspotEditorDataSourceTab', () => {
         cardConfig={cardConfigWithPresets}
         dataItems={dataItems}
         onChange={onChange}
+        translateWithId={() => {}}
       />
     );
     userEvent.click(screen.getAllByRole('button')[0]);
@@ -108,6 +109,7 @@ describe('HotspotEditorDataSourceTab', () => {
         cardConfig={cardConfigWithPresets}
         dataItems={dataItems}
         onChange={onChange}
+        translateWithId={() => {}}
       />
     );
     userEvent.click(screen.getAllByRole('button')[0]);
@@ -146,6 +148,7 @@ describe('HotspotEditorDataSourceTab', () => {
         cardConfig={cardConfigWithPresets}
         dataItems={dataItems}
         onChange={onChange}
+        translateWithId={() => {}}
       />
     );
     userEvent.click(screen.getAllByRole('button')[2]);
@@ -162,13 +165,18 @@ describe('HotspotEditorDataSourceTab', () => {
         cardConfig={cardConfigWithPresets}
         dataItems={dataItems}
         onChange={onChange}
+        translateWithId={() => {}}
       />
     );
 
     // edit button
     userEvent.click(screen.getAllByRole('button')[1]);
-    // add threshold
-    userEvent.click(screen.getAllByRole('button')[3]);
+
+    userEvent.click(
+      screen.getByRole('button', {
+        name: HotspotEditorDataSourceTab.defaultProps.i18n.dataItemEditorDataItemAddThreshold,
+      })
+    );
     // save
     userEvent.click(screen.getAllByRole('button')[11]);
     // Card config with the elevators hotspot removed
@@ -198,6 +206,7 @@ describe('HotspotEditorDataSourceTab', () => {
         cardConfig={cardConfigWithPresets}
         dataItems={dataItems}
         onChange={onChange}
+        translateWithId={() => {}}
       />
     );
     // edit button

--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/__snapshots__/HotspotEditorDataSourceTab.story.storyshot
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/__snapshots__/HotspotEditorDataSourceTab.story.storyshot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT Experimental/☢️ HotSpotEditorModal/HotspotEditorDataSourceTab Example with no hotspots 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT Experimental/☢️ HotSpotEditorModal/HotspotEditorDataSourceTab Example with state in story 1`] = `
 <div
   className="storybook-container"
 >

--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.story.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.story.jsx
@@ -53,16 +53,19 @@ const cardConfig = {
 const dataItems = [
   {
     dataSourceId: 'temp_last',
+    dataItemId: 'temp_last',
     label: '{high} temp',
     unit: '{unitVar}',
   },
   {
     dataSourceId: 'temperature',
+    dataItemId: 'temperature',
     label: 'Temperature',
     unit: '°',
   },
   {
     dataSourceId: 'pressure',
+    dataItemId: 'pressure',
     label: 'Pressure',
     unit: 'psi',
   },


### PR DESCRIPTION
Closes #2383

**Summary**
Fixed stories that weren't working for HotspotEditorModal and HotspotEditorDataSourceTab 

**Change List (commits, features, bugs, etc)**
- Updated stories to include `dataItemId` for the data items.
- Added the HotspotStateHook to the HotspotEditorDataSourceTab and removed the non working onChange functions
- Updated tests to remove warnings about missing required prop
- Renamed incorrectly named story for HotspotEditorDataSourceTab
- Replaced/removed hotspots in the HotspotEditorDataSourceTab story that were using an element as the content prop, something that we currently don't support. I created an issue (#2384) to sort out how such cases should be handled.

**Acceptance Test (how to verify the PR)**
1. Go to https://deploy-preview-2385--carbon-addons-iot-react.netlify.app/?path=/story/2-watson-iot-experimental-☢%EF%B8%8F-hotspoteditormodal--empty
2. Add a hotspot using ctrl + click
3. Click the Data source tab
4. Select a data item and make sure it is added to the list below
5. Click the edit pen of the selected data item and make sure all the information is correctly displayed

Verify that the following stories now are fully working :

- https://deploy-preview-2385--carbon-addons-iot-react.netlify.app?path=/story/2-watson-iot-experimental-☢%EF%B8%8F-hotspoteditormodal-hotspoteditordatasourcetab--with-state-in-story
- https://deploy-preview-2385--carbon-addons-iot-react.netlify.app?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-hotspoteditormodal-hotspoteditordatasourcetab--with-preset-values


**Regression Test (how to make sure this PR doesn't break old functionality)**
Go through all the stories for the HotspotEditorModal and make sure the Data source tab is working as expected

