### PR TITLE
fix(side-nav): add slight delay on hover open transition

### DIFF
--- a/packages/react/src/components/SideNav/_side-nav.scss
+++ b/packages/react/src/components/SideNav/_side-nav.scss
@@ -58,6 +58,11 @@ $hoverBgColor: #2c2c2c;
     background-color: $selectedBgColor;
     color: $textColor;
   }
+
+  &.#{$prefix}--side-nav.#{$prefix}--side-nav--rail:not(.#{$prefix}--side-nav--fixed):hover {
+    // stylelint-disable-next-line declaration-property-unit-blacklist
+    transition: width $duration--fast-01 motion(entrance, productive) 300ms;
+  }
 }
 
 html[dir='rtl'] {


### PR DESCRIPTION
Closes #2740 

**Summary**

- adds a 300ms delay on the opening transition of the SideNav on hover

**Acceptance Test (how to verify the PR)**

- SideNav should not open immediately on hover, but have a slight delay where the mouse needs to rest on it for a moment

**Regression Test (how to make sure this PR doesn't break old functionality)**

- no adverse effects.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
