### PR TITLE
fix(empty-state): node-sass build errors with `max`

### DIFF
--- a/packages/react/src/components/Table/_table.scss
+++ b/packages/react/src/components/Table/_table.scss
@@ -61,14 +61,14 @@ html[dir='rtl'] {
   }
   .empty-table-cell--default {
     --height-threshold: 500px;
-    --is-large-card: min(1px, max(var(--card-content-height) - var(--height-threshold), 0px));
+    --is-large-card: Min(1px, Max(var(--card-content-height) - var(--height-threshold), 0px));
     display: flex;
     align-items: flex-start;
     justify-content: center;
     flex-direction: column;
     // 3rem since we can't multiply 1px * 3rem in calc
     // stylelint-disable-next-line declaration-property-unit-blacklist
-    padding: max(calc(48 * var(--is-large-card)), 0px);
+    padding: Max(calc(48 * var(--is-large-card)), 0px);
     svg {
       margin: $spacing-05;
     }


### PR DESCRIPTION
Closes #2792 

**Summary**

- ~~Unfortunately, I cannot recreate the error in this issue. I rolled back to node-sass 4.14, but existing code still compiles in the test app. I'm making this case change suggested by @davidicus.~~
- node-sass 4.14.1 fails to compile `max`, but by changing it to uppercase `Max` it knows it's a css function and compiles fine.

**Change List (commits, features, bugs, etc)**

- change case to force sass to use the css version of `max`

**Acceptance Test (how to verify the PR)**

- follow the instructions in [this PR](https://github.com/carbon-design-system/carbon-addons-iot-react/pull/2775) to build a local version of the library, but use `node-sass@4.14.1` to build sass in the consuming application.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- medium TableCards still have 0 padding when in empty state: https://deploy-preview-2796--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-tablecard--with-multiple-actions

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
