### PR TITLE
fix(card-variables): handle null values in handle-card-variables

### DIFF
--- a/packages/react/src/utils/__tests__/cardUtilityFunctions.test.jsx
+++ b/packages/react/src/utils/__tests__/cardUtilityFunctions.test.jsx
@@ -1347,6 +1347,21 @@ describe('cardUtilityFunctions', () => {
         expect(updatedCard.thresholds[0].value).toEqual(100);
         expect(updatedCard.thresholds[1].value).toEqual('mystring');
       });
+
+      it('replaceVariables handles null targets', () => {
+        const card = {
+          title: 'untitled',
+          values: [{ value1: null, value2: 'a value: {value1}' }],
+        };
+        const cardVariables = {
+          value1: 'myValue1Value',
+        };
+        const variables = ['value1'];
+        expect(replaceVariables(variables, cardVariables, card)).toEqual({
+          title: 'untitled',
+          values: [{ value1: null, value2: 'a value: myValue1Value' }],
+        });
+      });
     });
   });
 

--- a/packages/react/src/utils/cardUtilityFunctions.js
+++ b/packages/react/src/utils/cardUtilityFunctions.js
@@ -174,7 +174,7 @@ export const replaceVariables = (variables, cardVariables, target) => {
   // if it's an object, then recursively replace each value unless it's a react element
   if (typeof target === 'object') {
     // if it's a react element, leave it alone
-    return React.isValidElement(target)
+    return React.isValidElement(target) || isNil(target)
       ? target
       : mapValues(target, (property) =>
           replaceVariables(variables, insensitiveCardVariables, property)


### PR DESCRIPTION
Closes #2498

**Summary**
`handleCardVariables` was not handling null values.

**Change List (commits, features, bugs, etc)**
 - Add a check for the target of `replaceVariables` to be !isNil

**Acceptance Test (how to verify the PR)**
Hard to recreate. The test should cover it.

**Regression Test (how to make sure this PR doesn't break old functionality)**
Make sure that stories with variables still work.
