### PR TITLE
fix(tearsheet): make tearsheet layout more dynamic 

### DIFF
--- a/packages/react/src/components/TearSheet/TearSheet.story.jsx
+++ b/packages/react/src/components/TearSheet/TearSheet.story.jsx
@@ -6,11 +6,15 @@ import Button from '../Button';
 import TearSheetWrapper from './TearSheetWrapper';
 import TearSheet from './TearSheet';
 
-const TearSheetChild = ({ openNextSheet, goToPreviousSheet, onClose }) => (
+const TearSheetChild = ({
+  setHeaderAdditionalContent,
+  clearHeaderContent,
+  openNextSheet,
+  goToPreviousSheet,
+  onClose,
+}) => (
   <div
     style={{
-      width: '1000px',
-      justifyContent: 'space-between',
       display: 'flex',
       flexDirection: 'column',
       height: '100%',
@@ -19,15 +23,30 @@ const TearSheetChild = ({ openNextSheet, goToPreviousSheet, onClose }) => (
     <Button
       kind="tertiary"
       onClick={openNextSheet}
-      style={{ margin: '2rem 2rem 0 2rem', maxWidth: '13rem' }}
+      style={{ margin: '2rem 2rem 0', maxWidth: '13rem' }}
     >
       Open 2nd sheet
+    </Button>
+    <Button
+      kind="tertiary"
+      onClick={setHeaderAdditionalContent}
+      style={{ marginLeft: '2rem', maxWidth: '13rem' }}
+    >
+      Set header additional content
+    </Button>
+    <Button
+      kind="tertiary"
+      onClick={clearHeaderContent}
+      style={{ marginLeft: '2rem', maxWidth: '13rem' }}
+    >
+      Clear header additional content
     </Button>
     <div
       style={{
         display: 'flex',
         justifyContent: 'flex-end',
         borderTop: '1px solid #e0e0e0',
+        marginTop: 'auto',
       }}
     >
       <Button
@@ -50,7 +69,6 @@ const TearSheetChild = ({ openNextSheet, goToPreviousSheet, onClose }) => (
 const TearSheetChild2 = ({ closeAllTearSheets }) => (
   <div
     style={{
-      width: '1000px',
       height: '100%',
       display: 'inline-flex',
       flexDirection: 'column',
@@ -116,6 +134,7 @@ const TearSheetChild2 = ({ closeAllTearSheets }) => (
 
 const StandardTearSheet = () => {
   const [isOpen, setOpen] = useState(false);
+  const [headerAdditionalContent, setHeaderAdditionalContent] = useState(null);
 
   return (
     <>
@@ -128,8 +147,19 @@ const StandardTearSheet = () => {
           title="First sheet"
           description="Generic description"
           onClose={() => setOpen(false)}
+          headerExtraContent={headerAdditionalContent}
         >
-          <TearSheetChild onClose={() => setOpen(false)} />
+          <TearSheetChild
+            onClose={() => setOpen(false)}
+            setHeaderAdditionalContent={() => {
+              setHeaderAdditionalContent(
+                <div style={{ height: '40px', display: 'flex', alignItems: 'center' }}>
+                  Header additional content
+                </div>
+              );
+            }}
+            clearHeaderContent={() => setHeaderAdditionalContent(null)}
+          />
         </TearSheet>
         <TearSheet title="Second sheet" description="Generic description">
           <TearSheetChild2 />

--- a/packages/react/src/components/TearSheet/TearSheet.test.jsx
+++ b/packages/react/src/components/TearSheet/TearSheet.test.jsx
@@ -33,7 +33,9 @@ describe('TearSheetWrapper', () => {
         <TearSheet {...commonProps} />
       </TearSheetWrapper>
     );
-    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).not.toHaveClass('is-visible');
+    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).not.toHaveClass(
+      `${iotPrefix}--tear-sheet-wrapper__is-visible`
+    );
     expect(screen.getByText('First TearSheet')).toBeInTheDocument();
     expect(screen.getByText('First TearSheet description')).toBeInTheDocument();
   });
@@ -43,7 +45,9 @@ describe('TearSheetWrapper', () => {
         <TearSheet {...commonProps} />
       </TearSheetWrapper>
     );
-    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).toHaveClass('is-visible');
+    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).toHaveClass(
+      `${iotPrefix}--tear-sheet-wrapper__is-visible`
+    );
     expect(screen.getByTestId('container-0')).toHaveStyle('bottom: 0');
   });
   it('renders TearSheetWrapper with 2 TearSheets and closes the second one', () => {
@@ -53,7 +57,9 @@ describe('TearSheetWrapper', () => {
         <TearSheet {...secondTearSheetCommonProps} />
       </TearSheetWrapper>
     );
-    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).toHaveClass('is-visible');
+    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).toHaveClass(
+      `${iotPrefix}--tear-sheet-wrapper__is-visible`
+    );
     expect(screen.getByTestId('container-0')).toHaveStyle('bottom: 0');
     expect(screen.getByText('Second TearSheet')).toBeInTheDocument();
     expect(screen.getByText('Second TearSheet description')).toBeInTheDocument();
@@ -84,9 +90,13 @@ describe('TearSheetWrapper', () => {
         );
       })
     );
-    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).not.toHaveClass('is-visible');
+    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).not.toHaveClass(
+      `${iotPrefix}--tear-sheet-wrapper__is-visible`
+    );
     await userEvent.click(screen.getByTestId('openTearSheetWrapper'));
-    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).toHaveClass('is-visible');
+    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).toHaveClass(
+      `${iotPrefix}--tear-sheet-wrapper__is-visible`
+    );
     expect(screen.getByTestId('container-0')).toHaveStyle('bottom: 0');
     await userEvent.click(screen.getByTestId('openNextSheet'));
     expect(screen.getByTestId('container-0')).toHaveClass('is-hidden');
@@ -116,13 +126,17 @@ describe('TearSheetWrapper', () => {
         </TearSheet>
       </TearSheetWrapper>
     );
-    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).toHaveClass('is-visible');
+    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).toHaveClass(
+      `${iotPrefix}--tear-sheet-wrapper__is-visible`
+    );
     expect(screen.getByTestId('container-0')).toHaveStyle('bottom: 0');
     await userEvent.click(screen.getByTestId('openNextSheet'));
     expect(screen.getByTestId('container-0')).toHaveClass('is-hidden');
     expect(screen.getByTestId('container-1')).toHaveStyle('bottom: 0');
     await userEvent.click(screen.getByTestId('closeAllTearSheets'));
-    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).not.toHaveClass('is-visible');
+    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).not.toHaveClass(
+      `${iotPrefix}--tear-sheet-wrapper__is-visible`
+    );
   });
   it('renders TearSheet, opens second TearSheet and closes all TearSheets without providing the onCloseAllTearSheets funcion', async () => {
     const TearSheetChild = ({ openNextSheet }) => (
@@ -146,13 +160,17 @@ describe('TearSheetWrapper', () => {
         </TearSheet>
       </TearSheetWrapper>
     );
-    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).toHaveClass('is-visible');
+    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).toHaveClass(
+      `${iotPrefix}--tear-sheet-wrapper__is-visible`
+    );
     expect(screen.getByTestId('container-0')).toHaveStyle('bottom: 0');
     await userEvent.click(screen.getByTestId('openNextSheet'));
     expect(screen.getByTestId('container-0')).toHaveClass('is-hidden');
     expect(screen.getByTestId('container-1')).toHaveStyle('bottom: 0');
     await userEvent.click(screen.getByTestId('closeAllTearSheets'));
-    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).not.toHaveClass('is-visible');
+    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).not.toHaveClass(
+      `${iotPrefix}--tear-sheet-wrapper__is-visible`
+    );
   });
   it('renders TearSheet, opens second TearSheet, goes back to first TearSheet and closes it', async () => {
     const TearSheetChild = ({ openNextSheet }) => (
@@ -176,7 +194,9 @@ describe('TearSheetWrapper', () => {
         </TearSheet>
       </TearSheetWrapper>
     );
-    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).toHaveClass('is-visible');
+    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).toHaveClass(
+      `${iotPrefix}--tear-sheet-wrapper__is-visible`
+    );
     expect(screen.getByTestId('container-0')).toHaveStyle('bottom: 0');
     await userEvent.click(screen.getByTestId('openNextSheet'));
     expect(screen.getByTestId('container-0')).toHaveClass('is-hidden');
@@ -185,6 +205,8 @@ describe('TearSheetWrapper', () => {
     expect(screen.getByTestId('container-0')).toHaveStyle('bottom: 0');
     expect(screen.getByTestId('container-1')).not.toHaveStyle('bottom: 0');
     await userEvent.click(screen.getByTestId('tearSheetCloseBtn0'));
-    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).not.toHaveClass('is-visible');
+    expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).not.toHaveClass(
+      `${iotPrefix}--tear-sheet-wrapper__is-visible`
+    );
   });
 });

