### PR TITLE
fix(combo-box): fix scss to not break OptimizeCSSAssets webpack plugin

### DIFF
--- a/packages/react/src/components/ComboBox/_combo-box.scss
+++ b/packages/react/src/components/ComboBox/_combo-box.scss
@@ -20,7 +20,10 @@
     $ai-apps-combobox-input-height-sm: $spacing-07;
     $ai-apps-combobox-input-height: $spacing-08;
     $ai-apps-combobox-input-height-xl: $spacing-09;
-    $ai-apps-combobox-helper-text-height: $spacing-05 + $spacing-02;
+    $ai-apps-combobox-helper-text-height: calc(#{$spacing-05} + #{$spacing-02});
+    $ai-apps-combobox-input-negative-height: calc(#{$ai-apps-combobox-input-height} * -1);
+    $ai-apps-combobox-input-negative-height-sm: calc(#{$ai-apps-combobox-input-height-sm} * -1);
+    $ai-apps-combobox-input-negative-height-xl: calc(#{$ai-apps-combobox-input-height-xl} * -1);
 
     &::after {
       content: attr(data-edit-option-text);
@@ -29,34 +32,34 @@
       right: $spacing-03;
       z-index: z('overlay') + 1;
       // half the height of the input/first list item
-      bottom: calc(-#{$ai-apps-combobox-input-height} / 2);
+      bottom: calc(#{$ai-apps-combobox-input-negative-height} / 2);
       // offset bottom calculation by half the height of the text (so it's vertically centered)
       transform: translateY(50%);
     }
     // when helperText is present, it's height must be accounted for
     &.#{$iot-prefix}--combobox-helper-text::after {
       bottom: calc(
-        (-#{$ai-apps-combobox-input-height} / 2) + #{$ai-apps-combobox-helper-text-height}
+        (#{$ai-apps-combobox-input-negative-height} / 2) + #{$ai-apps-combobox-helper-text-height}
       );
     }
 
     // sm field size variant
     &.#{$iot-prefix}--combobox-size-sm::after {
-      bottom: calc(-#{$ai-apps-combobox-input-height-sm} / 2);
+      bottom: calc(#{$ai-apps-combobox-input-negative-height-sm} / 2);
     }
     &.#{$iot-prefix}--combobox-size-sm.#{$iot-prefix}--combobox-helper-text::after {
       bottom: calc(
-        (-#{$ai-apps-combobox-input-height-sm} / 2) + #{$ai-apps-combobox-helper-text-height}
+        (#{$ai-apps-combobox-input-negative-height-sm} / 2) + #{$ai-apps-combobox-helper-text-height}
       );
     }
 
     // xl field size variant
     &.#{$iot-prefix}--combobox-size-xl::after {
-      bottom: calc(-#{$ai-apps-combobox-input-height-xl} / 2);
+      bottom: calc(#{$ai-apps-combobox-input-negative-height-xl} / 2);
     }
     &.#{$iot-prefix}--combobox-size-xl.#{$iot-prefix}--combobox-helper-text::after {
       bottom: calc(
-        (-#{$ai-apps-combobox-input-height-xl} / 2) + #{$ai-apps-combobox-helper-text-height}
+        (#{$ai-apps-combobox-input-negative-height-xl} / 2) + #{$ai-apps-combobox-helper-text-height}
       );
     }
   }

--- a/packages/react/src/components/PageTitleBar/_page-title-bar.scss
+++ b/packages/react/src/components/PageTitleBar/_page-title-bar.scss
@@ -152,7 +152,7 @@
     flex-direction: row;
     align-items: center;
     padding: $spacing-04 0 $spacing-02 $spacing-07;
-    max-height: clamp(0, $spacing-02, $spacing-08);
+    max-height: clamp(0rem, $spacing-02, $spacing-08);
     white-space: nowrap;
 
     [dir='rtl'] & {


### PR DESCRIPTION
Closes #2314 

**Summary**

- When using `@console/pal` themes along side `carbon-addons-iot-react` it enables certain feature flags that break webpack builds with OptimizeCSSAssetsPlugin. This adjusts the scss to work correctly in this instance.

**Change List (commits, features, bugs, etc)**

- refactor scss variables to prevent failures in building

**Acceptance Test (how to verify the PR)**

- Can build production builds of the test app when using `@console/pal` package theme, and `combo-box.scss` as detailed in the issue. Instructions for installing `@console/pal` are found in the issue as well. For steps to setup a test app see https://github.com/carbon-design-system/carbon-addons-iot-react/pull/2775

**Regression Test (how to make sure this PR doesn't break old functionality)**

- ComboBox stories remain unchanged.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
