### PR TITLE
2317 table column resize fails after all columns have been hidden

### DIFF
--- a/packages/react/src/components/Table/Table.story.jsx
+++ b/packages/react/src/components/Table/Table.story.jsx
@@ -2101,7 +2101,9 @@ export const WithOptionsToExploreColumnSettings = () => {
   };
   const onColumnResize = (cols) => {
     action('onColumnResize')(cols);
-    setMyColumns(cols);
+    if (selectedTableType === 'Table') {
+      setMyColumns(cols);
+    }
   };
   const onToggleColumnSelection = () => {
     action('onToggleColumnSelection')();

--- a/packages/react/src/components/Table/TableHead/TableHead.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.jsx
@@ -41,6 +41,7 @@ import {
   DEFAULT_COLUMN_WIDTH,
   addMissingColumnWidths,
   checkColumnWidthFormat,
+  hasVisibleColumns,
 } from './columnWidthUtilityFunctions';
 
 const { iotPrefix } = settings;
@@ -370,7 +371,7 @@ const TableHead = ({
 
         if (addedVisibleColumnIDs.length > 0 || removedColumnIDs.length > 0) {
           setCurrentColumnWidths(adjustedForRemovedAndAdded);
-        } else if (visibleColumnsHaveWidth(ordering, columns)) {
+        } else if (hasVisibleColumns(ordering) && visibleColumnsHaveWidth(ordering, columns)) {
           const propsColumnWidths = createNewWidthsMap(ordering, columns);
           if (!isEqual(currentColumnWidths, propsColumnWidths)) {
             setCurrentColumnWidths(propsColumnWidths);

--- a/packages/react/src/components/Table/TableHead/TableHead.test.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.test.jsx
@@ -507,6 +507,80 @@ describe('TableHead', () => {
       ]);
     });
 
+    it('handles column toggle show after all has been hidden, using min width if needed', () => {
+      myProps.options = {
+        hasResize: true,
+        preserveColumnWidths: false,
+      };
+
+      myProps.columns = [
+        { id: 'col1', name: 'Column 1' },
+        { id: 'col2', name: 'Column 2' },
+        { id: 'col3', name: 'Column 3' },
+      ];
+
+      myProps.tableState = {
+        ...myProps.tableState,
+        ordering: [
+          { columnId: 'col1', isHidden: true },
+          { columnId: 'col2', isHidden: true },
+          { columnId: 'col3', isHidden: true },
+        ],
+      };
+
+      mockGetBoundingClientRect.mockImplementation(() => ({ width: 200 }));
+
+      const { container, rerender } = render(<TableHead {...myProps} />, {
+        container: document.body.appendChild(document.createElement('table')),
+      });
+
+      userEvent.click(
+        within(
+          container.querySelector(`.${iotPrefix}--column-header-row--select-wrapper`)
+        ).getByText('Column 1')
+      );
+
+      const columnsAfterToggle = [
+        { id: 'col1', name: 'Column 1', width: `${MIN_COLUMN_WIDTH}px` },
+        { id: 'col2', name: 'Column 2', width: undefined },
+        { id: 'col3', name: 'Column 3', width: undefined },
+      ];
+      const orderingAfterToggle = [
+        { columnId: 'col1', isHidden: false },
+        { columnId: 'col2', isHidden: true },
+        { columnId: 'col3', isHidden: true },
+      ];
+      expect(myActions.onColumnResize).toHaveBeenCalledWith(columnsAfterToggle);
+      expect(myActions.onChangeOrdering).toHaveBeenCalledWith(orderingAfterToggle);
+
+      myProps.tableState = {
+        ...myProps.tableState,
+        ordering: orderingAfterToggle,
+      };
+      myProps.columns = columnsAfterToggle;
+
+      rerender(<TableHead {...myProps} />, {
+        container: document.body.appendChild(document.createElement('table')),
+      });
+
+      userEvent.click(
+        within(
+          container.querySelector(`.${iotPrefix}--column-header-row--select-wrapper`)
+        ).getByText('Column 2')
+      );
+
+      expect(myActions.onColumnResize).toHaveBeenCalledWith([
+        { id: 'col1', name: 'Column 1', width: `${MIN_COLUMN_WIDTH}px` },
+        { id: 'col2', name: 'Column 2', width: `${MIN_COLUMN_WIDTH}px` },
+        { id: 'col3', name: 'Column 3', width: undefined },
+      ]);
+      expect(myActions.onChangeOrdering).toHaveBeenCalledWith([
+        { columnId: 'col1', isHidden: false },
+        { columnId: 'col2', isHidden: false },
+        { columnId: 'col3', isHidden: true },
+      ]);
+    });
+
     it('handles column toggle when all columns are hidden and without width', () => {
       myProps.tableState = {
         ...myProps.tableState,

--- a/packages/react/src/components/Table/TableHead/TableHead.test.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.test.jsx
@@ -453,6 +453,105 @@ describe('TableHead', () => {
       ]);
     });
 
+    it('uses last known widths for hidden columns when all  columns in column prop lack width', () => {
+      myProps.options = {
+        hasResize: true,
+        preserveColumnWidths: false,
+      };
+
+      myProps.columns = [
+        { id: 'col1', name: 'Column 1', width: '200px' },
+        { id: 'col2', name: 'Column 2', width: '200px' },
+        { id: 'col3', name: 'Column 3', width: '200px' },
+      ];
+
+      mockGetBoundingClientRect.mockImplementation(() => ({ width: 200 }));
+
+      const { container, rerender } = render(<TableHead {...myProps} />, {
+        container: document.body.appendChild(document.createElement('table')),
+      });
+
+      myProps.tableState = {
+        ...myProps.tableState,
+        ordering: [
+          { columnId: 'col1', isHidden: true },
+          { columnId: 'col2', isHidden: true },
+          { columnId: 'col3', isHidden: true },
+        ],
+      };
+      myProps.columns = [
+        { id: 'col1', name: 'Column 1', width: undefined },
+        { id: 'col2', name: 'Column 2' },
+        { id: 'col3', name: 'Column 3' },
+      ];
+
+      rerender(<TableHead {...myProps} />, {
+        container: document.body.appendChild(document.createElement('table')),
+      });
+
+      userEvent.click(
+        within(
+          container.querySelector(`.${iotPrefix}--column-header-row--select-wrapper`)
+        ).getByText('Column 1')
+      );
+
+      expect(myActions.onColumnResize).toHaveBeenCalledWith([
+        { id: 'col1', name: 'Column 1', width: `${MIN_COLUMN_WIDTH}px` },
+        { id: 'col2', name: 'Column 2', width: '200px' },
+        { id: 'col3', name: 'Column 3', width: '200px' },
+      ]);
+      expect(myActions.onChangeOrdering).toHaveBeenCalledWith([
+        { columnId: 'col1', isHidden: false },
+        { columnId: 'col2', isHidden: true },
+        { columnId: 'col3', isHidden: true },
+      ]);
+    });
+
+    it('handles column toggle when all columns are hidden and without width', () => {
+      myProps.tableState = {
+        ...myProps.tableState,
+        ordering: [
+          { columnId: 'col1', isHidden: true },
+          { columnId: 'col2', isHidden: true },
+          { columnId: 'col3', isHidden: true },
+        ],
+      };
+      myProps.columns = [
+        { id: 'col1', name: 'Column 1', width: undefined },
+        { id: 'col2', name: 'Column 2' },
+        { id: 'col3', name: 'Column 3' },
+      ];
+
+      myProps.options = {
+        hasResize: true,
+        preserveColumnWidths: false,
+      };
+
+      mockGetBoundingClientRect.mockImplementation(() => ({ width: 200 }));
+
+      const { container } = render(<TableHead {...myProps} />, {
+        container: document.body.appendChild(document.createElement('table')),
+      });
+
+      // Show col3 which has no initial column width.
+      userEvent.click(
+        within(
+          container.querySelector(`.${iotPrefix}--column-header-row--select-wrapper`)
+        ).getByText('Column 3')
+      );
+
+      expect(myActions.onColumnResize).toHaveBeenCalledWith([
+        { id: 'col1', name: 'Column 1', width: undefined },
+        { id: 'col2', name: 'Column 2', width: undefined },
+        { id: 'col3', name: 'Column 3', width: `${MIN_COLUMN_WIDTH}px` },
+      ]);
+      expect(myActions.onChangeOrdering).toHaveBeenCalledWith([
+        { columnId: 'col1', isHidden: true },
+        { columnId: 'col2', isHidden: true },
+        { columnId: 'col3', isHidden: false },
+      ]);
+    });
+
     it('should not add resize handle to the last visible column if there is no expander column', () => {
       myProps.tableState = {
         ...myProps.tableState,

--- a/packages/react/src/components/Table/TableHead/columnWidthUtilityFunctions.js
+++ b/packages/react/src/components/Table/TableHead/columnWidthUtilityFunctions.js
@@ -121,6 +121,14 @@ export const getIDsOfAddedVisibleColumns = (ordering, currentColumnWidths) => {
 };
 
 /**
+ * Returns true if there are visible columns
+ * @param {array} ordering the table ordering prop that specifies the order and visibility of columns
+ */
+export const hasVisibleColumns = (ordering) => {
+  return ordering.some((col) => !col.isHidden);
+};
+
+/**
  * Returns true if all visible columns have a width.
  * @param {array} ordering the table ordering prop that specifies the order and visibility of columns
  * @param {array} columns The table column props
@@ -179,7 +187,8 @@ export const calculateWidthOnShow = (currentColumnWidths, ordering, colToShowIDs
   const newColumnsToShow = colToShowIDs.reduce((accumulator, colToShowId) => {
     const widthOfColumnToShow =
       getExistingColumnWidth(currentColumnWidths, columns, colToShowId) ||
-      getAverageVisibleColumnWidth(visibleColumns);
+      getAverageVisibleColumnWidth(visibleColumns) ||
+      DEFAULT_COLUMN_WIDTH;
     return [...accumulator, { id: colToShowId, width: Math.round(widthOfColumnToShow) }];
   }, []);
   const totalWidthNeeded = newColumnsToShow.reduce((acc, col) => acc + col.width, 0);
@@ -234,6 +243,10 @@ export const calculateWidthOnHide = (currentColumnWidths, ordering, colToHideIDs
  */
 export const adjustLastColumnWidth = (ordering, columns, measuredWidths) => {
   const visibleCols = ordering.filter((col) => !col.isHidden);
+
+  // If there are no visible columns there is nothing to adjust
+  if (!visibleCols.length) return measuredWidths;
+
   const lastIndex = visibleCols.length - 1;
   const lastColumn = columns.find((col) => col.id === visibleCols[lastIndex].columnId);
   const fixedWidth = lastColumn.width ? parseInt(lastColumn.width, 10) : 0;

--- a/packages/react/src/components/Table/TableHead/columnWidthUtilityFunctions.js
+++ b/packages/react/src/components/Table/TableHead/columnWidthUtilityFunctions.js
@@ -210,7 +210,7 @@ export const calculateWidthOnShow = (currentColumnWidths, ordering, colToShowIDs
 
   const adjustedCols = [
     // There are some scenarios where the new columns don't have an existing width
-    // and in that case they are adjusted to get a min with assigned.
+    // and in that case they are adjusted to get a min width assigned.
     ...newWidthColumns,
     // We adjust to shrink existing columns to make room for the new ones.
     ...shrinkColumns(shrinkableColumns, totalWidthNeeded),

--- a/packages/react/src/components/Table/TableHead/columnWidthUtilityFunctions.js
+++ b/packages/react/src/components/Table/TableHead/columnWidthUtilityFunctions.js
@@ -208,10 +208,8 @@ export const calculateWidthOnShow = (currentColumnWidths, ordering, colToShowIDs
     (col) => col.width > MIN_COLUMN_WIDTH
   );
 
-  // const newColsLacking = newColumnsToShow.filter((col) => col.width === MIN_COLUMN_WIDTH);
-
   const adjustedCols = [
-    // There are som scenarios where the new columns don't have an existing width
+    // There are some scenarios where the new columns don't have an existing width
     // and in that case they are adjusted to get a min with assigned.
     ...newWidthColumns,
     // We adjust to shrink existing columns to make room for the new ones.


### PR DESCRIPTION
Closes #2317

**Summary**
Added fixes to make sure column resize always work after _all_ columns have been hidden. I identified two different scenarios with different solutions that we should verify. Resorting to use min-width as fallback when column widths are missing is not perfect but since this is bit of an edge case I think it is okay.

I kept the code changes isolated to the old resize code since the new behaviour `preserveColumnWidths` did not have these problems. 

**Change List (commits, features, bugs, etc)**
* Added fix to `TableHead` and `columnWidthUtilityFunctions.js`
* Added unit tests corresponding two the scenarios
* Added small fix to the story so that knob value "Stateful Table" works as expected

**Acceptance Test (how to verify the PR)**
 
**Scenario 1**
Go to https://deploy-preview-2689--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table-table--with-options-to-explore-column-settings use the following knob configuration:

```
Type of Table: StatefulTable
Initial column width: undefined
table container width: auto (doesn't matter)
options.hasColumnSelection: true
options.hasResize: true
wrapCellText: auto (doesn't matter)
useAutoTableLayoutForResize: false
preserveColumnWidths: false
```

1. Hide all columns
2. show a few columns
3. Make sure resize works

**Scenario 2**
Go to https://deploy-preview-2689--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table-table--with-options-to-explore-column-settings use the following knob configuration:

```
Type of Table: Table
Initial column width: undefined
table container width: 800px (doesn't matter)
options.hasColumnSelection: true
options.hasResize: true
wrapCellText: always (doesn't matter)
useAutoTableLayoutForResize: false
preserveColumnWidths: false
```

1. Hide all columns one by one
2. Show the columns "String", "Date", "Select" & "Secret information"
3. Make sure the column "Secret information" can be resized


**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
