### PR TITLE
feat(list): Add angular list component 

### DIFF
--- a/packages/angular/src/list/index.ts
+++ b/packages/angular/src/list/index.ts
@@ -1,0 +1,7 @@
+export { ListComponent } from './list.component';
+export { ListHeaderComponent } from './list-header.component';
+export { ListItemComponent } from './list-item.component';
+export { ListModel } from './list-model.class';
+export { ListItem } from './list-item.class';
+
+export * from './list.module';

--- a/packages/angular/src/list/list-header.component.ts
+++ b/packages/angular/src/list/list-header.component.ts
@@ -13,13 +13,13 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
         <ibm-search
           placeholder="search"
           (valueChange)="onSearch.emit($event)"
-          (clear)="onSearch.emit('')">
+          (clear)="onSearch.emit('')"
+        >
         </ibm-search>
       </div>
     </div>
   `,
 })
-
 export class ListHeaderComponent {
   @Input() title: string;
   @Input() search: boolean;

--- a/packages/angular/src/list/list-header.component.ts
+++ b/packages/angular/src/list/list-header.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'ai-list-header',
+  template: `
+    <div class="iot--list-header-container">
+      <div class="iot--list-header">
+        <div class="iot--list-header--title">
+          {{ title }}
+        </div>
+      </div>
+    </div>
+  `,
+})
+
+export class ListHeaderComponent {
+  @Input() title;
+}

--- a/packages/angular/src/list/list-header.component.ts
+++ b/packages/angular/src/list/list-header.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
   selector: 'ai-list-header',
@@ -9,10 +9,20 @@ import { Component, Input } from '@angular/core';
           {{ title }}
         </div>
       </div>
+      <div *ngIf="search" class="iot--list-header--search">
+        <ibm-search
+          placeholder="search"
+          (valueChange)="onSearch.emit($event)"
+          (clear)="onSearch.emit('')">
+        </ibm-search>
+      </div>
     </div>
   `,
 })
 
 export class ListHeaderComponent {
-  @Input() title;
+  @Input() title: string;
+  @Input() search: boolean;
+
+  @Output() onSearch = new EventEmitter<any>();
 }

--- a/packages/angular/src/list/list-item.class.ts
+++ b/packages/angular/src/list/list-item.class.ts
@@ -1,0 +1,22 @@
+export class ListItem {
+  value: string;
+
+  items: ListItem[];
+
+  nestingLevel: number;
+
+  constructor(rawData?: any) {
+    const defaults = {
+      value: '',
+      nestingLevel: 0,
+      items: []
+    };
+
+    const data = Object.assign({}, defaults, rawData);
+    for (const property of Object.getOwnPropertyNames(data)) {
+      if (data.hasOwnProperty(property)) {
+        this[property] = data[property];
+      }
+    }
+  }
+}

--- a/packages/angular/src/list/list-item.class.ts
+++ b/packages/angular/src/list/list-item.class.ts
@@ -1,14 +1,34 @@
 export class ListItem {
+  /**
+   * Variable used for creating unique ids for ListItems.
+   */
+  static listItemCount = 0;
+
   value: string;
 
   items: ListItem[];
 
   nestingLevel: number;
 
+  id = `list-item-${ListItem.listItemCount}`;
+
+  expanded = true;
+
+  hidden = false;
+
+  parentId: string;
+
+  selected: boolean;
+
+  indeterminate: boolean;
+
   constructor(rawData?: any) {
+    ListItem.listItemCount++;
+
     const defaults = {
       value: '',
       nestingLevel: 0,
+      expanded: false,
       items: []
     };
 

--- a/packages/angular/src/list/list-item.class.ts
+++ b/packages/angular/src/list/list-item.class.ts
@@ -29,7 +29,7 @@ export class ListItem {
       value: '',
       nestingLevel: 0,
       expanded: false,
-      items: []
+      items: [],
     };
 
     const data = Object.assign({}, defaults, rawData);

--- a/packages/angular/src/list/list-item.component.ts
+++ b/packages/angular/src/list/list-item.component.ts
@@ -1,0 +1,31 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'ai-list-item',
+  template: `
+    <div>
+      <div class="iot--list-item">
+        <div
+          *ngIf="nestingLevel"
+          class="iot--list-item--nesting-offset"
+          [ngStyle]="{'width': 30*nestingLevel + 'px'}">
+        </div>
+        <div class="iot--list-item--content">
+          <div class="iot--list-item--content--values">
+            <div class="iot--list-item--content--values--main">
+              <div class="iot--list-item--content--values--value">
+                {{ value }}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  `,
+})
+
+export class ListItemComponent {
+  @Input() value;
+  @Input() secondaryValue;
+  @Input() nestingLevel = 0;
+}

