### PR TITLE
2802 table reducer improve test coverage

### DIFF
--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -27,6 +27,7 @@ module.exports = {
   coverageThreshold: {
     './src/components/DashboardEditor/editorUtils.jsx': all90Covered,
     './src/components/Table/baseTableReducer.js': all90Covered,
+    './src/components/Table/tableReducer.js': all90Covered,
     './src/components/Card/Card.jsx': all90Covered,
     './src/components/TimePickerSpinner/TimePickerSpinner.jsx': all90Covered,
     './src/components/List/HierarchyList/HierarchyList.jsx': all90Covered,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -156,9 +156,7 @@
       "src/components/BarChartCard/barChartUtils.js",
       "src/components/ComboChartCard/comboChartHelpers.js",
       "src/components/Table/Table.test.helpers.js",
-      "src/components/Table/TablePropTypes.js",
-      "src/components/Table/baseTableReducer.js",
-      "src/components/Table/tableReducer.js"
+      "src/components/Table/TablePropTypes.js"
     ],
     "branches": 80,
     "lines": 80,

--- a/packages/react/src/components/Table/tableReducer.js
+++ b/packages/react/src/components/Table/tableReducer.js
@@ -593,12 +593,11 @@ export const tableReducer = (state = {}, action) => {
     }
 
     case TABLE_ADVANCED_FILTER_CANCEL: {
-      const isOpen = state.view.toolbar.advancedFilterFlyoutOpen === true;
       return update(state, {
         view: {
           toolbar: {
             $set: {
-              advancedFilterFlyoutOpen: !isOpen,
+              advancedFilterFlyoutOpen: false,
             },
           },
         },

--- a/packages/react/src/components/Table/tableReducer.test.jsx
+++ b/packages/react/src/components/Table/tableReducer.test.jsx
@@ -702,18 +702,237 @@ describe('filter, search and sort', () => {
 
   it('TABLE_ADVANCED_FILTER_APPLY', () => {
     const myState = merge({}, initialState, {
-      view: { advancedFilters: [] },
+      view: {
+        advancedFilters: [
+          {
+            filterId: 'story-filter',
+            filterTitleText: 'test filter',
+            filterRules: {
+              groupLogic: 'ALL',
+              rules: [
+                {
+                  id: 'rsiru4rjba',
+                  columnId: 'date',
+                  operand: 'CONTAINS',
+                  value: '19',
+                },
+                {
+                  id: '34bvyub9jq',
+                  columnId: 'boolean',
+                  operand: 'NEQ',
+                  value: 'true',
+                },
+                {
+                  id: '89h2eiuhd9c',
+                  columnId: 'number',
+                  operand: 'GT',
+                  value: 100,
+                },
+              ],
+            },
+          },
+        ],
+      },
     });
     expect(myState.view.table.filteredData).toBeUndefined();
 
-    const filterState = {
+    const actionPayload = {
       simple: { select: 'option-C', string: 'whiteboard' },
       advanced: { filterIds: ['story-filter'] },
     };
-    const applyAction = tableAdvancedFiltersApply(filterState);
+    const applyAction = tableAdvancedFiltersApply(actionPayload);
     const newState = tableReducer(myState, applyAction);
     expect(newState.view.toolbar.advancedFilterFlyoutOpen).toBe(false);
-    expect(newState.view.selectedAdvancedFilterIds).toEqual([]);
-    expect(newState.view.table.filteredData).toHaveLength(13);
+    expect(newState.view.selectedAdvancedFilterIds).toEqual(['story-filter']);
+    expect(newState.view.table.filteredData).toHaveLength(1);
+  });
+
+  it('TABLE_ADVANCED_FILTER_APPLY - NEQ', () => {
+    const myState = merge({}, initialState, {
+      view: {
+        advancedFilters: [
+          {
+            filterId: 'test-filter',
+            filterRules: {
+              groupLogic: 'ALL',
+              rules: [
+                {
+                  id: 'testContains',
+                  columnId: 'date',
+                  operand: 'CONTAINS',
+                  value: '19',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    const applyAction = tableAdvancedFiltersApply({ advanced: { filterIds: ['test-filter'] } });
+    const newState = tableReducer(myState, applyAction);
+    expect(newState.view.table.filteredData).toHaveLength(38);
+  });
+
+  it('TABLE_ADVANCED_FILTER_APPLY - LT', () => {
+    const myState = merge({}, initialState, {
+      view: {
+        advancedFilters: [
+          {
+            filterId: 'test-filter',
+            filterRules: {
+              groupLogic: 'ALL',
+              rules: [
+                {
+                  id: 'testContains',
+                  columnId: 'number',
+                  operand: 'LT',
+                  value: '100',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    const applyAction = tableAdvancedFiltersApply({ advanced: { filterIds: ['test-filter'] } });
+    const newState = tableReducer(myState, applyAction);
+    expect(newState.view.table.filteredData).toHaveLength(1);
+  });
+
+  it('TABLE_ADVANCED_FILTER_APPLY - LTOET', () => {
+    const myState = merge({}, initialState, {
+      view: {
+        advancedFilters: [
+          {
+            filterId: 'test-filter',
+            filterRules: {
+              groupLogic: 'ALL',
+              rules: [
+                {
+                  id: 'testContains',
+                  columnId: 'number',
+                  operand: 'LTOET',
+                  value: '100',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    const applyAction = tableAdvancedFiltersApply({ advanced: { filterIds: ['test-filter'] } });
+    const newState = tableReducer(myState, applyAction);
+    expect(newState.view.table.filteredData).toHaveLength(2);
+  });
+
+  it('TABLE_ADVANCED_FILTER_APPLY - EQ', () => {
+    const myState = merge({}, initialState, {
+      view: {
+        advancedFilters: [
+          {
+            filterId: 'test-filter',
+            filterRules: {
+              groupLogic: 'ALL',
+              rules: [
+                {
+                  id: 'testContains',
+                  columnId: 'string',
+                  operand: 'EQ',
+                  value: 'as eat scott 3',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    const applyAction = tableAdvancedFiltersApply({ advanced: { filterIds: ['test-filter'] } });
+    const newState = tableReducer(myState, applyAction);
+    expect(newState.view.table.filteredData).toHaveLength(1);
+  });
+
+  it('TABLE_ADVANCED_FILTER_APPLY - GTOET', () => {
+    const myState = merge({}, initialState, {
+      view: {
+        advancedFilters: [
+          {
+            filterId: 'test-filter',
+            filterRules: {
+              groupLogic: 'ALL',
+              rules: [
+                {
+                  id: 'testContains',
+                  columnId: 'number',
+                  operand: 'GTOET',
+                  value: '100',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    const applyAction = tableAdvancedFiltersApply({ advanced: { filterIds: ['test-filter'] } });
+    const newState = tableReducer(myState, applyAction);
+    expect(newState.view.table.filteredData).toHaveLength(65);
+  });
+
+  it('TABLE_ADVANCED_FILTER_APPLY - GT', () => {
+    const myState = merge({}, initialState, {
+      view: {
+        advancedFilters: [
+          {
+            filterId: 'test-filter',
+            filterRules: {
+              groupLogic: 'ALL',
+              rules: [
+                {
+                  id: 'testContains',
+                  columnId: 'number',
+                  operand: 'GT',
+                  value: '100',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    const applyAction = tableAdvancedFiltersApply({ advanced: { filterIds: ['test-filter'] } });
+    const newState = tableReducer(myState, applyAction);
+    expect(newState.view.table.filteredData).toHaveLength(64);
+  });
+
+  it('TABLE_ADVANCED_FILTER_APPLY - CONTAINS', () => {
+    const myState = merge({}, initialState, {
+      view: {
+        advancedFilters: [
+          {
+            filterId: 'test-filter',
+            filterRules: {
+              groupLogic: 'ALL',
+              rules: [
+                {
+                  id: 'testContains',
+                  columnId: 'string',
+                  operand: 'CONTAINS',
+                  value: 'scott',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    const applyAction = tableAdvancedFiltersApply({ advanced: { filterIds: ['test-filter'] } });
+    const newState = tableReducer(myState, applyAction);
+    expect(newState.view.table.filteredData).toHaveLength(20);
   });
 });


### PR DESCRIPTION
Closes #2802 

**Summary**
Improved test coverage

**Change List (commits, features, bugs, etc)**
- Wrote more tests
- Removed threshold exception for the table reducers
- fix small issue in TABLE_ADVANCED_FILTER_CANCEL

**Acceptance Test (how to verify the PR)**
- Unit tests are passing

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
