### PR TITLE
fix(icon-dropdown): fix <button> in <button> warnings

### DIFF
--- a/packages/react/src/components/IconDropdown/IconDropdown.jsx
+++ b/packages/react/src/components/IconDropdown/IconDropdown.jsx
@@ -198,35 +198,40 @@ const IconDropdown = ({
 
     return (
       <>
-        <Button
-          className={classnames(
-            `${iotPrefix}--icon-dropdown__image-button`,
-            {
-              [`${iotPrefix}--icon-dropdown__image-button--leading`]: index % columnCount === 0,
-            },
-            {
-              [`${iotPrefix}--icon-dropdown__image-button--trailing`]:
-                (index + 1) % columnCount === 0,
-            },
-            {
-              [`${iotPrefix}--icon-dropdown__image-button--bottom`]:
-                index + columnCount >= items.length && !hasFooter && direction === 'bottom',
-            },
-            {
-              [`${iotPrefix}--icon-dropdown__image-button--top`]:
-                index < columnCount && hasFooter && direction === 'top',
-            }
-          )}
-          renderIcon={item?.icon}
-          kind="ghost"
-          hasIconOnly
-          disabled={disabled}
-          selected={item.id === selectedItem?.id}
-          testId={`dropdown-button__${item?.id}`}
-          iconDescription={item.text}
-          title={item?.text}
-        />
-
+        {
+          // only display this button when the dropdown is open, bc if it's shown when closed it's
+          // rendered in a different place and causes a <button> within <button> warning.
+          isOpen ? (
+            <Button
+              className={classnames(
+                `${iotPrefix}--icon-dropdown__image-button`,
+                {
+                  [`${iotPrefix}--icon-dropdown__image-button--leading`]: index % columnCount === 0,
+                },
+                {
+                  [`${iotPrefix}--icon-dropdown__image-button--trailing`]:
+                    (index + 1) % columnCount === 0,
+                },
+                {
+                  [`${iotPrefix}--icon-dropdown__image-button--bottom`]:
+                    index + columnCount >= items.length && !hasFooter && direction === 'bottom',
+                },
+                {
+                  [`${iotPrefix}--icon-dropdown__image-button--top`]:
+                    index < columnCount && hasFooter && direction === 'top',
+                }
+              )}
+              renderIcon={item?.icon}
+              kind="ghost"
+              hasIconOnly
+              disabled={disabled}
+              selected={item.id === selectedItem?.id}
+              testId={`dropdown-button__${item?.id}`}
+              iconDescription={item.text}
+              title={item?.text}
+            />
+          ) : null
+        }
         <div className={`${iotPrefix}--icon-dropdown__selected-icon-label`}>
           {React.createElement(item.icon)}
           <div className={`${iotPrefix}--icon-dropdown__selected-icon-label__content`}>
@@ -248,8 +253,7 @@ const IconDropdown = ({
         items={items}
         className={`${iotPrefix}--icon-dropdown__selection-buttons`}
         selectedItem={selectedItem}
-        onChange={(changes) => {
-          const { selectedItem: newSelected } = changes;
+        onChange={({ selectedItem: newSelected }) => {
           setInternalSelectedItem(newSelected);
           onChange(newSelected);
         }}

--- a/packages/react/src/components/IconDropdown/IconDropdown.test.jsx
+++ b/packages/react/src/components/IconDropdown/IconDropdown.test.jsx
@@ -26,7 +26,6 @@ describe('Icon Dropdown', () => {
     );
     expect(screen.getByTestId('ICON_DROPDOWN')).toBeDefined();
   });
-
   it('Renders default', () => {
     render(
       <IconDropdown
@@ -37,12 +36,9 @@ describe('Icon Dropdown', () => {
         }}
       />
     );
-
     const renderedLabel = screen.queryByText(iconDropdownProps.label);
-
     expect(renderedLabel).toBeDefined();
   });
-
   it('Renders selected item', () => {
     render(
       <IconDropdown
@@ -53,12 +49,9 @@ describe('Icon Dropdown', () => {
         }}
       />
     );
-
     const selectedItem = screen.queryAllByText(items[0].text)[0];
-
     expect(selectedItem).toBeDefined();
   });
-
   it('Renders icon buttons', () => {
     render(
       <IconDropdown
@@ -68,19 +61,13 @@ describe('Icon Dropdown', () => {
         }}
       />
     );
-
     const renderedLabel = screen.queryByText(iconDropdownProps.label);
-
     fireEvent.click(renderedLabel);
-
     expect(screen.queryByTestId(`dropdown-button__${items[3].id}`)).toBeDefined();
-
     expect(screen.queryByTestId(`dropdown-button__${items[5].id}`)).toBeDefined();
   });
-
   it('icon handles callback', () => {
     let selectedItem = null;
-
     render(
       <IconDropdown
         {...iconDropdownProps}
@@ -89,27 +76,21 @@ describe('Icon Dropdown', () => {
         }}
       />
     );
-
     const itemToSelect = items[3];
-
     fireEvent.click(screen.getByText(iconDropdownProps.label));
     fireEvent.click(screen.queryAllByText(itemToSelect.text)[0]);
-
     expect(selectedItem.id).toEqual(itemToSelect.id);
   });
-
   it('renders correct footer', () => {
     const renderFooter = (item) => {
       return <div data-testid={`test-${item.text}`}>{item.text}</div>;
     };
-
     const itemsWithFooter = items.map((item) => {
       return {
         ...item,
         footer: renderFooter(item),
       };
     });
-
     render(
       <IconDropdown
         {...iconDropdownProps}
@@ -121,15 +102,11 @@ describe('Icon Dropdown', () => {
         }}
       />
     );
-
     const itemToHighlight = items[3];
     const highlightedTestId = `test-${itemToHighlight.text}`;
-
     expect(screen.queryByTestId(highlightedTestId)).toBeNull();
-
     fireEvent.click(screen.getByText(iconDropdownProps.label));
     expect(screen.queryByTestId(highlightedTestId)).toBeNull();
-
     userEvent.hover(screen.getAllByText(itemToHighlight.text)[0]);
     expect(screen.queryByTestId(highlightedTestId)).toBeDefined();
   });


### PR DESCRIPTION
Closes #2448 

**Summary**

- There were <button> within <button> warnings when an icon was selected in the IconDropdown. I've changed the output to only display the <button> when the dropdown is open and then the button is rendered in a different location and the warning is avoided. This was marked as a v3 issue, but no changes were necessary to warrant that, so it's being merged into next.

**Change List (commits, features, bugs, etc)**

- only show <button> when dropdown is open.

**Acceptance Test (how to verify the PR)**

- no <button> in <button> warnings in test output

**Regression Test (how to make sure this PR doesn't break old functionality)**

- IconDropdown stories still function as expected.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
