### PR TITLE
feat(value-card): add onAttributeClick callback 

### DIFF
--- a/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -148,6 +148,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="89"
                         >
                           89
                         </span>
@@ -198,6 +199,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="76"
                         >
                           76
                         </span>
@@ -248,6 +250,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="21.4"
                         >
                           21.4
                         </span>
@@ -452,6 +455,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="62.1"
                         >
                           62.1
                         </span>
@@ -558,6 +562,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="62.1"
                         >
                           62.1
                         </span>
@@ -709,6 +714,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="76"
                         >
                           76
                         </span>
@@ -817,6 +823,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="35"
                         >
                           35
                         </span>
@@ -968,6 +975,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="Bad"
                         >
                           Bad
                         </span>
@@ -1074,6 +1082,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="13,572"
                         >
                           13,572
                         </span>
@@ -1388,6 +1397,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="Healthy"
                         >
                           Healthy
                         </span>
@@ -3078,6 +3088,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="89"
                         >
                           89
                         </span>
@@ -3128,6 +3139,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="76"
                         >
                           76
                         </span>
@@ -3178,6 +3190,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="21.4"
                         >
                           21.4
                         </span>
@@ -3382,6 +3395,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="62.1"
                         >
                           62.1
                         </span>
@@ -3488,6 +3502,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="62.1"
                         >
                           62.1
                         </span>
@@ -3639,6 +3654,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="76"
                         >
                           76
                         </span>
@@ -3747,6 +3763,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="35"
                         >
                           35
                         </span>
@@ -3898,6 +3915,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="Bad"
                         >
                           Bad
                         </span>
@@ -4004,6 +4022,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="13,572"
                         >
                           13,572
                         </span>
@@ -4318,6 +4337,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="Healthy"
                         >
                           Healthy
                         </span>
@@ -6043,6 +6063,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="89"
                         >
                           89
                         </span>
@@ -6093,6 +6114,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="76"
                         >
                           76
                         </span>
@@ -6143,6 +6165,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="21.4"
                         >
                           21.4
                         </span>
@@ -6347,6 +6370,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="62.1"
                         >
                           62.1
                         </span>
@@ -6453,6 +6477,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="62.1"
                         >
                           62.1
                         </span>
@@ -6604,6 +6629,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="76"
                         >
                           76
                         </span>
@@ -6712,6 +6738,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="35"
                         >
                           35
                         </span>
@@ -6863,6 +6890,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="Bad"
                         >
                           Bad
                         </span>
@@ -6969,6 +6997,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="13,572"
                         >
                           13,572
                         </span>
@@ -7283,6 +7312,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="Healthy"
                         >
                           Healthy
                         </span>
@@ -11609,6 +11639,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="89"
                         >
                           89
                         </span>
@@ -11659,6 +11690,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="76"
                         >
                           76
                         </span>
@@ -11709,6 +11741,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="21.4"
                         >
                           21.4
                         </span>
@@ -11913,6 +11946,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="62.1"
                         >
                           62.1
                         </span>
@@ -12019,6 +12053,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="62.1"
                         >
                           62.1
                         </span>
@@ -12170,6 +12205,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="76"
                         >
                           76
                         </span>
@@ -12278,6 +12314,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="35"
                         >
                           35
                         </span>
@@ -12429,6 +12466,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="Bad"
                         >
                           Bad
                         </span>
@@ -12535,6 +12573,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="13,572"
                         >
                           13,572
                         </span>
@@ -12849,6 +12888,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="Healthy"
                         >
                           Healthy
                         </span>
@@ -14672,6 +14712,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="13"
                           >
                             13
                           </span>
@@ -14772,6 +14813,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="1,352"
                           >
                             1,352
                           </span>
@@ -14874,6 +14916,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="103.2"
                           >
                             103.2
                           </span>
@@ -14976,6 +15019,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="107,324.3"
                           >
                             107,324.3
                           </span>
@@ -15078,6 +15122,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="1,709,384.1"
                           >
                             1,709,384.1
                           </span>
@@ -15287,6 +15332,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-font-size": "42px",
                                 "--value-renderer-max-lines": 1,
                               }
+                            }
+                            title={
+                              <span
+                                className="iot--value-card__value-renderer--boolean"
+                                data-testid="Card-attribute-0-value-boolean"
+                              >
+                                true
+                              </span>
                             }
                           >
                             <span
@@ -15466,6 +15519,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="13"
                           >
                             13
                           </span>
@@ -15566,6 +15620,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="1,352"
                           >
                             1,352
                           </span>
@@ -15668,6 +15723,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="103.2"
                           >
                             103.2
                           </span>
@@ -15770,6 +15826,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="107,324.3"
                           >
                             107,324.3
                           </span>
@@ -15872,6 +15929,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="1,709,384.1"
                           >
                             1,709,384.1
                           </span>
@@ -16082,6 +16140,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title={
+                              <span
+                                className="iot--value-card__value-renderer--boolean"
+                                data-testid="Card-attribute-0-value-boolean"
+                              >
+                                true
+                              </span>
+                            }
                           >
                             <span
                               className="iot--value-card__value-renderer--boolean"
@@ -16260,6 +16326,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="65.3"
                           >
                             65.3
                           </span>
@@ -16364,6 +16431,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="48.7"
                           >
                             48.7
                           </span>
@@ -16466,6 +16534,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="88.1"
                           >
                             88.1
                           </span>
@@ -16598,6 +16667,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="103.2"
                           >
                             103.2
                           </span>
@@ -16801,6 +16871,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="65.3"
                           >
                             65.3
                           </span>
@@ -16905,6 +16976,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="48.7"
                           >
                             48.7
                           </span>
@@ -17007,6 +17079,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="88.1"
                           >
                             88.1
                           </span>
@@ -17139,6 +17212,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="103.2"
                           >
                             103.2
                           </span>
@@ -17359,6 +17433,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="38.2"
                           >
                             38.2
                           </span>
@@ -17483,6 +17558,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="65.3"
                           >
                             65.3
                           </span>
@@ -17606,6 +17682,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="77.7"
                           >
                             77.7
                           </span>
@@ -17725,6 +17802,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="91"
                           >
                             91
                           </span>
@@ -17917,6 +17995,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="38.2"
                           >
                             38.2
                           </span>
@@ -18041,6 +18120,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="65.3"
                           >
                             65.3
                           </span>
@@ -18164,6 +18244,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="77.7"
                           >
                             77.7
                           </span>
