### PR TITLE
feat(table): add `hasFastSearch` prop to toggle onChange/onBlur

### DIFF
--- a/packages/react/cypress/plugins/index.js
+++ b/packages/react/cypress/plugins/index.js
@@ -80,6 +80,10 @@ const webpackConfig = {
           },
         ],
       },
+      {
+        test: /\.mdx?$/,
+        use: ['babel-loader', '@mdx-js/loader'],
+      },
     ],
   },
   resolve: {

--- a/packages/react/src/components/ComboChartCard/__snapshots__/ComboChartCard.story.storyshot
+++ b/packages/react/src/components/ComboChartCard/__snapshots__/ComboChartCard.story.storyshot
@@ -234,7 +234,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       className="bx--search-input"
                       data-testid="BarChartCard-table-table-toolbar-search"
                       id="BarChartCard-table-toolbar-search"
-                      onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
                       onKeyDown={[Function]}

--- a/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -1690,7 +1690,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           data-testid="table-for-card-alert-table1-table-toolbar-search"
                           disabled={false}
                           id="table-for-card-alert-table1-toolbar-search"
-                          onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
                           onKeyDown={[Function]}
@@ -4630,7 +4629,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           data-testid="table-for-card-alert-table1-table-toolbar-search"
                           disabled={false}
                           id="table-for-card-alert-table1-toolbar-search"
-                          onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
                           onKeyDown={[Function]}
@@ -7605,7 +7603,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           data-testid="table-for-card-alert-table1-table-toolbar-search"
                           disabled={false}
                           id="table-for-card-alert-table1-toolbar-search"
-                          onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
                           onKeyDown={[Function]}
@@ -9663,7 +9660,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           className="bx--search-input"
                           data-testid="table-for-card-expandedcard-table-toolbar-search"
                           id="table-for-card-expandedcard-toolbar-search"
-                          onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
                           onKeyDown={[Function]}
@@ -13181,7 +13177,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           data-testid="table-for-card-alert-table1-table-toolbar-search"
                           disabled={false}
                           id="table-for-card-alert-table1-toolbar-search"
-                          onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
                           onKeyDown={[Function]}
@@ -30827,7 +30822,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           data-testid="table-for-card-alert-table1-table-toolbar-search"
                           disabled={false}
                           id="table-for-card-alert-table1-toolbar-search"
-                          onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
                           onKeyDown={[Function]}

--- a/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
@@ -2190,7 +2190,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                       className="bx--search-input"
                       data-testid="table-for-card-tableCard-table-toolbar-search"
                       id="table-for-card-tableCard-toolbar-search"
-                      onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
                       onKeyDown={[Function]}

--- a/packages/react/src/components/RuleBuilder/__snapshots__/RuleBuilder.story.storyshot
+++ b/packages/react/src/components/RuleBuilder/__snapshots__/RuleBuilder.story.storyshot
@@ -932,7 +932,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                             className="bx--search-input"
                             data-testid="edit-table-table-toolbar-search"
                             id="edit-table-toolbar-search"
-                            onBlur={[Function]}
                             onChange={[Function]}
                             onFocus={[Function]}
                             onKeyDown={[Function]}
@@ -1447,7 +1446,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                             className="bx--search-input"
                             data-testid="read-table-table-toolbar-search"
                             id="read-table-toolbar-search"
-                            onBlur={[Function]}
                             onChange={[Function]}
                             onFocus={[Function]}
                             onKeyDown={[Function]}
@@ -5548,7 +5546,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                             className="bx--search-input"
                             data-testid="edit-table-table-toolbar-search"
                             id="edit-table-toolbar-search"
-                            onBlur={[Function]}
                             onChange={[Function]}
                             onFocus={[Function]}
                             onKeyDown={[Function]}
@@ -5827,7 +5824,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                             className="bx--search-input"
                             data-testid="read-table-table-toolbar-search"
                             id="read-table-toolbar-search"
-                            onBlur={[Function]}
                             onChange={[Function]}
                             onFocus={[Function]}
                             onKeyDown={[Function]}

--- a/packages/react/src/components/Table/StatefulTable.story.jsx
+++ b/packages/react/src/components/Table/StatefulTable.story.jsx
@@ -184,6 +184,10 @@ export const SimpleStatefulExample = () => {
           ['multi', 'single', false],
           'multi'
         ),
+        hasFastSearch: boolean(
+          "Enable search as typing (default) or only on 'Enter' (options.hasFastSearch).",
+          true
+        ),
         hasSearch: boolean('Enable searching on the table values (options.hasSearch)', false),
         hasSort: boolean('Enable sorting columns by a single dimension (options.hasSort)', false),
         preserveColumnWidths: boolean(

--- a/packages/react/src/components/Table/StatefulTable.test.e2e.jsx
+++ b/packages/react/src/components/Table/StatefulTable.test.e2e.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { mount } from '@cypress/react';
+
+import StatefulTable from './StatefulTable';
+import { tableColumns, tableData } from './Table.story';
+
+describe('StatefulTable', () => {
+  it('should search on keydown when hasFastSearch:true', () => {
+    const onApplySearch = cy.stub();
+    mount(
+      <StatefulTable
+        id="search-table"
+        columns={tableColumns}
+        data={tableData}
+        options={{
+          hasSearch: true,
+          hasPagination: false,
+        }}
+        actions={{
+          toolbar: {
+            onApplySearch,
+          },
+        }}
+      />
+    );
+    // 100 rows plus the header
+    cy.get('tr').should('have.length', 101);
+    cy.findByRole('searchbox')
+      .type('Ia2eQMSi8i')
+      .should(() => {
+        expect(onApplySearch).to.have.been.callCount(10);
+        expect(onApplySearch).to.have.been.calledWith('Ia2eQMSi8i');
+      });
+
+    cy.get('tr').should('have.length', 5);
+  });
+
+  it("should search on 'Enter' or Blur when hasFastSearch:false", () => {
+    const onApplySearch = cy.stub();
+    mount(
+      <StatefulTable
+        id="search-table"
+        columns={tableColumns}
+        data={tableData}
+        options={{
+          hasFastSearch: false,
+          hasSearch: true,
+          hasPagination: false,
+        }}
+        actions={{
+          toolbar: {
+            onApplySearch,
+          },
+        }}
+      />
+    );
+    cy.get('tr').should('have.length', 101);
+    cy.findByRole('searchbox')
+      .type('Ia2eQMSi8i{enter}')
+      .should(() => {
+        expect(onApplySearch).to.have.been.callCount(1);
+        expect(onApplySearch).to.have.been.calledWith('Ia2eQMSi8i');
+      });
+
+    cy.get('tr').should('have.length', 5);
+    cy.findByRole('searchbox').type(
+      '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}'
+    );
+    cy.get('tr').should('have.length', 5);
+    cy.findByRole('searchbox').trigger('blur');
+    cy.get('tr').should('have.length', 101);
+  });
+});

--- a/packages/react/src/components/Table/StatefulTable.test.jsx
+++ b/packages/react/src/components/Table/StatefulTable.test.jsx
@@ -18,6 +18,10 @@ import RowActionsCell from './TableBody/RowActionsCell/RowActionsCell';
 const { iotPrefix } = settings;
 
 describe('stateful table with real reducer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should clear filters', async () => {
     render(<StatefulTable {...initialState} actions={mockActions} />);
     const whiteboardFilter = await screen.findByDisplayValue('whiteboard');

--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -61,6 +61,8 @@ const propTypes = {
   options: PropTypes.shape({
     /** If true allows the table to aggregate values of columns in a special row */
     hasAggregations: PropTypes.bool,
+    /** If true, search is applied as typed. If false, only after 'Enter' is pressed */
+    hasFastSearch: PropTypes.bool,
     hasPagination: PropTypes.bool,
     hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
     hasRowExpansion: PropTypes.bool,
@@ -310,6 +312,7 @@ export const defaultProps = (baseProps) => ({
     hasFilter: false,
     hasAdvancedFilter: false,
     hasOnlyPageData: false,
+    hasFastSearch: true,
     hasSearch: false,
     hasColumnSelection: false,
     hasColumnSelectionConfig: false,
@@ -759,6 +762,7 @@ const Table = (props) => {
                 options,
                 'hasAggregations',
                 'hasColumnSelection',
+                'hasFastSearch',
                 'hasSearch',
                 'hasRowSelection',
                 'hasRowCountInHeader',

--- a/packages/react/src/components/Table/Table.story.jsx
+++ b/packages/react/src/components/Table/Table.story.jsx
@@ -650,6 +650,10 @@ export const BasicDumbTable = () => {
           ['multi', 'single', false],
           'multi'
         ),
+        hasFastSearch: boolean(
+          "Enable search as typing (default) or only on 'Enter' (options.hasFastSearch).",
+          true
+        ),
         hasSearch: boolean('Enable searching on the table values (options.hasSearch)', false),
         hasSort: boolean('Enable sorting columns by a single dimension (options.hasSort)', false),
         preserveColumnWidths: boolean(
@@ -2539,6 +2543,10 @@ export const AsyncColumnLoading = () => {
       options={{
         hasAggregations: boolean(
           'Aggregates column values and displays in a footer row (options.hasAggregations)',
+          true
+        ),
+        hasFastSearch: boolean(
+          "Enable search as typing (default) or only on 'Enter' (options.hasFastSearch).",
           true
         ),
         hasSearch: boolean('Enable searching on the table values (options.hasSearch)', true),

--- a/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -20,7 +20,10 @@ import {
   ActiveTableToolbarPropType,
   TableRowPropTypes,
 } from '../TablePropTypes';
-import { tableTranslateWithId } from '../../../utils/componentUtilityFunctions';
+import {
+  handleSpecificKeyDown,
+  tableTranslateWithId,
+} from '../../../utils/componentUtilityFunctions';
 import { settings } from '../../../constants/Settings';
 import { RuleGroupPropType } from '../../RuleBuilder/RuleBuilderPropTypes';
 
@@ -46,6 +49,7 @@ const propTypes = {
   options: PropTypes.shape({
     hasAdvancedFilter: PropTypes.bool,
     hasAggregations: PropTypes.bool,
+    hasFastSearch: PropTypes.bool,
     hasFilter: PropTypes.bool,
     hasSearch: PropTypes.bool,
     hasColumnSelection: PropTypes.bool,
@@ -164,6 +168,7 @@ const TableToolbar = ({
     hasAdvancedFilter,
     hasAggregations,
     hasColumnSelection,
+    hasFastSearch,
     hasFilter,
     hasSearch,
     hasRowSelection,
@@ -286,9 +291,18 @@ const TableToolbar = ({
               translateWithId={(...args) => tableTranslateWithId(i18n, ...args)}
               id={`${tableId}-toolbar-search`}
               onChange={(event, defaultValue) => {
-                // https://github.com/carbon-design-system/carbon/issues/6157
-                onApplySearch(event?.target?.value || defaultValue);
+                const value = event?.target?.value || defaultValue;
+                if (hasFastSearch) {
+                  // https://github.com/carbon-design-system/carbon/issues/6157
+                  onApplySearch(value);
+                }
               }}
+              onKeyDown={
+                hasFastSearch
+                  ? undefined
+                  : handleSpecificKeyDown(['Enter'], (e) => onApplySearch(e.target.value))
+              }
+              onBlur={hasFastSearch ? undefined : (e) => onApplySearch(e.target.value)}
               disabled={isDisabled}
               // TODO: remove deprecated 'testID' in v3
               data-testid={`${testID || testId}-search`}

--- a/packages/react/src/components/Table/__snapshots__/StatefulTable.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/StatefulTable.story.storyshot
@@ -44171,7 +44171,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               className="bx--search-input"
               data-testid="table-table-toolbar-search"
               id="table-toolbar-search"
-              onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -72531,7 +72530,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               className="bx--search-input"
               data-testid="table-table-toolbar-search"
               id="table-toolbar-search"
-              onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -81628,7 +81626,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             className="bx--search-input"
             data-testid="table-table-toolbar-search"
             id="table-toolbar-search"
-            onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -82510,7 +82507,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               className="bx--search-input"
               data-testid="table-table-toolbar-search"
               id="table-toolbar-search"
-              onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -86773,7 +86769,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               className="bx--search-input"
               data-testid="table-table-toolbar-search"
               id="table-toolbar-search"
-              onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}

--- a/packages/react/src/components/Table/__snapshots__/Table.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/Table.story.storyshot
@@ -23179,7 +23179,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             className="bx--search-input"
             data-testid="loading-table-table-toolbar-search"
             id="loading-table-toolbar-search"
-            onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -24520,7 +24519,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               className="bx--search-input"
               data-testid="table-table-toolbar-search"
               id="table-toolbar-search"
-              onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}

--- a/packages/react/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/packages/react/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -1590,7 +1590,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   className="bx--search-input"
                   data-testid="table-for-card-table-list-table-toolbar-search"
                   id="table-for-card-table-list-toolbar-search"
-                  onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -3061,7 +3060,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   className="bx--search-input"
                   data-testid="table-for-card-table-list-table-toolbar-search"
                   id="table-for-card-table-list-toolbar-search"
-                  onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -4718,7 +4716,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   className="bx--search-input"
                   data-testid="table-for-card-undefined-table-toolbar-search"
                   id="table-for-card-undefined-toolbar-search"
-                  onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -5661,7 +5658,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   className="bx--search-input"
                   data-testid="table-for-card-table-list-table-toolbar-search"
                   id="table-for-card-table-list-toolbar-search"
-                  onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -6891,7 +6887,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   className="bx--search-input"
                   data-testid="table-for-card-table-list-table-toolbar-search"
                   id="table-for-card-table-list-toolbar-search"
-                  onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -9343,7 +9338,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   className="bx--search-input"
                   data-testid="table-for-card-table-list-table-toolbar-search"
                   id="table-for-card-table-list-toolbar-search"
-                  onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -11629,7 +11623,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   className="bx--search-input"
                   data-testid="table-for-card-table-list-table-toolbar-search"
                   id="table-for-card-table-list-toolbar-search"
-                  onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -13435,7 +13428,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   className="bx--search-input"
                   data-testid="table-for-card-table-list-table-toolbar-search"
                   id="table-for-card-table-list-toolbar-search"
-                  onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -15580,7 +15572,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                   className="bx--search-input"
                   data-testid="table-for-card-table-list-table-toolbar-search"
                   id="table-for-card-table-list-toolbar-search"
-                  onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}

--- a/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -1029,7 +1029,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="bx--search-input"
                     data-testid="TimeSeries-table-table-toolbar-search"
                     id="TimeSeries-table-toolbar-search"
-                    onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
                     onKeyDown={[Function]}

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -466,6 +466,7 @@ Map {
         "hasAggregations": false,
         "hasColumnSelection": false,
         "hasColumnSelectionConfig": false,
+        "hasFastSearch": true,
         "hasFilter": false,
         "hasOnlyPageData": false,
         "hasPagination": false,
@@ -1145,6 +1146,9 @@ Map {
               "type": "bool",
             },
             "hasColumnSelectionConfig": Object {
+              "type": "bool",
+            },
+            "hasFastSearch": Object {
               "type": "bool",
             },
             "hasFilter": Object {
@@ -3782,6 +3786,9 @@ Map {
               "type": "bool",
             },
             "hasColumnSelection": Object {
+              "type": "bool",
+            },
+            "hasFastSearch": Object {
               "type": "bool",
             },
             "hasFilter": Object {


### PR DESCRIPTION
Closes #2871 

**Summary**

- add `hasFastSearch` prop to toggle search happening onChange or on `Enter` or onBlur.

**Change List (commits, features, bugs, etc)**

- add `hasFastSearch` prop to table
- set `hasFastSearch` to default to `true` to keep current behavior
- pass to TableToolbar
- add onKeyDown/onBlur handlers when `hasFastSearch:false`
- add cypress tests to cover

**Acceptance Test (how to verify the PR)**

- in the [simple stateful table story](https://deploy-preview-2874--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table-statefultable--simple-stateful-example), if you uncheck `hasFastSearch` the table should only update it's state when you press `Enter` or change focus away from the search box

**Regression Test (how to make sure this PR doesn't break old functionality)**

- existing search functionality should be unchanged.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
