### PR TITLE
fix(sidenav): added stateful example in storybook

### DIFF
--- a/packages/react/src/components/SideNav/SideNav.story.jsx
+++ b/packages/react/src/components/SideNav/SideNav.story.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, createElement, useEffect } from 'react';
 import { action } from '@storybook/addon-actions';
 import { Switcher24 } from '@carbon/icons-react';
 import Chip from '@carbon/icons-react/lib/chip/24';
@@ -219,3 +219,107 @@ SideNavComponent.parameters = {
   `,
   },
 };
+
+export const SideNavComponentWithState = () => {
+  const [linksState, setLinksState] = useState([]);
+  const onSideNavMenuItemClick = (linkLabel) => {
+    setLinksState((currentLinks) =>
+      currentLinks.map((group) => {
+        return {
+          ...group,
+          childContent: group.childContent.map((child) => ({
+            ...child,
+            isActive: linkLabel === child.metaData.label,
+          })),
+        };
+      })
+    );
+  };
+
+  useEffect(() => {
+    setLinksState([
+      {
+        isEnabled: true,
+        icon: Dashboard,
+        metaData: {
+          label: 'Dashboards',
+          element: 'button',
+        },
+        linkContent: 'Dashboards',
+        childContent: [
+          {
+            metaData: {
+              label: 'Link 1',
+              title: 'Link 1',
+              onClick: () => onSideNavMenuItemClick('Link 1'),
+              element: 'button',
+            },
+            content: 'Link 1',
+          },
+          {
+            metaData: {
+              label: 'Link 2',
+              title: 'Link 2',
+              onClick: () => onSideNavMenuItemClick('Link 2'),
+            },
+            content: 'Link 2',
+          },
+        ],
+      },
+      {
+        isEnabled: true,
+        icon: Group,
+        metaData: {
+          label: 'Members',
+          element: 'button',
+        },
+        linkContent: 'Members',
+        childContent: [
+          {
+            metaData: {
+              label: 'Link 3',
+              title: 'Link 3',
+              onClick: () => onSideNavMenuItemClick('Link 3'),
+              element: 'button',
+            },
+            content: 'Link 3',
+            isActive: true,
+          },
+          {
+            metaData: {
+              label: 'Link 4',
+              title: 'Link 4',
+              onClick: () => onSideNavMenuItemClick('Link 4'),
+              element: 'button',
+            },
+            content: 'Link 4',
+            isActive: false,
+          },
+        ],
+      },
+    ]);
+  }, []);
+
+  return (
+    <FullWidthWrapper withPadding={false}>
+      <HeaderContainer
+        render={({ isSideNavExpanded, onClickSideNavExpand }) => (
+          <>
+            <Header
+              {...HeaderProps}
+              isSideNavExpanded={isSideNavExpanded}
+              onClickSideNavExpand={onClickSideNavExpand}
+            />
+            <SideNav links={linksState} isSideNavExpanded={isSideNavExpanded} />
+            <div className={`${iotPrefix}--main-content`}>
+              <PageTitleBar title="Title" description="Description" />
+            </div>
+          </>
+        )}
+      />
+    </FullWidthWrapper>
+  );
+};
+
+SideNavComponentWithState.decorators = [createElement];
+SideNavComponentWithState.storyName = 'SideNav component with state';

--- a/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
+++ b/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
@@ -465,3 +465,372 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
   </div>
 </div>
 `;
+
+exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/SideNav SideNav component with state 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "height": "100vh",
+        "left": 0,
+        "overflow": "auto",
+        "position": "fixed",
+        "top": 0,
+        "width": "100vw",
+      }
+    }
+  >
+    <header
+      aria-label="main header"
+      className="bx--header custom-class-name"
+      data-testid="header"
+    >
+      <a
+        className="bx--skip-to-content"
+        href="#main-content"
+        tabIndex="0"
+      >
+        Skip to main content
+      </a>
+      <button
+        aria-label="Open menu"
+        className="bx--header__action bx--header__menu-trigger bx--header__menu-toggle bx--header__menu-toggle__hidden"
+        data-testid="header-menu-button"
+        onClick={[Function]}
+        title="Open menu"
+        type="button"
+      >
+        <svg
+          aria-hidden={true}
+          fill="currentColor"
+          focusable="false"
+          height={20}
+          preserveAspectRatio="xMidYMid meet"
+          viewBox="0 0 20 20"
+          width={20}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M2 14.8H18V16H2zM2 11.2H18V12.399999999999999H2zM2 7.6H18V8.799999999999999H2zM2 4H18V5.2H2z"
+          />
+        </svg>
+      </button>
+      <a
+        className="bx--header__name"
+        data-testid="header-name"
+        href="#"
+      >
+        <span
+          className="bx--header__name--prefix"
+        >
+          IBM
+        </span>
+         
+        <span>
+          Watson IoT Platform 
+        </span>
+        <span
+          className="iot--header__short-name"
+        >
+          Watson IoT Platform 
+        </span>
+      </a>
+      <div
+        className="bx--header__global"
+      >
+        <div
+          className="bx--header__global"
+          data-testid="header-action-group"
+        >
+          <button
+            aria-describedby={null}
+            aria-label="user"
+            aria-pressed={null}
+            className="bx--header-action-btn bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
+            data-testid="menu-item-user-global"
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            <div
+              className="bx--assistive-text"
+              onMouseEnter={[Function]}
+            >
+              user
+            </div>
+            <svg
+              aria-hidden={true}
+              className="bx--header__menu-item bx--header__menu-title"
+              description="Icon"
+              fill="white"
+              focusable="false"
+              height={24}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width={24}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M31 30H29V27a3 3 0 00-3-3H22a3 3 0 00-3 3v3H17V27a5 5 0 015-5h4a5 5 0 015 5zM24 12a3 3 0 11-3 3 3 3 0 013-3m0-2a5 5 0 105 5A5 5 0 0024 10zM15 22H13V19a3 3 0 00-3-3H6a3 3 0 00-3 3v3H1V19a5 5 0 015-5h4a5 5 0 015 5zM8 4A3 3 0 115 7 3 3 0 018 4M8 2a5 5 0 105 5A5 5 0 008 2z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </header>
+    <div
+      className="bx--side-nav__overlay"
+    />
+    <nav
+      aria-hidden={true}
+      aria-label="Side navigation"
+      className="bx--side-nav__navigation bx--side-nav bx--side-nav--rail iot--side-nav bx--side-nav--ux"
+      data-testid="side-nav"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <ul
+        className="bx--side-nav__items"
+      >
+        <li
+          className="bx--side-nav__item bx--side-nav__item--icon"
+          onKeyDown={[Function]}
+        >
+          <button
+            aria-expanded={false}
+            className="bx--side-nav__submenu"
+            onClick={[Function]}
+            type="button"
+          >
+            <div
+              className="bx--side-nav__icon"
+            >
+              <svg
+                aria-hidden={true}
+                fill="currentColor"
+                focusable="false"
+                height={24}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={24}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M24 21H26V26H24zM20 16H22V26H20zM11 26a5.0059 5.0059 0 01-5-5H8a3 3 0 103-3V16a5 5 0 010 10z"
+                />
+                <path
+                  d="M28,2H4A2.002,2.002,0,0,0,2,4V28a2.0023,2.0023,0,0,0,2,2H28a2.0027,2.0027,0,0,0,2-2V4A2.0023,2.0023,0,0,0,28,2Zm0,9H14V4H28ZM12,4v7H4V4ZM4,28V13H28.0007l.0013,15Z"
+                />
+              </svg>
+            </div>
+            <span
+              className="bx--side-nav__submenu-title"
+            >
+              Dashboards
+            </span>
+            <div
+              className="bx--side-nav__icon bx--side-nav__icon--small bx--side-nav__submenu-chevron"
+            >
+              <svg
+                aria-hidden={true}
+                fill="currentColor"
+                focusable="false"
+                height={20}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16 22L6 12 7.4 10.6 16 19.2 24.6 10.6 26 12z"
+                />
+              </svg>
+            </div>
+          </button>
+          <ul
+            className="bx--side-nav__menu"
+          >
+            <li
+              className="bx--side-nav__menu-item"
+            >
+              <button
+                className="bx--side-nav__link"
+                data-testid="side-nav-menu-item-0"
+                label="Link 1"
+                onClick={[Function]}
+                title="Link 1"
+              >
+                <span
+                  className="bx--side-nav__link-text"
+                >
+                  Link 1
+                </span>
+              </button>
+            </li>
+            <li
+              className="bx--side-nav__menu-item"
+            >
+              <a
+                className="bx--side-nav__link"
+                data-testid="side-nav-menu-item-0"
+                label="Link 2"
+                onClick={[Function]}
+                title="Link 2"
+              >
+                <span
+                  className="bx--side-nav__link-text"
+                >
+                  Link 2
+                </span>
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li
+          className="bx--side-nav__item bx--side-nav__item--active bx--side-nav__item--icon"
+          onKeyDown={[Function]}
+        >
+          <button
+            aria-expanded={false}
+            className="bx--side-nav__submenu"
+            onClick={[Function]}
+            type="button"
+          >
+            <div
+              className="bx--side-nav__icon"
+            >
+              <svg
+                aria-hidden={true}
+                fill="currentColor"
+                focusable="false"
+                height={24}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={24}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M31 30H29V27a3 3 0 00-3-3H22a3 3 0 00-3 3v3H17V27a5 5 0 015-5h4a5 5 0 015 5zM24 12a3 3 0 11-3 3 3 3 0 013-3m0-2a5 5 0 105 5A5 5 0 0024 10zM15 22H13V19a3 3 0 00-3-3H6a3 3 0 00-3 3v3H1V19a5 5 0 015-5h4a5 5 0 015 5zM8 4A3 3 0 115 7 3 3 0 018 4M8 2a5 5 0 105 5A5 5 0 008 2z"
+                />
+              </svg>
+            </div>
+            <span
+              className="bx--side-nav__submenu-title"
+            >
+              Members
+            </span>
+            <div
+              className="bx--side-nav__icon bx--side-nav__icon--small bx--side-nav__submenu-chevron"
+            >
+              <svg
+                aria-hidden={true}
+                fill="currentColor"
+                focusable="false"
+                height={20}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16 22L6 12 7.4 10.6 16 19.2 24.6 10.6 26 12z"
+                />
+              </svg>
+            </div>
+          </button>
+          <ul
+            className="bx--side-nav__menu"
+          >
+            <li
+              className="bx--side-nav__menu-item"
+            >
+              <button
+                className="bx--side-nav__link bx--side-nav__link--current"
+                data-testid="side-nav-menu-item-1"
+                label="Link 3"
+                onClick={[Function]}
+                title="Link 3"
+              >
+                <span
+                  className="bx--side-nav__link-text"
+                >
+                  Link 3
+                </span>
+              </button>
+            </li>
+            <li
+              className="bx--side-nav__menu-item"
+            >
+              <button
+                className="bx--side-nav__link"
+                data-testid="side-nav-menu-item-1"
+                label="Link 4"
+                onClick={[Function]}
+                title="Link 4"
+              >
+                <span
+                  className="bx--side-nav__link-text"
+                >
+                  Link 4
+                </span>
+              </button>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+    <div
+      className="iot--main-content"
+    >
+      <div
+        className="page-title-bar"
+        data-testid="page-title-bar"
+        style={
+          Object {
+            "--header-offset": "48px",
+            "--scroll-transition-progress": 1,
+          }
+        }
+      >
+        <div
+          className="page-title-bar-header"
+        >
+          <div
+            className="page-title-bar-breadcrumb-bg"
+          />
+          <div
+            className="page-title-bar-title"
+          >
+            <div
+              className="page-title-bar-title--text"
+            >
+              <h2
+                title="Title"
+              >
+                Title
+              </h2>
+            </div>
+          </div>
+          <p
+            className="page-title-bar-description"
+          >
+            Description
+          </p>
+          <div
+            className="page-title-bar-header-right"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/react/src/components/Table/TableSaveViewModal/__snapshots__/TableSaveViewModal.story.storyshot
+++ b/packages/react/src/components/Table/TableSaveViewModal/__snapshots__/TableSaveViewModal.story.storyshot
@@ -110,7 +110,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               onAnimationEnd={[Function]}
             >
               <button
