### PR TITLE
fix(dataseriesformitemmodal): allowed isLarge prop

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
@@ -74,6 +74,7 @@ const propTypes = {
   ),
   validDataItems: DataItemsPropTypes,
   isSummaryDashboard: PropTypes.bool,
+  isLarge: PropTypes.bool,
   i18n: PropTypes.shape({
     dataItemEditorDataItemTitle: PropTypes.string,
     dataItemEditorDataItemLabel: PropTypes.string,
@@ -134,6 +135,7 @@ const defaultProps = {
   editDataItem: {},
   setEditDataItem: null,
   isSummaryDashboard: false,
+  isLarge: false,
   validDataItems: [],
 };
 
@@ -164,6 +166,7 @@ const DataSeriesFormItemModal = ({
   availableDimensions,
   onChange,
   i18n,
+  isLarge,
 }) => {
   const mergedI18n = { ...defaultProps.i18n, ...i18n };
   const { id, type, content } = cardConfig;
@@ -546,6 +549,7 @@ const DataSeriesFormItemModal = ({
                   : mergedI18n.dataItemEditorDataSeriesTitle,
             }}
             size="xs"
+            isLarge={isLarge}
             footer={{
               primaryButtonLabel: mergedI18n.primaryButtonLabelText,
               secondaryButtonLabel: mergedI18n.secondaryButtonLabelText,

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.test.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.test.jsx
@@ -915,4 +915,44 @@ describe('DataSeriesFormItemModal', () => {
     const modalTitle = screen.getByText('Customize data series');
     expect(modalTitle).toBeInTheDocument();
   });
+
+  it('Renders the DataSeriesEditorTable as size xs by default', () => {
+    render(
+      <DataSeriesFormItemModal
+        {...commonProps}
+        showEditor
+        cardConfig={groupedBarConfig}
+        editDataItem={editGroupedBarDataItem}
+        editDataSeries={[editGroupedBarDataItem]}
+      />
+    );
+
+    const xsContainer = screen
+      .getByText('Customize data series')
+      .closest('.bx--modal-container--xs');
+    expect(xsContainer).toBeInTheDocument();
+
+    const largeContainer = screen
+      .queryByText('Customize data series')
+      .closest('.iot--composed-modal--large');
+    expect(largeContainer).not.toBeInTheDocument();
+  });
+
+  it('Renders the DataSeriesEditorTable as size large if isLarge prop is true', () => {
+    render(
+      <DataSeriesFormItemModal
+        {...commonProps}
+        showEditor
+        cardConfig={groupedBarConfig}
+        editDataItem={editGroupedBarDataItem}
+        editDataSeries={[editGroupedBarDataItem]}
+        isLarge
+      />
+    );
+
+    const largeContainer = screen
+      .getByText('Customize data series')
+      .closest('.iot--composed-modal--large');
+    expect(largeContainer).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Closes #2393

**Summary**
Adds isLarge prop to DataSeriesFormItemModal. The prop was expected to be present and working by the HotspotEditorDataSourceTab

**Change List (commits, features, bugs, etc)**
- Added prop with default false
- Added unit tests

**Acceptance Test (how to verify the PR)**

1. Verify that that the modals in https://deploy-preview-2394--carbon-addons-iot-react.netlify.app?path=/story/2-watson-iot-experimental-☢%EF%B8%8F-hotspoteditormodal-hotspoteditordatasourcetab--with-preset-values are opened as large modals


**Regression Test (how to make sure this PR doesn't break old functionality)**

1. Go to https://deploy-preview-2394--carbon-addons-iot-react.netlify.app?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-cardeditor--for-time-series
2. Click the edit icon for "Torque Max"
3. Make sure the modal is still size xs
