### PR TITLE
chore(testing): increase coverage on Dropdown

### DIFF
--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -33,6 +33,7 @@ module.exports = {
     './src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx': all90Covered,
     './src/components/Accordion/AccordionItemDefer.jsx': all90Covered,
     './src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx': all90Covered,
+    './src/components/Dropdown/Dropdown.jsx': all90Covered,
     './src/components/Table/Table.jsx': all90Covered,
     './src/components/Table/TableHead/TableHead.jsx': all90Covered,
     './src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx': all90Covered,

--- a/packages/react/src/components/Dropdown/Dropdown.test.jsx
+++ b/packages/react/src/components/Dropdown/Dropdown.test.jsx
@@ -2,8 +2,11 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { items } from '../IconDropdown/IconDropdown.story';
+import { settings } from '../../constants/Settings';
 
 import Dropdown from './Dropdown';
+
+const { prefix } = settings;
 
 const iconDropdownProps = {
   id: 'icon-dropdown-1',
@@ -127,5 +130,24 @@ describe('Dropdown with Icon and Labels', () => {
 
     fireEvent.click(screen.getByText(iconDropdownProps.label));
     expect(screen.getByText(items[0].text)).toBeDefined();
+  });
+
+  it('renders an empty string if item is falsey', () => {
+    const items = [
+      {
+        id: 'one',
+        text: 'one',
+      },
+      {
+        id: 'two',
+        text: 'two',
+      },
+      false,
+    ];
+
+    const { container } = render(<Dropdown {...iconDropdownProps} items={items} />);
+
+    fireEvent.click(screen.getByText(iconDropdownProps.label));
+    expect(container.querySelectorAll(`.${prefix}--list-box__menu-item__option`)).toHaveLength(3);
   });
 });


### PR DESCRIPTION
Closes #2567 

**Summary**

- increase coverage on Dropdown

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
