### PR TITLE
feat(theshold-form-item): allow strings when equal comparison

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ThresholdsFormItem.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ThresholdsFormItem.jsx
@@ -5,6 +5,7 @@ import omit from 'lodash/omit';
 import isEmpty from 'lodash/isEmpty';
 import uuid from 'uuid';
 import { red60 } from '@carbon/colors';
+import { TextInput } from 'carbon-components-react';
 
 import { settings } from '../../../../constants/Settings';
 import { Button, NumberInput, Dropdown } from '../../../../index';
@@ -209,22 +210,40 @@ const ThresholdsFormItem = ({
                 />
               </div>
               <div className={`${baseClassName}--threshold-input-group--item-end`}>
-                <NumberInput
-                  id={`${cardConfig.id}_value-card-threshold-value_${i}`}
-                  step={1}
-                  hideLabel
-                  invalid={false} // don't allow invalid state
-                  value={threshold.value?.toString() || 0}
-                  onChange={({ imaginaryTarget }) => {
-                    const updatedThresholds = [...thresholds];
-                    updatedThresholds[i] = {
-                      ...updatedThresholds[i],
-                      value: Number(imaginaryTarget.value) || imaginaryTarget.value,
-                    };
-                    onChange(updatedThresholds.map((item) => omit(item, 'id')));
-                    setThresholds(updatedThresholds);
-                  }}
-                />
+                {threshold.comparison === '=' ? (
+                  <TextInput
+                    data-testid={`threshold-${i}-text-input`}
+                    id={`${cardConfig.id}_value-card-threshold-value_${i}`}
+                    labelText=""
+                    value={threshold.value?.toString()}
+                    onChange={({ target }) => {
+                      const updatedThresholds = [...thresholds];
+                      updatedThresholds[i] = {
+                        ...updatedThresholds[i],
+                        value: target.value,
+                      };
+                      onChange(updatedThresholds.map((item) => omit(item, 'id')));
+                      setThresholds(updatedThresholds);
+                    }}
+                  />
+                ) : (
+                  <NumberInput
+                    id={`${cardConfig.id}_value-card-threshold-value_${i}`}
+                    step={1}
+                    hideLabel
+                    invalid={false} // don't allow invalid state
+                    value={threshold.value?.toString() || 0}
+                    onChange={({ imaginaryTarget }) => {
+                      const updatedThresholds = [...thresholds];
+                      updatedThresholds[i] = {
+                        ...updatedThresholds[i],
+                        value: Number(imaginaryTarget.value) || imaginaryTarget.value,
+                      };
+                      onChange(updatedThresholds.map((item) => omit(item, 'id')));
+                      setThresholds(updatedThresholds);
+                    }}
+                  />
+                )}
               </div>
               <Button
                 hasIconOnly

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ThresholdsFormItem.test.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ThresholdsFormItem.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { green50 } from '@carbon/colors';
 import { Help24 } from '@carbon/icons-react';
 
@@ -207,6 +208,37 @@ describe('ThresholdsFormItem', () => {
         comparison: '>',
         color: 'red',
         icon: 'Error',
+      },
+    ]);
+  });
+  it("should allow text input when comparison is '='", () => {
+    render(<ThresholdsFormItem {...commonProps} thresholds={thresholds} />);
+
+    const comparisonInput = screen.getAllByLabelText('Open menu')[4];
+    expect(comparisonInput).toBeInTheDocument();
+
+    fireEvent.click(comparisonInput);
+
+    const equalsOperator = screen.getByText('=');
+    expect(equalsOperator).toBeInTheDocument();
+
+    fireEvent.click(equalsOperator);
+    expect(mockOnChange).toHaveBeenCalledWith([
+      {
+        value: 5,
+        comparison: '=',
+        color: 'red',
+        icon: 'Warning',
+      },
+    ]);
+    expect(screen.getByTestId('threshold-0-text-input')).toBeDefined();
+    userEvent.type(screen.getByTestId('threshold-0-text-input'), '{backspace}orange');
+    expect(mockOnChange).toHaveBeenLastCalledWith([
+      {
+        value: 'orange',
+        comparison: '=',
+        color: 'red',
+        icon: 'Warning',
       },
     ]);
   });

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/__snapshots__/ThresholdsFormItem.story.storyshot
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/__snapshots__/ThresholdsFormItem.story.storyshot
@@ -1083,85 +1083,25 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
           className="iot--card-edit-form--threshold-input-group--item-end"
         >
           <div
-            className="bx--form-item"
+            className="bx--form-item bx--text-input-wrapper"
           >
             <div
-              className="bx--number bx--number--helpertext bx--number--nolabel"
+              className="bx--text-input__field-outer-wrapper"
             >
               <div
-                className="bx--number__input-wrapper"
+                className="bx--text-input__field-wrapper"
+                data-invalid={null}
               >
                 <input
-                  aria-describedby={null}
-                  aria-label="Numeric input field with increment and decrement buttons"
+                  className="bx--text-input bx--text__input"
+                  data-testid="threshold-2-text-input"
                   disabled={false}
                   id="undefined_value-card-threshold-value_2"
                   onChange={[Function]}
-                  pattern="[0-9]*"
-                  step={1}
-                  type="number"
+                  onClick={[Function]}
+                  type="text"
                   value="20"
                 />
-                <div
-                  className="bx--number__controls"
-                >
-                  <button
-                    aria-label="Decrement number"
-                    className="bx--number__control-btn down-icon"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex="-1"
-                    title="Decrement number"
-                    type="button"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="down-icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 15H24V17H8z"
-                      />
-                    </svg>
-                  </button>
-                  <div
-                    className="bx--number__rule-divider"
-                  />
-                  <button
-                    aria-label="Increment number"
-                    className="bx--number__control-btn up-icon"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex="-1"
-                    title="Increment number"
-                    type="button"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="up-icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
-                      />
-                    </svg>
-                  </button>
-                  <div
-                    className="bx--number__rule-divider"
-                  />
-                </div>
               </div>
             </div>
           </div>

--- a/packages/react/src/components/CardEditor/CardEditForm/_card-edit-form.scss
+++ b/packages/react/src/components/CardEditor/CardEditForm/_card-edit-form.scss
@@ -173,6 +173,9 @@
       .#{$prefix}--number input[type='number'] {
         padding-right: 0;
       }
+      .#{$prefix}--form-item input[type='text'] {
+        min-width: 9.375rem;
+      }
     }
     &--item-dropdown {
       margin-right: $spacing-05;


### PR DESCRIPTION
Closes #2388 

**Summary**

- Allow text input when threshold comparison is set to '='. Previously only allowed number inputs for all comparitors.

**Change List (commits, features, bugs, etc)**

- check current comparison operator and use a TextInput if it is '='

**Acceptance Test (how to verify the PR)**

- https://deploy-preview-2668--carbon-addons-iot-react.netlify.app/?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-cardeditor-cardeditformitems-thresholdformitem--example-with-initial-values Try input any text in the third threshold in this story. Change the comparison operator to '>' or '<' and ensure strings are not allowed.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- All other changes to the thresholds should be unaffected.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
