### PR TITLE
feat(table): allow lazy-loading of columns

### DIFF
--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -206,6 +206,7 @@ const propTypes = {
       loadingState: PropTypes.shape({
         isLoading: PropTypes.bool,
         rowCount: PropTypes.number,
+        columnCount: PropTypes.number,
       }),
       /* show the modal for selecting multi-sort columns */
       showMultiSortModal: PropTypes.bool,
@@ -340,6 +341,7 @@ export const defaultProps = (baseProps) => ({
       ordering: baseProps.columns && baseProps.columns.map((i) => ({ columnId: i.id })),
       loadingState: {
         rowCount: 5,
+        columnCount: 5,
       },
       singleRowEditButtons: null,
     },
@@ -826,61 +828,63 @@ const Table = (props) => {
           })}
           {...others}
         >
-          <TableHead
-            {...others}
-            i18n={i18n}
-            lightweight={lightweight}
-            options={{
-              ...pick(
-                options,
-                'hasAggregations',
-                'hasColumnSelectionConfig',
-                'hasResize',
-                'hasRowActions',
-                'hasRowExpansion',
-                'hasRowNesting',
-                'hasSingleRowEdit',
-                'hasRowSelection',
-                'useAutoTableLayoutForResize',
-                'hasMultiSort',
-                'preserveColumnWidths'
-              ),
-              wrapCellText: options.wrapCellText,
-              truncateCellText: useCellTextTruncate,
-            }}
-            columns={columns}
-            filters={view.filters}
-            actions={{
-              ...pick(actions.toolbar, 'onApplyFilter'),
-              ...pick(
-                actions.table,
-                'onSelectAll',
-                'onChangeSort',
-                'onChangeOrdering',
-                'onColumnSelectionConfig',
-                'onOverflowItemClicked'
-              ),
-              onColumnResize: handleOnColumnResize,
-            }}
-            selectAllText={i18n.selectAllAria}
-            clearFilterText={i18n.clearFilterAria}
-            filterText={i18n.filterAria}
-            clearSelectionText={i18n.clearSelectionAria}
-            openMenuText={i18n.openMenuAria}
-            closeMenuText={i18n.closeMenuAria}
-            tableId={id || tableId}
-            tableState={{
-              isDisabled: rowEditMode || singleRowEditMode,
-              activeBar: view.toolbar.activeBar,
-              filters: view.filters,
-              ...view.table,
-              selection: { isSelectAllSelected, isSelectAllIndeterminate },
-            }}
-            hasFastFilter={options?.hasFilter === 'onKeyPress'}
-            // TODO: remove id in v3
-            testId={`${id || testId}-table-head`}
-            showExpanderColumn={showExpanderColumn}
-          />
+          {columns.length ? (
+            <TableHead
+              {...others}
+              i18n={i18n}
+              lightweight={lightweight}
+              options={{
+                ...pick(
+                  options,
+                  'hasAggregations',
+                  'hasColumnSelectionConfig',
+                  'hasResize',
+                  'hasRowActions',
+                  'hasRowExpansion',
+                  'hasRowNesting',
+                  'hasSingleRowEdit',
+                  'hasRowSelection',
+                  'useAutoTableLayoutForResize',
+                  'hasMultiSort',
+                  'preserveColumnWidths'
+                ),
+                wrapCellText: options.wrapCellText,
+                truncateCellText: useCellTextTruncate,
+              }}
+              columns={columns}
+              filters={view.filters}
+              actions={{
+                ...pick(actions.toolbar, 'onApplyFilter'),
+                ...pick(
+                  actions.table,
+                  'onSelectAll',
+                  'onChangeSort',
+                  'onChangeOrdering',
+                  'onColumnSelectionConfig',
+                  'onOverflowItemClicked'
+                ),
+                onColumnResize: handleOnColumnResize,
+              }}
+              selectAllText={i18n.selectAllAria}
+              clearFilterText={i18n.clearFilterAria}
+              filterText={i18n.filterAria}
+              clearSelectionText={i18n.clearSelectionAria}
+              openMenuText={i18n.openMenuAria}
+              closeMenuText={i18n.closeMenuAria}
+              tableId={id || tableId}
+              tableState={{
+                isDisabled: rowEditMode || singleRowEditMode,
+                activeBar: view.toolbar.activeBar,
+                filters: view.filters,
+                ...view.table,
+                selection: { isSelectAllSelected, isSelectAllIndeterminate },
+              }}
+              hasFastFilter={options?.hasFilter === 'onKeyPress'}
+              // TODO: remove id in v3
+              testId={`${id || testId}-table-head`}
+              showExpanderColumn={showExpanderColumn}
+            />
+          ) : null}
 
           {
             // Table contents
@@ -889,6 +893,7 @@ const Table = (props) => {
                 columns={visibleColumns}
                 {...pick(options, 'hasRowSelection', 'hasRowExpansion', 'hasRowActions')}
                 rowCount={view.table.loadingState.rowCount}
+                columnCount={view.table.loadingState.columnCount}
                 // TODO: remove 'id' in v3.
                 testId={`${id || testId}-table-skeleton`}
                 showExpanderColumn={showExpanderColumn}

--- a/packages/react/src/components/Table/Table.story.jsx
+++ b/packages/react/src/components/Table/Table.story.jsx
@@ -616,6 +616,13 @@ export const BasicDumbTable = () => (
           },
         ],
       },
