### PR TITLE
fix(datetimepicker): disable apply for invalid values

### DIFF
--- a/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
@@ -308,6 +308,7 @@ const DateTimePicker = ({
   const [absoluteValue, setAbsoluteValue] = useState(null);
   const [focusOnFirstField, setFocusOnFirstField] = useState(true);
   const [isTooltipOpen, setIsTooltipOpen] = useState(false);
+  const [relativeLastNumberInvalid, setRelativeLastNumberInvalid] = useState(false);
 
   // Refs
   const [datePickerElem, setDatePickerElem] = useState(null);
@@ -787,7 +788,11 @@ const DateTimePicker = ({
 
   // on change functions that trigger a relative value update
   const onRelativeLastNumberChange = (event) => {
-    changeRelativePropertyValue('lastNumber', Number(event.imaginaryTarget.value));
+    const valid = !event.imaginaryTarget.getAttribute('data-invalid');
+    setRelativeLastNumberInvalid(!valid);
+    if (valid) {
+      changeRelativePropertyValue('lastNumber', Number(event.imaginaryTarget.value));
+    }
   };
   const onRelativeLastIntervalChange = (event) => {
     changeRelativePropertyValue('lastInterval', event.currentTarget.value);
@@ -1168,6 +1173,11 @@ const DateTimePicker = ({
               /* using on onKeyUp b/c something is preventing onKeyDown from firing with 'Enter' when the calendar is displayed */
               onKeyUp={handleSpecificKeyDown(['Enter', ' '], onApplyClick)}
               size="field"
+              disabled={
+                isCustomRange &&
+                customRangeKind === PICKER_KINDS.RELATIVE &&
+                relativeLastNumberInvalid
+              }
             >
               {strings.applyBtnLabel}
             </Button>

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
@@ -623,4 +623,32 @@ describe('DateTimePicker', () => {
     userEvent.click(screen.getByText('Relative'));
     expect(screen.getByText('Quarter')).toBeVisible();
   });
+
+  it('should disable apply button when number input is invalid', () => {
+    render(<DateTimePicker {...dateTimePickerProps} id="picker-test" />);
+    jest.runAllTimers();
+
+    userEvent.click(screen.getByTestId('date-time-picker__field'));
+    userEvent.click(screen.queryByText(DateTimePicker.defaultProps.i18n.customRangeLinkLabel));
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeEnabled();
+    const numberInput = screen.queryByRole('spinbutton', {
+      name: 'Numeric input field with increment and decrement buttons',
+    });
+    expect(numberInput).toBeValid();
+
+    // Empty value is invalid
+    userEvent.type(numberInput, '{backspace}');
+    expect(numberInput).toBeInvalid();
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+
+    // 0 is valid
+    userEvent.type(numberInput, '1');
+    expect(numberInput).toBeValid();
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeEnabled();
+
+    // -1 is invalid
+    userEvent.type(numberInput, '{backspace}-1');
+    expect(numberInput).toBeInvalid();
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+  });
 });


### PR DESCRIPTION
Closes #2832

**Summary**
Fix to disabled the apply button when the "last" NumberInput in relative dates is invalid.

**Change List (commits, features, bugs, etc)**
- Added check for invalid date and a state to use it 
- Added unit tests

**Acceptance Test (how to verify the PR)**

1. Got story ?path=/story/1-watson-iot-datetime-picker--default
2. Expand DateTimePicker component
3. Click Custom Range
4. Make sure Relative Radio is checked
5. Input an invalid number in the number-input, e.g. empty or minus, plus
6. Verify that the apply button is disabled
7. Change to Custom range: Absolute and verify that the apply button is enabled 
8. Click "Back" and verify that the button is enabled when not in custom range mode

**Regression Test (how to make sure this PR doesn't break old functionality)**

Verify that the other DatePicker functionality is unaffected

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
