### PR TITLE
chore(stateful-table): fix table story

### DIFF
--- a/packages/react/src/components/Table/StatefulTable.story.jsx
+++ b/packages/react/src/components/Table/StatefulTable.story.jsx
@@ -64,7 +64,7 @@ export const StatefulTableWithNestedRowItems = (props) => {
         : undefined,
   }));
   return (
-    <div>
+    <div style={{ width: select('table container width', ['auto', '300px', '800px'], 'auto') }}>
       <StatefulTable
         id="table"
         {...initialState}
@@ -75,7 +75,8 @@ export const StatefulTableWithNestedRowItems = (props) => {
           ...initialState.options,
           hasRowNesting: true,
           hasFilter: true,
-          wrapCellText: select('wrapCellText', selectTextWrapping, 'always'),
+          hasResize: true,
+          wrapCellText: select('wrapCellText', selectTextWrapping, 'alwaysTruncate'),
         }}
         view={{
           ...initialState.view,
@@ -180,7 +181,7 @@ export const StatefulExampleWithRowNestingAndFixedColumns = () => (
 );
 
 StatefulExampleWithRowNestingAndFixedColumns.storyName =
-  'Stateful Example with row nesting and fixed columns';
+  'Stateful Example with row nesting and resizable columns with initial width';
 
 StatefulExampleWithRowNestingAndFixedColumns.parameters = {
   info: {

--- a/packages/react/src/components/Table/__snapshots__/StatefulTable.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/StatefulTable.story.storyshot
@@ -48329,11 +48329,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/Table/StatefulTable Stateful Example with row nesting and fixed columns 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/Table/StatefulTable Stateful Example with row nesting and resizable columns with initial width 1`] = `
 <div
   className="storybook-container"
 >
-  <div>
+  <div
+    style={
+      Object {
+        "width": "auto",
+      }
+    }
+  >
     <div
       className="iot--table-container bx--data-table-container"
       data-testid="table-table-container"
@@ -48564,24 +48570,24 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           className="bx--data-table-content"
         >
           <table
-            className="bx--data-table iot--data-table--row-actions bx--data-table--no-border"
+            className="bx--data-table iot--data-table--resize iot--data-table--fixed iot--data-table--row-actions bx--data-table--no-border"
             data-testid="table"
             id="table"
             title={null}
           >
             <thead
               data-testid="table-table-head"
-              onMouseMove={null}
-              onMouseUp={null}
+              onMouseMove={[Function]}
+              onMouseUp={[Function]}
             >
               <tr>
                 <th
-                  className="bx--table-expand"
+                  className="bx--table-expand iot--table-expand-resize"
                   data-testid="table-table-head-row-expansion-column"
                   scope="col"
                 />
                 <th
-                  className="iot--table-header-checkbox"
+                  className="iot--table-header-checkbox iot--table-header-checkbox-resize"
                   data-testid="table-table-head-row-selection-column"
                   scope="col"
                   style={Object {}}
@@ -48616,7 +48622,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </th>
                 <th
                   align="start"
-                  className="table-header-label-start iot--table-head--table-header"
+                  className="table-header-label-start iot--table-head--table-header iot--table-header-resize"
                   data-column="string"
                   data-floating-menu-container={true}
                   data-testid="table-table-head-column-string"
@@ -48624,25 +48630,38 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   scope="col"
                   style={
                     Object {
-                      "width": undefined,
+                      "width": 0,
                     }
                   }
-                  width="50px"
                 >
                   <span
                     className="bx--table-header-label"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="String long text should get truncated"
                     >
                       String long text should get truncated
                     </span>
+                    <div
+                      aria-label="Resize column"
+                      className="iot--column-resize-handle"
+                      onClick={[Function]}
+                      onMouseDown={[Function]}
+                      role="button"
+                      style={
+                        Object {
+                          "left": "auto",
+                          "width": 4,
+                        }
+                      }
+                      tabIndex="0"
+                    />
                   </span>
                 </th>
                 <th
                   align="start"
-                  className="table-header-label-start iot--table-head--table-header"
+                  className="table-header-label-start iot--table-head--table-header iot--table-header-resize"
                   data-column="date"
                   data-floating-menu-container={true}
                   data-testid="table-table-head-column-date"
@@ -48650,25 +48669,38 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   scope="col"
                   style={
                     Object {
-                      "width": undefined,
+                      "width": 0,
                     }
                   }
-                  width="180px"
                 >
                   <span
                     className="bx--table-header-label"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="Date long text should get truncated"
                     >
                       Date long text should get truncated
                     </span>
+                    <div
+                      aria-label="Resize column"
+                      className="iot--column-resize-handle"
+                      onClick={[Function]}
+                      onMouseDown={[Function]}
+                      role="button"
+                      style={
+                        Object {
+                          "left": "auto",
+                          "width": 4,
+                        }
+                      }
+                      tabIndex="0"
+                    />
                   </span>
                 </th>
                 <th
                   align="start"
-                  className="table-header-label-start iot--table-head--table-header"
+                  className="table-header-label-start iot--table-head--table-header iot--table-header-resize"
                   data-column="select"
                   data-floating-menu-container={true}
                   data-testid="table-table-head-column-select"
@@ -48676,25 +48708,38 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   scope="col"
                   style={
                     Object {
-                      "width": undefined,
+                      "width": 0,
                     }
                   }
-                  width="120px"
                 >
                   <span
                     className="bx--table-header-label"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="Select long text should get truncated"
                     >
                       Select long text should get truncated
                     </span>
+                    <div
+                      aria-label="Resize column"
+                      className="iot--column-resize-handle"
+                      onClick={[Function]}
+                      onMouseDown={[Function]}
+                      role="button"
+                      style={
+                        Object {
+                          "left": "auto",
+                          "width": 4,
+                        }
+                      }
+                      tabIndex="0"
+                    />
                   </span>
                 </th>
                 <th
                   align="start"
-                  className="table-header-label-start iot--table-head--table-header"
+                  className="table-header-label-start iot--table-head--table-header iot--table-header-resize"
                   data-column="status"
                   data-floating-menu-container={true}
                   data-testid="table-table-head-column-status"
@@ -48702,25 +48747,38 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   scope="col"
                   style={
                     Object {
-                      "width": undefined,
+                      "width": 0,
                     }
                   }
-                  width="100px"
                 >
                   <span
                     className="bx--table-header-label"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="Status long text should get truncated"
                     >
                       Status long text should get truncated
                     </span>
+                    <div
+                      aria-label="Resize column"
+                      className="iot--column-resize-handle"
+                      onClick={[Function]}
+                      onMouseDown={[Function]}
+                      role="button"
+                      style={
+                        Object {
+                          "left": "auto",
+                          "width": 4,
+                        }
+                      }
+                      tabIndex="0"
+                    />
                   </span>
                 </th>
                 <th
                   align="start"
-                  className="table-header-label-start iot--table-head--table-header"
+                  className="table-header-label-start iot--table-head--table-header iot--table-header-resize"
                   data-column="number"
                   data-floating-menu-container={true}
                   data-testid="table-table-head-column-number"
@@ -48728,25 +48786,38 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   scope="col"
                   style={
                     Object {
-                      "width": undefined,
+                      "width": 0,
                     }
                   }
-                  width="80px"
                 >
                   <span
                     className="bx--table-header-label"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="Number long text should get truncated"
                     >
                       Number long text should get truncated
                     </span>
+                    <div
+                      aria-label="Resize column"
+                      className="iot--column-resize-handle"
+                      onClick={[Function]}
+                      onMouseDown={[Function]}
+                      role="button"
+                      style={
+                        Object {
+                          "left": "auto",
+                          "width": 4,
+                        }
+                      }
+                      tabIndex="0"
+                    />
                   </span>
                 </th>
                 <th
                   align="start"
-                  className="table-header-label-start iot--table-head--table-header"
+                  className="table-header-label-start iot--table-head--table-header iot--table-header-resize"
                   data-column="boolean"
                   data-floating-menu-container={true}
                   data-testid="table-table-head-column-boolean"
@@ -48754,25 +48825,38 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   scope="col"
                   style={
                     Object {
-                      "width": undefined,
+                      "width": 0,
                     }
                   }
-                  width="80px"
                 >
                   <span
                     className="bx--table-header-label"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="Boolean long text should get truncated"
                     >
                       Boolean long text should get truncated
                     </span>
+                    <div
+                      aria-label="Resize column"
+                      className="iot--column-resize-handle"
+                      onClick={[Function]}
+                      onMouseDown={[Function]}
+                      role="button"
+                      style={
+                        Object {
+                          "left": "auto",
+                          "width": 4,
+                        }
+                      }
+                      tabIndex="0"
+                    />
                   </span>
                 </th>
                 <th
                   align="start"
-                  className="table-header-label-start iot--table-head--table-header"
+                  className="table-header-label-start iot--table-head--table-header iot--table-header-resize"
                   data-column="node"
                   data-floating-menu-container={true}
                   data-testid="table-table-head-column-node"
@@ -48780,7 +48864,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   scope="col"
                   style={
                     Object {
-                      "width": undefined,
+                      "width": 0,
                     }
                   }
                 >
@@ -48788,11 +48872,37 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="bx--table-header-label"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="React Node long text should get truncated"
                     >
                       React Node long text should get truncated
                     </span>
+                    <div
+                      aria-label="Resize column"
+                      className="iot--column-resize-handle"
+                      onClick={[Function]}
+                      onMouseDown={[Function]}
+                      role="button"
+                      style={
+                        Object {
+                          "left": "auto",
+                          "width": 4,
+                        }
+                      }
+                      tabIndex="0"
+                    />
+                  </span>
+                </th>
+                <th
+                  className="iot--table-header-expander-column"
+                  data-testid="table-table-head-expander-column"
+                  scope="col"
+                  style={Object {}}
+                >
+                  <span
+                    className="bx--table-header-label"
+                  >
+                    
                   </span>
                 </th>
                 <th
@@ -48885,7 +48995,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="string"
                   data-offset={0}
                   id="cell-table-row-0-string"
@@ -48896,7 +49006,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="toyota toyota toyota 0"
                     >
                       toyota toyota toyota 0
@@ -48905,7 +49015,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="date"
                   data-offset={0}
                   id="cell-table-row-0-date"
@@ -48916,7 +49026,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="1973-03-03T09:46:40.000Z"
                     >
                       1973-03-03T09:46:40.000Z
@@ -48925,7 +49035,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="select"
                   data-offset={0}
                   id="cell-table-row-0-select"
@@ -48936,7 +49046,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="option-A"
                     >
                       option-A
@@ -48945,7 +49055,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="status"
                   data-offset={0}
                   id="cell-table-row-0-status"
@@ -48956,7 +49066,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                     >
                       <svg
                         height="10"
@@ -48976,7 +49086,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="number"
                   data-offset={0}
                   id="cell-table-row-0-number"
@@ -48989,7 +49099,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="boolean"
                   data-offset={0}
                   id="cell-table-row-0-boolean"
@@ -49000,7 +49110,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="true"
                     >
                       true
@@ -49009,7 +49119,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="node"
                   data-offset={0}
                   id="cell-table-row-0-node"
@@ -49034,6 +49144,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     </svg>
                   </span>
                 </td>
+                <td />
                 <td
                   className="iot--row-actions-cell--table-cell"
                 >
@@ -49167,7 +49278,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="string"
                   data-offset={0}
                   id="cell-table-row-1-string"
@@ -49178,7 +49289,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="helping whiteboard as 1"
                     >
                       helping whiteboard as 1
@@ -49187,7 +49298,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="date"
                   data-offset={0}
                   id="cell-table-row-1-date"
@@ -49198,7 +49309,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="1973-03-14T23:33:20.000Z"
                     >
                       1973-03-14T23:33:20.000Z
@@ -49207,7 +49318,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="select"
                   data-offset={0}
                   id="cell-table-row-1-select"
@@ -49218,7 +49329,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="option-B"
                     >
                       option-B
@@ -49227,7 +49338,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="status"
                   data-offset={0}
                   id="cell-table-row-1-status"
@@ -49238,7 +49349,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                     >
                       <svg
                         height="10"
@@ -49258,7 +49369,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="number"
                   data-offset={0}
                   id="cell-table-row-1-number"
@@ -49269,7 +49380,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title={1}
                     >
                       1
@@ -49278,7 +49389,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="boolean"
                   data-offset={0}
                   id="cell-table-row-1-boolean"
@@ -49289,7 +49400,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="false"
                     >
                       false
@@ -49298,7 +49409,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="node"
                   data-offset={0}
                   id="cell-table-row-1-node"
@@ -49323,6 +49434,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     </svg>
                   </span>
                 </td>
+                <td />
                 <td
                   className="iot--row-actions-cell--table-cell"
                 >
@@ -49489,7 +49601,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="string"
                   data-offset={0}
                   id="cell-table-row-2-string"
@@ -49500,7 +49612,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="whiteboard can eat 2"
                     >
                       whiteboard can eat 2
@@ -49509,7 +49621,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="date"
                   data-offset={0}
                   id="cell-table-row-2-date"
@@ -49520,7 +49632,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="1973-04-18T16:53:20.000Z"
                     >
                       1973-04-18T16:53:20.000Z
@@ -49529,7 +49641,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="select"
                   data-offset={0}
                   id="cell-table-row-2-select"
@@ -49540,7 +49652,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="option-C"
                     >
                       option-C
@@ -49549,7 +49661,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="status"
                   data-offset={0}
                   id="cell-table-row-2-status"
@@ -49560,7 +49672,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                     >
                       <svg
                         height="10"
@@ -49580,7 +49692,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="number"
                   data-offset={0}
                   id="cell-table-row-2-number"
@@ -49591,7 +49703,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title={4}
                     >
                       4
@@ -49600,7 +49712,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="boolean"
                   data-offset={0}
                   id="cell-table-row-2-boolean"
@@ -49611,7 +49723,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="true"
                     >
                       true
@@ -49620,7 +49732,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="node"
                   data-offset={0}
                   id="cell-table-row-2-node"
@@ -49645,6 +49757,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     </svg>
                   </span>
                 </td>
+                <td />
                 <td
                   className="iot--row-actions-cell--table-cell"
                 >
@@ -49811,7 +49924,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="string"
                   data-offset={0}
                   id="cell-table-row-3-string"
@@ -49822,7 +49935,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="as eat scott 3"
                     >
                       as eat scott 3
@@ -49831,7 +49944,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="date"
                   data-offset={0}
                   id="cell-table-row-3-date"
@@ -49842,7 +49955,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="1973-06-15T13:46:40.000Z"
                     >
                       1973-06-15T13:46:40.000Z
@@ -49851,7 +49964,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="select"
                   data-offset={0}
                   id="cell-table-row-3-select"
@@ -49862,7 +49975,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="option-A"
                     >
                       option-A
@@ -49871,7 +49984,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="status"
                   data-offset={0}
                   id="cell-table-row-3-status"
@@ -49882,7 +49995,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                     >
                       <svg
                         height="10"
@@ -49902,7 +50015,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="number"
                   data-offset={0}
                   id="cell-table-row-3-number"
@@ -49915,7 +50028,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="boolean"
                   data-offset={0}
                   id="cell-table-row-3-boolean"
@@ -49926,7 +50039,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="false"
                     >
                       false
@@ -49935,7 +50048,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="node"
                   data-offset={0}
                   id="cell-table-row-3-node"
@@ -49960,6 +50073,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     </svg>
                   </span>
                 </td>
+                <td />
                 <td
                   className="iot--row-actions-cell--table-cell"
                 >
@@ -50126,7 +50240,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="string"
                   data-offset={0}
                   id="cell-table-row-4-string"
@@ -50137,7 +50251,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="can pinocchio whiteboard 4"
                     >
                       can pinocchio whiteboard 4
@@ -50146,7 +50260,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="date"
                   data-offset={0}
                   id="cell-table-row-4-date"
@@ -50157,7 +50271,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="1973-09-04T14:13:20.000Z"
                     >
                       1973-09-04T14:13:20.000Z
@@ -50166,7 +50280,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="select"
                   data-offset={0}
                   id="cell-table-row-4-select"
@@ -50177,7 +50291,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="option-B"
                     >
                       option-B
@@ -50186,7 +50300,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="status"
                   data-offset={0}
                   id="cell-table-row-4-status"
@@ -50197,7 +50311,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                     >
                       <svg
                         height="10"
@@ -50217,7 +50331,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="number"
                   data-offset={0}
                   id="cell-table-row-4-number"
@@ -50228,7 +50342,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title={16}
                     >
                       16
@@ -50237,7 +50351,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="boolean"
                   data-offset={0}
                   id="cell-table-row-4-boolean"
@@ -50248,7 +50362,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="true"
                     >
                       true
@@ -50257,7 +50371,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="node"
                   data-offset={0}
                   id="cell-table-row-4-node"
@@ -50282,6 +50396,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     </svg>
                   </span>
                 </td>
+                <td />
                 <td
                   className="iot--row-actions-cell--table-cell"
                 >
@@ -50415,7 +50530,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="string"
                   data-offset={0}
                   id="cell-table-row-5-string"
@@ -50426,7 +50541,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="bottle toyota bottle 5"
                     >
                       bottle toyota bottle 5
@@ -50435,7 +50550,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="date"
                   data-offset={0}
                   id="cell-table-row-5-date"
@@ -50446,7 +50561,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="1973-12-17T18:13:20.000Z"
                     >
                       1973-12-17T18:13:20.000Z
@@ -50455,7 +50570,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="select"
                   data-offset={0}
                   id="cell-table-row-5-select"
@@ -50466,7 +50581,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="option-C"
                     >
                       option-C
@@ -50475,7 +50590,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="status"
                   data-offset={0}
                   id="cell-table-row-5-status"
@@ -50486,7 +50601,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                     >
                       <svg
                         height="10"
@@ -50506,7 +50621,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="number"
                   data-offset={0}
                   id="cell-table-row-5-number"
@@ -50517,7 +50632,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title={25}
                     >
                       25
@@ -50526,7 +50641,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="boolean"
                   data-offset={0}
                   id="cell-table-row-5-boolean"
@@ -50537,7 +50652,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="false"
                     >
                       false
@@ -50546,7 +50661,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="node"
                   data-offset={0}
                   id="cell-table-row-5-node"
@@ -50571,6 +50686,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     </svg>
                   </span>
                 </td>
+                <td />
                 <td
                   className="iot--row-actions-cell--table-cell"
                 >
@@ -50737,7 +50853,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="string"
                   data-offset={0}
                   id="cell-table-row-6-string"
@@ -50748,7 +50864,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="eat whiteboard pinocchio 6"
                     >
                       eat whiteboard pinocchio 6
@@ -50757,7 +50873,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="date"
                   data-offset={0}
                   id="cell-table-row-6-date"
@@ -50768,7 +50884,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="1974-04-24T01:46:40.000Z"
                     >
                       1974-04-24T01:46:40.000Z
@@ -50777,7 +50893,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="select"
                   data-offset={0}
                   id="cell-table-row-6-select"
@@ -50788,7 +50904,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="option-A"
                     >
                       option-A
@@ -50797,7 +50913,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="status"
                   data-offset={0}
                   id="cell-table-row-6-status"
@@ -50808,7 +50924,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                     >
                       <svg
                         height="10"
@@ -50828,7 +50944,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="number"
                   data-offset={0}
                   id="cell-table-row-6-number"
@@ -50841,7 +50957,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="boolean"
                   data-offset={0}
                   id="cell-table-row-6-boolean"
@@ -50852,7 +50968,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="true"
                     >
                       true
@@ -50861,7 +50977,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="node"
                   data-offset={0}
                   id="cell-table-row-6-node"
@@ -50886,6 +51002,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     </svg>
                   </span>
                 </td>
+                <td />
                 <td
                   className="iot--row-actions-cell--table-cell"
                 >
@@ -51052,7 +51169,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="string"
                   data-offset={0}
                   id="cell-table-row-7-string"
@@ -51063,7 +51180,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="chocolate can helping 7"
                     >
                       chocolate can helping 7
@@ -51072,7 +51189,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="date"
                   data-offset={0}
                   id="cell-table-row-7-date"
@@ -51083,7 +51200,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="1974-09-21T12:53:20.000Z"
                     >
                       1974-09-21T12:53:20.000Z
@@ -51092,7 +51209,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="select"
                   data-offset={0}
                   id="cell-table-row-7-select"
@@ -51103,7 +51220,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="option-B"
                     >
                       option-B
@@ -51112,7 +51229,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="status"
                   data-offset={0}
                   id="cell-table-row-7-status"
@@ -51123,7 +51240,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                     >
                       <svg
                         height="10"
@@ -51143,7 +51260,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="number"
                   data-offset={0}
                   id="cell-table-row-7-number"
@@ -51154,7 +51271,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title={49}
                     >
                       49
@@ -51163,7 +51280,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="boolean"
                   data-offset={0}
                   id="cell-table-row-7-boolean"
@@ -51174,7 +51291,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="false"
                     >
                       false
@@ -51183,7 +51300,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="node"
                   data-offset={0}
                   id="cell-table-row-7-node"
@@ -51208,6 +51325,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     </svg>
                   </span>
                 </td>
+                <td />
                 <td
                   className="iot--row-actions-cell--table-cell"
                 >
@@ -51374,7 +51492,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="string"
                   data-offset={0}
                   id="cell-table-row-8-string"
@@ -51385,7 +51503,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="pinocchio eat can 8"
                     >
                       pinocchio eat can 8
@@ -51394,7 +51512,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="date"
                   data-offset={0}
                   id="cell-table-row-8-date"
@@ -51405,7 +51523,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="1975-03-14T03:33:20.000Z"
                     >
                       1975-03-14T03:33:20.000Z
@@ -51414,7 +51532,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="select"
                   data-offset={0}
                   id="cell-table-row-8-select"
@@ -51425,7 +51543,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="option-C"
                     >
                       option-C
@@ -51434,7 +51552,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="status"
                   data-offset={0}
                   id="cell-table-row-8-status"
@@ -51445,7 +51563,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                     >
                       <svg
                         height="10"
@@ -51465,7 +51583,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="number"
                   data-offset={0}
                   id="cell-table-row-8-number"
@@ -51476,7 +51594,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title={64}
                     >
                       64
@@ -51485,7 +51603,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="boolean"
                   data-offset={0}
                   id="cell-table-row-8-boolean"
@@ -51496,7 +51614,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="true"
                     >
                       true
@@ -51505,7 +51623,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="node"
                   data-offset={0}
                   id="cell-table-row-8-node"
@@ -51530,6 +51648,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     </svg>
                   </span>
                 </td>
+                <td />
                 <td
                   className="iot--row-actions-cell--table-cell"
                 >
@@ -51663,7 +51782,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="string"
                   data-offset={0}
                   id="cell-table-row-9-string"
@@ -51674,7 +51793,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="scott pinocchio chocolate 9"
                     >
                       scott pinocchio chocolate 9
@@ -51683,7 +51802,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="date"
                   data-offset={0}
                   id="cell-table-row-9-date"
@@ -51694,7 +51813,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="1975-09-26T21:46:40.000Z"
                     >
                       1975-09-26T21:46:40.000Z
@@ -51703,7 +51822,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="select"
                   data-offset={0}
                   id="cell-table-row-9-select"
@@ -51714,7 +51833,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="option-A"
                     >
                       option-A
@@ -51723,7 +51842,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="status"
                   data-offset={0}
                   id="cell-table-row-9-status"
@@ -51734,7 +51853,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                     >
                       <svg
                         height="10"
@@ -51754,7 +51873,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="number"
                   data-offset={0}
                   id="cell-table-row-9-number"
@@ -51767,7 +51886,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="boolean"
                   data-offset={0}
                   id="cell-table-row-9-boolean"
@@ -51778,7 +51897,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                   >
                     <span
-                      className=""
+                      className="iot--table__cell-text--truncate"
                       title="false"
                     >
                       false
@@ -51787,7 +51906,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </td>
                 <td
                   align="start"
-                  className="data-table-start"
+                  className="data-table-start iot--table__cell--truncate"
                   data-column="node"
                   data-offset={0}
                   id="cell-table-row-9-node"
@@ -51812,6 +51931,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     </svg>
                   </span>
                 </td>
+                <td />
                 <td
                   className="iot--row-actions-cell--table-cell"
                 >

--- a/packages/react/src/components/Table/__snapshots__/StatefulTable.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/StatefulTable.story.storyshot
@@ -48520,7 +48520,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   scope="col"
                   style={
                     Object {
-                      "width": 0,
+                      "width": 150,
                     }
                   }
                 >
@@ -48559,7 +48559,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   scope="col"
                   style={
                     Object {
-                      "width": 0,
+                      "width": 150,
                     }
                   }
                 >
@@ -48598,7 +48598,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   scope="col"
                   style={
                     Object {
-                      "width": 0,
+                      "width": 150,
                     }
                   }
                 >
@@ -48637,7 +48637,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   scope="col"
                   style={
                     Object {
-                      "width": 0,
+                      "width": 150,
                     }
                   }
                 >
@@ -48676,7 +48676,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   scope="col"
                   style={
                     Object {
-                      "width": 0,
+                      "width": 150,
                     }
                   }
                 >
@@ -48715,7 +48715,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   scope="col"
                   style={
                     Object {
-                      "width": 0,
+                      "width": 150,
                     }
                   }
                 >
@@ -48754,7 +48754,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   scope="col"
                   style={
                     Object {
-                      "width": 0,
+                      "width": 150,
                     }
                   }
                 >


### PR DESCRIPTION
Closes #2291 

**Summary**

- the https://deploy-preview-2677--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table-statefultable--stateful-example-with-row-nesting-and-fixed-columns story was pulling props from another location that had been changed for another story. It was also missing props to make it work as described. These have been fixed.

**Acceptance Test (how to verify the PR)**

- The bad story should be renamed and new props added to make it match the described and implied behavior.

**Regression Test (how to make sure this PR doesn't break old functionality)**

n/a

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
