### PR TITLE
fix(table): wrap the column selection text

### DIFF
--- a/packages/react/src/components/Table/TableHead/ColumnHeaderRow/_column-header-row.scss
+++ b/packages/react/src/components/Table/TableHead/ColumnHeaderRow/_column-header-row.scss
@@ -15,6 +15,10 @@
       min-width: 12.75rem;
     }
   }
+
+  .#{$prefix}--table-header-label {
+    flex-wrap: wrap;
+  }
 }
 
 .#{$iot-prefix}--column-header-row--table-row {

--- a/packages/react/src/components/Table/TableHead/_table-head.scss
+++ b/packages/react/src/components/Table/TableHead/_table-head.scss
@@ -20,7 +20,6 @@
     display: flex;
     user-select: none;
     overflow: hidden;
-    flex-wrap: wrap;
     // allow the multiselect filter to expand to full height and the table to scroll
     .#{$prefix}--multi-select .#{$prefix}--list-box__menu {
       max-height: unset;

--- a/packages/react/src/components/Table/TableHead/_table-head.scss
+++ b/packages/react/src/components/Table/TableHead/_table-head.scss
@@ -20,6 +20,7 @@
     display: flex;
     user-select: none;
     overflow: hidden;
+    flex-wrap: wrap;
     // allow the multiselect filter to expand to full height and the table to scroll
     .#{$prefix}--multi-select .#{$prefix}--list-box__menu {
       max-height: unset;


### PR DESCRIPTION
Closes #2482 

**Summary**

- Improved the column selection button positioning. Column selection button appears at the end and is not visible on the page when table has many columns until its scrolled and hence its usability is missed.

**Change List (commits, features, bugs, etc)**

- added flex-wrap to the table-header-label so that column selection button automatically wraps and is visible even when there are many columns.

**Acceptance Test (how to verify the PR)**

- Can be tested in storybook https://deploy-preview-2489--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table-table--with-resize-and-no-initial-columns

**Regression Test (how to make sure this PR doesn't break old functionality)**