+      table: {
+        loadingState: {
+          isLoading: boolean('isLoading', false),
+          rowCount: number('rowCount', 7),
+          columnCount: number('columnCount', 6),
+        },
+      },
     }}
   />
 );
@@ -2364,3 +2371,56 @@ WithStickyHeaderExperimentalAndCellTooltipCalculation.parameters = {
     text: `StickyHeader is experimental. To properly render a tooltip in a table with sticky headers you need to pass a menuOffset or menuOffsetFlip calculation to <Tooltip>`,
   },
 };
+
+export const AsyncColumnLoading = () => {
+  const selectedTableType = select('Type of Table', ['Table', 'StatefulTable'], 'Table');
+  const MyTable = selectedTableType === 'StatefulTable' ? StatefulTable : Table;
+
+  const [columns, setColumns] = useState([]);
+  const [data, setData] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setColumns(tableColumns);
+      setData(tableData);
+      setIsLoading(false);
+    }, 3000);
+  }, []);
+
+  return (
+    <MyTable
+      id="loading-table"
+      columns={columns}
+      data={data}
+      options={{
+        hasAggregations: boolean('hasAggregations', true),
+        hasSearch: boolean('hasSearch', true),
+        hasFilter: boolean('hasFilter', true),
+        hasPagination: boolean('hasPagination', true),
+        hasRowEdit: boolean('hasRowEdit', false),
+      }}
+      view={{
+        aggregations: {
+          label: 'Total:',
+          columns: [
+            {
+              id: 'number',
+              align: 'start',
+              isSortable: false,
+            },
+          ],
+        },
+        table: {
+          loadingState: {
+            isLoading,
+            rowCount: number('rowCount', 10),
+            columnCount: number('columnCount', 9),
+          },
+        },
+      }}
+    />
+  );
+};
+AsyncColumnLoading.storyName = 'with async column loading';
+AsyncColumnLoading.decorators = [createElement];

--- a/packages/react/src/components/Table/Table.test.jsx
+++ b/packages/react/src/components/Table/Table.test.jsx
@@ -2210,4 +2210,61 @@ describe('Table', () => {
       });
     });
   });