--- a/packages/angular/src/list/list-item.component.ts
+++ b/packages/angular/src/list/list-item.component.ts
@@ -1,20 +1,59 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ListItem } from './list-item.class';
 
 @Component({
   selector: 'ai-list-item',
   template: `
     <div>
-      <div class="iot--list-item">
+      <div
+        class="iot--list-item"
+        [ngClass]="{
+          'iot--list-item__selectable' : isSelectable,
+          'iot--list-item__selected': listItem.selected
+        }">
         <div
-          *ngIf="nestingLevel"
+          *ngIf="listItem.nestingLevel > 0"
           class="iot--list-item--nesting-offset"
-          [ngStyle]="{'width': 30*nestingLevel + 'px'}">
+          [ngStyle]="{'width': 30*listItem.nestingLevel + 'px'}">
         </div>
-        <div class="iot--list-item--content">
+        <div
+          *ngIf="listItem.items.length > 0"
+          role="button"
+          (click)="onExpansionClick()"
+          tabindex="0"
+          class="iot--list-item--expand-icon">
+          <svg
+            *ngIf="!listItem.expanded"
+            ibmIcon="chevron--down"
+            size="16">
+          </svg>
+          <svg
+            *ngIf="listItem.expanded"
+            focusable="false"
+            preserveAspectRatio="xMidYMid meet"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="currentColor"
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            role="img">
+            <path d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"></path>
+          </svg>
+        </div>
+        <div
+          class="iot--list-item--content"
+          [ngClass]="{ 'iot--list-item--content__selected' : listItem.selected }">
+          <div *ngIf="isSelectable" class="iot--list-item--content--icon iot--list-item--content--icon__left">
+            <ibm-checkbox
+              (checkedChange)="onCheckedChange($event)"
+              [checked]="listItem.selected"
+              [indeterminate]="listItem.indeterminate">
+            </ibm-checkbox>
+          </div>
           <div class="iot--list-item--content--values">
             <div class="iot--list-item--content--values--main">
               <div class="iot--list-item--content--values--value">
-                {{ value }}
+                {{ listItem.value }}
               </div>
             </div>
           </div>
@@ -25,7 +64,18 @@ import { Component, Input } from '@angular/core';
 })
 
 export class ListItemComponent {
-  @Input() value;
-  @Input() secondaryValue;
-  @Input() nestingLevel = 0;
+  @Input() listItem: ListItem;
+  @Input() isSelectable: boolean;
+  @Input() search: boolean;
+
+  @Output() checkedChange = new EventEmitter<any>();
+  @Output() expansionClick = new EventEmitter<any>();
+
+  onCheckedChange(checked: boolean) {
+    this.checkedChange.emit({ id: this.listItem.id, checked });
+  }
+
+  onExpansionClick() {
+    this.expansionClick.emit(this.listItem.id);
+  }
 }

--- a/packages/angular/src/list/list-item.component.ts
+++ b/packages/angular/src/list/list-item.component.ts
@@ -8,25 +8,23 @@ import { ListItem } from './list-item.class';
       <div
         class="iot--list-item"
         [ngClass]="{
-          'iot--list-item__selectable' : isSelectable,
+          'iot--list-item__selectable': isSelectable,
           'iot--list-item__selected': listItem.selected
-        }">
+        }"
+      >
         <div
           *ngIf="listItem.nestingLevel > 0"
           class="iot--list-item--nesting-offset"
-          [ngStyle]="{'width': 30*listItem.nestingLevel + 'px'}">
-        </div>
+          [ngStyle]="{ width: 30 * listItem.nestingLevel + 'px' }"
+        ></div>
         <div
           *ngIf="listItem.items.length > 0"
           role="button"
           (click)="onExpansionClick()"
           tabindex="0"
-          class="iot--list-item--expand-icon">
-          <svg
-            *ngIf="!listItem.expanded"
-            ibmIcon="chevron--down"
-            size="16">
-          </svg>
+          class="iot--list-item--expand-icon"
+        >
+          <svg *ngIf="!listItem.expanded" ibmIcon="chevron--down" size="16"></svg>
           <svg
             *ngIf="listItem.expanded"
             focusable="false"
@@ -36,18 +34,24 @@ import { ListItem } from './list-item.class';
             width="16"
             height="16"
             viewBox="0 0 16 16"
-            role="img">
+            role="img"
+          >
             <path d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"></path>
           </svg>
         </div>
         <div
           class="iot--list-item--content"
-          [ngClass]="{ 'iot--list-item--content__selected' : listItem.selected }">
-          <div *ngIf="isSelectable" class="iot--list-item--content--icon iot--list-item--content--icon__left">
+          [ngClass]="{ 'iot--list-item--content__selected': listItem.selected }"
+        >
+          <div
+            *ngIf="isSelectable"
+            class="iot--list-item--content--icon iot--list-item--content--icon__left"
+          >
             <ibm-checkbox
               (checkedChange)="onCheckedChange($event)"
               [checked]="listItem.selected"
-              [indeterminate]="listItem.indeterminate">
+              [indeterminate]="listItem.indeterminate"
+            >
             </ibm-checkbox>
           </div>
           <div class="iot--list-item--content--values">
@@ -62,7 +66,6 @@ import { ListItem } from './list-item.class';
     </div>
   `,
 })
