### PR TITLE
fix(repo): use es build instead of lib in browser

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": "12.x || 14.x"
   },
-  "browser": "lib/index.js",
+  "browser": "es/index.js",
   "main": "lib/index.js",
   "module": "es/index.js",
   "unpkg": "umd/carbon-addons-iot-react.js",


### PR DESCRIPTION
Closes #2260 

**Summary**

- We were using the `lib` build instead of the `es` build in the browser property of `package.json`. This was forcing everything to be included and breaking tree shaking. The test app was 8.08MB when built and analyzed in its current state, but after the es switch it dropped to 2.1MB. 

**Change List (commits, features, bugs, etc)**

- change browser package to use es build

**Acceptance Test (how to verify the PR)**

1. Pull this branch down locally
2. create a new directory to hold the built project ie: `mkdir -p ~/tmp/pal-build`
3. run `yarn build`
4. copy built files to project directory created above: `cp -rf package.json umd scss lib es css ~/tmp/pal-build`
5. move to a fresh directory
6. create a test app: `npx create-iot-react-app pal-test`
7. cd into the test app directory:  `cd pal-test`
8. install the locally linked version of carbon-addons. This must be either a relative path or an absolute path (the `~` will not be expanded), so continuing with the `~/tmp/pal-build` example above it would become `yarn add "carbon-addons-iot-react@link:$HOME/tmp/pal-build"` (on mac)
9. build the test application. `yarn build`
10. use serve to serve the built project and confirm it works. `serve -s build`

Optional:
You can compare the build differences by installing source-map-explorer (`yarn add source-map-explorer` and running it on the built application: `yarn source-map-explorer 'build/static/js/*.js'`.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- consuming applications still work as expected

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
