### PR TITLE
fix(tabletoolbar): provide aria-label to CarbonTableToolbar

### DIFF
--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -426,6 +426,7 @@ export const defaultProps = (baseProps) => ({
     itemSelected: (selectedCount) => `${selectedCount} item selected`,
     rowCountInHeader: (totalRowCount) => `Results: ${totalRowCount}`,
     toggleAggregations: 'Toggle aggregations',
+    toolbarLabelAria: undefined,
     /** empty state */
     emptyMessage: 'There is no data',
     emptyMessageBody: '',
@@ -727,6 +728,7 @@ const Table = (props) => {
               downloadIconDescription: i18n.downloadIconDescription,
               rowCountInHeader: i18n.rowCountInHeader,
               toggleAggregations: i18n.toggleAggregations,
+              toolbarLabelAria: i18n.toolbarLabelAria,
             }}
             actions={{
               ...pick(

--- a/packages/react/src/components/Table/TablePropTypes.js
+++ b/packages/react/src/components/Table/TablePropTypes.js
@@ -170,6 +170,7 @@ export const I18NPropTypes = PropTypes.shape({
   closeMenuAria: PropTypes.string,
   clearSelectionAria: PropTypes.string,
   batchCancel: PropTypes.string,
+  toolbarLabelAria: PropTypes.string,
   /** String 'items selected' or function receiving the selectedCount as param:
    * (selectedCount) => `${selectedCount} items selected` */
   itemsSelected: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),

--- a/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -75,6 +75,7 @@ const propTypes = {
     filterAscending: PropTypes.string,
     filterDescending: PropTypes.string,
     toggleAggregations: PropTypes.string,
+    toolbarLabelAria: PropTypes.string,
   }),
   /**
    * Action callbacks to update tableState
@@ -215,6 +216,7 @@ const TableToolbar = ({
       // TODO: remove deprecated 'testID' in v3
       data-testid={testID || testId}
       className={classnames(`${iotPrefix}--table-toolbar`, className)}
+      aria-label={i18n.toolbarLabelAria}
     >
       <TableBatchActions
         // TODO: remove deprecated 'testID' in v3

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -457,6 +457,7 @@ Map {
         "selectRowAria": "Select row",
         "tableErrorStateTitle": "Unable to load the page",
         "toggleAggregations": "Toggle aggregations",
+        "toolbarLabelAria": undefined,
       },
       "id": null,
       "lightweight": false,
@@ -1119,6 +1120,9 @@ Map {
               "type": "string",
             },
             "toggleAggregations": Object {
+              "type": "string",
+            },
+            "toolbarLabelAria": Object {
               "type": "string",
             },
           },
@@ -2154,6 +2158,9 @@ Map {
               "type": "string",
             },
             "toggleAggregations": Object {
+              "type": "string",
+            },
+            "toolbarLabelAria": Object {
               "type": "string",
             },
           },
@@ -3766,6 +3773,9 @@ Map {
               "type": "string",
             },
             "toggleAggregations": Object {
+              "type": "string",
+            },
+            "toolbarLabelAria": Object {
               "type": "string",
             },
           },


### PR DESCRIPTION
Closes #2607

**Summary**

- Allows TableToolbar to send aria-label to the underlying carbon-component.

**Change List (commits, features, bugs, etc)**

- Add `toolbarLabelAria` to `Table`'s `i18n` prop and forwards it to `TableToolbar`
- `TableToolbar` now pull `toolbarLabelAria` out of `i18n` to pass to the underlying carbon-component

**Acceptance Test (how to verify the PR)**

- snapshots


**Regression Test (how to make sure this PR doesn't break old functionality)**

- Table still Renders
- TableToolbar still Renders

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