-
 export class ListItemComponent {
   @Input() listItem: ListItem;
   @Input() isSelectable: boolean;

--- a/packages/angular/src/list/list-model.class.ts
+++ b/packages/angular/src/list/list-model.class.ts
@@ -1,22 +1,135 @@
 import { ListItem } from './list-item.class';
 
 export class ListModel {
-    set items(items: ListItem[]) {
-        this._items = this.updateNestingLevels(items);
-        console.log(this._items);
-    }
+  set items(items: ListItem[]) {
+    this._items = this.initListItems(items, this.adjustDepth(items, 0));
+    this._displayedItems = this._items;
+  }
 
-    get items() {
-        return this._items;
-    }
+  get items() {
+    return this._displayedItems;
+  }
 
-    protected _items: ListItem[] = [];
+  // This is needed to kickstart the recursive template generation.
+  expanded = true;
 
-    updateNestingLevels(items: ListItem[], depth = 0) {
-        return items.map((item: ListItem) => ({
-            ...item,
-            nestingLevel: depth,
-            items: item.items && item.items.length ? this.updateNestingLevels(item.items, depth + 1) : []
-        }));
-    }
+  protected _displayedItems: ListItem[] = [];
+  protected _items: ListItem[] = [];
+
+  initListItems(items: ListItem[], depth = 0, parentId = null) {
+    return items.map((item: ListItem) => ({
+      ...item,
+      nestingLevel: item.items && item.items.length ? depth - 1 : depth,
+      parentId,
+      items: item.items && item.items.length
+        ? this.initListItems(item.items, this.adjustDepth(items, depth), item.id)
+        : []
+    }));
+  }
+
+  expandListItem(expansionId: string) {
+    this._items = this.toggleListItem(this._items, expansionId);
+    this._displayedItems = this._items;
+  }
+
+  selectListItem(selectedId: string, checked: boolean) {
+    this._items = this.updateAllChildrenSelectedStates(this._items, selectedId, checked);
+    this._items = this.updateAllParentsSelectedStates(this._items);
+    this._displayedItems = this._items;
+  }
+
+  search(searchString: string) {
+    this._displayedItems = this.searchForNestedItemValues(this._items, searchString);
+  }
+
+  protected adjustDepth(items: ListItem[], currentDepth: number) {
+    return items.some((item) => this.itemContainsChildren(item)) ? currentDepth + 1 : currentDepth;
+  }
+
+  protected toggleListItem(items: ListItem[], expansionId: string) {
+    return items.map((item: ListItem) => ({
+      ...item,
+      expanded: item.id === expansionId ? !item.expanded : item.expanded,
+      items: item.items && item.items.length ? this.toggleListItem(item.items, expansionId) : []
+    }));
+  }
+
+  // This sets all nested children `selected` values to the parent `selected` value.
+  protected updateAllChildrenSelectedStates(items: ListItem[], parentId: string, selected: boolean) {
+    return items.map((item: ListItem) => {
+      if (item.parentId === parentId || item.id === parentId) {
+        return {
+          ...item,
+          selected,
+          items: this.itemContainsChildren(item)
+            // Set selected state of all direct children of this item.
+            ? this.updateAllChildrenSelectedStates(item.items, item.id, selected)
+            : []
+        };
+      }
+
+      return {
+        ...item,
+        items: this.itemContainsChildren(item)
+          ? this.updateAllChildrenSelectedStates(item.items, parentId, selected)
+          : []
+      };
+    });
+  }
+
+  // This updates the `selected` values of all `ListItems` based on all
+  // their children's `selected` values.
+  // For every `ListItem`:
+  // set `selected` to `true` if all children are selected
+  // set `indeterminate` to `true` if some but not all children are selected
+  protected updateAllParentsSelectedStates(items: ListItem[]) {
+    return items.map((item: ListItem) => {
+      if (item.items && item.items.length) {
+        // We need to go bottom up in order to get the most up to date child selected states
+        // since parent's selected state depends on its children's selected states as well.
+        this.updateAllParentsSelectedStates(item.items);
+
+        if (item.items.every((item) => item.selected)) {
+          item.indeterminate = false;
+          item.selected = true;
+        } else if (item.items.some((item) => item.selected)) {
+          item.selected = false;
+          item.indeterminate = true;
+        } else {
+          item.selected = false;
+          item.indeterminate = false;
+        }
+      }
+
+      return item;
+    });
+  }
+
+  protected searchForNestedItemValues(items: ListItem[], searchString: string) {
+    return items.reduce((filteredItems: ListItem[], item: ListItem) => {
+      if (this.itemContainsChildren(item)) {
+        // If the parent matches the search then add the parent and all children.
+        if (item.value.toLowerCase().includes(searchString.toLowerCase())) {
+          filteredItems.push(item);
+        } else { // If its children did, we still need the item with only the search matching children.
+          const matchingChildren = this.searchForNestedItemValues(item.items, searchString);
+          if (matchingChildren.length > 0) {
+            filteredItems.push({
+              ...item,
+              expanded: true,
+              items: matchingChildren
+            });
+          }
+        }
+      } else if (item.value.toLowerCase().includes(searchString.toLowerCase())) {
+        filteredItems.push(item);
+      }
+
+      return filteredItems;
+    }, []);
+  }
+
+  protected itemContainsChildren(item: ListItem) {
+    return item.items && item.items.length > 0;
+  }
 }

--- a/packages/angular/src/list/list-model.class.ts
+++ b/packages/angular/src/list/list-model.class.ts
@@ -1,0 +1,22 @@
+import { ListItem } from './list-item.class';
+
+export class ListModel {
+    set items(items: ListItem[]) {
+        this._items = this.updateNestingLevels(items);
+        console.log(this._items);
+    }
+
+    get items() {
+        return this._items;
+    }
+
+    protected _items: ListItem[] = [];
+
+    updateNestingLevels(items: ListItem[], depth = 0) {
+        return items.map((item: ListItem) => ({
+            ...item,
+            nestingLevel: depth,
+            items: item.items && item.items.length ? this.updateNestingLevels(item.items, depth + 1) : []
+        }));
+    }
+}

--- a/packages/angular/src/list/list-model.class.ts
+++ b/packages/angular/src/list/list-model.class.ts
@@ -23,7 +23,7 @@ export class ListModel {
       parentId,
       items: item.items && item.items.length
         ? this.initListItems(item.items, this.adjustDepth(items, depth), item.id)
-        : []
+        : [],
     }));
   }
 
