### PR TITLE
fix(repo): fix copy plugin to include css

### DIFF
--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -184,10 +184,21 @@ export default [
             ],
             dest: ['es/node_modules', 'lib/node_modules'],
           },
-          // Copy CSS
+          // Copy CSS from tmp to ./lib/css, 'lib/css' folder is kept b/c flatten:false
           {
-            src: ['lib/css/'],
+            src: ['tmp/lib/css/'],
             dest: ['./'],
+          },
+        ],
+        verbose: env !== 'development', // logs the file copy list on production builds for easier debugging
+      }),
+      copy({
+        flatten: true,
+        targets: [
+          // Copy CSS from tmp to ./css, 'lib/css' folder isn't kept because flatten:true.
+          {
+            src: 'tmp/lib/css/*',
+            dest: './css/',
           },
         ],
         verbose: env !== 'development', // logs the file copy list on production builds for easier debugging


### PR DESCRIPTION
Closes #2671 

**Summary**

- After an upgrade to rollup-plugin-copy the css folders were no longer being copied correctly to be included into the build output

**Change List (commits, features, bugs, etc)**

- updated the rollup config to copy css from `tmp/lib/css` to `lib/css` and also from `tmp/lib/css` to simply `./css`

**Acceptance Test (how to verify the PR)**

- pull down this branch and locally build the project and ensure the css folder is contained in the output

**Regression Test (how to make sure this PR doesn't break old functionality)**

- no other adverse effects to the build process.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
