### PR TITLE
fix(timeseriescard): xaxis format incorrect with one datapoint in year interval

### DIFF
--- a/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.js
+++ b/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.js
@@ -190,6 +190,9 @@ export const formatGraphTick = (
   if (interval === 'month' && sameYear) {
     return currentTimestamp.format('MMM');
   }
+  if (interval === 'year' && index === 0) {
+    return currentTimestamp.format('YYYY');
+  }
   if (interval === 'year' && sameYear) {
     return ''; // if we're on the year boundary and the same year, then don't repeat
   }


### PR DESCRIPTION
…

Closes #

**Summary**

- Tiny bug where if only one datapoint existed in a TimeSeriesCard with a year interval, it totally skipped the x-axis graph tick

**Change List (commits, features, bugs, etc)**

- fix(timeSeriesUtils):  for yearly first tick always show a graph tick value

**Acceptance Test (how to verify the PR)**

- Verify that timeSeriesCard with one datapoint and year interval shows x-axis tick.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- verify with multiple years of data that it still looks good

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