-                aria-controls="accordion-item-1409"
+                aria-controls="accordion-item-1411"
                 aria-expanded={false}
                 className="bx--accordion__heading"
                 onClick={[Function]}
@@ -140,7 +140,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               </button>
               <div
                 className="bx--accordion__content"
-                id="accordion-item-1409"
+                id="accordion-item-1411"
               >
                 <p>
                   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -152,7 +152,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               onAnimationEnd={[Function]}
             >
               <button
-                aria-controls="accordion-item-1410"
+                aria-controls="accordion-item-1412"
                 aria-expanded={false}
                 className="bx--accordion__heading"
                 onClick={[Function]}
@@ -182,7 +182,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               </button>
               <div
                 className="bx--accordion__content"
-                id="accordion-item-1410"
+                id="accordion-item-1412"
               >
                 <p>
                   Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/packages/react/src/components/TileGallery/__snapshots__/TileGallery.story.storyshot
+++ b/packages/react/src/components/TileGallery/__snapshots__/TileGallery.story.storyshot
@@ -200,7 +200,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   onAnimationEnd={[Function]}
                 >
                   <button
-                    aria-controls="accordion-item-1479"
+                    aria-controls="accordion-item-1481"
                     aria-expanded={true}
                     className="bx--accordion__heading"
                     onClick={[Function]}
