### PR TITLE
fix(timeseriescard): Passing truncation type 'none' to chart tooltip options so that tooltip labels don’t get truncated.

### DIFF
--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -445,6 +445,9 @@ const TimeSeriesCard = ({
       },
       containerResizable: true,
       tooltip: {
+        truncation: {
+          type: 'none',
+        },
         valueFormatter: (tooltipValue) =>
           chartValueFormatter(tooltipValue, newSize, unit, locale, decimalPrecision),
         customHTML: (...args) =>


### PR DESCRIPTION
Closes #

It closes a label truncation issue found in a product that uses the `TimeSeriesChart`

**Summary**

`carbon-charts` supports tooltip label truncation settings. If not passed, the default is to chop any characters after the 14th character in the tooltip label. `TimeSeriesChart` was not overriding tooltip truncation settings, so now the truncation type is set to `'none'`, which means that the tooltip label can stretch the tooltip width as much as necessary for all the content to show without any cropping.

**Acceptance Test (how to verify the PR)**

Before the change:

![image](https://user-images.githubusercontent.com/12237934/126361878-85b0b50f-e785-47be-bc47-36ecace788d3.png)

After the change:

![image](https://user-images.githubusercontent.com/12237934/126361975-93561d4a-9ad2-41e1-913a-8678004c79c6.png)

**Regression Test (how to make sure this PR doesn't break old functionality)**

All unit tests are still passing and and stories are still working.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
