### PR TITLE
fix(time-series-card): fix refs in mocks for test output

### DIFF
--- a/packages/react/__mocks__/@carbon/charts-react/bar-chart-grouped.js
+++ b/packages/react/__mocks__/@carbon/charts-react/bar-chart-grouped.js
@@ -1,3 +1,5 @@
 const React = require('react');
 
-module.exports = () => React.createElement('div', { id: 'mock-bar-chart-grouped' });
+module.exports = React.forwardRef((props, ref) =>
+  React.createElement('div', { id: 'mock-bar-chart-grouped', ref })
+);

--- a/packages/react/__mocks__/@carbon/charts-react/bar-chart-simple.js
+++ b/packages/react/__mocks__/@carbon/charts-react/bar-chart-simple.js
@@ -1,3 +1,5 @@
 const React = require('react');
 
-module.exports = () => React.createElement('div', { id: 'mock-bar-chart-simple' });
+module.exports = React.forwardRef((props, ref) =>
+  React.createElement('div', { id: 'mock-bar-chart-simple', ref })
+);

--- a/packages/react/__mocks__/@carbon/charts-react/bar-chart-stacked.js
+++ b/packages/react/__mocks__/@carbon/charts-react/bar-chart-stacked.js
@@ -1,3 +1,5 @@
 const React = require('react');
 
-module.exports = () => React.createElement('div', { id: 'mock-bar-chart-stacked' });
+module.exports = React.forwardRef((props, ref) =>
+  React.createElement('div', { id: 'mock-bar-chart-stacked', ref })
+);

--- a/packages/react/__mocks__/@carbon/charts-react/combo-chart.js
+++ b/packages/react/__mocks__/@carbon/charts-react/combo-chart.js
@@ -1,3 +1,5 @@
 const React = require('react');
 
-module.exports = () => React.createElement('div', { id: 'mock-combo-chart' });
+module.exports = React.forwardRef((props, ref) =>
+  React.createElement('div', { id: 'mock-combo-chart', ref })
+);

--- a/packages/react/__mocks__/@carbon/charts-react/line-chart.js
+++ b/packages/react/__mocks__/@carbon/charts-react/line-chart.js
@@ -1,3 +1,5 @@
 const React = require('react');
 
-module.exports = () => React.createElement('div', { id: 'mock-line-chart' });
+module.exports = React.forwardRef((props, ref) =>
+  React.createElement('div', { id: 'mock-line-chart', ref })
+);

--- a/packages/react/__mocks__/@carbon/charts-react/pie-chart.js
+++ b/packages/react/__mocks__/@carbon/charts-react/pie-chart.js
@@ -1,3 +1,5 @@
 const React = require('react');
 
-module.exports = () => React.createElement('div', { id: 'mock-pie-chart' });
+module.exports = React.forwardRef((props, ref) =>
+  React.createElement('div', { id: 'mock-pie-chart', ref })
+);

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -552,9 +552,7 @@ const TimeSeriesCard = ({
             })}
           >
             <ChartComponent
-              ref={(el) => {
-                chartRef.current = el;
-              }}
+              ref={chartRef}
               data={chartData}
               options={options}
               width="100%"

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -234,7 +234,7 @@ const TimeSeriesCard = ({
     },
     values: valuesProp,
   } = handleCardVariables(titleProp, contentWithDefaults, initialValues, others);
-  let chartRef = useRef();
+  const chartRef = useRef(null);
   const previousTick = useRef();
   dayjs.locale(locale);
 
@@ -330,8 +330,8 @@ const TimeSeriesCard = ({
 
   /** This is needed to update the chart when the lines and values change */
   useEffect(() => {
-    if (chartRef && chartRef.chart && !isEqual(chartData, previousChartData)) {
-      chartRef.chart.model.setData(chartData);
+    if (chartRef?.current?.chart && !isEqual(chartData, previousChartData)) {
+      chartRef.current.chart.model.setData(chartData);
     }
   }, [chartData, previousChartData]);
 
@@ -553,7 +553,7 @@ const TimeSeriesCard = ({
           >
             <ChartComponent
               ref={(el) => {
-                chartRef = el;
+                chartRef.current = el;
               }}
               data={chartData}
               options={options}


### PR DESCRIPTION
Closes #2453 

**Summary**

- Testing output was throwing a "Functional components can not be given refs" error when using TimeSeriesCard. This PR fixes it by wrapping the mocked charts with React.forwardRef. This ended up not being a v3 change, so basing it against next.

**Change List (commits, features, bugs, etc)**

- add React.forwardRef calls to all mocked carbon charts
- fix useRef references in TimeSeriesCard

**Acceptance Test (how to verify the PR)**

- No testing noise when testing TimeSeriesCard (except for testID prop deprecation notices)

**Regression Test (how to make sure this PR doesn't break old functionality)**

- all TimeSeriesCard tests still pass and [stories](https://deploy-preview-2678--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-timeseriescard--multi-line-interval-data-choices) function as expected.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