@@ -50,21 +50,25 @@ export class ListModel {
     return items.map((item: ListItem) => ({
       ...item,
       expanded: item.id === expansionId ? !item.expanded : item.expanded,
-      items: item.items && item.items.length ? this.toggleListItem(item.items, expansionId) : []
+      items: item.items && item.items.length ? this.toggleListItem(item.items, expansionId) : [],
     }));
   }
 
   // This sets all nested children `selected` values to the parent `selected` value.
-  protected updateAllChildrenSelectedStates(items: ListItem[], parentId: string, selected: boolean) {
+  protected updateAllChildrenSelectedStates(
+    items: ListItem[],
+    parentId: string,
+    selected: boolean
+  ) {
     return items.map((item: ListItem) => {
       if (item.parentId === parentId || item.id === parentId) {
+        // Set selected state of all direct children of this item.
         return {
           ...item,
           selected,
           items: this.itemContainsChildren(item)
-            // Set selected state of all direct children of this item.
             ? this.updateAllChildrenSelectedStates(item.items, item.id, selected)
-            : []
+            : [],
         };
       }
 
@@ -72,7 +76,7 @@ export class ListModel {
         ...item,
         items: this.itemContainsChildren(item)
           ? this.updateAllChildrenSelectedStates(item.items, parentId, selected)
-          : []
+          : [],
       };
     });
   }
@@ -111,13 +115,14 @@ export class ListModel {
         // If the parent matches the search then add the parent and all children.
         if (item.value.toLowerCase().includes(searchString.toLowerCase())) {
           filteredItems.push(item);
-        } else { // If its children did, we still need the item with only the search matching children.
+        } else {
+          // If its children did, we still need the item with only the search matching children.
           const matchingChildren = this.searchForNestedItemValues(item.items, searchString);
           if (matchingChildren.length > 0) {
             filteredItems.push({
               ...item,
               expanded: true,
-              items: matchingChildren
+              items: matchingChildren,
             });
           }
         }

--- a/packages/angular/src/list/list.component.ts
+++ b/packages/angular/src/list/list.component.ts
@@ -1,0 +1,37 @@
+import { Component, Input } from '@angular/core';
+
+import { ListModel } from './list-model.class';
+
+@Component({
+  selector: 'ai-list',
+  template: `
+    <div class="iot--list">
+      <ai-list-header [title]="title"></ai-list-header>
+      <div class="iot--list--content">
+        <ng-template
+          [ngTemplateOutlet]="listItemTemplateRef"
+          [ngTemplateOutletContext]="{ $implicit: model }">
+        </ng-template>
+      </div>
+    </div>
+
+    <ng-template #listItemTemplateRef let-data>
+      <ng-container *ngIf="data.value">
+        <ai-list-item [value]="data.value" [nestingLevel]="data.nestingLevel"></ai-list-item>
+      </ng-container>
+
+      <ng-container *ngIf="data.items && data.items.length">
+        <ng-template
+          ngFor
+          [ngForOf]="data.items"
+          [ngForTemplate]="listItemTemplateRef">
+        </ng-template>
+      </ng-container>
+    </ng-template>
+  `,
+})
+
+export class ListComponent {
+  @Input() model: ListModel;
+  @Input() title;
+}

--- a/packages/angular/src/list/list.component.ts
+++ b/packages/angular/src/list/list.component.ts
@@ -6,15 +6,13 @@ import { ListModel } from './list-model.class';
   selector: 'ai-list',
   template: `
     <div class="iot--list">
-      <ai-list-header
-        [title]="title"
-        [search]="true"
-        (onSearch)="onSearch($event)">
+      <ai-list-header [title]="title" [search]="true" (onSearch)="onSearch($event)">
       </ai-list-header>
       <div class="iot--list--content">
         <ng-template
           [ngTemplateOutlet]="listItemTemplateRef"
-          [ngTemplateOutletContext]="{ $implicit: model }">
+          [ngTemplateOutletContext]="{ $implicit: model }"
+        >
         </ng-template>
       </div>
     </div>
@@ -25,21 +23,18 @@ import { ListModel } from './list-model.class';
           [listItem]="data"
           [isSelectable]="isSelectable"
           (checkedChange)="onSelect($event)"
-          (expansionClick)="onExpand($event)">
+          (expansionClick)="onExpand($event)"
+        >
         </ai-list-item>
       </ng-container>
 
       <ng-container *ngIf="data.items && data.items.length && data.expanded">
-        <ng-template
-          ngFor
-          [ngForOf]="data.items"
-          [ngForTemplate]="listItemTemplateRef">
+        <ng-template ngFor [ngForOf]="data.items" [ngForTemplate]="listItemTemplateRef">
         </ng-template>
       </ng-container>
     </ng-template>
   `,
 })
