### PR TITLE
chore(testing): increase coverage on List

### DIFF
--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -26,6 +26,7 @@ module.exports = {
   coverageDirectory: 'jest/coverage',
   coverageThreshold: {
     './src/components/Table/TableBody/RowActionsCell/RowActionsError.jsx': all90Covered,
+    './src/components/List/List.jsx': all90Covered,
     './src/components/Breadcrumb/Breadcrumb.jsx': all90Covered,
     './src/components/ComposedModal/ComposedModal.jsx': all90Covered,
     './src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx': all90Covered,

--- a/packages/react/src/components/List/List.jsx
+++ b/packages/react/src/components/List/List.jsx
@@ -192,7 +192,7 @@ const List = forwardRef((props, ref) => {
           editingStyle={editingStyle}
           secondaryValue={secondaryValue}
           rowActions={rowActions}
-          onSelect={editingStyle ? () => {} : () => handleSelect(item.id, parentId)}
+          onSelect={() => handleSelect(item.id, parentId)}
           onExpand={toggleExpansion}
           onItemMoved={onItemMoved}
           itemWillMove={itemWillMove}

--- a/packages/react/src/components/List/List.test.jsx
+++ b/packages/react/src/components/List/List.test.jsx
@@ -145,7 +145,15 @@ describe('List', () => {
   });
   it('should not call onSelect when editingStyle is set', () => {
     const onSelect = jest.fn();
-    render(<List title="list" items={getListItems(1)} onSelect={onSelect} editingStyle="single" />);
+    render(
+      <List
+        title="list"
+        items={getListItems(1)}
+        handleSelect={onSelect}
+        editingStyle="single-nesting"
+        isSelectable
+      />
+    );
     userEvent.click(screen.getByTitle('Item 1'));
     expect(onSelect).not.toHaveBeenCalled();
   });

--- a/packages/react/src/components/List/List.test.jsx
+++ b/packages/react/src/components/List/List.test.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { Checkbox } from '../..';
+import { settings } from '../../constants/Settings';
 
 import List, { UnconnectedList } from './List';
 import { sampleHierarchy } from './List.story';
 
+const { iotPrefix } = settings;
 const defaultEmptyText = 'No list items to show';
 
 describe('List', () => {
@@ -135,5 +138,15 @@ describe('List', () => {
     const emptyComponent = <div data-testid="emptyState">{emptyText}</div>;
     render(<List title="list" hasEmptyState emptyState={emptyComponent} />);
     expect(screen.getByTestId('emptyState').textContent).toEqual(emptyText);
+  });
+  it('should show skeleton text when loading', () => {
+    const { container } = render(<List title="list" items={getListItems(1)} isLoading />);
+    expect(container.querySelectorAll(`.${iotPrefix}--list--skeleton`)).toHaveLength(1);
+  });
+  it('should not call onSelect when editingStyle is set', () => {
+    const onSelect = jest.fn();
+    render(<List title="list" items={getListItems(1)} onSelect={onSelect} editingStyle="single" />);
+    userEvent.click(screen.getByTitle('Item 1'));
+    expect(onSelect).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #2526 

**Summary**

- increase coverage and remove unreachable code in `onSelect` when creating the list items.

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- 90%+ coverage

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Lists function as expected

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