@@ -18283,6 +18364,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="91"
                           >
                             91
                           </span>
@@ -18458,6 +18540,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Low"
                           >
                             Low
                           </span>
@@ -18560,6 +18643,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Guarded"
                           >
                             Guarded
                           </span>
@@ -18662,6 +18746,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Elevated"
                           >
                             Elevated
                           </span>
@@ -18764,6 +18849,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="High"
                           >
                             High
                           </span>
@@ -18866,6 +18952,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Severe"
                           >
                             Severe
                           </span>
@@ -19041,6 +19128,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Low"
                           >
                             Low
                           </span>
@@ -19143,6 +19231,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Guarded"
                           >
                             Guarded
                           </span>
@@ -19245,6 +19334,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Elevated"
                           >
                             Elevated
                           </span>
@@ -19347,6 +19437,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="High"
                           >
                             High
                           </span>
@@ -19449,6 +19540,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Severe"
                           >
                             Severe
                           </span>
@@ -19624,6 +19716,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="13"
                           >
                             13
                           </span>
@@ -19724,6 +19817,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="1,352"
                           >
                             1,352
                           </span>
@@ -19826,6 +19920,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="103.2"
                           >
                             103.2
                           </span>
@@ -19928,6 +20023,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="107,324.3"
                           >
                             107,324.3
                           </span>
@@ -20030,6 +20126,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="1,709,384.1"
                           >
                             1,709,384.1
                           </span>
@@ -20131,6 +20228,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-font-size": "42px",
                                 "--value-renderer-max-lines": 1,
                               }
+                            }
+                            title={
+                              <span
+                                className="iot--value-card__value-renderer--boolean"
+                                data-testid="Card-attribute-0-value-boolean"
+                              >
+                                false
+                              </span>
                             }
                           >
                             <span
@@ -20237,6 +20342,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title={
+                              <span
+                                className="iot--value-card__value-renderer--boolean"
+                                data-testid="Card-attribute-0-value-boolean"
+                              >
+                                true
+                              </span>
+                            }
                           >
                             <span
                               className="iot--value-card__value-renderer--boolean"
@@ -20342,6 +20455,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="65.3"
                           >
                             65.3
                           </span>
@@ -20446,6 +20560,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="48.7"
                           >
                             48.7
                           </span>
@@ -20548,6 +20663,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="88.1"
                           >
                             88.1
                           </span>
@@ -20680,6 +20796,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="103.2"
                           >
                             103.2
                           </span>
@@ -20827,6 +20944,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="38.2"
                           >
                             38.2
                           </span>
@@ -20951,6 +21069,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="65.3"
                           >
                             65.3
                           </span>
@@ -21074,6 +21193,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="77.7"
                           >
                             77.7
                           </span>
@@ -21193,6 +21313,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="91"
                           >
                             91
                           </span>
@@ -21295,6 +21416,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Low"
                           >
                             Low
                           </span>
@@ -21397,6 +21519,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Guarded"
                           >
                             Guarded
                           </span>
@@ -21499,6 +21622,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Elevated"
                           >
                             Elevated
                           </span>
@@ -21601,6 +21725,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="High"
                           >
                             High
                           </span>
@@ -21703,6 +21828,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Severe"
                           >
                             Severe
                           </span>
@@ -21878,6 +22004,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="13"
                           >
                             13
                           </span>
@@ -21978,6 +22105,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="1,352"
                           >
                             1,352
                           </span>
@@ -22080,6 +22208,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="103.2"
                           >
                             103.2
                           </span>
@@ -22182,6 +22311,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="107,324.3"
                           >
                             107,324.3
                           </span>
@@ -22284,6 +22414,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="1,709,384.1"
                           >
                             1,709,384.1
                           </span>
@@ -22385,6 +22516,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-font-size": "42px",
                                 "--value-renderer-max-lines": 1,
                               }
+                            }
+                            title={
+                              <span
+                                className="iot--value-card__value-renderer--boolean"
+                                data-testid="Card-attribute-0-value-boolean"
+                              >
+                                false
+                              </span>
                             }
                           >
                             <span
@@ -22491,6 +22630,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title={
+                              <span
+                                className="iot--value-card__value-renderer--boolean"
+                                data-testid="Card-attribute-0-value-boolean"
+                              >
+                                true
+                              </span>
+                            }
                           >
                             <span
                               className="iot--value-card__value-renderer--boolean"
@@ -22596,6 +22743,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="65.3"
                           >
                             65.3
                           </span>
@@ -22700,6 +22848,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="48.7"
                           >
                             48.7
                           </span>
@@ -22802,6 +22951,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="88.1"
                           >
                             88.1
                           </span>
@@ -22934,6 +23084,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="103.2"
                           >
                             103.2
                           </span>
@@ -23081,6 +23232,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="38.2"
                           >
                             38.2
                           </span>
@@ -23205,6 +23357,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="65.3"
                           >
                             65.3
                           </span>
@@ -23328,6 +23481,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="77.7"
                           >
                             77.7
                           </span>
@@ -23447,6 +23601,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="91"
                           >
                             91
                           </span>
@@ -23549,6 +23704,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Low"
                           >
                             Low
                           </span>
@@ -23651,6 +23807,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Guarded"
                           >
                             Guarded
                           </span>
@@ -23753,6 +23910,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Elevated"
                           >
                             Elevated
                           </span>
@@ -23855,6 +24013,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="High"
                           >
                             High
                           </span>
@@ -23957,6 +24116,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Severe"
                           >
                             Severe
                           </span>
@@ -24134,6 +24294,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="89.2"
                           >
                             89.2
                           </span>
@@ -24184,6 +24345,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="21.3"
                           >
                             21.3
                           </span>
@@ -24288,6 +24450,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="88.3"
                           >
                             88.3
                           </span>
@@ -24338,6 +24501,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Elevated"
                           >
                             Elevated
                           </span>
@@ -24440,6 +24604,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="103.7"
                           >
                             103.7
                           </span>
@@ -24490,6 +24655,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="1,709,384.1"
                           >
                             1,709,384.1
                           </span>
@@ -24667,6 +24833,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="89.2"
                           >
                             89.2
                           </span>
@@ -24717,6 +24884,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="21.3"
                           >
                             21.3
                           </span>
@@ -24821,6 +24989,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="88.3"
                           >
                             88.3
                           </span>
@@ -24871,6 +25040,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Elevated"
                           >
                             Elevated
                           </span>
