### PR TITLE
fix(date-time-picker): wait until finished typing to parse dates

### DIFF
--- a/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
@@ -398,14 +398,16 @@ const DateTimePicker = ({
       }
       case PICKER_KINDS.ABSOLUTE: {
         let startDate = dayjs(value.absolute.start);
-        if (value.absolute.startTime) {
+        // wait to parse it until fully typed
+        if (value.absolute.startTime && value.absolute.startTime.length === 5) {
           startDate = startDate.hours(value.absolute.startTime.split(':')[0]);
           startDate = startDate.minutes(value.absolute.startTime.split(':')[1]);
         }
         returnValue.absolute.start = new Date(startDate.valueOf());
         if (value.absolute.end) {
           let endDate = dayjs(value.absolute.end);
-          if (value.absolute.endTime) {
+          // wait to parse it until fully typed
+          if (value.absolute.endTime && value.absolute.endTime.length === 5) {
             endDate = endDate.hours(value.absolute.endTime.split(':')[0]);
             endDate = endDate.minutes(value.absolute.endTime.split(':')[1]);
           }


### PR DESCRIPTION
Closes #2771 

**Summary**

- DateTimePicker wasn't waiting until the user had finished typing to parse times, so it was throwing invalid dates.

**Change List (commits, features, bugs, etc)**

- don't parse absolute times until 5 characters have been typed.

**Acceptance Test (how to verify the PR)**

- Open DateTimePicker default story
- Click Custom Range
- click Absolute
- Click two dates (same and different)
- Click the Start time input
- Backspace to clear the box and type a time
- tab to the End time input
- type an end time
- click apply
- The correct chosen date should be visible

**Regression Test (how to make sure this PR doesn't break old functionality)**

- no adverse side-effects for absolute dates.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