--- a/packages/react/src/components/TearSheet/TearSheet.test.jsx
+++ b/packages/react/src/components/TearSheet/TearSheet.test.jsx
@@ -48,7 +48,6 @@ describe('TearSheetWrapper', () => {
     expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).toHaveClass(
       `${iotPrefix}--tear-sheet-wrapper__is-visible`
     );
-    expect(screen.getByTestId('container-0')).toHaveStyle('bottom: 0');
   });
   it('renders TearSheetWrapper with 2 TearSheets and closes the second one', () => {
     render(
@@ -60,7 +59,6 @@ describe('TearSheetWrapper', () => {
     expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).toHaveClass(
       `${iotPrefix}--tear-sheet-wrapper__is-visible`
     );
-    expect(screen.getByTestId('container-0')).toHaveStyle('bottom: 0');
     expect(screen.getByText('Second TearSheet')).toBeInTheDocument();
     expect(screen.getByText('Second TearSheet description')).toBeInTheDocument();
   });
@@ -97,13 +95,14 @@ describe('TearSheetWrapper', () => {
     expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).toHaveClass(
       `${iotPrefix}--tear-sheet-wrapper__is-visible`
     );
-    expect(screen.getByTestId('container-0')).toHaveStyle('bottom: 0');
     await userEvent.click(screen.getByTestId('openNextSheet'));
-    expect(screen.getByTestId('container-0')).toHaveClass('is-hidden');
-    expect(screen.getByTestId('container-1')).toHaveStyle('bottom: 0');
+    expect(screen.getByTestId('container-0')).toHaveClass(
+      `${iotPrefix}--tear-sheet-wrapper--container__is-hidden`
+    );
     await userEvent.click(screen.getByTestId('tearSheetCloseBtn1'));
-    expect(screen.getByTestId('container-0')).not.toHaveClass('is-hidden');
-    expect(screen.getByTestId('container-1')).not.toHaveStyle('bottom: 0');
+    expect(screen.getByTestId('container-0')).not.toHaveClass(
+      `${iotPrefix}--tear-sheet-wrapper--container__is-hidden`
+    );
   });
   it('renders TearSheet, opens second TearSheet and closes all TearSheets', async () => {
     const TearSheetChild = ({ openNextSheet }) => (
@@ -129,10 +128,10 @@ describe('TearSheetWrapper', () => {
     expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).toHaveClass(
       `${iotPrefix}--tear-sheet-wrapper__is-visible`
     );
-    expect(screen.getByTestId('container-0')).toHaveStyle('bottom: 0');
     await userEvent.click(screen.getByTestId('openNextSheet'));
-    expect(screen.getByTestId('container-0')).toHaveClass('is-hidden');
-    expect(screen.getByTestId('container-1')).toHaveStyle('bottom: 0');
+    expect(screen.getByTestId('container-0')).toHaveClass(
+      `${iotPrefix}--tear-sheet-wrapper--container__is-hidden`
+    );
     await userEvent.click(screen.getByTestId('closeAllTearSheets'));
     expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).not.toHaveClass(
       `${iotPrefix}--tear-sheet-wrapper__is-visible`
@@ -163,10 +162,10 @@ describe('TearSheetWrapper', () => {
     expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).toHaveClass(
       `${iotPrefix}--tear-sheet-wrapper__is-visible`
     );
-    expect(screen.getByTestId('container-0')).toHaveStyle('bottom: 0');
     await userEvent.click(screen.getByTestId('openNextSheet'));
-    expect(screen.getByTestId('container-0')).toHaveClass('is-hidden');
-    expect(screen.getByTestId('container-1')).toHaveStyle('bottom: 0');
+    expect(screen.getByTestId('container-0')).toHaveClass(
+      `${iotPrefix}--tear-sheet-wrapper--container__is-hidden`
+    );
     await userEvent.click(screen.getByTestId('closeAllTearSheets'));
     expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).not.toHaveClass(
       `${iotPrefix}--tear-sheet-wrapper__is-visible`
@@ -197,13 +196,11 @@ describe('TearSheetWrapper', () => {
     expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).toHaveClass(
       `${iotPrefix}--tear-sheet-wrapper__is-visible`
     );
-    expect(screen.getByTestId('container-0')).toHaveStyle('bottom: 0');
     await userEvent.click(screen.getByTestId('openNextSheet'));
-    expect(screen.getByTestId('container-0')).toHaveClass('is-hidden');
-    expect(screen.getByTestId('container-1')).toHaveStyle('bottom: 0');
+    expect(screen.getByTestId('container-0')).toHaveClass(
+      `${iotPrefix}--tear-sheet-wrapper--container__is-hidden`
+    );
     await userEvent.click(screen.getByTestId('goToPreviousSheet'));
-    expect(screen.getByTestId('container-0')).toHaveStyle('bottom: 0');
-    expect(screen.getByTestId('container-1')).not.toHaveStyle('bottom: 0');
     await userEvent.click(screen.getByTestId('tearSheetCloseBtn0'));
     expect(screen.getByTestId(`${iotPrefix}--tear-sheet-wrapper`)).not.toHaveClass(
       `${iotPrefix}--tear-sheet-wrapper__is-visible`

--- a/packages/react/src/components/TearSheet/TearSheetWrapper.jsx
+++ b/packages/react/src/components/TearSheet/TearSheetWrapper.jsx
@@ -1,4 +1,4 @@
-import React, { Children, cloneElement, useEffect, useState, createRef } from 'react';
+import React, { Children, cloneElement, useEffect, useState, useMemo, createRef } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
@@ -26,13 +26,10 @@ const defaultProps = {
 const baseClassName = `${iotPrefix}--tear-sheet-wrapper`;
 
 const TearSheetWrapper = ({ isOpen, className, onCloseAllTearSheets, children }) => {
-  // const windowSize = useWindowSize();
   const [activeTearSheetIdx, setActiveTearSheetIdx] = useState(null);
-  const childrenArray = Children.toArray(children).slice(0, 2); // Limit of 2 TearSheets
+  const childrenArray = useMemo(Children.toArray(children).slice(0, 2), [children]); // Limit of 2 TearSheets
   const [containers] = useState(childrenArray.map(() => createRef()));
-  // const [initialContainersWidth, setInitialContainersWidth] = useState(null);
-  // const [containersStyles, setContainersStyles] = useState({});
-  const [animationClasses, setAnimationClasses] = useState(
+  const [animationClasses, setAnimationClasses] = useState(() =>
     childrenArray.reduce(
       (acc, c, idx) => ({
         ...acc,

--- a/packages/react/src/components/TearSheet/TearSheetWrapper.jsx
+++ b/packages/react/src/components/TearSheet/TearSheetWrapper.jsx
@@ -27,7 +27,7 @@ const baseClassName = `${iotPrefix}--tear-sheet-wrapper`;
 
 const TearSheetWrapper = ({ isOpen, className, onCloseAllTearSheets, children }) => {
   const [activeTearSheetIdx, setActiveTearSheetIdx] = useState(null);
-  const childrenArray = useMemo(Children.toArray(children).slice(0, 2), [children]); // Limit of 2 TearSheets
+  const childrenArray = useMemo(() => Children.toArray(children).slice(0, 2), [children]); // Limit of 2 TearSheets
   const [containers] = useState(childrenArray.map(() => createRef()));
   const [animationClasses, setAnimationClasses] = useState(() =>
     childrenArray.reduce(

--- a/packages/react/src/components/TearSheet/TearSheetWrapper.jsx
+++ b/packages/react/src/components/TearSheet/TearSheetWrapper.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import { settings } from '../../constants/Settings';
-import useWindowSize from '../../hooks/useWindowSize';
 
 const { iotPrefix } = settings;
 
@@ -17,13 +16,6 @@ const propTypes = {
   children: PropTypes.node,
 };
 
-const tearSheetConstants = {
-  DISTANCE_FROM_TOP: 88,
-  WIDTH_DECREASE: 24,
-  BOTTOM_POSITION_WHEN_HIDDEN: 12,
-  DISTANCE_FROM_EACH_SIDE: 64,
-};
-
 const defaultProps = {
   isOpen: false,
   className: undefined,
@@ -31,13 +23,15 @@ const defaultProps = {
   children: undefined,
 };
 
+const baseClassName = `${iotPrefix}--tear-sheet-wrapper`;
+
 const TearSheetWrapper = ({ isOpen, className, onCloseAllTearSheets, children }) => {
-  const windowSize = useWindowSize();
+  // const windowSize = useWindowSize();
   const [activeTearSheetIdx, setActiveTearSheetIdx] = useState(null);
   const childrenArray = Children.toArray(children).slice(0, 2); // Limit of 2 TearSheets
   const [containers] = useState(childrenArray.map(() => createRef()));
-  const [initialContainersWidth, setInitialContainersWidth] = useState(null);
-  const [containersStyles, setContainersStyles] = useState({});
+  // const [initialContainersWidth, setInitialContainersWidth] = useState(null);
+  // const [containersStyles, setContainersStyles] = useState({});
   const [animationClasses, setAnimationClasses] = useState(
     childrenArray.reduce(
       (acc, c, idx) => ({
@@ -51,16 +45,6 @@ const TearSheetWrapper = ({ isOpen, className, onCloseAllTearSheets, children })
   useEffect(() => (isOpen ? setActiveTearSheetIdx(0) : setActiveTearSheetIdx(null)), [isOpen]);
 
   useEffect(() => {
-    if (!initialContainersWidth) {
-      setInitialContainersWidth(containers[0].current.offsetWidth);
-    }
-  }, [containers, initialContainersWidth]);
-
-  useEffect(() => {
-    const greaterHeaderTopPosition = Math.max(
-      ...containers.map((c) => c.current.children[0]?.children[1]?.offsetTop ?? 0)
-    );
-
     setAnimationClasses((prevState) => {
       if (activeTearSheetIdx === null) {
         return {
@@ -72,57 +56,16 @@ const TearSheetWrapper = ({ isOpen, className, onCloseAllTearSheets, children })
         ...Object.keys(prevState).reduce(
           (acc, i) =>
             i === 'overlay'
-              ? { ...acc, [i]: ['is-visible'] }
+              ? { ...acc, [i]: [`${baseClassName}__is-visible`] }
               : i === `container${activeTearSheetIdx}`
               ? { ...acc, [i]: [] }
-              : { ...acc, [i]: ['is-hidden'] },
+              : { ...acc, [i]: [`${baseClassName}--container__is-hidden`] },
 
           {}
         ),
       };
     });
-
-    const isWindowWidthSmallerThanContainer =
-      windowSize.width < initialContainersWidth + tearSheetConstants.DISTANCE_FROM_EACH_SIDE * 2;
-    const containerMaxWidth = windowSize?.width - tearSheetConstants.DISTANCE_FROM_EACH_SIDE * 2;
-    setContainersStyles(
-      containers.reduce((acc, c, idx) => {
-        const currentWidth = isWindowWidthSmallerThanContainer
-          ? containerMaxWidth - (activeTearSheetIdx - idx) * tearSheetConstants.WIDTH_DECREASE
-          : activeTearSheetIdx === null || activeTearSheetIdx <= idx
-          ? initialContainersWidth
-          : initialContainersWidth - (activeTearSheetIdx - idx) * tearSheetConstants.WIDTH_DECREASE;
-
-        const currentBottom =
-          activeTearSheetIdx !== null
-            ? activeTearSheetIdx < idx
-              ? 0 - windowSize.height
-              : activeTearSheetIdx === idx
-              ? 0
-              : (activeTearSheetIdx - idx) * tearSheetConstants.BOTTOM_POSITION_WHEN_HIDDEN
-            : 0 - windowSize.height;
-
-        return {
-          ...acc,
-          [`container${idx}`]: {
-            bottom: `${currentBottom}px`,
-            width: `${currentWidth}px`,
-            '--content-max-height': `${
-              windowSize?.height - greaterHeaderTopPosition - tearSheetConstants.DISTANCE_FROM_TOP
-            }px`,
-            '--content-max-width': `${containerMaxWidth}px`,
-          },
-        };
-      }, {})
-    );
-  }, [
-    containers,
-    activeTearSheetIdx,
-    initialContainersWidth,
-    windowSize.width,
-    windowSize.height,
-    windowSize,
-  ]);
+  }, [activeTearSheetIdx]);
 
   const goToSheet = (idx) => setActiveTearSheetIdx(idx);
 
@@ -137,10 +80,9 @@ const TearSheetWrapper = ({ isOpen, className, onCloseAllTearSheets, children })
 
   return (
     <div
-      className={classnames(`${iotPrefix}--tear-sheet-wrapper`, className, {
+      className={classnames(baseClassName, className, {
         ...animationClasses?.overlay?.reduce((acc, curr) => ({ ...acc, [curr]: isOpen }), {}),
       })}
-      style={{ '--window-height': `${windowSize.height}px` }}
       data-testid={`${iotPrefix}--tear-sheet-wrapper`}
     >
       {childrenArray.map((tearSheet, idx, arr) => {
@@ -156,14 +98,13 @@ const TearSheetWrapper = ({ isOpen, className, onCloseAllTearSheets, children })
             id={`container-${idx}`}
             key={`container-${idx}`}
             data-testid={`container-${idx}`}
-            className={classnames(`${iotPrefix}--tear-sheet-wrapper--container`, {
+            className={classnames(`${baseClassName}--container`, {
               ...animationClasses?.[`container${idx}`]?.reduce(
                 (acc, curr) => ({ ...acc, [curr]: true }),
                 {}
               ),
             })}
             ref={containers[idx]}
-            style={containersStyles?.[`container${idx}`]}
             onClick={(e) => e.stopPropagation()}
           >
             {newTearSheet}

--- a/packages/react/src/components/TearSheet/__snapshots__/TearSheet.story.storyshot
+++ b/packages/react/src/components/TearSheet/__snapshots__/TearSheet.story.storyshot
@@ -31,25 +31,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
     <div
       className="iot--tear-sheet-wrapper"
       data-testid="iot--tear-sheet-wrapper"
-      style={
-        Object {
-          "--window-height": "768px",
-        }
-      }
     >
       <div
         className="iot--tear-sheet-wrapper--container"
         data-testid="container-0"
         id="container-0"
         onClick={[Function]}
-        style={
-          Object {
-            "--content-max-height": "680px",
-            "--content-max-width": "896px",
-            "bottom": "-768px",
-            "width": "0px",
-          }
-        }
       >
         <div
           className="iot--tear-sheet"
@@ -107,8 +94,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   "display": "flex",
                   "flexDirection": "column",
                   "height": "100%",
-                  "justifyContent": "space-between",
-                  "width": "1000px",
                 }
               }
             >
@@ -120,7 +105,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 onClick={[Function]}
                 style={
                   Object {
-                    "margin": "2rem 2rem 0 2rem",
+                    "margin": "2rem 2rem 0",
                     "maxWidth": "13rem",
                   }
                 }
@@ -129,12 +114,47 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               >
                 Open 2nd sheet
               </button>
+              <button
+                aria-pressed={null}
+                className="iot--btn bx--btn bx--btn--tertiary"
+                data-testid="Button"
+                disabled={false}
+                onClick={[Function]}
+                style={
+                  Object {
+                    "marginLeft": "2rem",
+                    "maxWidth": "13rem",
+                  }
+                }
+                tabIndex={0}
+                type="button"
+              >
+                Set header additional content
+              </button>
+              <button
+                aria-pressed={null}
+                className="iot--btn bx--btn bx--btn--tertiary"
+                data-testid="Button"
+                disabled={false}
+                onClick={[Function]}
+                style={
+                  Object {
+                    "marginLeft": "2rem",
+                    "maxWidth": "13rem",
+                  }
+                }
+                tabIndex={0}
+                type="button"
+              >
+                Clear header additional content
+              </button>
               <div
                 style={
                   Object {
                     "borderTop": "1px solid #e0e0e0",
                     "display": "flex",
                     "justifyContent": "flex-end",
+                    "marginTop": "auto",
                   }
                 }
               >
@@ -181,14 +201,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
         data-testid="container-1"
         id="container-1"
         onClick={[Function]}
-        style={
-          Object {
-            "--content-max-height": "680px",
-            "--content-max-width": "896px",
-            "bottom": "-768px",
-            "width": "0px",
-          }
-        }
       >
         <div
           className="iot--tear-sheet"
@@ -247,7 +259,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   "flexDirection": "column",
                   "height": "100%",
                   "justifyContent": "space-between",
-                  "width": "1000px",
                 }
               }
             >

--- a/packages/react/src/components/TearSheet/tear-sheet-wrapper.scss
+++ b/packages/react/src/components/TearSheet/tear-sheet-wrapper.scss
@@ -16,7 +16,7 @@
     transform: translate(-50%, 100vh);
     transition: all $duration--slow-01 motion(standard, expressive);
     height: calc(100vh - 5.5rem);
-    width: calc(100vw - 4rem);
+    width: calc(100vw - 8rem);
     opacity: 1;
     margin: 0 auto;
 
@@ -28,7 +28,7 @@
     .#{$iot-prefix}--tear-sheet-wrapper__is-visible &__is-hidden {
       filter: brightness(75%);
       transform: translate(-50%, 100vw);
-      width: calc(100vw - 5rem);
+      width: calc(100vw - 9.5rem);
       & * {
         transition: all $duration--slow-01 motion(standard, expressive);
       }
@@ -36,7 +36,7 @@
 
     .#{$iot-prefix}--tear-sheet-wrapper__is-visible
       &:first-child.#{$iot-prefix}--tear-sheet-wrapper--container__is-hidden {
-      transform: translate(-50%, -20px);
+      transform: translate(-50%, -1.25rem);
     }
   }
 

--- a/packages/react/src/components/TearSheet/tear-sheet-wrapper.scss
+++ b/packages/react/src/components/TearSheet/tear-sheet-wrapper.scss
@@ -2,7 +2,7 @@
   top: 0;
   left: 0;
   height: 100vh;
-  width: 100vw;
+  width: 100%;
   opacity: 0;
   z-index: -1;
   position: fixed;
@@ -16,7 +16,7 @@
     transform: translate(-50%, 100vh);
     transition: all $duration--slow-01 motion(standard, expressive);
     height: calc(100vh - 5.5rem);
-    width: calc(100vw - 8rem);
+    width: calc(100% - 8rem);
     opacity: 1;
     margin: 0 auto;
 
@@ -27,8 +27,8 @@
 
     .#{$iot-prefix}--tear-sheet-wrapper__is-visible &__is-hidden {
       filter: brightness(75%);
-      transform: translate(-50%, 100vw);
-      width: calc(100vw - 9.5rem);
+      transform: translate(-50%, 100vh);
+      width: calc(100% - 9.5rem);
       & * {
         transition: all $duration--slow-01 motion(standard, expressive);
       }
@@ -36,7 +36,7 @@
 
     .#{$iot-prefix}--tear-sheet-wrapper__is-visible
       &:first-child.#{$iot-prefix}--tear-sheet-wrapper--container__is-hidden {
-      transform: translate(-50%, -1.25rem);
+      transform: translate(-50%, -0.75rem);
     }
   }
 

--- a/packages/react/src/components/TearSheet/tear-sheet-wrapper.scss
+++ b/packages/react/src/components/TearSheet/tear-sheet-wrapper.scss
@@ -35,7 +35,10 @@
     }
 
     .#{$iot-prefix}--tear-sheet-wrapper__is-visible
-      &:first-child.#{$iot-prefix}--tear-sheet-wrapper--container__is-hidden {
+      &:first-child.#{$iot-prefix}--tear-sheet-wrapper--container__is-hidden,
+    .#{$iot-prefix}--tear-sheet-wrapper__is-visible
+      &:first-child.#{$iot-prefix}--tear-sheet-wrapper--container__is-hidden
+      + .#{$iot-prefix}--tear-sheet-wrapper--container__is-hidden {
       transform: translate(-50%, -0.75rem);
     }
   }

--- a/packages/react/src/components/TearSheet/tear-sheet-wrapper.scss
+++ b/packages/react/src/components/TearSheet/tear-sheet-wrapper.scss
@@ -1,39 +1,50 @@
 .#{$iot-prefix}--tear-sheet-wrapper {
   top: 0;
   left: 0;
-  height: 100%;
-  width: 100%;
+  height: 100vh;
+  width: 100vw;
   opacity: 0;
   z-index: -1;
   position: fixed;
-  transition: all $duration--slow-01 motion(standard, expressive);
+  transition: all $duration--slow-01 motion(standard, expressive) $duration--slow-01;
 
   &--container {
-    position: fixed;
-    left: 50%;
-    transform: translate(-50%, 0);
+    position: absolute;
     background: none;
+    left: 50%;
+    top: 5.5rem;
+    transform: translate(-50%, 100vh);
     transition: all $duration--slow-01 motion(standard, expressive);
-    width: initial;
-    max-height: calc(var(--window-height) - 88px);
-    max-width: var(--content-max-width);
-    height: auto;
-    .#{$iot-prefix}--tear-sheet {
-      max-width: inherit;
-      width: 100%;
+    height: calc(100vh - 5.5rem);
+    width: calc(100vw - 4rem);
+    opacity: 1;
+    margin: 0 auto;
+
+    .#{$iot-prefix}--tear-sheet-wrapper__is-visible
+      &:not(.#{$iot-prefix}--tear-sheet-wrapper--container__is-hidden) {
+      transform: translate(-50%, 0);
     }
-    &.is-hidden {
+
+    .#{$iot-prefix}--tear-sheet-wrapper__is-visible &__is-hidden {
       filter: brightness(75%);
+      transform: translate(-50%, 100vw);
+      width: calc(100vw - 5rem);
       & * {
-        transition: filter duration--slow-01 motion(standard, expressive);
+        transition: all $duration--slow-01 motion(standard, expressive);
       }
+    }
+
+    .#{$iot-prefix}--tear-sheet-wrapper__is-visible
+      &:first-child.#{$iot-prefix}--tear-sheet-wrapper--container__is-hidden {
+      transform: translate(-50%, -20px);
     }
   }
 
-  &.is-visible {
+  &.#{$iot-prefix}--tear-sheet-wrapper__is-visible {
     background-color: $overlay-01;
     z-index: 5999;
-    transition: background-color $duration--slow-02 motion(standard, productive);
+    transition: opacity $duration--slow-01 motion(standard, expressive),
+      background-color $duration--slow-02 motion(standard, productive);
     opacity: 1;
   }
 }

--- a/packages/react/src/components/TearSheet/tear-sheet.scss
+++ b/packages/react/src/components/TearSheet/tear-sheet.scss
@@ -11,6 +11,11 @@
   &--header {
     padding: $spacing-06 $spacing-11 $spacing-06 $spacing-07;
     border-bottom: 1px solid $selected-ui;
+
+    [dir='rtl'] & {
+      padding: $spacing-06 $spacing-07 $spacing-06 $spacing-11;
+    }
+
     h1 {
       margin-bottom: $spacing-03;
     }
@@ -25,6 +30,11 @@
       position: absolute;
       top: 0;
       right: 0;
+
+      [dir='rtl'] & {
+        left: 0;
+        right: unset;
+      }
     }
   }
 

--- a/packages/react/src/components/TearSheet/tear-sheet.scss
+++ b/packages/react/src/components/TearSheet/tear-sheet.scss
@@ -1,6 +1,8 @@
 .#{$iot-prefix}--tear-sheet {
-  height: 100%;
   background-color: $ui-01;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 
   & * {
     max-width: 100%;
@@ -27,9 +29,7 @@
   }
 
   &--content {
-    max-height: var(--content-max-height);
-    height: var(--content-max-height);
-    overflow-y: auto;
-    overflow-x: auto;
+    flex: 1;
+    overflow: auto;
   }
 }


### PR DESCRIPTION
Closes #2403 

**Summary**

Copied from #2390 

**Summary**
- This fixes an issue where if a content were dynamically added to the TearSheet header, the TearSheet content would expand beyond its container and get cropped by the bottom of the viewport.

**Acceptance Test (how to verify the PR)**
- Check the component story. I've added buttons on the tear sheets to include additional content to their header. The tear sheet size should be readjusted to prevent it from being cropped.

**Regression Test (how to make sure this PR doesn't break old functionality)**
The tests below can be checked via story
- Check the stack feature (one tear sheet on top of the other) to see if they still behave like before. 
- Check if the tear sheet's whole content is displayed