@@ -24973,6 +25143,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="103.7"
                           >
                             103.7
                           </span>
@@ -25023,6 +25194,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="1,709,384.1"
                           >
                             1,709,384.1
                           </span>
@@ -25200,6 +25372,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="89.2"
                           >
                             89.2
                           </span>
@@ -25278,6 +25451,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="21.3"
                           >
                             21.3
                           </span>
@@ -25410,6 +25584,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="88.3"
                           >
                             88.3
                           </span>
@@ -25488,6 +25663,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Elevated"
                           >
                             Elevated
                           </span>
@@ -25590,6 +25766,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="103.7"
                           >
                             103.7
                           </span>
@@ -25667,6 +25844,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="1,709,384.1"
                           >
                             1,709,384.1
                           </span>
@@ -25872,6 +26050,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="89.2"
                           >
                             89.2
                           </span>
@@ -25950,6 +26129,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="21.3"
                           >
                             21.3
                           </span>
@@ -26082,6 +26262,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="88.3"
                           >
                             88.3
                           </span>
@@ -26160,6 +26341,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Elevated"
                           >
                             Elevated
                           </span>
@@ -26262,6 +26444,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="103.7"
                           >
                             103.7
                           </span>
@@ -26339,6 +26522,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="1,709,384.1"
                           >
                             1,709,384.1
                           </span>
@@ -26561,6 +26745,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="38.2"
                           >
                             38.2
                           </span>
@@ -26633,6 +26818,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="65.3"
                           >
                             65.3
                           </span>
@@ -26758,6 +26944,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="77.2"
                           >
                             77.2
                           </span>
@@ -26825,6 +27012,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="91.3"
                           >
                             91.3
                           </span>
@@ -27019,6 +27207,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="38.2"
                           >
                             38.2
                           </span>
@@ -27091,6 +27280,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="65.3"
                           >
                             65.3
                           </span>
@@ -27216,6 +27406,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="77.2"
                           >
                             77.2
                           </span>
@@ -27283,6 +27474,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="91.3"
                           >
                             91.3
                           </span>
@@ -27460,6 +27652,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="13,634.56"
                           >
                             13,634.56
                           </span>
@@ -27510,6 +27703,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="1,047.2"
                           >
                             1,047.2
                           </span>
@@ -27588,6 +27782,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="314.5"
                           >
                             314.5
                           </span>
@@ -27720,6 +27915,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Severe"
                           >
                             Severe
                           </span>
@@ -27768,6 +27964,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Low"
                           >
                             Low
                           </span>
@@ -27816,6 +28013,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="High"
                           >
                             High
                           </span>
@@ -27940,6 +28138,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Low"
                           >
                             Low
                           </span>
@@ -28005,6 +28204,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Severe"
                           >
                             Severe
                           </span>
@@ -28074,6 +28274,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Elevated"
                           >
                             Elevated
                           </span>
@@ -28249,6 +28450,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="13,634.56"
                           >
                             13,634.56
                           </span>
@@ -28299,6 +28501,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="1,047.2"
                           >
                             1,047.2
                           </span>
@@ -28377,6 +28580,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="314.5"
                           >
                             314.5
                           </span>
@@ -28509,6 +28713,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Severe"
                           >
                             Severe
                           </span>
@@ -28557,6 +28762,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Low"
                           >
                             Low
                           </span>
@@ -28605,6 +28811,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="High"
                           >
                             High
                           </span>
@@ -28729,6 +28936,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Low"
                           >
                             Low
                           </span>
@@ -28794,6 +29002,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Severe"
                           >
                             Severe
                           </span>
@@ -28863,6 +29072,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                                 "--value-renderer-max-lines": 1,
                               }
                             }
+                            title="Elevated"
                           >
                             Elevated
                           </span>
@@ -29071,6 +29281,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="89"
                         >
                           89
                         </span>
@@ -29121,6 +29332,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="76"
                         >
                           76
                         </span>
@@ -29171,6 +29383,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="21.4"
                         >
                           21.4
                         </span>
@@ -29375,6 +29588,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="62.1"
                         >
                           62.1
                         </span>
@@ -29481,6 +29695,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="62.1"
                         >
                           62.1
                         </span>
@@ -29632,6 +29847,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="76"
                         >
                           76
                         </span>
@@ -29740,6 +29956,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="35"
                         >
                           35
                         </span>
@@ -29891,6 +30108,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="Bad"
                         >
                           Bad
                         </span>
@@ -29997,6 +30215,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="13,572"
                         >
                           13,572
                         </span>
@@ -30311,6 +30530,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                               "--value-renderer-max-lines": 1,
                             }
                           }
+                          title="Healthy"
                         >
                           Healthy
                         </span>

--- a/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
@@ -761,6 +761,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                           "--value-renderer-max-lines": 1,
                         }
                       }
+                      title="88"
                     >
                       88
                     </span>

--- a/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -1991,6 +1991,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                                     "--value-renderer-max-lines": 1,
                                   }
                                 }
+                                title="--"
                               >
                                 --
                               </span>
@@ -10009,6 +10010,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                                   "--value-renderer-max-lines": 1,
                                 }
                               }
+                              title="--"
                             >
                               --
                             </span>
@@ -10059,6 +10061,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                                   "--value-renderer-max-lines": 1,
                                 }
                               }
+                              title="--"
                             >
                               --
                             </span>
@@ -21259,6 +21262,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                                   "--value-renderer-max-lines": 1,
                                 }
                               }
+                              title="--"
                             >
                               --
                             </span>
@@ -21309,6 +21313,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                                   "--value-renderer-max-lines": 1,
                                 }
                               }
+                              title="--"
                             >
                               --
                             </span>

