### PR TITLE
chore(table): fix sticky header/tooltip story so tooltips appear

### DIFF
--- a/packages/react/src/components/Table/Table.story.jsx
+++ b/packages/react/src/components/Table/Table.story.jsx
@@ -2286,13 +2286,6 @@ export const WithStickyHeaderExperimentalAndCellTooltipCalculation = () => {
         id="table-tooltip"
         triggerId="table-tooltip-trigger"
         triggerText=""
-        menuOffset={(menuBody) => {
-          const container = menuBody.closest('[data-floating-menu-container]');
-          return {
-            top: -container.getBoundingClientRect().y - window.pageYOffset + 4,
-            left: -container.getBoundingClientRect().x - window.pageXOffset + 10,
-          };
-        }}
       >
         <p>This scroll with the table body</p>
       </Tooltip>


### PR DESCRIPTION
Closes #2294 

**Summary**

- Fixed table story so that tooltips appear correctly in the sticky header story.

**Change List (commits, features, bugs, etc)**

- removed no longer needed menuOffset function preventing tooltips from appearing.
- confirmed this behavior matches original behavior (see https://deploy-preview-906--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-table--with-sticky-header-and-cell-tooltip-calculation)

**Acceptance Test (how to verify the PR)**

- tooltips should now appear and scroll with the table in the [sticky header/tooltip table story](https://deploy-preview-2676--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table-table--with-sticky-header-experimental-and-cell-tooltip-calculation).

**Regression Test (how to make sure this PR doesn't break old functionality)**

n/a

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
