### PR TITLE
fix(simple-list): update state properly when external props change

### DIFF
--- a/packages/react/src/components/List/SimpleList/SimpleList.jsx
+++ b/packages/react/src/components/List/SimpleList/SimpleList.jsx
@@ -129,9 +129,8 @@ const SimpleList = ({
       const searchFilteredItems = items.filter((item) => {
         if (item.content.value !== '' && item.content.value !== undefined) {
           if (
-            item.content.secondaryValue !== '' &&
-            item.content.secondaryValue !== undefined &&
-            typeof item.content.secondaryValue === 'string'
+            typeof item.content.secondaryValue === 'string' &&
+            item.content.secondaryValue !== ''
           ) {
             return (
               item.content.value.toLowerCase().search(searchTerm.toLowerCase()) !== -1 ||
@@ -164,7 +163,7 @@ const SimpleList = ({
   const maxPage = Math.ceil(numberOfItems / rowPerPage);
 
   /**
-   * Then the items array updates, make sure to update the filteredItems, but also re-apply
+   * When the items array updates, make sure to update the filteredItems, but also re-apply
    * search values if there were any.
    */
   useEffect(() => {

--- a/packages/react/src/components/List/SimpleList/SimpleList.jsx
+++ b/packages/react/src/components/List/SimpleList/SimpleList.jsx
@@ -163,6 +163,10 @@ const SimpleList = ({
 
   const maxPage = Math.ceil(numberOfItems / rowPerPage);
 
+  /**
+   * Then the items array updates, make sure to update the filteredItems, but also re-apply
+   * search values if there were any.
+   */
   useEffect(() => {
     setFilteredItems(items);
     if (searchValue) {
@@ -170,6 +174,20 @@ const SimpleList = ({
     }
   }, [items, handleSearch, searchValue]);
 
+  /**
+   * to maintain the correct page and items from that page, we must update the
+   * itemsToShow array based on the current page and the number of rows shown based on
+   * the pageSize prop.
+   */
+  useEffect(() => {
+    const startIndex = (currentPageNumber - 1) * rowPerPage;
+    setItemsToShow(filteredItems.slice(startIndex, startIndex + rowPerPage));
+  }, [currentPageNumber, filteredItems, rowPerPage]);
+
+  /**
+   * If we were on a higher page and the number of items drop, we need to ensure we
+   * reset to the first page when the number of items drops below our previous max page.
+   */
   useEffect(() => {
     if (currentPageNumber > maxPage) {
       onPage(1);

--- a/packages/react/src/components/List/SimpleList/SimpleList.story.jsx
+++ b/packages/react/src/components/List/SimpleList/SimpleList.story.jsx
@@ -39,7 +39,7 @@ const rowActionsOverFlowMenu = [
   </OverflowMenu>,
 ];
 
-const getListItemsWithActions = (num) =>
+export const getListItemsWithActions = (num) =>
   Array(num)
     .fill(0)
     .map((i, idx) => ({
@@ -127,7 +127,7 @@ export default {
     },
   },
 
-  excludeStories: ['getListItems'],
+  excludeStories: ['getListItems', 'getListItemsWithActions'],
 };
 
 export const Basic = () => (

--- a/packages/react/src/components/List/SimpleList/SimpleList.story.jsx
+++ b/packages/react/src/components/List/SimpleList/SimpleList.story.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Add16, Close16, Edit16 } from '@carbon/icons-react';
-import { boolean, select, text } from '@storybook/addon-knobs';
+import { boolean, select, text, number } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { spacing03 } from '@carbon/layout';
 import { Button, OverflowMenu, OverflowMenuItem } from 'carbon-components-react';
@@ -140,7 +140,7 @@ export const Basic = () => (
         pageOfPagesText: (pageNumber) => `Page ${pageNumber}`,
       }}
       buttons={buttonsToRender}
-      items={getListItems(30)}
+      items={getListItems(number('items to render', 30))}
       isFullHeight={boolean('isFullHeight', true)}
       pageSize={select('pageSize', ['sm', 'lg', 'xl'], 'xl')}
       isLoading={boolean('isLoading', false)}

--- a/packages/react/src/components/List/SimpleList/SimpleList.test.e2e.jsx
+++ b/packages/react/src/components/List/SimpleList/SimpleList.test.e2e.jsx
@@ -60,4 +60,49 @@ describe('SimpleList', () => {
         ]);
       });
   });
+
+  it("handles calls the default onListUpdated when one isn't provided", () => {
+    const onListUpdated = cy.spy(SimpleList.defaultProps, 'onListUpdated');
+    mount(
+      <SimpleList
+        title="Simple list"
+        hasSearch
+        items={getListItems(3)}
+        pageSize="sm"
+        editingStyle={EditingStyle.Multiple}
+      />
+    );
+
+    cy.findByTestId('1-checkbox').click({ force: true });
+    cy.findByTestId('2-checkbox').click({ force: true });
+    cy.findAllByText('Item 1')
+      .eq(1)
+      .drag(':nth-child(3) > [draggable="true"]', { position: 'bottom' })
+      .should(() => {
+        expect(onListUpdated).to.be.calledWith([
+          {
+            id: '3',
+            content: {
+              value: 'Item 3',
+            },
+            isSelectable: true,
+            children: [],
+          },
+          {
+            id: '1',
+            content: {
+              value: 'Item 1',
+            },
+            isSelectable: true,
+          },
+          {
+            id: '2',
+            content: {
+              value: 'Item 2',
+            },
+            isSelectable: true,
+          },
+        ]);
+      });
+  });
 });

--- a/packages/react/src/components/List/SimpleList/SimpleList.test.jsx
+++ b/packages/react/src/components/List/SimpleList/SimpleList.test.jsx
@@ -6,6 +6,7 @@ import { settings } from '../../../constants/Settings';
 import * as dndUtils from '../../../utils/DragAndDropUtils';
 
 import SimpleList from './SimpleList';
+import { getListItemsWithActions } from './SimpleList.story';
 
 const { EditingStyle } = dndUtils;
 
@@ -265,5 +266,156 @@ describe('SimpleList', () => {
       null
     );
     jest.resetAllMocks();
+  });
+
+  it('should change the list when items are changed via props', () => {
+    const { rerender } = render(
+      <SimpleList title="Simple list" hasSearch items={getListItems(2)} />
+    );
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(2);
+
+    rerender(<SimpleList title="Simple list" hasSearch items={getListItems(3)} />);
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(3);
+  });
+
+  it('should change the list when items are changed via props and maintain search filters', () => {
+    const { rerender } = render(
+      <SimpleList title="Simple list" hasSearch items={getListItems(2)} />
+    );
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(2);
+    userEvent.type(screen.getByRole('searchbox'), '2');
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(1);
+
+    rerender(<SimpleList title="Simple list" hasSearch items={getListItems(3)} />);
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(1);
+  });
+
+  it('should change the list when items are changed via props and maintain pagination', () => {
+    const { rerender } = render(
+      <SimpleList title="Simple list" hasSearch items={getListItems(10)} pageSize="sm" />
+    );
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(5);
+    expect(screen.getByText('Item 5')).toBeVisible();
+    expect(screen.getByText('Page 1')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Prev page' })).toHaveClass(
+      `${iotPrefix}-addons-simple-pagination-button-disabled`
+    );
+    userEvent.click(screen.getByRole('button', { name: 'Next page' }));
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(5);
+    expect(screen.getByText('Item 10')).toBeVisible();
+    expect(screen.getByText('Page 2')).toBeVisible();
+
+    rerender(<SimpleList title="Simple list" hasSearch items={getListItems(15)} pageSize="sm" />);
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(5);
+    expect(screen.getByText('Item 10')).toBeVisible();
+    expect(screen.getByText('Page 2')).toBeVisible();
+
+    userEvent.click(screen.getByRole('button', { name: 'Next page' }));
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(5);
+    expect(screen.getByText('Item 15')).toBeVisible();
+    expect(screen.getByText('Page 3')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Next page' })).toHaveClass(
+      `${iotPrefix}-addons-simple-pagination-button-disabled`
+    );
+
+    rerender(<SimpleList title="Simple list" hasSearch items={getListItems(5)} pageSize="sm" />);
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(5);
+    expect(screen.getByText('Item 5')).toBeVisible();
+    expect(screen.getByText('Page 1')).toBeVisible();
+    expect(screen.queryByRole('button', { name: 'Next page' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Prev page' })).toBeNull();
+  });
+
+  it('should change the list when items are changed via props and maintain both pagination and search', () => {
+    const { rerender } = render(
+      <SimpleList title="Simple list" hasSearch items={getListItems(15)} pageSize="sm" />
+    );
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(5);
+    expect(screen.getByText('Item 5')).toBeVisible();
+    expect(screen.getByText('Page 1')).toBeVisible();
+    userEvent.click(screen.getByRole('button', { name: 'Next page' }));
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(5);
+    expect(screen.getByText('Item 10')).toBeVisible();
+    expect(screen.getByText('Page 2')).toBeVisible();
+
+    userEvent.type(screen.getByRole('searchbox'), '5');
+
+    rerender(<SimpleList title="Simple list" hasSearch items={getListItems(50)} pageSize="sm" />);
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(5);
+    expect(screen.getByText('Item 5')).toBeVisible();
+    expect(screen.getByText('Item 15')).toBeVisible();
+    expect(screen.getByText('Item 25')).toBeVisible();
+    expect(screen.getByText('Item 35')).toBeVisible();
+    expect(screen.getByText('Item 45')).toBeVisible();
+    expect(screen.getByText('Page 1')).toBeVisible();
+    userEvent.click(screen.getByRole('button', { name: 'Next page' }));
+    expect(screen.getByText('Item 50')).toBeVisible();
+    expect(screen.getByText('Page 2')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Next page' })).toHaveClass(
+      `${iotPrefix}-addons-simple-pagination-button-disabled`
+    );
+
+    rerender(<SimpleList title="Simple list" hasSearch items={getListItems(5)} pageSize="sm" />);
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(1);
+    expect(screen.getByText('Item 5')).toBeVisible();
+    expect(screen.getByText('Page 1')).toBeVisible();
+    expect(screen.queryByRole('button', { name: 'Next page' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Prev page' })).toBeNull();
+  });
+
+  it('should change the list when items are changed via props with icons', () => {
+    const { rerender } = render(
+      <SimpleList title="Simple list" hasSearch items={getListItemsWithActions(10)} pageSize="sm" />
+    );
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(5);
+    expect(screen.getByText('Item 5')).toBeVisible();
+    expect(screen.getByText('Page 1')).toBeVisible();
+    userEvent.click(screen.getByRole('button', { name: 'Next page' }));
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(5);
+    expect(screen.getByText('Item 10')).toBeVisible();
+    expect(screen.getByText('Page 2')).toBeVisible();
+    rerender(
+      <SimpleList title="Simple list" hasSearch items={getListItemsWithActions(20)} pageSize="lg" />
+    );
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(10);
+    expect(screen.getByText('Item 10')).toBeVisible();
+    expect(screen.getByText('Page 1')).toBeVisible();
+    userEvent.click(screen.getByRole('button', { name: 'Next page' }));
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(10);
+    expect(screen.getByText('Item 20')).toBeVisible();
+    expect(screen.getByText('Page 2')).toBeVisible();
+  });
+
+  it('should fallback to an empty string if the search event has no value', () => {
+    render(<SimpleList title="Simple list" hasSearch items={getListItems(10)} pageSize="sm" />);
+
+    fireEvent.change(screen.getByPlaceholderText('Enter a value'), {
+      target: { value: null },
+    });
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(5);
+  });
+
+  it('should not render pagination when hasPagination:false even when pageSize given', () => {
+    render(
+      <SimpleList
+        title="Simple list"
+        hasSearch
+        items={getListItems(10)}
+        pageSize="sm"
+        hasPagination={false}
+      />
+    );
+
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(10);
+  });
+
+  it('should call onselect when provided', () => {
+    const onSelect = jest.fn();
+    render(
+      <SimpleList title="Simple list" hasSearch items={getListItems(10)} onSelect={onSelect} />
+    );
+
+    userEvent.click(screen.getByTitle('Item 1'));
+    expect(onSelect).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react/src/components/List/SimpleList/SimpleList.test.jsx
+++ b/packages/react/src/components/List/SimpleList/SimpleList.test.jsx
@@ -418,4 +418,20 @@ describe('SimpleList', () => {
     userEvent.click(screen.getByTitle('Item 1'));
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
+
+  it('should update the number of items visible when changing pagination props', () => {
+    const { rerender } = render(
+      <SimpleList title="Simple list" hasSearch items={getListItems(30)} pageSize="sm" />
+    );
+
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(5);
+    rerender(<SimpleList title="Simple list" hasSearch items={getListItems(30)} pageSize="lg" />);
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(10);
+    rerender(<SimpleList title="Simple list" hasSearch items={getListItems(30)} pageSize="xl" />);
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(20);
+    rerender(
+      <SimpleList title="Simple list" hasSearch items={getListItems(30)} hasPagination={false} />
+    );
+    expect(screen.getAllByTitle(/Item /)).toHaveLength(30);
+  });
 });


### PR DESCRIPTION
Closes #2316 

**Summary**

Previously, the whole list needed to be thrown out when any props changed, but now I've added useEffects to update the state as new items are passed or as pageSize change, for example. It should maintain the previous state, so if you were on Page 2 and new items are added you'll stay on Page 2, but if items are removed you'll reset back to page 1. If you previously had a search value and you add more items the search value will be maintained.

**Change List (commits, features, bugs, etc)**

- added useEffects to update state when items or pagination props change
- added new tests to cover all this functionality and increase coverage even more

**Acceptance Test (how to verify the PR)**

- Open the Basic SimpleList story
- change the number of items rendering to 10
- confirm only 10 items shown
- change pageSize to sm 
- confirm only 5 items shown
- move to page 2
- change the number of items rendering to 20
- confirm still on page 2
- move to page 3
- confirm 20 items are being rendered
- Repeat similar steps with search and confirm items shown and pagination is maintained when changing other external props

**Regression Test (how to make sure this PR doesn't break old functionality)**

- All previous functionality works as expected.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