--- a/packages/react/src/components/ValueCard/Attribute.jsx
+++ b/packages/react/src/components/ValueCard/Attribute.jsx
@@ -45,6 +45,8 @@ const propTypes = {
   /** number of attributes */
   attributeCount: PropTypes.number.isRequired,
   testId: PropTypes.string,
+  /** callback when the attribute is clicked to trigger further action like opening a modal */
+  onValueClick: PropTypes.func,
 };
 
 const defaultProps = {
@@ -56,6 +58,7 @@ const defaultProps = {
   customFormatter: null,
   isEditable: false,
   testId: 'attribute',
+  onValueClick: null,
 };
 
 const BEM_BASE = `${BASE_CLASS_NAME}__attribute`;
@@ -65,7 +68,7 @@ const BEM_BASE = `${BASE_CLASS_NAME}__attribute`;
  * He also determines which threshold applies to a given attribute (perhaps that should be moved)
  */
 const Attribute = ({
-  attribute: { label, unit, thresholds, precision },
+  attribute: { label, unit, thresholds, precision, dataSourceId },
   attributeCount,
   customFormatter,
   isEditable,
@@ -77,6 +80,7 @@ const Attribute = ({
   fontSize,
   isNumberValueCompact,
   testId,
+  onValueClick,
 }) => {
   // matching threshold will be the first match in the list, or a value of null if not isEditable
   const matchingThreshold = thresholds
@@ -148,6 +152,8 @@ const Attribute = ({
             fontSize={fontSize}
             isNumberValueCompact={isNumberValueCompact}
             testId={`${testId}-value`}
+            dataSourceId={dataSourceId}
+            onClick={onValueClick}
           />
           <UnitRenderer unit={unit} testId={`${testId}-unit`} />
         </div>

--- a/packages/react/src/components/ValueCard/ValueCard.jsx
+++ b/packages/react/src/components/ValueCard/ValueCard.jsx
@@ -44,6 +44,7 @@ const ValueCard = ({
   isNumberValueCompact,
   testID,
   testId,
+  onAttributeClick,
   ...others
 }) => {
   const availableActions = {
@@ -126,6 +127,7 @@ const ValueCard = ({
               isNumberValueCompact={isNumberValueCompact}
               // TODO: remove deprecated 'testID' in v3.
               testId={`${testID || testId}-attribute-${index}`}
+              onValueClick={onAttributeClick}
             />
           ))
         ) : (
@@ -157,6 +159,7 @@ ValueCard.defaultProps = {
   isNumberValueCompact: false,
   // TODO: fix this default in V3, so that cards are unique not inherited from the base Card
   testId: 'Card',
+  onAttributeClick: null,
 };
 
 export default ValueCard;

--- a/packages/react/src/components/ValueCard/ValueCard.story.jsx
+++ b/packages/react/src/components/ValueCard/ValueCard.story.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { text, select, object, boolean, number } from '@storybook/addon-knobs';
 import { Bee16, Checkmark16 } from '@carbon/icons-react';
 import { spacing05 } from '@carbon/layout';
+import { action } from '@storybook/addon-actions';
 
 import { CARD_SIZES, CARD_DATA_STATE } from '../../constants/LayoutConstants';
 import { getCardMinSize } from '../../utils/componentUtilityFunctions';
@@ -58,7 +59,7 @@ export const SmallLongNoUnits = () => {
   );
 };
 
-SmallLongNoUnits.storyName = 'with long text and no units';
+SmallLongNoUnits.storyName = 'with long text, no units, no click handler';
 
 SmallLongNoUnits.parameters = {
   info: {
@@ -109,6 +110,7 @@ export const WithTrends = () => {
         isNumberValueCompact={boolean('isNumberValueCompact', false)}
         locale={select('locale', ['de', 'fr', 'en', 'ja'], 'en')}
         fontSize={number('fontSize', 42)}
+        onAttributeClick={action('onAttributeClick')}
       />
     </div>
   );
@@ -174,6 +176,7 @@ export const WithThresholds = () => {
         isNumberValueCompact={boolean('isNumberValueCompact', false)}
         locale={select('locale', ['de', 'fr', 'en', 'ja'], 'en')}
         fontSize={number('fontSize', 42)}
+        onAttributeClick={action('onAttributeClick')}
       />
     </div>
   );
@@ -221,6 +224,7 @@ export const SmallWideThresholdsString = () => {
         isNumberValueCompact={boolean('isNumberValueCompact', false)}
         locale={select('locale', ['de', 'fr', 'en', 'ja'], 'en')}
         fontSize={number('fontSize', 42)}
+        onAttributeClick={action('onAttributeClick')}
       />
     </div>
   );
@@ -314,6 +318,7 @@ export const MediumThin3 = () => {
         isNumberValueCompact={boolean('isNumberValueCompact', false)}
         locale={select('locale', ['de', 'fr', 'en', 'ja'], 'en')}
         fontSize={number('fontSize', 42)}
+        onAttributeClick={action('onAttributeClick')}
       />
     </div>
   );
@@ -365,6 +370,7 @@ export const WithFourDataPoints = () => {
         isNumberValueCompact={boolean('isNumberValueCompact', false)}
         locale={select('locale', ['de', 'fr', 'en', 'ja'], 'en')}
         fontSize={number('fontSize', 42)}
+        onAttributeClick={action('onAttributeClick')}
       />
     </div>
   );
@@ -415,6 +421,7 @@ export const Large5 = () => {
         isNumberValueCompact={boolean('isNumberValueCompact', false)}
         locale={select('locale', ['de', 'fr', 'en', 'ja'], 'en')}
         fontSize={number('fontSize', 42)}
+        onAttributeClick={action('onAttributeClick')}
       />
     </div>
   );
@@ -469,6 +476,7 @@ export const LargeThin6 = () => {
         isNumberValueCompact={boolean('isNumberValueCompact', false)}
         locale={select('locale', ['de', 'fr', 'en', 'ja'], 'en')}
         fontSize={number('fontSize', 42)}
+        onAttributeClick={action('onAttributeClick')}
       />
     </div>
   );
@@ -517,6 +525,7 @@ export const DataStateNoDataMediumScrollPage = () => {
         size={size}
         id="myStoryId"
         locale={select('locale', ['de', 'fr', 'en', 'ja'], 'en')}
+        onAttributeClick={action('onAttributeClick')}
       />
 
       <div style={{ height: '150vh' }} />
@@ -559,6 +568,7 @@ export const Editable = () => {
         isNumberValueCompact={boolean('isNumberValueCompact', false)}
         locale={select('locale', ['de', 'fr', 'en', 'ja'], 'en')}
         fontSize={number('fontSize', 42)}
+        onAttributeClick={action('onAttributeClick')}
       />
     </div>
   );
@@ -604,6 +614,7 @@ export const DataFilters = () => {
         isNumberValueCompact={boolean('isNumberValueCompact', false)}
         locale={select('locale', ['de', 'fr', 'en', 'ja'], 'en')}
         fontSize={number('fontSize', 42)}
+        onAttributeClick={action('onAttributeClick')}
       />
     </div>
   );

--- a/packages/react/src/components/ValueCard/ValueCard.test.jsx
+++ b/packages/react/src/components/ValueCard/ValueCard.test.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { CARD_DATA_STATE, CARD_SIZES } from '../../constants/LayoutConstants';
 import { settings } from '../../constants/Settings';
 
 import ValueCard from './ValueCard';
+import { PREVIEW_DATA } from './valueCardUtils';
 
 const { iotPrefix } = settings;
 
@@ -42,7 +43,7 @@ describe('ValueCard', () => {
   });
 
   it('DataState prop shows DataState elements instead of content', () => {
-    const wrapperWithoutDataState = mount(
+    const { container, rerender } = render(
       <ValueCard
         title="Health score"
         content={{ attributes: [{ label: 'title', dataSourceId: 'v' }] }}
@@ -50,9 +51,9 @@ describe('ValueCard', () => {
         values={{ v: 'value' }}
       />
     );
-    expect(wrapperWithoutDataState.find(`.${iotPrefix}--data-state-container`)).toHaveLength(0);
+    expect(container.querySelectorAll(`.${iotPrefix}--data-state-container`)).toHaveLength(0);
 
-    const wrapperWithDataState = mount(
+    rerender(
       <ValueCard
         title="Health score"
         content={{ attributes: [{ label: 'title', dataSourceId: 'v' }] }}
@@ -65,11 +66,11 @@ describe('ValueCard', () => {
         values={{ v: 'value' }}
       />
     );
-    expect(wrapperWithDataState.find(`.${iotPrefix}--data-state-container`)).toHaveLength(1);
+    expect(container.querySelectorAll(`.${iotPrefix}--data-state-container`)).toHaveLength(1);
   });
 
   it('Id is passed down to the card', () => {
-    const wrapper = mount(
+    const { container } = render(
       <ValueCard
         id="myIdTest"
         title="Health score"
@@ -78,7 +79,7 @@ describe('ValueCard', () => {
         values={{ v: 'value' }}
       />
     );
-    expect(wrapper.find('Card#myIdTest')).toHaveLength(1);
+    expect(container.querySelectorAll('#myIdTest')).toHaveLength(1);
   });
 
   it('Custom formatter is used', () => {
@@ -107,7 +108,7 @@ describe('ValueCard', () => {
     expect(screen.queryByText(testValue)).toBeTruthy();
   });
   it('Precision value for attribute is used', () => {
-    render(
+    const { rerender } = render(
       <ValueCard
         id="myIdTest"
         title="Health score"
@@ -118,7 +119,7 @@ describe('ValueCard', () => {
     );
     expect(screen.queryByText('10,000.00')).toBeTruthy();
 
-    render(
+    rerender(
       <ValueCard
         id="myIdTest"
         title="Health score"
@@ -128,5 +129,52 @@ describe('ValueCard', () => {
       />
     );
     expect(screen.queryByText('10,000.0')).toBeTruthy();
+  });
+
+  it('should use onAttributeClick when provided', () => {
+    const onAttributeClick = jest.fn();
+    render(
+      <ValueCard
+        id="myIdTest"
+        title="Health score"
+        content={{ attributes: [{ label: 'title', dataSourceId: 'v', precision: 2 }] }}
+        size={CARD_SIZES.SMALL}
+        values={{ v: 10000 }}
+        onAttributeClick={onAttributeClick}
+      />
+    );
+    const button = screen.queryByText('10,000.00');
+    userEvent.click(button);
+    expect(onAttributeClick).toHaveBeenCalledWith({ dataSourceId: 'v', value: 10000 });
+  });
+
+  it('should should PREVIEW_DATA as secondary value when editable', () => {
+    render(
+      <ValueCard
+        id="myIdTest"
+        title="Health score"
+        content={{
+          attributes: [
+            {
+              label: 'title',
+              dataSourceId: 'v',
+              precision: 2,
+              secondaryValue: {
+                dataSourceId: 'trend',
+                trend: 'down',
+                color: 'red',
+              },
+            },
+          ],
+        }}
+        size={CARD_SIZES.SMALL}
+        values={{ v: 10000 }}
+        isEditable
+      />
+    );
+    const previewData = screen.getAllByText(PREVIEW_DATA);
+    expect(previewData).toHaveLength(2);
+    expect(previewData[1]).toHaveClass(`${iotPrefix}--value-card__attribute-secondary-value`);
+    expect(previewData[1]).toHaveStyle('--secondary-value-color:red');
   });
 });

--- a/packages/react/src/components/ValueCard/ValueCard.test.jsx
+++ b/packages/react/src/components/ValueCard/ValueCard.test.jsx
@@ -131,6 +131,19 @@ describe('ValueCard', () => {
     expect(screen.queryByText('10,000.0')).toBeTruthy();
   });
 
+  it('should render a span when no onAttributeClick provided', () => {
+    render(
+      <ValueCard
+        id="myIdTest"
+        title="Health score"
+        content={{ attributes: [{ label: 'title', dataSourceId: 'v', precision: 2 }] }}
+        size={CARD_SIZES.SMALL}
+        values={{ v: 10000 }}
+      />
+    );
+    expect(screen.queryByText('10,000.00').tagName).toEqual('SPAN');
+  });
+
   it('should use onAttributeClick when provided', () => {
     const onAttributeClick = jest.fn();
     render(
@@ -145,10 +158,11 @@ describe('ValueCard', () => {
     );
     const button = screen.queryByText('10,000.00');
     userEvent.click(button);
+    expect(button.tagName).toEqual('BUTTON');
     expect(onAttributeClick).toHaveBeenCalledWith({ dataSourceId: 'v', value: 10000 });
   });
 
-  it('should should PREVIEW_DATA as secondary value when editable', () => {
+  it('should show PREVIEW_DATA as secondary value when editable', () => {
     render(
       <ValueCard
         id="myIdTest"

--- a/packages/react/src/components/ValueCard/ValueRenderer.jsx
+++ b/packages/react/src/components/ValueCard/ValueRenderer.jsx
@@ -84,6 +84,7 @@ const ValueRenderer = ({
       // otherwise, trucate the first line
       '--value-renderer-max-lines': fontSize < 20 ? 2 : 1,
     },
+    title: renderValue,
   };
 
   return (

--- a/packages/react/src/components/ValueCard/ValueRenderer.jsx
+++ b/packages/react/src/components/ValueCard/ValueRenderer.jsx
@@ -2,9 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import isNil from 'lodash/isNil';
 import classnames from 'classnames';
+import { blue60 } from '@carbon/colors';
 
 import { CARD_LAYOUTS } from '../../constants/LayoutConstants';
 import { formatNumberWithPrecision } from '../../utils/cardUtilityFunctions';
+import Button from '../Button';
 
 import { BASE_CLASS_NAME, PREVIEW_DATA } from './valueCardUtils';
 
@@ -19,6 +21,9 @@ const propTypes = {
   /** optional option to determine whether the number should be abbreviated (i.e. 10,000 = 10K) */
   isNumberValueCompact: PropTypes.bool.isRequired,
   testId: PropTypes.string,
+  /** callback to trigger further action when clicking the value */
+  onClick: PropTypes.func,
+  dataSourceId: PropTypes.string.isRequired,
 };
 
 const defaultProps = {
@@ -28,6 +33,7 @@ const defaultProps = {
   locale: 'en',
   customFormatter: null,
   testId: 'value',
+  onClick: null,
 };
 
 /**
@@ -45,6 +51,8 @@ const ValueRenderer = ({
   fontSize,
   isNumberValueCompact,
   testId,
+  onClick,
+  dataSourceId,
 }) => {
   let renderValue = value;
   if (typeof value === 'boolean') {
@@ -64,23 +72,29 @@ const ValueRenderer = ({
 
   renderValue = isNil(customFormatter) ? renderValue : customFormatter(renderValue, value);
 
+  const commonProps = {
+    'data-testid': testId,
+    className: classnames(`${BASE_CLASS_NAME}__value-renderer--value`, {
+      [`${BASE_CLASS_NAME}__value-renderer--value--vertical`]: layout === CARD_LAYOUTS.VERTICAL,
+    }),
+    style: {
+      '--value-renderer-font-size': `${fontSize}px`,
+      '--value-renderer-color': color || (onClick && blue60),
+      // if the font size is small enough to fit in the boundary box, wrap to 2 lines
+      // otherwise, trucate the first line
+      '--value-renderer-max-lines': fontSize < 20 ? 2 : 1,
+    },
+  };
+
   return (
     <div className={`${BASE_CLASS_NAME}__value-renderer--wrapper`}>
-      <span
-        data-testid={testId}
-        className={classnames(`${BASE_CLASS_NAME}__value-renderer--value`, {
-          [`${BASE_CLASS_NAME}__value-renderer--value--vertical`]: layout === CARD_LAYOUTS.VERTICAL,
-        })}
-        style={{
-          '--value-renderer-font-size': `${fontSize}px`,
-          '--value-renderer-color': color,
-          // if the font size is small enough to fit in the boundary box, wrap to 2 lines
-          // otherwise, trucate the first line
-          '--value-renderer-max-lines': fontSize < 20 ? 2 : 1,
-        }}
-      >
-        {renderValue}
-      </span>
+      {onClick ? (
+        <Button {...commonProps} onClick={() => onClick({ dataSourceId, value })} kind="ghost">
+          {renderValue}
+        </Button>
+      ) : (
+        <span {...commonProps}>{renderValue}</span>
+      )}
     </div>
   );
 };

--- a/packages/react/src/components/ValueCard/ValueRenderer.test.jsx
+++ b/packages/react/src/components/ValueCard/ValueRenderer.test.jsx
@@ -1,5 +1,7 @@
-import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { blue60 } from '@carbon/colors';
 
 import { PREVIEW_DATA } from './valueCardUtils';
 import ValueRenderer from './ValueRenderer';
@@ -8,6 +10,7 @@ const commonProps = {
   isNumberValueCompact: true,
   fontSize: 48,
   testId: 'value-renderer-test',
+  dataSourceId: 'π',
 };
 
 describe('ValueRenderer', () => {
@@ -29,5 +32,29 @@ describe('ValueRenderer', () => {
     expect(value).toHaveStyle('--value-renderer-max-lines:1');
     expect(value).toHaveStyle('--value-renderer-font-size:48px');
     expect(value).not.toHaveStyle('--value-renderer-color:null');
+  });
+
+  it('should handle onClick when provided', () => {
+    const onClick = jest.fn();
+    render(<ValueRenderer {...commonProps} precision={5} value={Math.PI} onClick={onClick} />);
+
+    const button = screen.getByRole('button', { name: '3.14159' });
+    userEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onClick).toHaveBeenCalledWith({ value: Math.PI, dataSourceId: 'π' });
+    expect(button).toHaveStyle(`--value-renderer-color:${blue60}`);
+  });
+
+  it('should handle onClick and colors together', () => {
+    const onClick = jest.fn();
+    render(
+      <ValueRenderer {...commonProps} precision={5} color="red" value={Math.PI} onClick={onClick} />
+    );
+
+    const button = screen.getByRole('button', { name: '3.14159' });
+    userEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onClick).toHaveBeenCalledWith({ value: Math.PI, dataSourceId: 'π' });
+    expect(button).toHaveStyle(`--value-renderer-color:red`);
   });
 });

--- a/packages/react/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/packages/react/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -1289,6 +1289,114 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ValueCard with long text, no units, no click handler 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "margin": "1rem4",
+        "width": "252px",
+      }
+    }
+  >
+    <div
+      className="iot--card iot--value-card__horizontal iot--card--wrapper"
+      data-testid="Card"
+      id="facilitycard"
+      role="presentation"
+      style={
+        Object {
+          "--card-default-height": "144px",
+        }
+      }
+    >
+      <div
+        className="iot--card--header"
+        data-testid="Card-header"
+      >
+        <span
+          className="iot--card--title"
+          data-testid="Card-title"
+          title="Tagpath"
+        >
+          <div
+            className="iot--card--title--text"
+          >
+            Tagpath
+          </div>
+        </span>
+      </div>
+      <div
+        className="iot--card--content"
+        data-testid="Card-content"
+        style={
+          Object {
+            "--card-content-height": "96px",
+          }
+        }
+      >
+        <div
+          className="iot--value-card__content-wrapper"
+        >
+          <div
+            className="iot--value-card__attribute-wrapper iot--value-card__attribute-wrapper--horizontal"
+            style={
+              Object {
+                "--value-card-attribute-width": "100%",
+              }
+            }
+          >
+            <div
+              className="iot--value-card__attribute-label"
+            >
+              <span
+                data-testid="Card-attribute-0-threshold-label"
+              >
+                Tagpath
+              </span>
+            </div>
+            <div
+              className="iot--value-card__attribute"
+            >
+              <div
+                className="iot--value-card__value-renderer--wrapper"
+              >
+                <span
+                  className="iot--value-card__value-renderer--value"
+                  data-testid="Card-attribute-0-value"
+                  style={
+                    Object {
+                      "--value-renderer-color": null,
+                      "--value-renderer-font-size": "42px",
+                      "--value-renderer-max-lines": 1,
+                    }
+                  }
+                >
+                  rutherford/rooms/northadd/ah2/ft_supflow/eurutherford/rooms/northadd/ah2/ft_supflow/eu
+                </span>
+              </div>
+              <span
+                className="iot--value-card__attribute-unit"
+                data-testid="Card-attribute-0-unit"
+                style={
+                  Object {
+                    "--default-font-size": "1.25rem",
+                  }
+                }
+              >
+                
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ValueCard with six data points 1`] = `
 <div
   className="storybook-container"

--- a/packages/react/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/packages/react/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -252,6 +252,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="100"
                   type="button"
                 >
                   100
@@ -312,6 +313,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="50"
                   type="button"
                 >
                   50
@@ -430,6 +432,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="89"
                   type="button"
                 >
                   89
@@ -490,6 +493,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="76.7"
                   type="button"
                 >
                   76.7
@@ -550,6 +554,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="76"
                   type="button"
                 >
                   76
@@ -610,6 +615,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="50"
                   type="button"
                 >
                   50
@@ -670,6 +676,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="0.567"
                   type="button"
                 >
                   0.567
@@ -788,6 +795,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="Good"
                   type="button"
                 >
                   Good
@@ -848,6 +856,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="Healthy"
                   type="button"
                 >
                   Healthy
@@ -908,6 +917,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="None"
                   type="button"
                 >
                   None
@@ -968,6 +978,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="Unbearable"
                   type="button"
                 >
                   Unbearable
@@ -1086,6 +1097,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="--"
                   type="button"
                 >
                   --
@@ -1146,6 +1158,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="--"
                   type="button"
                 >
                   --
@@ -1161,124 +1174,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                 }
               >
                 Wh
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ValueCard with long text and no units 1`] = `
-<div
-  className="storybook-container"
->
-  <div
-    style={
-      Object {
-        "margin": "1rem4",
-        "width": "252px",
-      }
-    }
-  >
-    <div
-      className="iot--card iot--value-card__horizontal iot--card--wrapper"
-      data-testid="Card"
-      id="facilitycard"
-      role="presentation"
-      style={
-        Object {
-          "--card-default-height": "144px",
-        }
-      }
-    >
-      <div
-        className="iot--card--header"
-        data-testid="Card-header"
-      >
-        <span
-          className="iot--card--title"
-          data-testid="Card-title"
-          title="Tagpath"
-        >
-          <div
-            className="iot--card--title--text"
-          >
-            Tagpath
-          </div>
-        </span>
-      </div>
-      <div
-        className="iot--card--content"
-        data-testid="Card-content"
-        style={
-          Object {
-            "--card-content-height": "96px",
-          }
-        }
-      >
-        <div
-          className="iot--value-card__content-wrapper"
-        >
-          <div
-            className="iot--value-card__attribute-wrapper iot--value-card__attribute-wrapper--horizontal"
-            style={
-              Object {
-                "--value-card-attribute-width": "100%",
-              }
-            }
-          >
-            <div
-              className="iot--value-card__attribute-label"
-            >
-              <span
-                data-testid="Card-attribute-0-threshold-label"
-              >
-                Tagpath
-              </span>
-            </div>
-            <div
-              className="iot--value-card__attribute"
-            >
-              <div
-                className="iot--value-card__value-renderer--wrapper"
-              >
-                <button
-                  aria-describedby={null}
-                  aria-pressed={null}
-                  className="iot--value-card__value-renderer--value iot--btn bx--btn bx--btn--ghost"
-                  data-testid="Button"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  style={
-                    Object {
-                      "--value-renderer-color": "#0f62fe",
-                      "--value-renderer-font-size": "42px",
-                      "--value-renderer-max-lines": 1,
-                    }
-                  }
-                  tabIndex={0}
-                  type="button"
-                >
-                  rutherford/rooms/northadd/ah2/ft_supflow/eurutherford/rooms/northadd/ah2/ft_supflow/eu
-                </button>
-              </div>
-              <span
-                className="iot--value-card__attribute-unit"
-                data-testid="Card-attribute-0-unit"
-                style={
-                  Object {
-                    "--default-font-size": "1.25rem",
-                  }
-                }
-              >
-                
               </span>
             </div>
           </div>
@@ -1373,6 +1268,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  title="rutherford/rooms/northadd/ah2/ft_supflow/eurutherford/rooms/northadd/ah2/ft_supflow/eu"
                 >
                   rutherford/rooms/northadd/ah2/ft_supflow/eurutherford/rooms/northadd/ah2/ft_supflow/eu
                 </span>
@@ -1490,6 +1386,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="89"
                   type="button"
                 >
                   89
@@ -1550,6 +1447,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="76.7"
                   type="button"
                 >
                   76.7
@@ -1610,6 +1508,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="76"
                   type="button"
                 >
                   76
@@ -1670,6 +1569,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="76"
                   type="button"
                 >
                   76
@@ -1730,6 +1630,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="76"
                   type="button"
                 >
                   76
@@ -1790,6 +1691,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="Australia"
                   type="button"
                 >
                   Australia
@@ -1850,6 +1752,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="76"
                   type="button"
                 >
                   76
@@ -1989,6 +1892,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="345,678,234,234,234,240"
                   type="button"
                 >
                   345,678,234,234,234,240
@@ -2070,6 +1974,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="456,778,234,234,234,240.0"
                   type="button"
                 >
                   456,778,234,234,234,240.0
@@ -2151,6 +2056,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="88,888,678,234,234,240,000.0"
                   type="button"
                 >
                   88,888,678,234,234,240,000.0
@@ -2284,6 +2190,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="Unhealthy"
                   type="button"
                 >
                   Unhealthy
@@ -2420,6 +2327,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="70"
                   type="button"
                 >
                   70
@@ -2538,6 +2446,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                     }
                   }
                   tabIndex={0}
+                  title="13,572"
                   type="button"
                 >
                   13,572

--- a/packages/react/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/packages/react/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -233,19 +233,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical"
-                  data-testid="Card-attribute-0-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   100
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -283,19 +293,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical"
-                  data-testid="Card-attribute-1-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   50
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -391,19 +411,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical"
-                  data-testid="Card-attribute-0-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   89
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -441,19 +471,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical"
-                  data-testid="Card-attribute-1-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   76.7
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -491,19 +531,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical"
-                  data-testid="Card-attribute-2-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   76
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -541,19 +591,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical"
-                  data-testid="Card-attribute-3-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   50
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -591,19 +651,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical"
-                  data-testid="Card-attribute-4-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   0.567
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -699,19 +769,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value"
-                  data-testid="Card-attribute-0-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   Good
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -749,19 +829,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value"
-                  data-testid="Card-attribute-1-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   Healthy
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -799,19 +889,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value"
-                  data-testid="Card-attribute-2-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   None
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -849,19 +949,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value"
-                  data-testid="Card-attribute-3-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   Unbearable
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -957,19 +1067,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical"
-                  data-testid="Card-attribute-0-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   --
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -1007,19 +1127,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical"
-                  data-testid="Card-attribute-1-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   --
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -1115,19 +1245,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value"
-                  data-testid="Card-attribute-0-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   rutherford/rooms/northadd/ah2/ft_supflow/eurutherford/rooms/northadd/ah2/ft_supflow/eu
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -1223,19 +1363,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical"
-                  data-testid="Card-attribute-0-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   89
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -1273,19 +1423,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical"
-                  data-testid="Card-attribute-1-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   76.7
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -1323,19 +1483,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical"
-                  data-testid="Card-attribute-2-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   76
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -1373,19 +1543,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical"
-                  data-testid="Card-attribute-3-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   76
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -1423,19 +1603,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical"
-                  data-testid="Card-attribute-4-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   76
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -1473,19 +1663,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical"
-                  data-testid="Card-attribute-5-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   Australia
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -1523,19 +1723,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical"
-                  data-testid="Card-attribute-6-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   76
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -1652,19 +1862,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical"
-                  data-testid="Card-attribute-0-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   345,678,234,234,234,240
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -1723,19 +1943,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical"
-                  data-testid="Card-attribute-1-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   456,778,234,234,234,240.0
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -1794,19 +2024,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical"
-                  data-testid="Card-attribute-2-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--value-card__value-renderer--value--vertical iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   88,888,678,234,234,240,000.0
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -1917,19 +2157,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value"
-                  data-testid="Card-attribute-0-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   Unhealthy
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -2043,19 +2293,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value"
-                  data-testid="Card-attribute-0-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   70
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"
@@ -2151,19 +2411,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               <div
                 className="iot--value-card__value-renderer--wrapper"
               >
-                <span
-                  className="iot--value-card__value-renderer--value"
-                  data-testid="Card-attribute-0-value"
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="iot--value-card__value-renderer--value iot--btn bx--btn bx--btn--ghost"
+                  data-testid="Button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   style={
                     Object {
-                      "--value-renderer-color": null,
+                      "--value-renderer-color": "#0f62fe",
                       "--value-renderer-font-size": "42px",
                       "--value-renderer-max-lines": 1,
                     }
                   }
+                  tabIndex={0}
+                  type="button"
                 >
                   13,572
-                </span>
+                </button>
               </div>
               <span
                 className="iot--value-card__attribute-unit"

--- a/packages/react/src/components/ValueCard/_value-renderer.scss
+++ b/packages/react/src/components/ValueCard/_value-renderer.scss
@@ -2,9 +2,16 @@
 
 .#{$iot-prefix}--value-card__value-renderer {
   &--wrapper {
-    overflow: hidden;
     text-overflow: ellipsis;
     display: flex;
+
+    .#{$iot-prefix}--value-card__attribute-wrapper--horizontal & {
+      width: 100%;
+    }
+
+    .#{$iot-prefix}--value-card__content-wrapper--vertical & {
+      overflow: hidden;
+    }
   }
 
   &--value {
@@ -20,7 +27,7 @@
     word-break: break-all;
     /* override default button styles to match span visuals when using a button */
     &.#{$prefix}--btn {
-      padding: 0;
+      padding: $spacing-01;
       flex: 1;
       white-space: nowrap;
     }

--- a/packages/react/src/components/ValueCard/_value-renderer.scss
+++ b/packages/react/src/components/ValueCard/_value-renderer.scss
@@ -18,6 +18,12 @@
     line-height: $line-height;
     @include multiline-text-overflow($max-lines, $line-height);
     word-break: break-all;
+    /* override default button styles to match span visuals when using a button */
+    &.#{$prefix}--btn {
+      padding: 0;
+      flex: 1;
+      white-space: nowrap;
+    }
 
     &--vertical {
       text-align: left;

--- a/packages/react/src/constants/CardPropTypes.js
+++ b/packages/react/src/constants/CardPropTypes.js
@@ -118,6 +118,8 @@ export const ValueCardPropTypes = {
   fontSize: PropTypes.number,
   /** option to determine whether the number should be abbreviated (i.e. 10,000 = 10K) */
   isNumberValueCompact: PropTypes.bool,
+  /** Callback fired when an attribute is clicked to take further action like opening a modal */
+  onAttributeClick: PropTypes.func,
 };
 
 export const TableCardPropTypes = {

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -13770,6 +13770,7 @@ Map {
       "fontSize": 42,
       "isNumberValueCompact": false,
       "locale": "en",
+      "onAttributeClick": null,
       "size": "MEDIUM",
       "testId": "Card",
       "values": null,
@@ -14606,6 +14607,9 @@ Map {
       },
       "locale": Object {
         "type": "string",
+      },
+      "onAttributeClick": Object {
+        "type": "func",
       },
       "onBlur": Object {
         "type": "func",


### PR DESCRIPTION
Closes #2376 

**Summary**

- Adds an `onAttributeClick` callback to the ValueCards. This gets passed down to each attribute on the card, and when the attribute is clicked it returns an object with the value and the dataSourceId.

**Change List (commits, features, bugs, etc)**

- add onAttributeClick to ValueCard
- update stories with actions
- add tests coverage
- fix style differences between span/button tags

**Acceptance Test (how to verify the PR)**

- The ValueCard stories should now have an `onAttributeClick` action that gets called when the value is clicked
- The stories with the callback should have blue text (unless a different color was supplied in the props)

**Regression Test (how to make sure this PR doesn't break old functionality)**

- The styles of next/deploypreview should match except for color when onAttributeClick is provided.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