+
+  it('should render a loading state without columns', () => {
+    const { container } = render(
+      <Table
+        id="loading-table"
+        columns={[]}
+        data={[]}
+        view={{ table: { loadingState: { isLoading: true, rowCount: 10, columnCount: 3 } } }}
+      />
+    );
+
+    const headerRows = container.querySelectorAll(
+      `.${iotPrefix}--table-skeleton-with-headers--table-row--head`
+    );
+    expect(headerRows).toHaveLength(1);
+    expect(headerRows[0].querySelectorAll('td')).toHaveLength(3);
+
+    const allRows = container.querySelectorAll(
+      `.${iotPrefix}--table-skeleton-with-headers--table-row`
+    );
+    expect(allRows).toHaveLength(10);
+  });
+
+  it('should show data after loading is finished', () => {
+    const { container, rerender } = render(
+      <Table
+        id="loading-table"
+        columns={[]}
+        data={[]}
+        view={{ table: { loadingState: { isLoading: true, rowCount: 10, columnCount: 3 } } }}
+      />
+    );
+
+    const allRows = container.querySelectorAll(
+      `.${iotPrefix}--table-skeleton-with-headers--table-row`
+    );
+    expect(allRows).toHaveLength(10);
+    expect(screen.queryByTitle('String')).toBeNull();
+    expect(screen.queryByTitle('Date')).toBeNull();
+
+    rerender(
+      <Table
+        id="loading-table"
+        columns={tableColumns}
+        data={tableData}
+        view={{ table: { loadingState: { isLoading: false, rowCount: 10, columnCount: 3 } } }}
+      />
+    );
+    expect(
+      container.querySelectorAll(`.${iotPrefix}--table-skeleton-with-headers--table-row`)
+    ).toHaveLength(0);
+
+    // 20 rows plus the header
+    expect(container.querySelectorAll('tr')).toHaveLength(21);
+    expect(screen.getByTitle('String')).toBeVisible();
+    expect(screen.getByTitle('Date')).toBeVisible();
+  });
 });

--- a/packages/react/src/components/Table/TableSaveViewModal/__snapshots__/TableSaveViewModal.story.storyshot
+++ b/packages/react/src/components/Table/TableSaveViewModal/__snapshots__/TableSaveViewModal.story.storyshot
@@ -110,7 +110,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               onAnimationEnd={[Function]}
             >
               <button
-                aria-controls="accordion-item-1406"
+                aria-controls="accordion-item-1408"
                 aria-expanded={false}
                 className="bx--accordion__heading"
                 onClick={[Function]}
@@ -140,7 +140,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               </button>
               <div
                 className="bx--accordion__content"
-                id="accordion-item-1406"
+                id="accordion-item-1408"
               >
                 <p>
                   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -152,7 +152,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               onAnimationEnd={[Function]}
             >
               <button
-                aria-controls="accordion-item-1407"
+                aria-controls="accordion-item-1409"
                 aria-expanded={false}
                 className="bx--accordion__heading"
                 onClick={[Function]}
@@ -182,7 +182,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               </button>
               <div
                 className="bx--accordion__content"
-                id="accordion-item-1407"
+                id="accordion-item-1409"
               >
                 <p>
                   Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/packages/react/src/components/Table/TableSkeletonWithHeaders/TableSkeletonWithHeaders.jsx
+++ b/packages/react/src/components/Table/TableSkeletonWithHeaders/TableSkeletonWithHeaders.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { DataTable, SkeletonText } from 'carbon-components-react';
+import classnames from 'classnames';
 
 import { settings } from '../../../constants/Settings';
 import deprecate from '../../../internal/deprecate';
