### PR TITLE
fix(filter-tags): force <a> tags in overflow menu

### DIFF
--- a/packages/react/src/components/FilterTags/FilterTags.jsx
+++ b/packages/react/src/components/FilterTags/FilterTags.jsx
@@ -107,11 +107,16 @@ const FilterTags = ({ children, hasOverflow, id, tagContainer, onChange, i18n, t
         >
           {overflowItems.map((child, i) => (
             <OverflowMenuItem
+              // adding href="#" to force the OverflowMenuItem to use an a tag to prevent <button> within <button> errors
+              href="#"
               data-testid={`${testId}-overflow-menu-item-${i}`}
               className={`${iotPrefix}--filtertags-overflow-item`}
               title={child.props.children}
               key={`${child.props.children}-${i}`}
-              onClick={child.props.onClose}
+              onClick={(e) => {
+                e.preventDefault();
+                child.props.onClose();
+              }}
               itemText={<OverflowTag>{child.props.children}</OverflowTag>}
             />
           ))}


### PR DESCRIPTION
Closes #2449 

**Summary**

- Forces the overflow item to be an <a> tag to prevent <button> within <button> errors in FilterTags with overflow
- this is considered a breaking changes and is being merged into v3

**Change List (commits, features, bugs, etc)**

- overflow items in FilterTags now use a tags

**Acceptance Test (how to verify the PR)**

- no <button> within <button> warnings when testing FilterTags

**Regression Test (how to make sure this PR doesn't break old functionality)**

- FilterTag stories still function as expected.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