-
 export class ListComponent {
   @Input() model: ListModel;
   @Input() title: string;

--- a/packages/angular/src/list/list.component.ts
+++ b/packages/angular/src/list/list.component.ts
@@ -6,7 +6,11 @@ import { ListModel } from './list-model.class';
   selector: 'ai-list',
   template: `
     <div class="iot--list">
-      <ai-list-header [title]="title"></ai-list-header>
+      <ai-list-header
+        [title]="title"
+        [search]="true"
+        (onSearch)="onSearch($event)">
+      </ai-list-header>
       <div class="iot--list--content">
         <ng-template
           [ngTemplateOutlet]="listItemTemplateRef"
@@ -15,12 +19,17 @@ import { ListModel } from './list-model.class';
       </div>
     </div>
 
-    <ng-template #listItemTemplateRef let-data>
+    <ng-template #listItemTemplateRef let-data let-index="index">
       <ng-container *ngIf="data.value">
-        <ai-list-item [value]="data.value" [nestingLevel]="data.nestingLevel"></ai-list-item>
+        <ai-list-item
+          [listItem]="data"
+          [isSelectable]="isSelectable"
+          (checkedChange)="onSelect($event)"
+          (expansionClick)="onExpand($event)">
+        </ai-list-item>
       </ng-container>
 
-      <ng-container *ngIf="data.items && data.items.length">
+      <ng-container *ngIf="data.items && data.items.length && data.expanded">
         <ng-template
           ngFor
           [ngForOf]="data.items"
@@ -33,5 +42,19 @@ import { ListModel } from './list-model.class';
 
 export class ListComponent {
   @Input() model: ListModel;
-  @Input() title;
+  @Input() title: string;
+  @Input() isSelectable: boolean;
+  @Input() search: boolean;
+
+  onExpand(id: string) {
+    this.model.expandListItem(id);
+  }
+
+  onSelect({ id, checked }) {
+    this.model.selectListItem(id, checked);
+  }
+
+  onSearch(searchString: string) {
+    this.model.search(searchString);
+  }
 }

--- a/packages/angular/src/list/list.module.ts
+++ b/packages/angular/src/list/list.module.ts
@@ -10,16 +10,8 @@ export { ListModel } from './list-model.class';
 export { ListItem } from './list-item.class';
 
 @NgModule({
-  declarations: [
-    ListComponent,
-    ListHeaderComponent,
-    ListItemComponent
-  ],
-  exports: [
-    ListComponent,
-    ListHeaderComponent,
-    ListItemComponent
-  ],
+  declarations: [ListComponent, ListHeaderComponent, ListItemComponent],
+  exports: [ListComponent, ListHeaderComponent, ListItemComponent],
   imports: [CommonModule, IconModule, CheckboxModule, SearchModule],
 })
 export class ListModule {}

--- a/packages/angular/src/list/list.module.ts
+++ b/packages/angular/src/list/list.module.ts
@@ -4,7 +4,7 @@ import { CommonModule } from '@angular/common';
 import { ListComponent } from './list.component';
 import { ListHeaderComponent } from './list-header.component';
 import { ListItemComponent } from './list-item.component';
-import { IconModule } from 'carbon-components-angular';
+import { CheckboxModule, IconModule, SearchModule } from 'carbon-components-angular';
 
 export { ListModel } from './list-model.class';
 export { ListItem } from './list-item.class';
@@ -20,6 +20,6 @@ export { ListItem } from './list-item.class';
     ListHeaderComponent,
     ListItemComponent
   ],
-  imports: [CommonModule, IconModule],
+  imports: [CommonModule, IconModule, CheckboxModule, SearchModule],
 })
 export class ListModule {}

--- a/packages/angular/src/list/list.module.ts
+++ b/packages/angular/src/list/list.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { ListComponent } from './list.component';
+import { ListHeaderComponent } from './list-header.component';
+import { ListItemComponent } from './list-item.component';
+import { IconModule } from 'carbon-components-angular';
+
+export { ListModel } from './list-model.class';
+export { ListItem } from './list-item.class';
+
+@NgModule({
+  declarations: [
+    ListComponent,
+    ListHeaderComponent,
+    ListItemComponent
+  ],
+  exports: [
+    ListComponent,
+    ListHeaderComponent,
+    ListItemComponent
+  ],
+  imports: [CommonModule, IconModule],
+})
+export class ListModule {}

--- a/packages/angular/src/list/list.stories.ts
+++ b/packages/angular/src/list/list.stories.ts
@@ -1,0 +1,53 @@
+import { storiesOf, moduleMetadata } from '@storybook/angular';
+import { withKnobs } from '@storybook/addon-knobs';
+
+import { ListModule } from './list.module';
+import { ListModel } from './list-model.class';
+import { ListItem } from './list-item.class';
+import { DialogModule, IconModule, IconService } from 'carbon-components-angular';
+
+const nestedListModel = new ListModel();
+nestedListModel.items = [
+  new ListItem({
+    value: 'DJ LeMahieu',
+    items: [
+      new ListItem({
+        value: 'Recursion!',
+        items: [
+          new ListItem({
+            value: 'DJ LeMahieu',
+            items: [new ListItem({ value: 'I think you get the point' })]
+          }),
+          new ListItem({ value: 'DJ LeMahieu' }),
+          new ListItem({ value: 'DJ LeMahieu' })
+        ]
+      })
+    ]
+  }),
+  new ListItem({ value: 'DJ LeMahieu' }),
+  new ListItem({ value: 'DJ LeMahieu' }),
+  new ListItem({
+    value: 'DJ LeMahieu',
+    items: [
+      new ListItem({ value: 'DJ LeMahieu' })
+    ]
+  }),
+  new ListItem({ value: 'DJ LeMahieu' })
+];
+
+
+storiesOf('Components/List', module)
+  .addDecorator(
+    moduleMetadata({
+      imports: [ListModule, DialogModule, IconModule],
+    })
+  )
+  .addDecorator(withKnobs)
+  .add('Simple list', () => ({
+    template: `
+      <ai-list [model]="model" title="Nested list items"></ai-list>
+    `,
+    props: {
+      model: nestedListModel
+    },
+  }));

--- a/packages/angular/src/list/list.stories.ts
+++ b/packages/angular/src/list/list.stories.ts
@@ -9,32 +9,91 @@ import { DialogModule, IconModule, IconService } from 'carbon-components-angular
 const nestedListModel = new ListModel();
 nestedListModel.items = [
   new ListItem({
-    value: 'DJ LeMahieu',
+    value: 'Category 1',
+    expanded: true,
     items: [
       new ListItem({
-        value: 'Recursion!',
+        value: 'Sub category 1',
+        expanded: true,
         items: [
           new ListItem({
-            value: 'DJ LeMahieu',
-            items: [new ListItem({ value: 'I think you get the point' })]
+            value: 'Sub sub category 1',
+            expanded: true,
+            items: [
+              new ListItem({ value: 'Sloth' }),
+              new ListItem({
+                value: 'Sub sub sub category 1',
+                expanded: true,
+                items: [
+                  new ListItem({ value: 'Armadillo' }),
+                  new ListItem({ value: 'Catfish' }),
+                  new ListItem({ value: 'Alligator' })
+                ]
+              })
+            ]
           }),
-          new ListItem({ value: 'DJ LeMahieu' }),
-          new ListItem({ value: 'DJ LeMahieu' })
+          new ListItem({ value: 'Fox' }),
+          new ListItem({ value: 'Elephant' })
+        ]
+      }),
+      new ListItem({
+        value: 'Cat'
+      })
+    ]
+  }),
+  new ListItem({ value: 'Dog' }),
+  new ListItem({ value: 'Fish' }),
+  new ListItem({
+    value: 'Category 2',
+    expanded: true,
+    items: [
+      new ListItem({ value: 'Anteater' }),
+      new ListItem({
+        value: 'Sub category 1',
+        expanded: true,
+        items: [
+          new ListItem({ value: 'Sloth' }),
+          new ListItem({
+            value: 'Sub sub category 2',
+            expanded: true,
+            items: [
+              new ListItem({ value: 'Armadillo' }),
+              new ListItem({ value: 'Catfish' }),
+              new ListItem({ value: 'Alligator' })
+            ]
+          })
+        ]
+      }),
+      new ListItem({
+        value: 'Sub category 2',
+        expanded: true,
+        items: [
+          new ListItem({ value: 'Sloth' }),
+          new ListItem({
+            value: 'Sub sub category 2',
+            expanded: true,
+            items: [
+              new ListItem({ value: 'Armadillo' }),
+              new ListItem({ value: 'Catfish' }),
+              new ListItem({ value: 'Alligator' })
+            ]
+          })
         ]
       })
     ]
   }),
-  new ListItem({ value: 'DJ LeMahieu' }),
-  new ListItem({ value: 'DJ LeMahieu' }),
-  new ListItem({
-    value: 'DJ LeMahieu',
-    items: [
-      new ListItem({ value: 'DJ LeMahieu' })
-    ]
-  }),
-  new ListItem({ value: 'DJ LeMahieu' })
+  new ListItem({ value: 'Giraffe' })
 ];
 
+const simpleListModel = new ListModel();
+simpleListModel.items = [
+  new ListItem({ value: 'Sloth' }),
+  new ListItem({ value: 'Elephant' }),
+  new ListItem({ value: 'Giraffe' }),
+  new ListItem({ value: 'Elk' }),
+  new ListItem({ value: 'Anteater' }),
+  new ListItem({ value: 'Armadillo' })
+];
 
 storiesOf('Components/List', module)
   .addDecorator(
@@ -45,7 +104,15 @@ storiesOf('Components/List', module)
   .addDecorator(withKnobs)
   .add('Simple list', () => ({
     template: `
-      <ai-list [model]="model" title="Nested list items"></ai-list>
+      <ai-list [model]="model" title="Simple list items" [isSelectable]="true"></ai-list>
+    `,
+    props: {
+      model: simpleListModel
+    }
+  }))
+  .add('Hierarchical list', () => ({
+    template: `
+      <ai-list [model]="model" title="Nested list items" [isSelectable]="true" [search]="true"></ai-list>
     `,
     props: {
       model: nestedListModel

--- a/packages/angular/src/list/list.stories.ts
+++ b/packages/angular/src/list/list.stories.ts
@@ -27,19 +27,19 @@ nestedListModel.items = [
                 items: [
                   new ListItem({ value: 'Armadillo' }),
                   new ListItem({ value: 'Catfish' }),
-                  new ListItem({ value: 'Alligator' })
-                ]
-              })
-            ]
+                  new ListItem({ value: 'Alligator' }),
+                ],
+              }),
+            ],
           }),
           new ListItem({ value: 'Fox' }),
-          new ListItem({ value: 'Elephant' })
-        ]
+          new ListItem({ value: 'Elephant' }),
+        ],
       }),
       new ListItem({
-        value: 'Cat'
-      })
-    ]
+        value: 'Cat',
+      }),
+    ],
   }),
   new ListItem({ value: 'Dog' }),
   new ListItem({ value: 'Fish' }),
@@ -59,10 +59,10 @@ nestedListModel.items = [
             items: [
               new ListItem({ value: 'Armadillo' }),
               new ListItem({ value: 'Catfish' }),
-              new ListItem({ value: 'Alligator' })
-            ]
-          })
-        ]
+              new ListItem({ value: 'Alligator' }),
+            ],
+          }),
+        ],
       }),
       new ListItem({
         value: 'Sub category 2',
@@ -75,14 +75,14 @@ nestedListModel.items = [
             items: [
               new ListItem({ value: 'Armadillo' }),
               new ListItem({ value: 'Catfish' }),
-              new ListItem({ value: 'Alligator' })
-            ]
-          })
-        ]
-      })
-    ]
+              new ListItem({ value: 'Alligator' }),
+            ],
+          }),
+        ],
+      }),
+    ],
   }),
-  new ListItem({ value: 'Giraffe' })
+  new ListItem({ value: 'Giraffe' }),
 ];
 
 const simpleListModel = new ListModel();
@@ -92,7 +92,7 @@ simpleListModel.items = [
   new ListItem({ value: 'Giraffe' }),
   new ListItem({ value: 'Elk' }),
   new ListItem({ value: 'Anteater' }),
-  new ListItem({ value: 'Armadillo' })
+  new ListItem({ value: 'Armadillo' }),
 ];
 
 storiesOf('Components/List', module)
@@ -107,14 +107,14 @@ storiesOf('Components/List', module)
       <ai-list [model]="model" title="Simple list items" [isSelectable]="true"></ai-list>
     `,
     props: {
-      model: simpleListModel
-    }
+      model: simpleListModel,
+    },
   }))
   .add('Hierarchical list', () => ({
     template: `
       <ai-list [model]="model" title="Nested list items" [isSelectable]="true" [search]="true"></ai-list>
     `,
     props: {
-      model: nestedListModel
+      model: nestedListModel,
     },
   }));

--- a/packages/angular/src/list/package.json
+++ b/packages/angular/src/list/package.json
@@ -1,0 +1,7 @@
+{
+	"ngPackage": {
+		"lib": {
+			"entryFile": "index.ts"
+		}
+	}
+}


### PR DESCRIPTION
Closes #2245 

Todo:
- [ ] Add support for single select
- [ ] Add secondary value for list item
- [ ] Add icon support for list item
- [ ] Add support for custom list item/header templates
- [ ] Add documentation
- [ ] Add more storybook examples
- [ ] Create a secondary hierarchical list component that wraps the list component so that list model no longer requires `_displayed` items and can just deal with `items` or maybe deal with filtering through a `hidden` tag which would potentially over-complicate things
- [ ] Make search function in list model easily overridable
- [ ] Find a way to recursively render list items without the need for the `expanded` field in the list model