@@ -13,6 +14,8 @@ const propTypes = {
   hasRowExpansion: PropTypes.bool,
   hasRowActions: PropTypes.bool,
   rowCount: PropTypes.number,
+  /* used to show X number of loading skeletons when columns are unknown */
+  columnCount: PropTypes.number,
   columns: PropTypes.arrayOf(PropTypes.shape({ id: PropTypes.string.isRequired })),
   // TODO: remove deprecated 'testID' in v3
   // eslint-disable-next-line react/require-default-props
@@ -30,6 +33,7 @@ const defaultProps = {
   hasRowExpansion: false,
   hasRowActions: false,
   rowCount: 10,
+  columnCount: 5,
   columns: [],
   testId: '',
   showExpanderColumn: false,
@@ -42,42 +46,57 @@ const TableSkeletonWithHeaders = ({
   hasRowActions,
   columns,
   rowCount,
+  columnCount,
   testID,
   testId,
   showExpanderColumn,
-}) => (
-  <TableBody data-testid={testID || testId}>
-    <TableRow className={`${iotPrefix}--table-skeleton-with-headers--table-row`}>
-      {hasRowSelection === 'multi' ? <TableCell /> : null}
-      {hasRowExpansion ? <TableCell /> : null}
-      {columns.map((column) => (
-        <TableCell key={`skeletonCol-${column.id}`}>
-          <SkeletonText />
-        </TableCell>
-      ))}
-      {showExpanderColumn ? (
-        <TableCell data-testid={`${testID || testId}-expander-column`} />
-      ) : null}
-      {hasRowActions ? <TableCell /> : null}
-    </TableRow>
-    {[...Array(rowCount > 0 ? rowCount - 1 : 0)].map((row, index) => (
+}) => {
+  const rows = [...Array(rowCount > 0 ? rowCount - 1 : 0)];
+  const loadingColumns = columns.length
+    ? columns
+    : [...Array(columnCount > 0 ? columnCount : 1)].map((c, i) => ({ id: i }));
+  return (
+    <TableBody data-testid={testID || testId}>
       <TableRow
-        key={`skeletonRow-${index}`}
-        className={`${iotPrefix}--table-skeleton-with-headers--table-row`}
+        className={classnames(`${iotPrefix}--table-skeleton-with-headers--table-row`, {
+          [`${iotPrefix}--table-skeleton-with-headers--table-row--head`]: !columns.length,
+        })}
       >
         {hasRowSelection === 'multi' ? <TableCell /> : null}
         {hasRowExpansion ? <TableCell /> : null}
-        {columns.map((column) => (
-          <TableCell key={`emptycell-${column.id}`} />
+        {loadingColumns.map((column) => (
+          <TableCell key={`skeletonCol-${column.id}`}>
+            <SkeletonText />
+          </TableCell>
         ))}
         {showExpanderColumn ? (
-          <TableCell data-testid={`${testID || testId}-skeletonRow-${index}-expander-column`} />
+          <TableCell data-testid={`${testID || testId}-expander-column`} />
         ) : null}
         {hasRowActions ? <TableCell /> : null}
       </TableRow>
-    ))}
-  </TableBody>
-);
+      {rows.map((row, rowIndex) => (
+        <TableRow
+          key={`skeletonRow-${rowIndex}`}
+          className={`${iotPrefix}--table-skeleton-with-headers--table-row`}
+        >
+          {hasRowSelection === 'multi' ? <TableCell /> : null}
+          {hasRowExpansion ? <TableCell /> : null}
+          {loadingColumns.map((v, colIndex) => (
+            <TableCell key={`emptycell-${colIndex}`}>
+              {rowIndex === 0 && !columns.length ? <SkeletonText /> : null}
+            </TableCell>
+          ))}
+          {showExpanderColumn ? (
+            <TableCell
+              data-testid={`${testID || testId}-skeletonRow-${rowIndex}-expander-column`}
+            />
+          ) : null}
+          {hasRowActions ? <TableCell /> : null}
+        </TableRow>
+      ))}
+    </TableBody>
+  );
+};
 
 TableSkeletonWithHeaders.propTypes = propTypes;
 TableSkeletonWithHeaders.defaultProps = defaultProps;

--- a/packages/react/src/components/Table/TableSkeletonWithHeaders/_table-skeleton-with-headers.scss
+++ b/packages/react/src/components/Table/TableSkeletonWithHeaders/_table-skeleton-with-headers.scss
@@ -5,4 +5,22 @@
     border: 1px solid #dfe3e6;
     background: inherit;
   }
+
+  .#{$prefix}--skeleton__text {
+    margin-bottom: 0;
+  }
+
+  &--head {
+    td {
+      background-color: $ui-03;
+    }
+
+    .#{$prefix}--skeleton__text {
+      background: $ui-04;
+
+      &:before {
+        background: $text-03;
+      }
+    }
+  }
 }

