### PR TITLE
refactor(table): refactor wrap truncate code

### DIFF
--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -452,6 +452,12 @@ export const defaultProps = (baseProps) => ({
   testId: null,
 });
 
+export const CELL_TEXT_OVERFLOW = {
+  TRUNCATE: 'truncate',
+  GROW: 'grow',
+  WRAP: 'wrap',
+};
+
 const Table = (props) => {
   const {
     id,
@@ -539,16 +545,24 @@ const Table = (props) => {
   const [tableId] = useState(() => uniqueId('table-'));
   const [, forceUpdateCellTextWidth] = useState(0);
 
-  const useCellTextTruncate = useMemo(
-    () =>
-      options
-        ? options.wrapCellText === 'alwaysTruncate' ||
-          (options.wrapCellText !== 'always' &&
-            ((options.hasResize && !options.useAutoTableLayoutForResize) ||
-              columns.some((col) => col.hasOwnProperty('width'))))
-        : undefined,
-    [options, columns]
-  );
+  const cellTextOverflow = useMemo(() => {
+    const fixedTableLayout = !options?.useAutoTableLayoutForResize;
+    const hasInitalColumnWidths = columns.some((col) => col.hasOwnProperty('width'));
+    const hasCalculatedColumnWidths = options.hasResize && fixedTableLayout;
+    const dynamicCellWidths = !hasInitalColumnWidths && !hasCalculatedColumnWidths;
+
+    switch (options?.wrapCellText) {
+      case 'alwaysTruncate':
+        return CELL_TEXT_OVERFLOW.TRUNCATE;
+      case 'never':
+        return dynamicCellWidths ? CELL_TEXT_OVERFLOW.GROW : CELL_TEXT_OVERFLOW.TRUNCATE;
+      case 'auto':
+        return dynamicCellWidths ? CELL_TEXT_OVERFLOW.WRAP : CELL_TEXT_OVERFLOW.TRUNCATE;
+      case 'always':
+      default:
+        return CELL_TEXT_OVERFLOW.WRAP;
+    }
+  }, [options, columns]);
 
   const handleClearFilters = () => {
     if (actions.toolbar && actions.toolbar.onClearAllFilters) {
@@ -847,8 +861,7 @@ const Table = (props) => {
                 'hasMultiSort',
                 'preserveColumnWidths'
               ),
-              wrapCellText: options.wrapCellText,
-              truncateCellText: useCellTextTruncate,
+              cellTextOverflow,
             }}
             columns={columns}
             filters={view.filters}
@@ -938,8 +951,7 @@ const Table = (props) => {
                   'shouldExpandOnRowClick',
                   'shouldLazyRender'
                 )}
-                wrapCellText={options.wrapCellText}
-                truncateCellText={useCellTextTruncate}
+                cellTextOverflow={cellTextOverflow}
                 ordering={view.table.ordering}
                 rowEditMode={rowEditMode}
                 actions={pick(

--- a/packages/react/src/components/Table/Table.test.jsx
+++ b/packages/react/src/components/Table/Table.test.jsx
@@ -12,8 +12,6 @@ import { Modal } from '../Modal';
 import { getTableColumns, mockActions, getNestedRows, getNestedRowIds } from './Table.test.helpers';
 import Table, { defaultProps } from './Table';
 import TableToolbar from './TableToolbar/TableToolbar';
-import TableBodyRow from './TableBody/TableBodyRow/TableBodyRow';
-import TableHead from './TableHead/TableHead';
 import { initialState } from './Table.story';
 
 const { iotPrefix, prefix } = settings;
@@ -565,81 +563,6 @@ describe('Table', () => {
     expect(wrapper.find('.bx--search-input').prop('value')).toEqual('');
   });
 
-  it('cells should always wrap by default', () => {
-    const wrapper = mount(
-      <Table columns={tableColumns} data={[tableData[0]]} options={{ hasResize: true }} />
-    );
-    expect(wrapper.find(TableBodyRow).prop('options').wrapCellText).toEqual('always');
-    expect(wrapper.find(TableHead).prop('options').wrapCellText).toEqual('always');
-
-    const wrapper2 = mount(
-      <Table
-        columns={tableColumns.map((col) => ({ ...col, width: '100px' }))}
-        data={[tableData[0]]}
-        options={{ hasResize: false }}
-      />
-    );
-    expect(wrapper2.find(TableBodyRow).prop('options').wrapCellText).toEqual('always');
-    expect(wrapper2.find(TableHead).prop('options').wrapCellText).toEqual('always');
-
-    const wrapper3 = mount(<Table columns={tableColumns} data={[tableData[0]]} />);
-    expect(wrapper3.find(TableBodyRow).prop('options').wrapCellText).toEqual('always');
-    expect(wrapper3.find(TableHead).prop('options').wrapCellText).toEqual('always');
-  });
-
-  it('cells should truncate with wrapCellText:auto if resize or fixed col widths', () => {
-    const wrapper = mount(
-      <Table
-        columns={tableColumns}
-        data={[tableData[0]]}
-        options={{ hasResize: true, wrapCellText: 'auto' }}
-      />
-    );
-    expect(wrapper.find(TableBodyRow).prop('options').truncateCellText).toBeTruthy();
-    expect(wrapper.find(TableHead).prop('options').truncateCellText).toBeTruthy();
-
-    const wrapper2 = mount(
-      <Table
-        columns={tableColumns.map((col) => ({ ...col, width: '100px' }))}
-        data={[tableData[0]]}
-        options={{ hasResize: false, wrapCellText: 'auto' }}
-      />
-    );
-    expect(wrapper2.find(TableBodyRow).prop('options').truncateCellText).toBeTruthy();
-    expect(wrapper2.find(TableHead).prop('options').truncateCellText).toBeTruthy();
-
-    const wrapper3 = mount(
-      <Table
-        columns={tableColumns.map((col) => ({
-          ...col,
-          width: undefined,
-          renderDataFunction: () => 'hello this is a custom rendered long string',
-        }))}
-        data={[tableData[0]]}
-        options={{ hasResize: false, wrapCellText: 'auto' }}
-      />
-    );
-    expect(
-      wrapper3
-        .find('TableCell .iot--table__cell--truncate .iot--table__cell-text--truncate')
-        .first()
-    ).toHaveLength(1);
-  });
-
-  it('cells should wrap (not truncate) with wrapCellText:auto if no resize nor fixed col widths', () => {
-    const wrapper3 = mount(
-      <Table
-        columns={tableColumns}
-        data={[tableData[0]]}
-        options={{ hasResize: false, wrapCellText: 'auto' }}
-      />
-    );
-    expect(wrapper3.find(TableBodyRow).prop('options').truncateCellText).toBeFalsy();
-    expect(wrapper3.find(TableHead).prop('options').truncateCellText).toBeFalsy();
-    expect(wrapper3.find(TableBodyRow).prop('options').wrapCellText).toEqual('auto');
-    expect(wrapper3.find(TableHead).prop('options').wrapCellText).toEqual('auto');
-  });
-
   it('should render RowActionsCell dropdowns in the right direction for different language directions ', async () => {
     const id = 'TableId3';
     // Should render correctly by default even if no lang attribute exist
@@ -666,58 +589,6 @@ describe('Table', () => {
 
     // unmounting to be sure to clean up the documentElement
     unmount();
-  });
-
-  it('cells should wrap (not truncate) for wrapCellText:auto + resize + table-layout:auto', () => {
-    const wrapper = mount(
-      <Table
-        columns={tableColumns}
-        data={[tableData[0]]}
-        options={{
-          wrapCellText: 'auto',
-          hasResize: true,
-          useAutoTableLayoutForResize: true,
-        }}
-      />
-    );
-    expect(wrapper.find(TableBodyRow).prop('options').wrapCellText).toEqual('auto');
-    expect(wrapper.find(TableHead).prop('options').wrapCellText).toEqual('auto');
-    expect(wrapper.find(TableBodyRow).prop('options').truncateCellText).toBeFalsy();
-    expect(wrapper.find(TableHead).prop('options').truncateCellText).toBeFalsy();
-  });
-
-  it('cells should always wrap when wrapCellText is always', () => {
-    const wrapper = mount(
-      <Table
-        columns={tableColumns}
-        data={[tableData[0]]}
-        options={{ hasResize: true, wrapCellText: 'always' }}
-      />
-    );
-    expect(wrapper.find(TableBodyRow).prop('options').wrapCellText).toEqual('always');
-    expect(wrapper.find(TableHead).prop('options').wrapCellText).toEqual('always');
-    expect(wrapper.find(TableBodyRow).prop('options').truncateCellText).toBeFalsy();
-    expect(wrapper.find(TableHead).prop('options').truncateCellText).toBeFalsy();
-
-    const wrapper2 = mount(
-      <Table
-        columns={tableColumns.map((col) => ({ ...col, width: '100px' }))}
-        data={[tableData[0]]}
-        options={{ wrapCellText: 'always' }}
-      />
-    );
-    expect(wrapper2.find(TableBodyRow).prop('options').wrapCellText).toEqual('always');
-    expect(wrapper2.find(TableHead).prop('options').wrapCellText).toEqual('always');
-    expect(wrapper2.find(TableBodyRow).prop('options').truncateCellText).toBeFalsy();
-    expect(wrapper2.find(TableHead).prop('options').truncateCellText).toBeFalsy();
-
-    const wrapper3 = mount(
-      <Table columns={tableColumns} data={[tableData[0]]} options={{ wrapCellText: 'always' }} />
-    );
-    expect(wrapper3.find(TableBodyRow).prop('options').wrapCellText).toEqual('always');
-    expect(wrapper3.find(TableHead).prop('options').wrapCellText).toEqual('always');
-    expect(wrapper3.find(TableBodyRow).prop('options').truncateCellText).toBeFalsy();
-    expect(wrapper3.find(TableHead).prop('options').truncateCellText).toBeFalsy();
   });
 
   describe('Text truncation and wrapping', () => {

--- a/packages/react/src/components/Table/TableBody/TableBody.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBody.jsx
@@ -9,6 +9,7 @@ import {
   TableRowPropTypes,
   TableColumnsPropTypes,
   RowActionsStatePropTypes,
+  CellTextOverflowPropType,
 } from '../TablePropTypes';
 import deprecate from '../../../internal/deprecate';
 
@@ -68,8 +69,7 @@ const propTypes = {
     }),
   ]),
   hasRowActions: PropTypes.bool,
-  wrapCellText: PropTypes.oneOf(['always', 'never', 'auto', 'alwaysTruncate']).isRequired,
-  truncateCellText: PropTypes.bool.isRequired,
+  cellTextOverflow: CellTextOverflowPropType,
   /** the current state of the row actions */
   rowActionsState: RowActionsStatePropTypes,
   shouldExpandOnRowClick: PropTypes.bool,
@@ -131,6 +131,7 @@ const defaultProps = {
   langDir: 'ltr',
   showExpanderColumn: false,
   testId: '',
+  cellTextOverflow: null,
 };
 
 const TableBody = ({
@@ -158,8 +159,7 @@ const TableBody = ({
   shouldExpandOnRowClick,
   shouldLazyRender,
   ordering,
-  wrapCellText,
-  truncateCellText,
+  cellTextOverflow,
   locale,
   rowEditMode,
   singleRowEditButtons,
@@ -311,8 +311,7 @@ const TableBody = ({
           hasRowNesting,
           hasRowActions,
           shouldExpandOnRowClick,
-          wrapCellText,
-          truncateCellText,
+          cellTextOverflow,
         }}
         nestingLevel={nestingLevel}
         nestingChildCount={row.children ? row.children.length : 0}

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -11,9 +11,11 @@ import {
   RowActionPropTypes,
   RowActionErrorPropTypes,
   TableColumnsPropTypes,
+  CellTextOverflowPropType,
 } from '../../TablePropTypes';
 import { stopPropagationAndCallback } from '../../../../utils/componentUtilityFunctions';
 import { COLORS } from '../../../../styles/styles';
+import { CELL_TEXT_OVERFLOW } from '../../Table';
 
 const { TableRow, TableExpandRow, TableCell } = DataTable;
 const { prefix, iotPrefix } = settings;
@@ -57,8 +59,7 @@ const propTypes = {
       }),
     ]),
     shouldExpandOnRowClick: PropTypes.bool,
-    wrapCellText: PropTypes.oneOf(['always', 'never', 'auto', 'alwaysTruncate']).isRequired,
-    truncateCellText: PropTypes.bool.isRequired,
+    cellTextOverflow: CellTextOverflowPropType,
   }),
 
   /** The unique row id */
@@ -128,7 +129,7 @@ const defaultProps = {
   rowDetails: null,
   nestingLevel: 0,
   nestingChildCount: 0,
-  options: {},
+  options: { cellTextOverflow: null },
   rowEditMode: false,
   singleRowEditMode: false,
   singleRowEditButtons: null,
@@ -380,8 +381,7 @@ const TableBodyRow = ({
     hasRowActions,
     hasRowNesting,
     shouldExpandOnRowClick,
-    wrapCellText,
-    truncateCellText,
+    cellTextOverflow,
   },
   tableActions: { onRowSelected, onRowExpanded, onRowClicked, onApplyRowAction, onClearRowError },
   isExpanded,
@@ -468,7 +468,8 @@ const TableBodyRow = ({
             offset={offset}
             align={align}
             className={classnames(`data-table-${align}`, {
-              [`${iotPrefix}--table__cell--truncate`]: truncateCellText,
+              [`${iotPrefix}--table__cell--truncate`]:
+                cellTextOverflow === CELL_TEXT_OVERFLOW.TRUNCATE,
               [`${iotPrefix}--table__cell--sortable`]: sortable,
             })}
             width={initialColumnWidth}
@@ -483,8 +484,7 @@ const TableBodyRow = ({
                 })
               ) : (
                 <TableCellRenderer
-                  wrapText={wrapCellText}
-                  truncateCellText={truncateCellText}
+                  cellTextOverflow={cellTextOverflow}
                   locale={locale}
                   renderDataFunction={col.renderDataFunction}
                   columnId={col.columnId}

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.story.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.story.jsx
@@ -23,8 +23,7 @@ const tableBodyRowProps = {
     'onClearRowError'
   ),
   options: {
-    wrapCellText: 'never',
-    truncateCellText: false,
+    cellTextOverflow: 'grow',
   },
 };
 

--- a/packages/react/src/components/Table/TableCellRenderer/TableCellRenderer.jsx
+++ b/packages/react/src/components/Table/TableCellRenderer/TableCellRenderer.jsx
@@ -4,13 +4,14 @@ import classnames from 'classnames';
 import { Tooltip, TooltipDefinition } from 'carbon-components-react';
 
 import { settings } from '../../../constants/Settings';
+import { CellTextOverflowPropType } from '../TablePropTypes';
+import { CELL_TEXT_OVERFLOW } from '../Table';
 
 const { iotPrefix } = settings;
 
 const propTypes = {
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.bool]),
-  wrapText: PropTypes.oneOf(['always', 'never', 'auto', 'alwaysTruncate']).isRequired,
-  truncateCellText: PropTypes.bool.isRequired,
+  cellTextOverflow: CellTextOverflowPropType,
   allowTooltip: PropTypes.bool,
   /** What locale should the number be rendered in */
   locale: PropTypes.string,
@@ -28,6 +29,7 @@ const defaultProps = {
   renderDataFunction: null,
   columnId: null,
   rowId: null,
+  cellTextOverflow: null,
 };
 
 const isElementTruncated = (element) => element.offsetWidth < element.scrollWidth;
@@ -45,9 +47,8 @@ const renderCustomCell = (renderDataFunction, args, className) => {
 /** Supports our default render decisions for primitive values */
 const TableCellRenderer = ({
   children,
-  wrapText,
   allowTooltip,
-  truncateCellText,
+  cellTextOverflow,
   locale,
   tooltip,
   renderDataFunction,
@@ -57,8 +58,8 @@ const TableCellRenderer = ({
 }) => {
   const mySpanRef = React.createRef();
   const myClasses = classnames({
-    [`${iotPrefix}--table__cell-text--truncate`]: wrapText !== 'always' && truncateCellText,
-    [`${iotPrefix}--table__cell-text--no-wrap`]: wrapText === 'never',
+    [`${iotPrefix}--table__cell-text--truncate`]: cellTextOverflow === CELL_TEXT_OVERFLOW.TRUNCATE,
+    [`${iotPrefix}--table__cell-text--no-wrap`]: cellTextOverflow === CELL_TEXT_OVERFLOW.GROW,
   });
 
   const [useTooltip, setUseTooltip] = useState(false);
@@ -88,10 +89,15 @@ const TableCellRenderer = ({
   useEffect(() => {
     const canBeTruncated =
       typeof children === 'string' || typeof children === 'number' || typeof children === 'boolean';
-    if (canBeTruncated && truncateCellText && allowTooltip && mySpanRef && mySpanRef.current) {
+    if (
+      canBeTruncated &&
+      cellTextOverflow === CELL_TEXT_OVERFLOW.TRUNCATE &&
+      allowTooltip &&
+      mySpanRef.current
+    ) {
       setUseTooltip(isElementTruncated(mySpanRef.current));
     }
-  }, [mySpanRef, children, wrapText, truncateCellText, allowTooltip]);
+  }, [mySpanRef, children, cellTextOverflow, allowTooltip]);
 
   const cellContent = renderDataFunction ? (
     renderCustomCell(renderDataFunction, { value: children, columnId, rowId, row }, myClasses)

--- a/packages/react/src/components/Table/TableCellRenderer/TableCellRenderer.test.jsx
+++ b/packages/react/src/components/Table/TableCellRenderer/TableCellRenderer.test.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
@@ -100,19 +99,17 @@ describe('TableCellRenderer', () => {
     setOffsetWidth(10);
     setScrollWidth(20);
 
-    const wrapper = mount(
+    const { rerender, container } = render(
       <TableCellRenderer cellTextOverflow="truncate">{cellText}</TableCellRenderer>
     );
-    expect(wrapper.find(`.${prefix}--tooltip__label`)).toHaveLength(1);
-    expect(wrapper.find(`.${iotPrefix}--table__cell-text--truncate`)).toHaveLength(1);
+    expect(container.querySelectorAll(`.${prefix}--tooltip__label`)).toHaveLength(1);
+    expect(container.querySelectorAll(`.${iotPrefix}--table__cell-text--truncate`)).toHaveLength(1);
 
     setOffsetWidth(20);
     setScrollWidth(10);
-    const wrapper2 = mount(
-      <TableCellRenderer cellTextOverflow="truncate">{cellText}</TableCellRenderer>
-    );
-    expect(wrapper2.find(`.${prefix}--tooltip__label`)).toHaveLength(0);
-    expect(wrapper2.find(`.${iotPrefix}--table__cell-text--truncate`)).toHaveLength(1);
+    rerender(<TableCellRenderer cellTextOverflow="truncate">{cellText}</TableCellRenderer>);
+    expect(container.querySelectorAll(`.${prefix}--tooltip__label`)).toHaveLength(0);
+    expect(container.querySelectorAll(`.${iotPrefix}--table__cell-text--truncate`)).toHaveLength(1);
 
     setOffsetWidth(0);
     setScrollWidth(0);
@@ -123,31 +120,31 @@ describe('TableCellRenderer', () => {
     setScrollWidth(20);
 
     const cellText = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit';
-    const wrapper = mount(
+    const { container } = render(
       <TableCellRenderer cellTextOverflow="truncate" allowTooltip={false}>
         {cellText}
       </TableCellRenderer>
     );
-    expect(wrapper.find(`.${prefix}--tooltip__label`)).toHaveLength(0);
-    expect(wrapper.find(`.${iotPrefix}--table__cell-text--truncate`)).toHaveLength(1);
+    expect(container.querySelectorAll(`.${prefix}--tooltip__label`)).toHaveLength(0);
+    expect(container.querySelectorAll(`.${iotPrefix}--table__cell-text--truncate`)).toHaveLength(1);
 
     setOffsetWidth(0);
     setScrollWidth(0);
   });
 
   it('locale formats numbers', () => {
-    const wrapper = mount(
+    const { rerender } = render(
       <TableCellRenderer locale="fr" truncateCellText wrapText="never">
         {35.6}
       </TableCellRenderer>
     );
-    expect(wrapper.text()).toContain('35,6'); // french locale should have commas for decimals
+    expect(screen.getByText('35,6')).toBeInTheDocument(); // french locale should have commas for decimals
 
-    const wrapper2 = mount(
+    rerender(
       <TableCellRenderer locale="en" truncateCellText wrapText="never">
         {35.1234567}
       </TableCellRenderer>
     );
-    expect(wrapper2.text()).toContain('35.1234567'); // no limit on the count of decimals
+    expect(screen.getByText('35.1234567')).toBeInTheDocument(); // no limit on the count of decimals
   });
 });

--- a/packages/react/src/components/Table/TableHead/TableHead.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.jsx
@@ -15,6 +15,7 @@ import {
   defaultI18NPropTypes,
   ActiveTableToolbarPropType,
   TableSortPropType,
+  CellTextOverflowPropType,
 } from '../TablePropTypes';
 import TableCellRenderer from '../TableCellRenderer/TableCellRenderer';
 import { tableTranslateWithId } from '../../../utils/componentUtilityFunctions';
@@ -56,12 +57,11 @@ const propTypes = {
     hasRowActions: PropTypes.bool,
     hasResize: PropTypes.bool,
     hasSingleRowEdit: PropTypes.bool,
-    wrapCellText: PropTypes.oneOf(['always', 'never', 'auto', 'alwaysTruncate']).isRequired,
-    truncateCellText: PropTypes.bool.isRequired,
     hasMultiSort: PropTypes.bool,
     useAutoTableLayoutForResize: PropTypes.bool,
     /** Preserves the widths of existing columns when one or more columns are added, removed, hidden, shown or resized. */
     preserveColumnWidths: PropTypes.bool,
+    cellTextOverflow: CellTextOverflowPropType,
   }),
   /** List of columns */
   columns: TableColumnsPropTypes.isRequired,
@@ -168,8 +168,7 @@ const TableHead = ({
     hasRowSelection,
     hasRowNesting,
     hasResize,
-    wrapCellText,
-    truncateCellText,
+    cellTextOverflow,
     hasSingleRowEdit,
     hasMultiSort,
     useAutoTableLayoutForResize,
@@ -503,8 +502,7 @@ const TableHead = ({
             >
               <TableCellRenderer
                 className={`${iotPrefix}--table-head--text`}
-                wrapText={wrapCellText}
-                truncateCellText={truncateCellText}
+                cellTextOverflow={cellTextOverflow}
                 allowTooltip={false}
                 tooltip={matchingColumnMeta.tooltip}
               >

--- a/packages/react/src/components/Table/TablePropTypes.js
+++ b/packages/react/src/components/Table/TablePropTypes.js
@@ -292,3 +292,6 @@ export const TableSortPropType = PropTypes.shape({
   columnId: PropTypes.string,
   direction: PropTypes.oneOf(['NONE', 'ASC', 'DESC']),
 });
+
+/** How should long cell texts be handled, the implicit default is wrapping */
+export const CellTextOverflowPropType = PropTypes.oneOf(['grow', 'truncate', 'wrap']);


### PR DESCRIPTION
Closes #1652 

**Summary**
The wrap and truncate code and unit tests were refactored as part of PR 1645 but we decided to move the refactoring into a separate issue and add it to the next major release in order to mitigate the risk of regressions. 

**Change List (commits, features, bugs, etc)**
* Removed internal props  `wrapCellText` and `truncateCellText` and replaced with `cellTextOverflow`
* Lifted logic from the subcomponents to the table 
* Removed superfluous and old unit tests that were based on checking the presence of prop values

**Acceptance Test (how to verify the PR)**
- Verify that the external `wrapCellText` prop still work as expected for the tables

**Regression Test (how to make sure this PR doesn't break old functionality)**
- Verify that the external `wrapCellText` prop still work as expected for the tables

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
