### PR TITLE
fix(table-card): adjust padding on empty state for medium cards

### DIFF
--- a/packages/react/src/components/Table/_table.scss
+++ b/packages/react/src/components/Table/_table.scss
@@ -60,12 +60,15 @@ html[dir='rtl'] {
     background: inherit;
   }
   .empty-table-cell--default {
+    --height-threshold: 500px;
+    --is-large-card: min(1px, max(var(--card-content-height) - var(--height-threshold), 0px));
     display: flex;
-    align-items: left;
-    justify-content: middle;
+    align-items: flex-start;
+    justify-content: center;
     flex-direction: column;
-    padding: $spacing-09;
-
+    // 3rem since we can't multiply 1px * 3rem in calc
+    // stylelint-disable-next-line declaration-property-unit-blacklist
+    padding: max(calc(48 * var(--is-large-card)), 0px);
     svg {
       margin: $spacing-05;
     }

--- a/packages/react/src/components/TableCard/TableCard.story.jsx
+++ b/packages/react/src/components/TableCard/TableCard.story.jsx
@@ -23,7 +23,11 @@ export default {
 };
 
 export const WithMultipleActions = () => {
-  const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGEWIDE);
+  const size = select(
+    'size',
+    [CARD_SIZES.MEDIUM, CARD_SIZES.MEDIUMWIDE, CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE],
+    CARD_SIZES.LARGEWIDE
+  );
   const breakpoint = select('breakpoint', ['lg', 'md', 'sm', 'xs'], 'lg');
 
   const tableDataWithActions = tableData.map((item) => {


### PR DESCRIPTION
Closes #2628 

**Summary**

- used some css wizardry to adjust the padding of the empty-state in medium sized TableCards to make it fit. 
- **Still leaves the question if we need to adjust to PropTypes to allow medium sized TableCards without a warning**

**Change List (commits, features, bugs, etc)**

- css only fix for padding

**Acceptance Test (how to verify the PR)**

- Empty-State should fit into a MEDIUM/MEDIUMWIDE TableCard now. 
- Check the `with multiple actions` TableCard story, set the 'no data' knob, and change to a MEDIUM/MEDIUMWIDE card

**Regression Test (how to make sure this PR doesn't break old functionality)**

- no adverse EmptyState style changes

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