--- a/packages/react/src/components/Table/__snapshots__/Table.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/Table.story.storyshot
@@ -61730,6 +61730,530 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/Table/Table with async column loading 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    className="iot--table-container bx--data-table-container"
+    data-testid="loading-table-table-container"
+  >
+    <section
+      aria-label="data table toolbar"
+      className="bx--table-toolbar"
+      data-testid="loading-table-table-toolbar"
+    >
+      <div
+        aria-hidden={true}
+        className="bx--batch-actions iot--table-batch-actions"
+        data-testid="loading-table-table-toolbar-batch-actions"
+      >
+        <div
+          className="bx--batch-summary"
+        >
+          <p
+            className="bx--batch-summary__para"
+          >
+            <span>
+              0 items selected
+            </span>
+          </p>
+        </div>
+        <div
+          className="bx--action-list"
+        >
+          <button
+            aria-describedby={null}
+            aria-pressed={null}
+            className="bx--batch-summary__cancel bx--btn bx--btn--primary"
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            tabIndex={-1}
+            type="button"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+      <div
+        className="bx--toolbar-content iot--table-toolbar-content"
+        data-testid="loading-table-table-toolbar-content"
+      >
+        <div
+          aria-labelledby="loading-table-toolbar-search-search"
+          className="bx--search bx--search--xl table-toolbar-search bx--toolbar-search-container-expandable"
+          role="search"
+        >
+          <div
+            className="bx--search-magnifier"
+          >
+            <svg
+              aria-hidden={true}
+              className="bx--search-magnifier-icon"
+              fill="currentColor"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+              />
+            </svg>
+          </div>
+          <label
+            className="bx--label"
+            htmlFor="loading-table-toolbar-search"
+            id="loading-table-toolbar-search-search"
+          >
+            Search
+          </label>
+          <input
+            autoComplete="off"
+            className="bx--search-input"
+            data-testid="loading-table-table-toolbar-search"
+            id="loading-table-toolbar-search"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            placeholder="Search"
+            role="searchbox"
+            tabIndex="0"
+            type="text"
+            value=""
+          />
+          <button
+            aria-label="Clear search input"
+            className="bx--search-close bx--search-close--hidden"
+            onClick={[Function]}
+            type="button"
+          >
+            <svg
+              aria-hidden={true}
+              fill="currentColor"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+        <button
+          aria-describedby={null}
+          aria-pressed={null}
+          className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn bx--btn bx--btn--ghost"
+          data-testid="filter-button"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          tabIndex={0}
+          title="Filters"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            aria-label="Filters"
+            className="bx--btn__icon"
+            fill="currentColor"
+            focusable="false"
+            height={20}
+            preserveAspectRatio="xMidYMid meet"
+            role="img"
+            viewBox="0 0 32 32"
+            width={20}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M18,28H14a2,2,0,0,1-2-2V18.41L4.59,11A2,2,0,0,1,4,9.59V6A2,2,0,0,1,6,4H26a2,2,0,0,1,2,2V9.59A2,2,0,0,1,27.41,11L20,18.41V26A2,2,0,0,1,18,28ZM6,6V9.59l8,8V26h4V17.59l8-8V6Z"
+            />
+          </svg>
+        </button>
+        <button
+          aria-expanded={false}
+          aria-haspopup={true}
+          aria-label="open and close list of options"
+          className="iot--table-toolbar-aggregations__overflow-menu bx--overflow-menu"
+          data-testid="table-head--overflow"
+          onClick={[Function]}
+          onClose={[Function]}
+          onKeyDown={[Function]}
+          open={false}
+          type="button"
+        >
+          <svg
+            aria-label="open and close list of options"
+            className="bx--overflow-menu__icon iot--table-toolbar-aggregations__overflow-icon"
+            fill="currentColor"
+            focusable="false"
+            height={20}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            preserveAspectRatio="xMidYMid meet"
+            role="img"
+            viewBox="0 0 32 32"
+            width={20}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="16"
+              cy="8"
+              r="2"
+            />
+            <circle
+              cx="16"
+              cy="16"
+              r="2"
+            />
+            <circle
+              cx="16"
+              cy="24"
+              r="2"
+            />
+            <title>
+              open and close list of options
+            </title>
+          </svg>
+        </button>
+      </div>
+    </section>
+    <div
+      className="addons-iot-table-container"
+    >
+      <div
+        className="bx--data-table-content"
+      >
+        <table
+          className="bx--data-table bx--data-table--no-border"
+          data-testid="loading-table"
+          id="loading-table"
+          title={null}
+        >
+          <tbody
+            aria-live="polite"
+            data-testid="loading-table-table-skeleton"
+          >
+            <tr
+              className="iot--table-skeleton-with-headers--table-row iot--table-skeleton-with-headers--table-row--head"
+            >
+              <td>
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+              </td>
+              <td>
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+              </td>
+              <td>
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+              </td>
+              <td>
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+              </td>
+              <td>
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+              </td>
+              <td>
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+              </td>
+              <td>
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+              </td>
+              <td>
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+              </td>
+              <td>
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+              </td>
+            </tr>
+            <tr
+              className="iot--table-skeleton-with-headers--table-row"
+            >
+              <td>
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+              </td>
+              <td>
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+              </td>
+              <td>
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+              </td>
+              <td>
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+              </td>
+              <td>
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+              </td>
+              <td>
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+              </td>
+              <td>
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+              </td>
+              <td>
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+              </td>
+              <td>
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+              </td>
+            </tr>
+            <tr
+              className="iot--table-skeleton-with-headers--table-row"
+            >
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+            </tr>
+            <tr
+              className="iot--table-skeleton-with-headers--table-row"
+            >
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+            </tr>
+            <tr
+              className="iot--table-skeleton-with-headers--table-row"
+            >
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+            </tr>
+            <tr
+              className="iot--table-skeleton-with-headers--table-row"
+            >
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+            </tr>
+            <tr
+              className="iot--table-skeleton-with-headers--table-row"
+            >
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+            </tr>
+            <tr
+              className="iot--table-skeleton-with-headers--table-row"
+            >
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+            </tr>
+            <tr
+              className="iot--table-skeleton-with-headers--table-row"
+            >
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+            </tr>
+            <tr
+              className="iot--table-skeleton-with-headers--table-row"
+            >
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+              <td />
+            </tr>
+          </tbody>
+          <tfoot
+            className="iot-table-foot"
+            data-testid="loading-table-table-foot"
+          >
+            <tr />
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/Table/Table with custom states states: no data, custom empty, error, and loading 1`] = `
 <div
   className="storybook-container"