@@ -230,7 +230,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </button>
                   <div
                     className="bx--accordion__content"
-                    id="accordion-item-1479"
+                    id="accordion-item-1481"
                   >
                     <div
                       className="tile-gallery--section--items"
@@ -640,7 +640,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   onAnimationEnd={[Function]}
                 >
                   <button
-                    aria-controls="accordion-item-1480"
+                    aria-controls="accordion-item-1482"
                     aria-expanded={true}
                     className="bx--accordion__heading"
                     onClick={[Function]}
@@ -670,7 +670,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </button>
                   <div
                     className="bx--accordion__content"
-                    id="accordion-item-1480"
+                    id="accordion-item-1482"
                   >
                     <div
                       className="tile-gallery--section--items"
@@ -1538,7 +1538,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   onAnimationEnd={[Function]}
                 >
                   <button
-                    aria-controls="accordion-item-1486"
+                    aria-controls="accordion-item-1488"
                     aria-expanded={true}
                     className="bx--accordion__heading"
                     onClick={[Function]}
@@ -1568,7 +1568,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </button>
                   <div
                     className="bx--accordion__content"
-                    id="accordion-item-1486"
+                    id="accordion-item-1488"
                   >
                     <div
                       className="tile-gallery--section--items"
@@ -1738,7 +1738,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             onAnimationEnd={[Function]}
           >
             <button
