### PR TITLE
fix(combo-box): more explicit prop selection for carbon ComboBox

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.jsx
+++ b/packages/react/src/components/ComboBox/ComboBox.jsx
@@ -2,8 +2,10 @@ import React, { useState, useMemo, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { ComboBox as CarbonComboBox, Tag } from 'carbon-components-react';
+import pick from 'lodash/pick';
 
 import { settings } from '../../constants/Settings';
+import { filterValidAttributes } from '../../utils/componentUtilityFunctions';
 
 const { iotPrefix } = settings;
 
@@ -226,7 +228,26 @@ const ComboBox = ({
         disabled={disabled || (loading !== undefined && loading !== false)}
         helperText={helperText}
         shouldFilterItem={hasMultiValue || addToList ? shouldFilterItemForTags : shouldFilterItem}
-        {...rest}
+        {...pick(
+          rest,
+          'ariaLabel',
+          'direction',
+          'downshiftProps',
+          'initialSelectedItem',
+          'invalid',
+          'invalidText',
+          'itemToElement',
+          'light',
+          'onToggleClick',
+          'placeholder',
+          'selectedItem',
+          'titleText',
+          'translateWithId',
+          'type',
+          'warn',
+          'warnText'
+        )}
+        {...filterValidAttributes(rest)}
       />
       {hasMultiValue ? (
         <ul data-testid={`${testId}-tags`} className={`${iotPrefix}--combobox-tags`}>

--- a/packages/react/src/components/ComboBox/ComboBox.test.jsx
+++ b/packages/react/src/components/ComboBox/ComboBox.test.jsx
@@ -32,6 +32,15 @@ describe('ComboBox', () => {
     return list;
   };
 
+  it('should filter bad props, but not good ones.', async () => {
+    jest.spyOn(console, 'error');
+    const { container } = render(
+      <ComboBox {...defaultProps} aBadProp="100" data-test-check="100" />
+    );
+    expect(console.error).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-test-check]')).toBeDefined();
+  });
+
   it('renders with default props', async () => {
     render(<ComboBox {...defaultProps} />);
     const tags = screen.getByTestId('combo-tags');


### PR DESCRIPTION
Closes #2608 

**Summary**

- Previously we were just passing all props to the carbon ComboBox. Now, we're selectively choosing those props relevant to the ComboBox or all valid html props.

**Change List (commits, features, bugs, etc)**

- added a `pick` to the `...rest` object passed to the CarbonComboBox to only select valid ComboBox props.
- then also run filterValidAttributes on rest and pass those as well.

**Acceptance Test (how to verify the PR)**

- No errors should be thrown when invalid props are passed to the combobox.
- all valid HTML props should be accepted.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- stories and tests work and pass as expected to ensure to props are inadvertently filtered.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