--- a/packages/react/src/components/Table/tableReducer.js
+++ b/packages/react/src/components/Table/tableReducer.js
@@ -541,6 +541,7 @@ export const tableReducer = (state = {}, action) => {
               $set: {
                 isLoading: action.payload.isLoading,
                 rowCount: get(state, 'view.table.loadingState.rowCount') || 0,
+                columnCount: get(state, 'view.table.loadingState.columnCount') || 0,
               },
             },
             // Reset the selection to the previous values

--- a/packages/react/src/components/TileCatalogNew/__snapshots__/TileCatalogNew.story.storyshot
+++ b/packages/react/src/components/TileCatalogNew/__snapshots__/TileCatalogNew.story.storyshot
@@ -31,7 +31,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               Product name
             </div>
             <div
-              aria-labelledby="29-search"
+              aria-labelledby="30-search"
               className="bx--search bx--search--xl iot--tile-catalog--tile-canvas--header--search bx--toolbar-search-container-expandable"
               role="search"
             >
@@ -56,8 +56,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               </div>
               <label
                 className="bx--label"
-                htmlFor="29"
-                id="29-search"
+                htmlFor="30"
+                id="30-search"
               >
                 Filter table
               </label>
@@ -65,7 +65,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 autoComplete="off"
                 className="bx--search-input"
                 data-testid="tile-catalog-new-search-input"
-                id="29"
+                id="30"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -377,7 +377,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               Product name
             </div>
             <div
-              aria-labelledby="30-search"
+              aria-labelledby="31-search"
               className="bx--search bx--search--xl iot--tile-catalog--tile-canvas--header--search bx--toolbar-search-container-expandable"
               role="search"
             >
@@ -402,8 +402,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               </div>
               <label
                 className="bx--label"
-                htmlFor="30"
-                id="30-search"
+                htmlFor="31"
+                id="31-search"
               >
                 Filter table
               </label>
@@ -411,7 +411,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 autoComplete="off"
                 className="bx--search-input"
                 data-testid="tile-catalog-new-search-input"
-                id="30"
+                id="31"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -626,7 +626,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               Product name
             </div>
             <div
-              aria-labelledby="32-search"
+              aria-labelledby="33-search"
               className="bx--search bx--search--xl iot--tile-catalog--tile-canvas--header--search bx--toolbar-search-container-expandable"
               role="search"
             >
@@ -651,8 +651,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               </div>
               <label
                 className="bx--label"
-                htmlFor="32"
-                id="32-search"
+                htmlFor="33"
+                id="33-search"
               >
                 Filter table
               </label>
@@ -660,7 +660,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 autoComplete="off"
                 className="bx--search-input"
                 data-testid="tile-catalog-new-search-input"
-                id="32"
+                id="33"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -824,7 +824,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               Product name
             </div>
             <div
