### PR TITLE
fix(internal): fix FullWidthWrapper to use correct styles

### DIFF
--- a/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -14520,7 +14520,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
   className="storybook-container"
 >
   <div
-    style={Object {}}
+    style={
+      Object {
+        "width": "calc(100vw - 6rem)",
+      }
+    }
   >
     <div
       style={

--- a/packages/react/src/components/Table/__snapshots__/StatefulTable.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/StatefulTable.story.storyshot
@@ -17091,7 +17091,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
   className="storybook-container"
 >
   <div
-    style={Object {}}
+    style={
+      Object {
+        "width": "calc(100vw - 6rem)",
+      }
+    }
   >
     <div
       className="bx--modal iot--manage-views-modal iot--composed-modal"

--- a/packages/react/src/components/Table/__snapshots__/Table.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/Table.story.storyshot
@@ -3543,7 +3543,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
   className="storybook-container"
 >
   <div
-    style={Object {}}
+    style={
+      Object {
+        "width": "calc(100vw - 6rem)",
+      }
+    }
   >
     <div
       className="bx--modal iot--manage-views-modal iot--composed-modal"
@@ -98742,7 +98746,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
   className="storybook-container"
 >
   <div
-    style={Object {}}
+    style={
+      Object {
+        "width": "calc(100vw - 6rem)",
+      }
+    }
   >
     <style>
       #custom-row-height table tr { height: 5rem;}

--- a/packages/react/src/internal/FullWidthWrapper.jsx
+++ b/packages/react/src/internal/FullWidthWrapper.jsx
@@ -16,13 +16,7 @@ const FullWidthWrapper = ({ withPadding, style, children }) => {
         ...style,
       };
 
-  return (
-    <div
-      style={children && children.type && children.type.name !== 'DeprecationNotice' ? styles : {}}
-    >
-      {children}
-    </div>
-  );
+  return <div style={children?.type?.name === 'DeprecationNotice' ? {} : styles}>{children}</div>;
 };
 
 FullWidthWrapper.propTypes = {


### PR DESCRIPTION
Closes #2470 

**Summary**

- correctly applies FullWidthStyles to all children except DeprecationNotice.

**Acceptance Test (how to verify the PR)**

- Table Example with Create & Save Views story should now have full-width styles applied.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- confirm FullWidthStyles are not applied to DeprecationNotices

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
