### PR TITLE
TearSheet header height change fix

### DIFF
--- a/packages/react/src/components/TearSheet/TearSheet.story.jsx
+++ b/packages/react/src/components/TearSheet/TearSheet.story.jsx
@@ -6,7 +6,13 @@ import Button from '../Button';
 import TearSheetWrapper from './TearSheetWrapper';
 import TearSheet from './TearSheet';
 
-const TearSheetChild = ({ openNextSheet, goToPreviousSheet, onClose }) => (
+const TearSheetChild = ({
+  setHeaderAdditionalContent,
+  clearHeaderContent,
+  openNextSheet,
+  goToPreviousSheet,
+  onClose,
+}) => (
   <div
     style={{
       width: '1000px',
@@ -22,6 +28,20 @@ const TearSheetChild = ({ openNextSheet, goToPreviousSheet, onClose }) => (
       style={{ margin: '2rem 2rem 0 2rem', maxWidth: '13rem' }}
     >
       Open 2nd sheet
+    </Button>
+    <Button
+      kind="tertiary"
+      onClick={setHeaderAdditionalContent}
+      style={{ marginLeft: '2rem', maxWidth: '13rem' }}
+    >
+      Set header additional content
+    </Button>
+    <Button
+      kind="tertiary"
+      onClick={clearHeaderContent}
+      style={{ marginLeft: '2rem', maxWidth: '13rem' }}
+    >
+      Clear header additional content
     </Button>
     <div
       style={{
@@ -47,7 +67,11 @@ const TearSheetChild = ({ openNextSheet, goToPreviousSheet, onClose }) => (
   </div>
 );
 
-const TearSheetChild2 = ({ closeAllTearSheets }) => (
+const TearSheetChild2 = ({
+  closeAllTearSheets,
+  setHeaderAdditionalContent,
+  clearHeaderContent,
+}) => (
   <div
     style={{
       width: '1000px',
@@ -61,7 +85,20 @@ const TearSheetChild2 = ({ closeAllTearSheets }) => (
       <Button onClick={closeAllTearSheets} style={{ marginBottom: '2rem' }}>
         Close all TearSheets
       </Button>
-
+      <Button
+        kind="tertiary"
+        onClick={setHeaderAdditionalContent}
+        style={{ marginLeft: '2rem', maxWidth: '13rem' }}
+      >
+        Set header additional content
+      </Button>
+      <Button
+        kind="tertiary"
+        onClick={clearHeaderContent}
+        style={{ marginLeft: '2rem', maxWidth: '13rem' }}
+      >
+        Clear header additional content
+      </Button>
       <h1>Lorem ipsum dolor</h1>
       <h2 style={{ padding: '1rem 0' }}>sit amet</h2>
       <p>
@@ -116,7 +153,8 @@ const TearSheetChild2 = ({ closeAllTearSheets }) => (
 
 const StandardTearSheet = () => {
   const [isOpen, setOpen] = useState(false);
-
+  const [headerAdditionalContent, setHeaderAdditionalContent] = useState(null);
+  const [headerAdditionalContent2, setHeaderAdditionalContent2] = useState(null);
   return (
     <>
       <Button style={{ margin: '8rem 0 0 8rem' }} onClick={() => setOpen(true)}>
@@ -128,11 +166,35 @@ const StandardTearSheet = () => {
           title="First sheet"
           description="Generic description"
           onClose={() => setOpen(false)}
+          headerExtraContent={headerAdditionalContent}
         >
-          <TearSheetChild onClose={() => setOpen(false)} />
+          <TearSheetChild
+            onClose={() => setOpen(false)}
+            setHeaderAdditionalContent={() => {
+              setHeaderAdditionalContent(
+                <div style={{ height: '40px', display: 'flex', alignItems: 'center' }}>
+                  Header additional content
+                </div>
+              );
+            }}
+            clearHeaderContent={() => setHeaderAdditionalContent(null)}
+          />
         </TearSheet>
-        <TearSheet title="Second sheet" description="Generic description">
-          <TearSheetChild2 />
+        <TearSheet
+          title="Second sheet"
+          description="Generic description"
+          headerExtraContent={headerAdditionalContent2}
+        >
+          <TearSheetChild2
+            setHeaderAdditionalContent={() => {
+              setHeaderAdditionalContent2(
+                <div style={{ height: '40px', display: 'flex', alignItems: 'center' }}>
+                  Header additional content
+                </div>
+              );
+            }}
+            clearHeaderContent={() => setHeaderAdditionalContent2(null)}
+          />
         </TearSheet>
       </TearSheetWrapper>
     </>

--- a/packages/react/src/components/TearSheet/TearSheetWrapper.jsx
+++ b/packages/react/src/components/TearSheet/TearSheetWrapper.jsx
@@ -38,7 +38,7 @@ const TearSheetWrapper = ({ isOpen, className, onCloseAllTearSheets, children })
   const [containers] = useState(childrenArray.map(() => createRef()));
   const [initialContainersWidth, setInitialContainersWidth] = useState(null);
   const [containersStyles, setContainersStyles] = useState({});
-  const [openTearSheetHeaderHeight, setOpenTearSheetHeaderHeight] = useState(null);
+  const [activeTearSheetHeaderHeight, setActiveTearSheetHeaderHeight] = useState(null);
   const [animationClasses, setAnimationClasses] = useState(
     childrenArray.reduce(
       (acc, c, idx) => ({
@@ -62,18 +62,18 @@ const TearSheetWrapper = ({ isOpen, className, onCloseAllTearSheets, children })
           tearSheetsNodes?.[activeTearSheetIdx]?.children?.[0].getBoundingClientRect().height
         )
       ) &&
-      openTearSheetHeaderHeight !==
+      activeTearSheetHeaderHeight !==
         Math.round(
           tearSheetsNodes?.[activeTearSheetIdx]?.children?.[0].getBoundingClientRect().height
         )
     ) {
-      setOpenTearSheetHeaderHeight(
+      setActiveTearSheetHeaderHeight(
         Math.round(
           tearSheetsNodes?.[activeTearSheetIdx]?.children?.[0].getBoundingClientRect().height
         )
       );
     }
-  }, [activeTearSheetIdx, tearSheetsNodes, openTearSheetHeaderHeight]);
+  }, [activeTearSheetIdx, tearSheetsNodes, activeTearSheetHeaderHeight]);
 
   useEffect(() => (isOpen ? setActiveTearSheetIdx(0) : setActiveTearSheetIdx(null)), [isOpen]);
 
@@ -146,7 +146,7 @@ const TearSheetWrapper = ({ isOpen, className, onCloseAllTearSheets, children })
     windowSize.width,
     windowSize.height,
     windowSize,
-    openTearSheetHeaderHeight,
+    activeTearSheetHeaderHeight,
   ]);
 
   const goToSheet = (idx) => setActiveTearSheetIdx(idx);

--- a/packages/react/src/components/TearSheet/TearSheetWrapper.jsx
+++ b/packages/react/src/components/TearSheet/TearSheetWrapper.jsx
@@ -38,6 +38,7 @@ const TearSheetWrapper = ({ isOpen, className, onCloseAllTearSheets, children })
   const [containers] = useState(childrenArray.map(() => createRef()));
   const [initialContainersWidth, setInitialContainersWidth] = useState(null);
   const [containersStyles, setContainersStyles] = useState({});
+  const [openTearSheetHeaderHeight, setOpenTearSheetHeaderHeight] = useState(null);
   const [animationClasses, setAnimationClasses] = useState(
     childrenArray.reduce(
       (acc, c, idx) => ({
@@ -48,6 +49,32 @@ const TearSheetWrapper = ({ isOpen, className, onCloseAllTearSheets, children })
     )
   );
 
+  const tearSheetsNodes = containers.reduce(
+    (acc, curr) => [...acc, curr?.current?.children[0]],
+    []
+  );
+
+  useEffect(() => {
+    if (
+      activeTearSheetIdx !== null &&
+      !Number.isNaN(
+        Math.round(
+          tearSheetsNodes?.[activeTearSheetIdx]?.children?.[0].getBoundingClientRect().height
+        )
+      ) &&
+      openTearSheetHeaderHeight !==
+        Math.round(
+          tearSheetsNodes?.[activeTearSheetIdx]?.children?.[0].getBoundingClientRect().height
+        )
+    ) {
+      setOpenTearSheetHeaderHeight(
+        Math.round(
+          tearSheetsNodes?.[activeTearSheetIdx]?.children?.[0].getBoundingClientRect().height
+        )
+      );
+    }
+  }, [activeTearSheetIdx, tearSheetsNodes, openTearSheetHeaderHeight]);
+
   useEffect(() => (isOpen ? setActiveTearSheetIdx(0) : setActiveTearSheetIdx(null)), [isOpen]);
 
   useEffect(() => {
@@ -57,10 +84,6 @@ const TearSheetWrapper = ({ isOpen, className, onCloseAllTearSheets, children })
   }, [containers, initialContainersWidth]);
 
   useEffect(() => {
-    const greaterHeaderTopPosition = Math.max(
-      ...containers.map((c) => c.current.children[0]?.children[1]?.offsetTop ?? 0)
-    );
-
     setAnimationClasses((prevState) => {
       if (activeTearSheetIdx === null) {
         return {
@@ -87,6 +110,7 @@ const TearSheetWrapper = ({ isOpen, className, onCloseAllTearSheets, children })
     const containerMaxWidth = windowSize?.width - tearSheetConstants.DISTANCE_FROM_EACH_SIDE * 2;
     setContainersStyles(
       containers.reduce((acc, c, idx) => {
+        const currentHeaderHeight = c.current.children[0]?.children[1]?.offsetTop ?? 0;
         const currentWidth = isWindowWidthSmallerThanContainer
           ? containerMaxWidth - (activeTearSheetIdx - idx) * tearSheetConstants.WIDTH_DECREASE
           : activeTearSheetIdx === null || activeTearSheetIdx <= idx
@@ -108,7 +132,7 @@ const TearSheetWrapper = ({ isOpen, className, onCloseAllTearSheets, children })
             bottom: `${currentBottom}px`,
             width: `${currentWidth}px`,
             '--content-max-height': `${
-              windowSize?.height - greaterHeaderTopPosition - tearSheetConstants.DISTANCE_FROM_TOP
+              windowSize?.height - currentHeaderHeight - tearSheetConstants.DISTANCE_FROM_TOP
             }px`,
             '--content-max-width': `${containerMaxWidth}px`,
           },
@@ -122,6 +146,7 @@ const TearSheetWrapper = ({ isOpen, className, onCloseAllTearSheets, children })
     windowSize.width,
     windowSize.height,
     windowSize,
+    openTearSheetHeaderHeight,
   ]);
 
   const goToSheet = (idx) => setActiveTearSheetIdx(idx);

--- a/packages/react/src/components/TearSheet/TearSheetWrapper.jsx
+++ b/packages/react/src/components/TearSheet/TearSheetWrapper.jsx
@@ -55,23 +55,15 @@ const TearSheetWrapper = ({ isOpen, className, onCloseAllTearSheets, children })
   );
 
   useEffect(() => {
+    const tearSheetHeaderHeight = Math.round(
+      tearSheetsNodes?.[activeTearSheetIdx]?.children?.[0].getBoundingClientRect().height
+    );
     if (
       activeTearSheetIdx !== null &&
-      !Number.isNaN(
-        Math.round(
-          tearSheetsNodes?.[activeTearSheetIdx]?.children?.[0].getBoundingClientRect().height
-        )
-      ) &&
-      activeTearSheetHeaderHeight !==
-        Math.round(
-          tearSheetsNodes?.[activeTearSheetIdx]?.children?.[0].getBoundingClientRect().height
-        )
+      !Number.isNaN(tearSheetHeaderHeight) &&
+      activeTearSheetHeaderHeight !== tearSheetHeaderHeight
     ) {
-      setActiveTearSheetHeaderHeight(
-        Math.round(
-          tearSheetsNodes?.[activeTearSheetIdx]?.children?.[0].getBoundingClientRect().height
-        )
-      );
+      setActiveTearSheetHeaderHeight(tearSheetHeaderHeight);
     }
   }, [activeTearSheetIdx, tearSheetsNodes, activeTearSheetHeaderHeight]);
 

--- a/packages/react/src/components/TearSheet/TearSheetWrapper.jsx
+++ b/packages/react/src/components/TearSheet/TearSheetWrapper.jsx
@@ -1,4 +1,11 @@
-import React, { Children, cloneElement, useEffect, useState, createRef } from 'react';
+import React, {
+  Children,
+  cloneElement,
+  useEffect,
+  useState,
+  createRef,
+  useLayoutEffect,
+} from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
@@ -54,7 +61,7 @@ const TearSheetWrapper = ({ isOpen, className, onCloseAllTearSheets, children })
     []
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const tearSheetHeaderHeight = Math.round(
       tearSheetsNodes?.[activeTearSheetIdx]?.children?.[0].getBoundingClientRect().height
     );

--- a/packages/react/src/components/TearSheet/__snapshots__/TearSheet.story.storyshot
+++ b/packages/react/src/components/TearSheet/__snapshots__/TearSheet.story.storyshot
@@ -129,6 +129,40 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               >
                 Open 2nd sheet
               </button>
+              <button
+                aria-pressed={null}
+                className="iot--btn bx--btn bx--btn--tertiary"
+                data-testid="Button"
+                disabled={false}
+                onClick={[Function]}
+                style={
+                  Object {
+                    "marginLeft": "2rem",
+                    "maxWidth": "13rem",
+                  }
+                }
+                tabIndex={0}
+                type="button"
+              >
+                Set header additional content
+              </button>
+              <button
+                aria-pressed={null}
+                className="iot--btn bx--btn bx--btn--tertiary"
+                data-testid="Button"
+                disabled={false}
+                onClick={[Function]}
+                style={
+                  Object {
+                    "marginLeft": "2rem",
+                    "maxWidth": "13rem",
+                  }
+                }
+                tabIndex={0}
+                type="button"
+              >
+                Clear header additional content
+              </button>
               <div
                 style={
                   Object {
@@ -273,6 +307,40 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   type="button"
                 >
                   Close all TearSheets
+                </button>
+                <button
+                  aria-pressed={null}
+                  className="iot--btn bx--btn bx--btn--tertiary"
+                  data-testid="Button"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginLeft": "2rem",
+                      "maxWidth": "13rem",
+                    }
+                  }
+                  tabIndex={0}
+                  type="button"
+                >
+                  Set header additional content
+                </button>
+                <button
+                  aria-pressed={null}
+                  className="iot--btn bx--btn bx--btn--tertiary"
+                  data-testid="Button"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginLeft": "2rem",
+                      "maxWidth": "13rem",
+                    }
+                  }
+                  tabIndex={0}
+                  type="button"
+                >
+                  Clear header additional content
                 </button>
                 <h1>
                   Lorem ipsum dolor

--- a/packages/react/src/components/TearSheet/tear-sheet.scss
+++ b/packages/react/src/components/TearSheet/tear-sheet.scss
@@ -31,5 +31,6 @@
     height: var(--content-max-height);
     overflow-y: auto;
     overflow-x: auto;
+    transition: all $duration--slow-01 motion(standard, expressive);
   }
 }


### PR DESCRIPTION
**Summary**
- This fixes an issue where if a content were dynamically added to the TearSheet header, the TearSheet content would expand beyond its container and get cropped by the bottom of the viewport.

**Acceptance Test (how to verify the PR)**
- Check the component story. I've added buttons on the tear sheets to include additional content to their header. The tear sheet size should be readjusted to prevent it from being cropped.

**Regression Test (how to make sure this PR doesn't break old functionality)**
The tests below can be checked via story
- Check the stack feature (one tear sheet on top of the other) to see if they still behave like before. 
- Check if the tear sheet's whole content is displayed