-              aria-labelledby="31-search"
+              aria-labelledby="32-search"
               className="bx--search bx--search--xl iot--tile-catalog--tile-canvas--header--search bx--toolbar-search-container-expandable"
               role="search"
             >
@@ -849,8 +849,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               </div>
               <label
                 className="bx--label"
-                htmlFor="31"
-                id="31-search"
+                htmlFor="32"
+                id="32-search"
               >
                 Filter table
               </label>
@@ -858,7 +858,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 autoComplete="off"
                 className="bx--search-input"
                 data-testid="tile-catalog-new-search-input"
-                id="31"
+                id="32"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -1025,7 +1025,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               Product name
             </div>
             <div
-              aria-labelledby="35-search"
+              aria-labelledby="36-search"
               className="bx--search bx--search--xl iot--tile-catalog--tile-canvas--header--search bx--toolbar-search-container-expandable"
               role="search"
             >
@@ -1050,8 +1050,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               </div>
               <label
                 className="bx--label"
-                htmlFor="35"
-                id="35-search"
+                htmlFor="36"
+                id="36-search"
               >
                 Filter table
               </label>
@@ -1059,7 +1059,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 autoComplete="off"
                 className="bx--search-input"
                 data-testid="tile-catalog-new-search-input"
-                id="35"
+                id="36"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -1485,7 +1485,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               Product name
             </div>
             <div
-              aria-labelledby="33-search"
+              aria-labelledby="34-search"
               className="bx--search bx--search--xl iot--tile-catalog--tile-canvas--header--search bx--toolbar-search-container-expandable"
               role="search"
             >
@@ -1510,8 +1510,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               </div>
               <label
                 className="bx--label"
-                htmlFor="33"
-                id="33-search"
+                htmlFor="34"
+                id="34-search"
               >
                 Filter table
               </label>
@@ -1519,7 +1519,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 autoComplete="off"
                 className="bx--search-input"
                 data-testid="tile-catalog-new-search-input"
-                id="33"
+                id="34"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -2070,7 +2070,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               Product name
             </div>
             <div
-              aria-labelledby="34-search"
+              aria-labelledby="35-search"
               className="bx--search bx--search--xl iot--tile-catalog--tile-canvas--header--search bx--toolbar-search-container-expandable"
               role="search"
             >
@@ -2095,8 +2095,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               </div>
               <label
                 className="bx--label"
-                htmlFor="34"
-                id="34-search"
+                htmlFor="35"
+                id="35-search"
               >
                 Filter table
               </label>
@@ -2104,7 +2104,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 autoComplete="off"
                 className="bx--search-input"
                 data-testid="tile-catalog-new-search-input"
-                id="34"
+                id="35"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}

--- a/packages/react/src/components/TileGallery/__snapshots__/TileGallery.story.storyshot
+++ b/packages/react/src/components/TileGallery/__snapshots__/TileGallery.story.storyshot
@@ -200,7 +200,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   onAnimationEnd={[Function]}
                 >
                   <button
-                    aria-controls="accordion-item-1476"
+                    aria-controls="accordion-item-1478"
                     aria-expanded={true}
                     className="bx--accordion__heading"
                     onClick={[Function]}
@@ -230,7 +230,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </button>
                   <div
                     className="bx--accordion__content"
-                    id="accordion-item-1476"
+                    id="accordion-item-1478"
                   >
                     <div
                       className="tile-gallery--section--items"
@@ -640,7 +640,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   onAnimationEnd={[Function]}
                 >
                   <button
-                    aria-controls="accordion-item-1477"
+                    aria-controls="accordion-item-1479"
                     aria-expanded={true}
                     className="bx--accordion__heading"
                     onClick={[Function]}
@@ -670,7 +670,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </button>
                   <div
                     className="bx--accordion__content"
-                    id="accordion-item-1477"
+                    id="accordion-item-1479"
                   >
                     <div
                       className="tile-gallery--section--items"
@@ -1538,7 +1538,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   onAnimationEnd={[Function]}
                 >
                   <button
-                    aria-controls="accordion-item-1483"
+                    aria-controls="accordion-item-1485"
                     aria-expanded={true}
                     className="bx--accordion__heading"
                     onClick={[Function]}
@@ -1568,7 +1568,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   </button>
                   <div
                     className="bx--accordion__content"