-              aria-controls="accordion-item-1483"
+              aria-controls="accordion-item-1485"
               aria-expanded={true}
               className="bx--accordion__heading"
               onClick={[Function]}
@@ -1768,7 +1768,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             </button>
             <div
               className="bx--accordion__content"
-              id="accordion-item-1483"
+              id="accordion-item-1485"
             >
               <div
                 className="tile-gallery--section--items"
@@ -2203,7 +2203,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             onAnimationEnd={[Function]}
           >
             <button
-              aria-controls="accordion-item-1484"
+              aria-controls="accordion-item-1486"
               aria-expanded={true}
               className="bx--accordion__heading"
               onClick={[Function]}
@@ -2233,7 +2233,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             </button>
             <div
               className="bx--accordion__content"
-              id="accordion-item-1484"
+              id="accordion-item-1486"
             >
               <div
                 className="tile-gallery--section--items"
@@ -2495,7 +2495,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               onAnimationEnd={[Function]}
             >
               <button
-                aria-controls="accordion-item-1481"
+                aria-controls="accordion-item-1483"
                 aria-expanded={true}
                 className="bx--accordion__heading"
                 onClick={[Function]}
@@ -2525,7 +2525,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               </button>
               <div
                 className="bx--accordion__content"
-                id="accordion-item-1481"
+                id="accordion-item-1483"
               >
                 <div
                   className="tile-gallery--section--items"
@@ -2960,7 +2960,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               onAnimationEnd={[Function]}
             >
               <button
-                aria-controls="accordion-item-1482"
+                aria-controls="accordion-item-1484"
                 aria-expanded={true}
                 className="bx--accordion__heading"
                 onClick={[Function]}
@@ -2990,7 +2990,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               </button>
               <div
                 className="bx--accordion__content"
-                id="accordion-item-1482"
+                id="accordion-item-1484"
               >
                 <div
                   className="tile-gallery--section--items"


### PR DESCRIPTION
Closes #2645 

**Summary**
It is not a blue border of the "selected current" that we see in the scenario described by the issue. The component in the story is stateless so there is no "selection" taking place when a SideNavMenuItem is clicked. Instead the button inside the clicked SideNavMenuItem gets the focus and activates `.bx--side-nav__link:focus` which is not the same as `bx--side-nav__link--current` although they use the same styling. 

In a scenario where there is a managed state for a SideNav component this problem does not exist, so I created a story that shows this. 

Note that if a user expands a menu group and moves the mouse away without selecting a menu item the group will remain expanded when the Navbar is collapsed again. 

**Change List (commits, features, bugs, etc)**
- Added story with state for active Sidenav menu items.

**Acceptance Test (how to verify the PR)**
1. Go to https://deploy-preview-2774--carbon-addons-iot-react.netlify.app?path=/story/1-watson-iot-sidenav--side-nav-component-with-state
2. Verify that "Members" is selected
3. Click on "Dashboard"
4. Click on "Link 2"
5. Verify that the Sidenav was collapsed back into "rail" mode and that all top menu groups are now collapsed and that "Dashboard" is selected.
5. Expand "Dashboard" to make sure "Link 2" is selected.

**Regression Test (how to make sure this PR doesn't break old functionality)**
no code change to the component

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
