### PR TITLE
chore(testing): increase coverage on StatefulTable

### DIFF
--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -31,6 +31,8 @@ module.exports = {
     './src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx': all90Covered,
     './src/components/Accordion/AccordionItemDefer.jsx': all90Covered,
     './src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx': all90Covered,
+    './src/components/Table/StatefulTable.jsx': all90Covered,
+    './src/components/Table/statefulTableUtilities.js': all90Covered,
     './src/components/Table/Table.jsx': all90Covered,
     './src/components/BarChartCard/barChartUtils.js': all90Covered,
     './src/components/Table/TableSaveViewModal/TableSaveViewForm.jsx': all90Covered,

--- a/packages/react/src/components/Table/StatefulTable.jsx
+++ b/packages/react/src/components/Table/StatefulTable.jsx
@@ -3,6 +3,7 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 import merge from 'lodash/merge';
 import get from 'lodash/get';
 
+import { getRowAction } from './statefulTableUtilities';
 import { tableReducer } from './tableReducer';
 import {
   tableRegister,
@@ -158,32 +159,6 @@ const StatefulTable = ({ data: initialData, expandedData, ...other }) => {
     onAddMultiSortColumn,
     onRemoveMultiSortColumn,
   } = table || {};
-
-  const getRowAction = (data, actionId, rowId) => {
-    let item;
-    for (let idx = 0; idx < data.length; idx += 1) {
-      const element = data[idx];
-      if (element.id === rowId) {
-        item = element.rowActions.find((action) => action.id === actionId);
-        if (item) {
-          break;
-        }
-        if (Array.isArray(element?.children)) {
-          item = getRowAction(element.children, actionId, rowId);
-          if (item) {
-            break;
-          }
-        }
-      }
-      if (Array.isArray(element?.children)) {
-        item = getRowAction(element.children, actionId, rowId);
-        if (item) {
-          break;
-        }
-      }
-    }
-    return item;
-  };
 
   // In addition to updating the store, I always callback to the parent in case they want to do something
   const actions = {

--- a/packages/react/src/components/Table/StatefulTable.test.jsx
+++ b/packages/react/src/components/Table/StatefulTable.test.jsx
@@ -5,11 +5,12 @@ import pick from 'lodash/pick';
 import { screen, render, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import * as reducer from './baseTableReducer';
 import StatefulTable from './StatefulTable';
 import TableSkeletonWithHeaders from './TableSkeletonWithHeaders/TableSkeletonWithHeaders';
 import { StatefulTableWithNestedRowItems } from './StatefulTable.story';
 import { mockActions, getNestedRows, getNestedRowIds } from './Table.test.helpers';
-import { initialState } from './Table.story';
+import { initialState, tableData } from './Table.story';
 import RowActionsCell from './TableBody/RowActionsCell/RowActionsCell';
 
 describe('stateful table with real reducer', () => {
@@ -669,5 +670,137 @@ describe('stateful table with real reducer', () => {
       'row-1_B-2-A',
       'row-1_B-2-B',
     ]);
+  });
+
+  it('should open the multi-sort modal', () => {
+    render(
+      <StatefulTable
+        id="multi-sort-table"
+        columns={[
+          {
+            id: 'string',
+            name: 'String',
+            isSortable: true,
+          },
+          {
+            id: 'boolean',
+            name: 'Boolean',
+            isSortable: true,
+          },
+        ]}
+        options={{
+          hasMultiSort: true,
+        }}
+        data={tableData.slice(0, 2)}
+      />
+    );
+
+    userEvent.click(screen.getAllByRole('button', { name: 'open and close list of options' })[0]);
+    userEvent.click(screen.getByText('Multi-sort'));
+    expect(screen.getByText('Select columns to sort')).toBeVisible();
+  });
+
+  it('should only update resize state when hasUserViewManagement:true', () => {
+    const onColumnResize = jest.fn();
+    jest.spyOn(reducer, 'baseTableReducer');
+    const { rerender } = render(
+      <StatefulTable
+        id="multi-sort-table"
+        columns={[
+          {
+            id: 'string',
+            name: 'String',
+          },
+          {
+            id: 'boolean',
+            name: 'Boolean',
+          },
+        ]}
+        options={{
+          hasUserViewManagement: true,
+          hasResize: true,
+        }}
+        data={tableData.slice(0, 2)}
+        actions={{
+          table: {
+            onColumnResize,
+          },
+        }}
+      />
+    );
+
+    const resizeFirstColumn = () => {
+      const handles = screen.getAllByLabelText('Resize column');
+      fireEvent.mouseDown(handles[0]);
+      fireEvent.mouseMove(handles[0], {
+        clientX: 196,
+      });
+      fireEvent.mouseUp(handles[0]);
+    };
+
+    resizeFirstColumn();
+
+    expect(reducer.baseTableReducer).toHaveBeenLastCalledWith(
+      // table state.
+      expect.objectContaining({
+        columns: [
+          { id: 'string', name: 'String' },
+          { id: 'boolean', name: 'Boolean' },
+        ],
+      }),
+      // dispatched action
+      expect.objectContaining({
+        instanceId: null,
+        payload: [
+          { id: 'string', name: 'String', width: '200px' },
+          { id: 'boolean', name: 'Boolean', width: '100px' },
+        ],
+        type: 'TABLE_COLUMN_RESIZE',
+      })
+    );
+
+    expect(onColumnResize).toHaveBeenCalledWith([
+      { id: 'string', name: 'String', width: '200px' },
+      { id: 'boolean', name: 'Boolean', width: '100px' },
+    ]);
+
+    jest.clearAllMocks();
+
+    rerender(
+      <StatefulTable
+        id="multi-sort-table"
+        columns={[
+          {
+            id: 'string',
+            name: 'String',
+          },
+          {
+            id: 'boolean',
+            name: 'Boolean',
+          },
+        ]}
+        options={{
+          hasUserViewManagement: false,
+          hasResize: true,
+        }}
+        data={tableData.slice(0, 2)}
+        actions={{
+          table: {
+            onColumnResize,
+          },
+        }}
+      />
+    );
+
+    resizeFirstColumn();
+
+    expect(reducer.baseTableReducer).not.toHaveBeenCalled();
+
+    expect(onColumnResize).toHaveBeenCalledWith([
+      { id: 'string', name: 'String', width: '200px' },
+      { id: 'boolean', name: 'Boolean', width: '100px' },
+    ]);
+
+    jest.resetAllMocks();
   });
 });

--- a/packages/react/src/components/Table/statefulTableUtilities.js
+++ b/packages/react/src/components/Table/statefulTableUtilities.js
@@ -1,0 +1,25 @@
+export const getRowAction = (data, actionId, rowId) => {
+  let item;
+  for (let idx = 0; idx < data.length; idx += 1) {
+    const element = data[idx];
+    if (element.id === rowId) {
+      item = element.rowActions.find((action) => action.id === actionId);
+      if (item) {
+        break;
+      }
+      if (Array.isArray(element?.children)) {
+        item = getRowAction(element.children, actionId, rowId);
+        if (item) {
+          break;
+        }
+      }
+    }
+    if (Array.isArray(element?.children)) {
+      item = getRowAction(element.children, actionId, rowId);
+      if (item) {
+        break;
+      }
+    }
+  }
+  return item;
+};

--- a/packages/react/src/components/Table/statefulTableUtilities.test.js
+++ b/packages/react/src/components/Table/statefulTableUtilities.test.js
@@ -1,0 +1,72 @@
+import { Add16 } from '@carbon/icons-react';
+
+import { getRowAction } from './statefulTableUtilities';
+
+describe('statefulTableUtilities', () => {
+  describe('getRowAction', () => {
+    it('it should traverse the children looking for the action', () => {
+      // this is a very contrived example that _may_ not even be possible within
+      // the table, but I didn't want to remove the code just in case there's an edge
+      // case of which I'm unaware.
+      const data = [
+        {
+          id: 'row-0',
+          values: { string: 'row-0' },
+          rowActions: [],
+          children: [
+            {
+              id: 'row-0',
+              values: { string: 'test string 0 A' },
+              rowActions: [
+                {
+                  id: 'Add',
+                  renderIcon: Add16,
+                  iconDescription: 'Add',
+                  labelText: 'Add',
+                },
+              ],
+            },
+            { id: 'row-0_A', values: { string: 'test string 0 C' } },
+          ],
+        },
+      ];
+
+      expect(getRowAction(data, 'Add', 'row-0')).toEqual({
+        id: 'Add',
+        renderIcon: expect.anything(),
+        iconDescription: 'Add',
+        labelText: 'Add',
+      });
+    });
+
+    it("it should return undefined if it isn't found in the children either", () => {
+      // this is a very contrived example that _may_ not even be possible within
+      // the table, but I didn't want to remove the code just in case there's an edge
+      // case of which I'm unaware.
+      const data = [
+        {
+          id: 'row-0',
+          values: { string: 'row-0' },
+          rowActions: [],
+          children: [
+            {
+              id: 'row-0',
+              values: { string: 'test string 0 A' },
+              rowActions: [
+                {
+                  id: '',
+                  renderIcon: Add16,
+                  iconDescription: 'Add',
+                  labelText: 'Add',
+                },
+              ],
+            },
+            { id: 'row-0_A', values: { string: 'test string 0 C' } },
+          ],
+        },
+      ];
+
+      expect(getRowAction(data, 'Add', 'row-0')).toEqual(undefined);
+    });
+  });
+});


### PR DESCRIPTION
Closes #2587 

**Summary**

- increases coverage on StatefulTable
- pulls a helper function out into it's own file to test separately

**Acceptance Test (how to verify the PR)**

- coverage is now 90%+

**Regression Test (how to make sure this PR doesn't break old functionality)**

- n/a

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