-                    id="accordion-item-1483"
+                    id="accordion-item-1485"
                   >
                     <div
                       className="tile-gallery--section--items"
@@ -1738,7 +1738,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             onAnimationEnd={[Function]}
           >
             <button
-              aria-controls="accordion-item-1480"
+              aria-controls="accordion-item-1482"
               aria-expanded={true}
               className="bx--accordion__heading"
               onClick={[Function]}
@@ -1768,7 +1768,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             </button>
             <div
               className="bx--accordion__content"
-              id="accordion-item-1480"
+              id="accordion-item-1482"
             >
               <div
                 className="tile-gallery--section--items"
@@ -2203,7 +2203,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             onAnimationEnd={[Function]}
           >
             <button
-              aria-controls="accordion-item-1481"
+              aria-controls="accordion-item-1483"
               aria-expanded={true}
               className="bx--accordion__heading"
               onClick={[Function]}
@@ -2233,7 +2233,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             </button>
             <div
               className="bx--accordion__content"
-              id="accordion-item-1481"
+              id="accordion-item-1483"
             >
               <div
                 className="tile-gallery--section--items"
@@ -2495,7 +2495,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               onAnimationEnd={[Function]}
             >
               <button
-                aria-controls="accordion-item-1478"
+                aria-controls="accordion-item-1480"
                 aria-expanded={true}
                 className="bx--accordion__heading"
                 onClick={[Function]}
@@ -2525,7 +2525,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               </button>
               <div
                 className="bx--accordion__content"
-                id="accordion-item-1478"
+                id="accordion-item-1480"
               >
                 <div
                   className="tile-gallery--section--items"
@@ -2960,7 +2960,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               onAnimationEnd={[Function]}
             >
               <button
-                aria-controls="accordion-item-1479"
+                aria-controls="accordion-item-1481"
                 aria-expanded={true}
                 className="bx--accordion__heading"
                 onClick={[Function]}
@@ -2990,7 +2990,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               </button>
               <div
                 className="bx--accordion__content"
-                id="accordion-item-1479"
+                id="accordion-item-1481"
               >
                 <div
                   className="tile-gallery--section--items"

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -510,6 +510,7 @@ Map {
           "expandedIds": Array [],
           "isSelectAllSelected": undefined,
           "loadingState": Object {
+            "columnCount": 5,
             "rowCount": 5,
           },
           "ordering": undefined,
@@ -1498,6 +1499,9 @@ Map {
                   "loadingState": Object {
                     "args": Array [
                       Object {
+                        "columnCount": Object {
+                          "type": "number",
+                        },
                         "isLoading": Object {
                           "type": "bool",
                         },
@@ -3396,6 +3400,7 @@ Map {
   },
   "TableSkeletonWithHeaders" => Object {
     "defaultProps": Object {
+      "columnCount": 5,
       "columns": Array [],
       "hasRowActions": false,
       "hasRowExpansion": false,
@@ -3405,6 +3410,9 @@ Map {
       "testId": "",
     },
     "propTypes": Object {
+      "columnCount": Object {
+        "type": "number",
+      },
       "columns": Object {
         "args": Array [
           Object {


### PR DESCRIPTION
Closes #2436 

**Summary**

Previously the isLoading prop only effected the rows, but the header would still display and show columns. This PR allows columns to be an empty array and the isLoading prop will loading skeleton text in place of the column headers. It's customizable via a prop to load X number of columns just like rows.

**Change List (commits, features, bugs, etc)**

- added new PropTypes to have loadable columns
- changed `<TableHead>` to only display when the columns array isn't empty.
- changed the `<TableSkeletonWithHeaders>` to match the styles of the `<TableHead>` if no columns are passed and show skeleton text as a placeholder while loading
- add tests cases for both Table/StatefulTable
- added new story to simulate async loading of both columns and data
- updated snapshots

**Acceptance Test (how to verify the PR)**

- The new `with async column loading` story should show loading indicators for both columns and rows
- after 3 seconds normal table data should appear
- when the knob for StatefulTable is set all function like filters, sorting, etc, should function as expected after loading has completed.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- prior loading states are maintained. ie. if columns are known and passed to the table, the loading header should not appear, but loading rows will
- No adverse side-effects for features not working after columns/data has been async loaded.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
