### PR TITLE
2803 base table reducer improve unit test coverage

### DIFF
--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -26,6 +26,7 @@ module.exports = {
   coverageDirectory: 'jest/coverage',
   coverageThreshold: {
     './src/components/DashboardEditor/editorUtils.jsx': all90Covered,
+    './src/components/Table/baseTableReducer.js': all90Covered,
     './src/components/Card/Card.jsx': all90Covered,
     './src/components/TimePickerSpinner/TimePickerSpinner.jsx': all90Covered,
     './src/components/List/HierarchyList/HierarchyList.jsx': all90Covered,

--- a/packages/react/src/components/Table/TableHead/_table-head.scss
+++ b/packages/react/src/components/Table/TableHead/_table-head.scss
@@ -138,8 +138,6 @@
 
     .#{$prefix}--table-header-label {
       height: 100%;
-      min-width: var(--table-header-width);
-      max-width: var(--table-header-width);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;

--- a/packages/react/src/components/Table/tableReducer.test.jsx
+++ b/packages/react/src/components/Table/tableReducer.test.jsx
@@ -29,6 +29,12 @@ describe('table reducer', () => {
   it('nothing', () => {
     expect(tableReducer(undefined, { type: 'BOGUS' })).toEqual({});
   });
+  it('return the same state if there is a missmatching instanceId', () => {
+    // We use an action that will be forwarded to the base reducer
+    expect(tableReducer(initialState, tablePageChange({ page: 3, pageSize: 10 }, 'id1'))).toBe(
+      initialState
+    );
+  });
   it('row action tests', () => {
     const updatedRowActionState = tableReducer(initialState, tableRowActionStart('row-1'));
     const newRowActions = updatedRowActionState.view.table.rowActions;
@@ -96,6 +102,9 @@ describe('table reducer', () => {
     it('TABLE_TOOLBAR_TOGGLE ', () => {
       const updatedState = tableReducer(initialState, tableToolbarToggle('column'));
       expect(updatedState.view.toolbar.activeBar).toEqual('column');
+
+      const updatedState2 = tableReducer(updatedState, tableToolbarToggle('column'));
+      expect(updatedState2.view.toolbar.activeBar).not.toEqual('column');
     });
     it('TABLE_SEARCH_APPLY filter should search data', () => {
       const searchString = 'searchString';
@@ -171,6 +180,39 @@ describe('table reducer', () => {
         tableSortedNone.view.table.filteredData
       );
     });
+
+    it('TABLE_COLUMN_SORT multisort', () => {
+      const multiSortState = merge({}, initialState, {
+        view: {
+          table: {
+            sort: [
+              {
+                columnId: 'string',
+                direction: 'ASC',
+              },
+              {
+                columnId: 'date',
+                direction: 'ASC',
+              },
+            ],
+          },
+        },
+      });
+      const sortColumnAction = tableColumnSort('string');
+      const tableSorted = tableReducer(multiSortState, sortColumnAction);
+
+      expect(tableSorted.view.table.sort).toEqual([
+        {
+          columnId: 'string',
+          direction: 'DESC',
+        },
+        {
+          columnId: 'date',
+          direction: 'ASC',
+        },
+      ]);
+    });
+
     it('TABLE_COLUMN_SORT custom sort function', () => {
       const sortColumnAction = tableColumnSort(tableColumns[4].id);
       const mockSortFunction = jest.fn().mockReturnValue(initialState.data);


### PR DESCRIPTION
Closes #2803

**Summary**
Improved testing coverage

**Change List (commits, features, bugs, etc)**

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
