### PR TITLE
fix(suite-header): no javascript urls in links, fix testing output errors

### DIFF
--- a/packages/react/src/components/Header/Header.test.jsx
+++ b/packages/react/src/components/Header/Header.test.jsx
@@ -120,9 +120,9 @@ describe('Header', () => {
 
       content: React.forwardRef((props, ref) => (
         // eslint-disable-next-line jsx-a11y/anchor-is-valid
-        <a href="#" ref={ref} {...props}>
+        <button ref={ref} type="button" {...props}>
           Header panel content
-        </a>
+        </button>
       )),
     };
     render(<Header {...HeaderProps} headerPanel={headerPanel} />);
@@ -194,9 +194,9 @@ describe('Header', () => {
       // eslint-disable-next-line react/no-multi-comp
       content: React.forwardRef((props, ref) => (
         // eslint-disable-next-line jsx-a11y/anchor-is-valid
-        <a href="#" ref={ref} {...props}>
+        <button ref={ref} type="button" {...props}>
           Header panel content
-        </a>
+        </button>
       )),
     };
     render(<Header {...HeaderProps} headerPanel={headerPanel} />);
@@ -217,10 +217,9 @@ describe('Header', () => {
       className: 'header-panel',
       // eslint-disable-next-line react/no-multi-comp
       content: React.forwardRef((props, ref) => (
-        // eslint-disable-next-line jsx-a11y/anchor-is-valid
-        <a href="#" ref={ref} {...props}>
+        <button type="button" ref={ref} {...props}>
           Header panel content
-        </a>
+        </button>
       )),
     };
     render(<Header {...HeaderProps} headerPanel={headerPanel} />);
@@ -235,10 +234,9 @@ describe('Header', () => {
       className: 'header-panel',
       // eslint-disable-next-line react/no-multi-comp
       content: React.forwardRef((props, ref) => (
-        // eslint-disable-next-line jsx-a11y/anchor-is-valid
-        <a href="#" ref={ref} {...props}>
+        <button type="button" ref={ref} {...props}>
           Header panel content
-        </a>
+        </button>
       )),
     };
     render(<Header {...HeaderProps} headerPanel={headerPanel} />);
@@ -255,9 +253,9 @@ describe('Header', () => {
       // eslint-disable-next-line react/no-multi-comp
       content: React.forwardRef((props, ref) => (
         // eslint-disable-next-line jsx-a11y/anchor-is-valid
-        <a href="#" ref={ref} {...props}>
+        <button type="button" ref={ref} {...props}>
           Header panel content
-        </a>
+        </button>
       )),
     };
     render(<Header {...HeaderProps} headerPanel={headerPanel} />);
@@ -274,9 +272,9 @@ describe('Header', () => {
       // eslint-disable-next-line react/no-multi-comp
       content: React.forwardRef((props, ref) => (
         // eslint-disable-next-line jsx-a11y/anchor-is-valid
-        <a href="#" ref={ref} {...props}>
+        <button type="button" ref={ref} {...props}>
           Header panel content
-        </a>
+        </button>
       )),
     };
     render(<Header {...HeaderProps} headerPanel={headerPanel} />);
@@ -296,6 +294,7 @@ describe('Header', () => {
   });
 
   it('should move icons into overflow menu when area too small', () => {
+    jest.useFakeTimers();
     const originalWidth = window.innerWidth;
     Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
     const originalBounding = Element.prototype.getBoundingClientRect;
@@ -377,7 +376,10 @@ describe('Header', () => {
         y: 0,
       };
     };
-    userEvent.click(overflowMenuButton);
+    act(() => {
+      userEvent.click(overflowMenuButton);
+      jest.runAllTimers();
+    });
     expect(screen.getByText('Watson')).toBeVisible();
     expect(screen.getByText('Custom icon 1')).toBeVisible();
     userEvent.click(screen.getByRole('menuitem', { name: 'help' }));
@@ -390,10 +392,12 @@ describe('Header', () => {
     expect(screen.queryByText('Custom icon 1')).toBeNull();
     act(() => {
       userEvent.click(screen.getByLabelText('Open menu', { selector: 'svg' }));
+      jest.runAllTimers();
     });
     expect(screen.getByText('Watson')).toBeVisible();
     expect(screen.getByText('Custom icon 1')).toBeVisible();
     HTMLElement.prototype.getBoundingClientRect = originalBounding;
     window.innerWidth = originalWidth;
+    jest.useRealTimers();
   });
 });

--- a/packages/react/src/components/Header/HeaderAction/HeaderActionMenu.jsx
+++ b/packages/react/src/components/Header/HeaderAction/HeaderActionMenu.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { HeaderMenuItem } from 'carbon-components-react/es/components/UIShell';
 
 import { ChildContentPropTypes } from '../Header';
+import { handleSpecificKeyDown } from '../../../utils/componentUtilityFunctions';
 
 const { prefix } = settings;
 
@@ -113,6 +114,7 @@ class HeaderActionMenu extends React.Component {
     // Prevents the a element from navigating to it's href target
     const handleDefaultClick = (event) => {
       event.preventDefault();
+      event.stopPropagation();
       onToggleExpansion();
     };
 
@@ -131,8 +133,8 @@ class HeaderActionMenu extends React.Component {
           aria-haspopup="menu" // eslint-disable-line jsx-a11y/aria-proptypes
           aria-expanded={isExpanded}
           className={classnames(`${prefix}--header__menu-item`, `${prefix}--header__menu-title`)}
-          href=""
-          onKeyDown={this.handleOnKeyDown}
+          href="#"
+          onKeyDown={handleSpecificKeyDown(['Enter', 'Space', 'Escape'], handleDefaultClick)}
           onClick={handleDefaultClick}
           ref={focusRef}
           data-testid="menuitem"

--- a/packages/react/src/components/Header/HeaderAction/__snapshots__/HeaderActionMenu.test.jsx.snap
+++ b/packages/react/src/components/Header/HeaderAction/__snapshots__/HeaderActionMenu.test.jsx.snap
@@ -11,7 +11,7 @@ exports[`HeaderActionMenu should render 1`] = `
       aria-label="Accessibility label"
       class="bx--header__menu-item bx--header__menu-title"
       data-testid="menuitem"
-      href=""
+      href="#"
       role="menuitem"
       tabindex="0"
     >

--- a/packages/react/src/components/Header/__snapshots__/Header.story.storyshot
+++ b/packages/react/src/components/Header/__snapshots__/Header.story.storyshot
@@ -236,8 +236,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                 aria-label="user"
                 className="bx--header__menu-item bx--header__menu-title"
                 data-testid="menuitem"
-                href=""
+                href="#"
                 onClick={[Function]}
+                onKeyDown={[Function]}
                 role="menuitem"
                 tabIndex={0}
               >
@@ -601,8 +602,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                 aria-label="user"
                 className="bx--header__menu-item bx--header__menu-title"
                 data-testid="menuitem"
-                href=""
+                href="#"
                 onClick={[Function]}
+                onKeyDown={[Function]}
                 role="menuitem"
                 tabIndex={0}
               >
@@ -785,8 +787,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                 aria-label="user"
                 className="bx--header__menu-item bx--header__menu-title"
                 data-testid="menuitem"
-                href=""
+                href="#"
                 onClick={[Function]}
+                onKeyDown={[Function]}
                 role="menuitem"
                 tabIndex={0}
               >
@@ -991,8 +994,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                 aria-label="user"
                 className="bx--header__menu-item bx--header__menu-title"
                 data-testid="menuitem"
-                href=""
+                href="#"
                 onClick={[Function]}
+                onKeyDown={[Function]}
                 role="menuitem"
                 tabIndex={0}
               >
@@ -1470,8 +1474,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                 aria-label="user"
                 className="bx--header__menu-item bx--header__menu-title"
                 data-testid="menuitem"
-                href=""
+                href="#"
                 onClick={[Function]}
+                onKeyDown={[Function]}
                 role="menuitem"
                 tabIndex={0}
               >

--- a/packages/react/src/components/Header/__snapshots__/Header.test.jsx.snap
+++ b/packages/react/src/components/Header/__snapshots__/Header.test.jsx.snap
@@ -164,7 +164,7 @@ exports[`Header should render 1`] = `
               aria-label="user"
               class="bx--header__menu-item bx--header__menu-title"
               data-testid="menuitem"
-              href=""
+              href="#"
               role="menuitem"
               tabindex="0"
             >

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
@@ -221,7 +221,7 @@ const SuiteHeader = ({
     setIsSideNavExpandedState((prevIsSideNavExpanded) => !prevIsSideNavExpanded);
   }, [setIsSideNavExpandedState]);
 
-  const navigatorRoute = routes?.navigator || 'javascript:void(0)';
+  const navigatorRoute = routes?.navigator || '#';
 
   // If there are custom help links, include an extra child content entry for the separator
   const mergedCustomHelpLinks =
@@ -254,8 +254,9 @@ const SuiteHeader = ({
           subtitle={
             <>
               <Link
-                href="javascript:void(0)"
-                onClick={async () => {
+                href="#"
+                onClick={async (e) => {
+                  e.preventDefault();
                   const result = await onRouteChange(ROUTE_TYPES.SURVEY, surveyData.surveyLink);
                   if (result) {
                     window.open(surveyData.surveyLink, '_blank', 'noopener noreferrer');
@@ -266,8 +267,9 @@ const SuiteHeader = ({
               </Link>
               <div className={`${settings.iotPrefix}--suite-header-survey-policy-link`}>
                 <Link
-                  href="javascript:void(0)"
-                  onClick={async () => {
+                  href="#"
+                  onClick={async (e) => {
+                    e.preventDefault();
                     const result = await onRouteChange(ROUTE_TYPES.SURVEY, surveyData.surveyLink);
                     if (result) {
                       window.open(surveyData.privacyLink, '_blank', 'noopener noreferrer');
@@ -332,6 +334,7 @@ const SuiteHeader = ({
         url={navigatorRoute}
         hasSideNav={hasSideNav || sideNavProps !== null}
         onClickSideNavExpand={(evt) => {
+          evt.preventDefault();
           onSideNavToggled(evt);
           handleSideNavButtonClick(evt);
         }}
@@ -341,7 +344,7 @@ const SuiteHeader = ({
               applications={applications}
               customApplications={customApplications}
               allApplicationsLink={routes?.navigator}
-              noAccessLink={routes?.gettingStarted || 'javascript:void(0)'}
+              noAccessLink={routes?.gettingStarted || '#'}
               onRouteChange={onRouteChange}
               i18n={{
                 myApplications: mergedI18N.switcherMyApplications,
@@ -418,7 +421,7 @@ const SuiteHeader = ({
                     metaData: {
                       element: 'a',
                       'data-testid': `suite-header-help--${item}`,
-                      href: 'javascript:void(0)',
+                      href: '#',
                       title: mergedI18N[item],
                       onClick: async () => {
                         const result = await onRouteChange(ROUTE_TYPES.DOCUMENTATION, routes[item]);
@@ -433,7 +436,7 @@ const SuiteHeader = ({
                     metaData: {
                       element: 'a',
                       'data-testid': 'suite-header-help--about',
-                      href: 'javascript:void(0)',
+                      href: '#',
                       title: mergedI18N.about,
                       onClick: async () => {
                         const result = await onRouteChange(ROUTE_TYPES.ABOUT, routes.about);
@@ -504,9 +507,12 @@ const SuiteHeader = ({
                       className: `${settings.iotPrefix}--suite-header--logout`,
                       element: 'a',
                       'data-testid': 'suite-header-profile--logout',
-                      href: 'javascript:void(0)',
+                      href: '#',
                       title: mergedI18N.logout,
-                      onClick: () => setShowLogoutModal(true),
+                      onClick: (e) => {
+                        e.preventDefault();
+                        setShowLogoutModal(true);
+                      },
                     },
                     content: <span id="suite-header-profile-menu-logout">{mergedI18N.logout}</span>,
                   }

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.story.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.story.jsx
@@ -229,8 +229,11 @@ const customHelpLinks = [
   {
     metaData: {
       element: 'a',
-      href: 'javascript:void(0)',
-      onClick: () => alert('custom help menu action'),
+      href: '#',
+      onClick: (e) => {
+        e.preventDefault();
+        alert('custom help menu action');
+      },
     },
     content: (
       <span id="yet-another-custom-help-link">
@@ -262,8 +265,11 @@ const customProfileLinks = [
   {
     metaData: {
       element: 'a',
-      href: 'javascript:void(0)',
-      onClick: () => alert('custom profile menu action'),
+      href: '#',
+      onClick: (e) => {
+        e.preventDefault();
+        alert('custom profile menu action');
+      },
     },
     content: (
       <span id="yet-another-custom-profile-link">

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
@@ -58,7 +58,8 @@ const SuiteHeaderAppSwitcher = ({
     : null;
 
   const handleRouteChange = useCallback(
-    ({ href, id, isExternal }) => async () => {
+    ({ href, id, isExternal }) => async (e) => {
+      e.preventDefault();
       const result = await onRouteChange(SuiteHeader.ROUTE_TYPES.APPLICATION, href, {
         appId: id,
       });
@@ -73,12 +74,16 @@ const SuiteHeaderAppSwitcher = ({
     [onRouteChange]
   );
 
-  const handleAllApplicationRoute = useCallback(async () => {
-    const result = await onRouteChange(SuiteHeader.ROUTE_TYPES.NAVIGATOR, allApplicationsLink);
-    if (result) {
-      window.location.href = allApplicationsLink;
-    }
-  }, [allApplicationsLink, onRouteChange]);
+  const handleAllApplicationRoute = useCallback(
+    async (e) => {
+      e.preventDefault();
+      const result = await onRouteChange(SuiteHeader.ROUTE_TYPES.NAVIGATOR, allApplicationsLink);
+      if (result) {
+        window.location.href = allApplicationsLink;
+      }
+    },
+    [allApplicationsLink, onRouteChange]
+  );
 
   return (
     <ul data-testid={testId} className={baseClassName}>
@@ -139,9 +144,10 @@ const SuiteHeaderAppSwitcher = ({
           </div>
           <span>{mergedI18n.requestAccess}</span>
           <a
-            href="javascript:void(0)"
+            href="#"
             data-testid="suite-header-app-switcher--no-access"
-            onClick={async () => {
+            onClick={async (e) => {
+              e.preventDefault();
               const result = await onRouteChange(
                 SuiteHeader.ROUTE_TYPES.DOCUMENTATION,
                 noAccessLink

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/__snapshots__/SuiteHeaderAppSwitcher.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/__snapshots__/SuiteHeaderAppSwitcher.story.storyshot
@@ -183,7 +183,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
         </span>
         <a
           data-testid="suite-header-app-switcher--no-access"
-          href="javascript:void(0)"
+          href="#"
           onClick={[Function]}
         >
           Learn more

--- a/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
@@ -246,8 +246,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
               aria-label="Help"
               className="bx--header__menu-item bx--header__menu-title"
               data-testid="menuitem"
-              href=""
+              href="#"
               onClick={[Function]}
+              onKeyDown={[Function]}
               role="menuitem"
               tabIndex={0}
             >
@@ -288,7 +289,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--whatsNew"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="What's new"
@@ -308,7 +309,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--gettingStarted"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Getting started"
@@ -328,7 +329,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--documentation"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Documentation"
@@ -348,7 +349,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--requestEnhancement"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Request enhancement"
@@ -368,7 +369,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--support"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Support"
@@ -388,7 +389,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--about"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="About"
@@ -422,8 +423,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
               aria-label="user"
               className="bx--header__menu-item bx--header__menu-title"
               data-testid="menuitem"
-              href=""
+              href="#"
               onClick={[Function]}
+              onKeyDown={[Function]}
               role="menuitem"
               tabIndex={0}
             >
@@ -531,7 +533,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-profile--logout"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Logout"
@@ -1060,8 +1062,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
               aria-label="car"
               className="bx--header__menu-item bx--header__menu-title"
               data-testid="menuitem"
-              href=""
+              href="#"
               onClick={[Function]}
+              onKeyDown={[Function]}
               role="menuitem"
               tabIndex={0}
             >
@@ -1227,8 +1230,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
               aria-label="Help"
               className="bx--header__menu-item bx--header__menu-title"
               data-testid="menuitem"
-              href=""
+              href="#"
               onClick={[Function]}
+              onKeyDown={[Function]}
               role="menuitem"
               tabIndex={0}
             >
@@ -1306,7 +1310,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
               <li>
                 <a
                   className="bx--header__menu-item"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                 >
@@ -1339,7 +1343,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--whatsNew"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="What's new"
@@ -1359,7 +1363,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--gettingStarted"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Getting started"
@@ -1379,7 +1383,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--documentation"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Documentation"
@@ -1399,7 +1403,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--requestEnhancement"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Request enhancement"
@@ -1419,7 +1423,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--support"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Support"
@@ -1439,7 +1443,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--about"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="About"
@@ -1473,8 +1477,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
               aria-label="user"
               className="bx--header__menu-item bx--header__menu-title"
               data-testid="menuitem"
-              href=""
+              href="#"
               onClick={[Function]}
+              onKeyDown={[Function]}
               role="menuitem"
               tabIndex={0}
             >
@@ -1617,7 +1622,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
               <li>
                 <a
                   className="bx--header__menu-item"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                 >
@@ -1638,7 +1643,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-profile--logout"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Logout"
@@ -2109,8 +2114,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
               aria-label="Help"
               className="bx--header__menu-item bx--header__menu-title"
               data-testid="menuitem"
-              href=""
+              href="#"
               onClick={[Function]}
+              onKeyDown={[Function]}
               role="menuitem"
               tabIndex={0}
             >
@@ -2151,7 +2157,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--whatsNew"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="What's new"
@@ -2171,7 +2177,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--gettingStarted"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Getting started"
@@ -2191,7 +2197,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--documentation"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Documentation"
@@ -2211,7 +2217,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--requestEnhancement"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Request enhancement"
@@ -2231,7 +2237,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--support"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Support"
@@ -2251,7 +2257,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--about"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="About"
@@ -2285,8 +2291,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
               aria-label="user"
               className="bx--header__menu-item bx--header__menu-title"
               data-testid="menuitem"
-              href=""
+              href="#"
               onClick={[Function]}
+              onKeyDown={[Function]}
               role="menuitem"
               tabIndex={0}
             >
@@ -2394,7 +2401,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-profile--logout"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Logout"
@@ -2906,8 +2913,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
               aria-label="Help"
               className="bx--header__menu-item bx--header__menu-title"
               data-testid="menuitem"
-              href=""
+              href="#"
               onClick={[Function]}
+              onKeyDown={[Function]}
               role="menuitem"
               tabIndex={0}
             >
@@ -2948,7 +2956,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--whatsNew"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="What's new"
@@ -2968,7 +2976,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--gettingStarted"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Getting started"
@@ -2988,7 +2996,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--documentation"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Documentation"
@@ -3008,7 +3016,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--requestEnhancement"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Request enhancement"
@@ -3028,7 +3036,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--support"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Support"
@@ -3048,7 +3056,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--about"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="About"
@@ -3082,8 +3090,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
               aria-label="user"
               className="bx--header__menu-item bx--header__menu-title"
               data-testid="menuitem"
-              href=""
+              href="#"
               onClick={[Function]}
+              onKeyDown={[Function]}
               role="menuitem"
               tabIndex={0}
             >
@@ -3191,7 +3200,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-profile--logout"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Logout"
@@ -3625,8 +3634,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
               aria-label="Help"
               className="bx--header__menu-item bx--header__menu-title"
               data-testid="menuitem"
-              href=""
+              href="#"
               onClick={[Function]}
+              onKeyDown={[Function]}
               role="menuitem"
               tabIndex={0}
             >
@@ -3667,7 +3677,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--whatsNew"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="What's new"
@@ -3687,7 +3697,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--gettingStarted"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Getting started"
@@ -3707,7 +3717,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--documentation"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Documentation"
@@ -3727,7 +3737,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--requestEnhancement"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Request enhancement"
@@ -3747,7 +3757,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--support"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Support"
@@ -3767,7 +3777,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--about"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="About"
@@ -3801,8 +3811,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
               aria-label="user"
               className="bx--header__menu-item bx--header__menu-title"
               data-testid="menuitem"
-              href=""
+              href="#"
               onClick={[Function]}
+              onKeyDown={[Function]}
               role="menuitem"
               tabIndex={0}
             >
@@ -3910,7 +3921,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-profile--logout"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Logout"
@@ -4432,7 +4443,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
       >
         <a
           className="bx--link"
-          href="javascript:void(0)"
+          href="#"
           onClick={[Function]}
           rel={null}
         >
@@ -4443,7 +4454,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
         >
           <a
             className="bx--link"
-            href="javascript:void(0)"
+            href="#"
             onClick={[Function]}
             rel={null}
           >
@@ -4697,8 +4708,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
               aria-label="Help"
               className="bx--header__menu-item bx--header__menu-title"
               data-testid="menuitem"
-              href=""
+              href="#"
               onClick={[Function]}
+              onKeyDown={[Function]}
               role="menuitem"
               tabIndex={0}
             >
@@ -4739,7 +4751,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--whatsNew"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="What's new"
@@ -4759,7 +4771,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--gettingStarted"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Getting started"
@@ -4779,7 +4791,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--documentation"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Documentation"
@@ -4799,7 +4811,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--requestEnhancement"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Request enhancement"
@@ -4819,7 +4831,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--support"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Support"
@@ -4839,7 +4851,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--about"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="About"
@@ -4873,8 +4885,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
               aria-label="user"
               className="bx--header__menu-item bx--header__menu-title"
               data-testid="menuitem"
-              href=""
+              href="#"
               onClick={[Function]}
+              onKeyDown={[Function]}
               role="menuitem"
               tabIndex={0}
             >
@@ -4982,7 +4995,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-profile--logout"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Logout"
@@ -5290,7 +5303,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
     <a
       className="bx--header__name"
       data-testid="suite-header-name"
-      href="javascript:void(0)"
+      href="#"
     >
       <span
         className="bx--header__name--prefix"
@@ -5379,8 +5392,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
               aria-label="Help"
               className="bx--header__menu-item bx--header__menu-title"
               data-testid="menuitem"
-              href=""
+              href="#"
               onClick={[Function]}
+              onKeyDown={[Function]}
               role="menuitem"
               tabIndex={0}
             >
@@ -5501,8 +5515,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
               aria-label="user"
               className="bx--header__menu-item bx--header__menu-title"
               data-testid="menuitem"
-              href=""
+              href="#"
               onClick={[Function]}
+              onKeyDown={[Function]}
               role="menuitem"
               tabIndex={0}
             >
@@ -5970,8 +5985,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
               aria-label="Help"
               className="bx--header__menu-item bx--header__menu-title"
               data-testid="menuitem"
-              href=""
+              href="#"
               onClick={[Function]}
+              onKeyDown={[Function]}
               role="menuitem"
               tabIndex={0}
             >
@@ -6012,7 +6028,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--whatsNew"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="What's new"
@@ -6032,7 +6048,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--gettingStarted"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Getting started"
@@ -6052,7 +6068,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--documentation"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Documentation"
@@ -6072,7 +6088,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--requestEnhancement"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Request enhancement"
@@ -6092,7 +6108,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--support"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Support"
@@ -6112,7 +6128,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-help--about"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="About"
@@ -6146,8 +6162,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
               aria-label="user"
               className="bx--header__menu-item bx--header__menu-title"
               data-testid="menuitem"
-              href=""
+              href="#"
               onClick={[Function]}
+              onKeyDown={[Function]}
               role="menuitem"
               tabIndex={0}
             >
@@ -6255,7 +6272,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 <a
                   className="bx--header__menu-item"
                   data-testid="suite-header-profile--logout"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   tabIndex={0}
                   title="Logout"


### PR DESCRIPTION
Closes #2450 

**Summary**

- This is being merged into the v3 branch b/c it contains breaking changes.
- SuiteHeader/Header were using `javascript:void(0)` urls in many places. This replaces those with `#` and event.preventDefault() in the click handlers.
- There were also many testing error output causes by <a> within <a> tags, and those were also fixed in this PR. I'll create another issue and backport those changes and make a PR for them into next. 

**Change List (commits, features, bugs, etc)**

- replace all instances of `javascript:void(0)` with `#`
- add event.preventDefault() to all click handlers in SuiteHeader
- fix <a> within <a> test errors by using <button> tags in headerPanel.content props.

**Acceptance Test (how to verify the PR)**

- no test error outputs for `javascript:void(0)` urls
- no test error outputs for <a> within <a> tags


**Regression Test (how to make sure this PR doesn't break old functionality)**

- all SuiteHeader/Header stories function as expected.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
