### PR TITLE
fix(row-actions-cell): set overflow menu to closed after overflow action

### DIFF
--- a/packages/react/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
+++ b/packages/react/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
@@ -65,11 +65,6 @@ const defaultProps = {
   langDir: 'ltr',
 };
 
-const onClick = (e, id, action, onApplyRowAction) => {
-  onApplyRowAction(action, id);
-  e.preventDefault();
-  e.stopPropagation();
-};
 const renderBundledIconUsingName = (iconName, label) => {
   const Icon = icons[iconName];
   return <Icon aria-label={label} />;
@@ -92,6 +87,13 @@ class RowActionsCell extends React.Component {
     if (isOpen) {
       this.setState({ isOpen: false });
     }
+  };
+
+  onClick = (e, id, action, onApplyRowAction) => {
+    onApplyRowAction(action, id);
+    e.preventDefault();
+    e.stopPropagation();
+    this.handleClose();
   };
 
   render() {
@@ -164,7 +166,7 @@ class RowActionsCell extends React.Component {
                       tooltipPosition="left"
                       tooltipAlignment="end"
                       size="small"
-                      onClick={(e) => onClick(e, id, actionId, onApplyRowAction)}
+                      onClick={(e) => this.onClick(e, id, actionId, onApplyRowAction)}
                     >
                       {labelText}
                     </Button>
@@ -190,7 +192,7 @@ class RowActionsCell extends React.Component {
                         })}
                         data-testid={`${tableId}-${id}-row-actions-cell-overflow-menu-item-${action.id}`}
                         key={`${id}-row-actions-button-${action.id}`}
-                        onClick={(e) => onClick(e, id, action.id, onApplyRowAction)}
+                        onClick={(e) => this.onClick(e, id, action.id, onApplyRowAction)}
                         requireTitle={!action.renderIcon}
                         hasDivider={action.hasDivider}
                         isDelete={action.isDelete}


### PR DESCRIPTION
Closes #2854 

**Summary**

- when clicking an action in the overflow menu makes sure to trigger the close so that the other buttons get hidden

**Change List (commits, features, bugs, etc)**

- change onClick event to also trigger closing of the overflow menu (and therefore a class change to hide the other buttons)

**Acceptance Test (how to verify the PR)**

- when clicking an action in the overflow menu the "Drill in..." button is hidden. [https://deploy-preview-2870--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table-statefultable--stateful-example-with-row-nesting-and-fixed-columns](https://deploy-preview-2870--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table-statefultable--stateful-example-with-row-nesting-and-fixed-columns)

**Regression Test (how to make sure this PR doesn't break old functionality)**

- no adverse effects for other actions

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
