### PR TITLE
fix(suite-header): all cmd+click/ctrl+click to open new window

### DIFF
--- a/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
@@ -174,6 +174,9 @@ const propTypes = {
   isActionItemVisible: Header.propTypes.isActionItemVisible,
 };
 
+export const shouldOpenInNewWindow = (e) =>
+  navigator.userAgent.indexOf('Mac') !== -1 ? e.metaKey : e.ctrlKey;
+
 const SuiteHeader = ({
   className,
   suiteName,
@@ -389,16 +392,21 @@ const SuiteHeader = ({
                 />
               </span>
             ),
-            onClick: async () => {
+            onClick: async (e) => {
               let href = routes.admin;
               let routeType = ROUTE_TYPES.ADMIN;
+              const newWindow = shouldOpenInNewWindow(e);
               if (isAdminView) {
                 href = navigatorRoute;
                 routeType = ROUTE_TYPES.NAVIGATOR;
               }
               const result = await onRouteChange(routeType, href);
               if (result) {
-                window.location.href = href;
+                if (newWindow) {
+                  window.open(href, '_blank', 'noopener noreferrer');
+                } else {
+                  window.location.href = href;
+                }
               }
             },
           },
@@ -441,10 +449,15 @@ const SuiteHeader = ({
                       'data-testid': 'suite-header-help--about',
                       href: 'javascript:void(0)',
                       title: mergedI18N.about,
-                      onClick: async () => {
+                      onClick: async (e) => {
+                        const newWindow = shouldOpenInNewWindow(e);
                         const result = await onRouteChange(ROUTE_TYPES.ABOUT, routes.about);
                         if (result) {
-                          window.location.href = routes.about;
+                          if (newWindow) {
+                            window.open(routes.about, '_blank', 'noopener noreferrer');
+                          } else {
+                            window.location.href = routes.about;
+                          }
                         }
                       },
                     },
@@ -489,10 +502,15 @@ const SuiteHeader = ({
                     <SuiteHeaderProfile
                       displayName={userDisplayName}
                       username={username}
-                      onProfileClick={async () => {
+                      onProfileClick={async (e) => {
+                        const newWindow = shouldOpenInNewWindow(e);
                         const result = await onRouteChange(ROUTE_TYPES.PROFILE, routes.profile);
                         if (result) {
-                          window.location.href = routes.profile;
+                          if (newWindow) {
+                            window.open(routes.profile, '_blank', 'noopener noreferrer');
+                          } else {
+                            window.location.href = routes.profile;
+                          }
                         }
                       }}
                       i18n={{

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
@@ -245,6 +245,18 @@ const SuiteHeader = ({
         ]
       : [];
 
+  const handleOnClick = (routeType, href, isExternal) => async (e) => {
+    const newWindow = isExternal ? true : shouldOpenInNewWindow(e);
+    const result = await onRouteChange(routeType, href);
+    if (result) {
+      if (newWindow) {
+        window.open(href, '_blank', 'noopener noreferrer');
+      } else {
+        window.location.href = href;
+      }
+    }
+  };
+
   return (
     <>
       {walkmePath ? <Walkme path={walkmePath} lang={walkmeLang} /> : null}
@@ -262,24 +274,14 @@ const SuiteHeader = ({
             <>
               <Link
                 href="javascript:void(0)"
-                onClick={async () => {
-                  const result = await onRouteChange(ROUTE_TYPES.SURVEY, surveyData.surveyLink);
-                  if (result) {
-                    window.open(surveyData.surveyLink, '_blank', 'noopener noreferrer');
-                  }
-                }}
+                onClick={handleOnClick(ROUTE_TYPES.SURVEY, surveyData.surveyLink, true)}
               >
                 {mergedI18N.surveyText}
               </Link>
               <div className={`${settings.iotPrefix}--suite-header-survey-policy-link`}>
                 <Link
                   href="javascript:void(0)"
-                  onClick={async () => {
-                    const result = await onRouteChange(ROUTE_TYPES.SURVEY, surveyData.surveyLink);
-                    if (result) {
-                      window.open(surveyData.privacyLink, '_blank', 'noopener noreferrer');
-                    }
-                  }}
+                  onClick={handleOnClick(ROUTE_TYPES.SURVEY, surveyData.surveyLink, true)}
                 >
                   {mergedI18N.surveyPrivacyPolicy}
                 </Link>
@@ -303,12 +305,7 @@ const SuiteHeader = ({
       <SuiteHeaderLogoutModal
         isOpen={showLogoutModal}
         onClose={() => setShowLogoutModal(false)}
-        onLogout={async () => {
-          const result = await onRouteChange(ROUTE_TYPES.LOGOUT, routes.logout);
-          if (result) {
-            window.location.href = routes.logout;
-          }
-        }}
+        onLogout={handleOnClick(ROUTE_TYPES.LOGOUT, routes.logout)}
         i18n={{
           heading: mergedI18N.profileLogoutModalHeading,
           primaryButton: mergedI18N.profileLogoutModalPrimaryButton,
@@ -395,19 +392,11 @@ const SuiteHeader = ({
             onClick: async (e) => {
               let href = routes.admin;
               let routeType = ROUTE_TYPES.ADMIN;
-              const newWindow = shouldOpenInNewWindow(e);
               if (isAdminView) {
                 href = navigatorRoute;
                 routeType = ROUTE_TYPES.NAVIGATOR;
               }
-              const result = await onRouteChange(routeType, href);
-              if (result) {
-                if (newWindow) {
-                  window.open(href, '_blank', 'noopener noreferrer');
-                } else {
-                  window.location.href = href;
-                }
-              }
+              handleOnClick(routeType, href)(e);
             },
           },
           {
@@ -434,12 +423,7 @@ const SuiteHeader = ({
                       'data-testid': `suite-header-help--${item}`,
                       href: 'javascript:void(0)',
                       title: mergedI18N[item],
-                      onClick: async () => {
-                        const result = await onRouteChange(ROUTE_TYPES.DOCUMENTATION, routes[item]);
-                        if (result) {
-                          window.open(routes[item], '_blank', 'noopener noreferrer');
-                        }
-                      },
+                      onClick: handleOnClick(ROUTE_TYPES.DOCUMENTATION, routes[item], true),
                     },
                     content: <span id={`suite-header-help-menu-${item}`}>{mergedI18N[item]}</span>,
                   })),
@@ -449,17 +433,7 @@ const SuiteHeader = ({
                       'data-testid': 'suite-header-help--about',
                       href: 'javascript:void(0)',
                       title: mergedI18N.about,
-                      onClick: async (e) => {
-                        const newWindow = shouldOpenInNewWindow(e);
-                        const result = await onRouteChange(ROUTE_TYPES.ABOUT, routes.about);
-                        if (result) {
-                          if (newWindow) {
-                            window.open(routes.about, '_blank', 'noopener noreferrer');
-                          } else {
-                            window.location.href = routes.about;
-                          }
-                        }
-                      },
+                      onClick: handleOnClick(ROUTE_TYPES.ABOUT, routes.about),
                     },
                     content: <span id="suite-header-help-menu-about">{mergedI18N.about}</span>,
                   },
@@ -502,17 +476,7 @@ const SuiteHeader = ({
                     <SuiteHeaderProfile
                       displayName={userDisplayName}
                       username={username}
-                      onProfileClick={async (e) => {
-                        const newWindow = shouldOpenInNewWindow(e);
-                        const result = await onRouteChange(ROUTE_TYPES.PROFILE, routes.profile);
-                        if (result) {
-                          if (newWindow) {
-                            window.open(routes.profile, '_blank', 'noopener noreferrer');
-                          } else {
-                            window.location.href = routes.profile;
-                          }
-                        }
-                      }}
+                      onProfileClick={handleOnClick(ROUTE_TYPES.PROFILE, routes.profile)}
                       i18n={{
                         profileTitle: mergedI18N.profileTitle,
                         profileButton: mergedI18N.profileManageButton,

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
@@ -281,7 +281,7 @@ const SuiteHeader = ({
               <div className={`${settings.iotPrefix}--suite-header-survey-policy-link`}>
                 <Link
                   href="javascript:void(0)"
-                  onClick={handleOnClick(ROUTE_TYPES.SURVEY, surveyData.surveyLink, true)}
+                  onClick={handleOnClick(ROUTE_TYPES.SURVEY, surveyData.privacyLink, true)}
                 >
                   {mergedI18N.surveyPrivacyPolicy}
                 </Link>
@@ -305,7 +305,7 @@ const SuiteHeader = ({
       <SuiteHeaderLogoutModal
         isOpen={showLogoutModal}
         onClose={() => setShowLogoutModal(false)}
-        onLogout={handleOnClick(ROUTE_TYPES.LOGOUT, routes.logout)}
+        onLogout={handleOnClick(ROUTE_TYPES.LOGOUT, routes?.logout)}
         i18n={{
           heading: mergedI18N.profileLogoutModalHeading,
           primaryButton: mergedI18N.profileLogoutModalPrimaryButton,
@@ -476,7 +476,7 @@ const SuiteHeader = ({
                     <SuiteHeaderProfile
                       displayName={userDisplayName}
                       username={username}
-                      onProfileClick={handleOnClick(ROUTE_TYPES.PROFILE, routes.profile)}
+                      onProfileClick={handleOnClick(ROUTE_TYPES.PROFILE, routes?.profile)}
                       i18n={{
                         profileTitle: mergedI18N.profileTitle,
                         profileButton: mergedI18N.profileManageButton,

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.mdx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.mdx
@@ -221,8 +221,8 @@ import { SuiteHeader } from 'carbon-addons-iot-react';
 
 ## Opening a route in a new window
 
-The SuiteHeader and SideNav are very versatle. Application developers have control over the elements and metadata used to render a SideNav link or custom actions.
-All of the built-in actions in the SuiteHeader (Administation link, help, profile, or Application Switcher) can be opened in a new window by holding <kbd>⌘</kbd>+<kbd>Left-Click</kbd> (Mac) or <kbd>Ctrl</kbd>+<kbd>Left-Click</kbd> (Windows).
+The SuiteHeader and SideNav are very versatile. Application developers have control over the elements and metadata used to render a SideNav link or custom actions.
+All of the built-in actions in the SuiteHeader (Administration link, help, profile, or Application Switcher) can be opened in a new window by holding <kbd>⌘</kbd>+<kbd>Left-Click</kbd> (Mac) or <kbd>Ctrl</kbd>+<kbd>Left-Click</kbd> (Windows).
 
 For example, if you would like a link in the sideNav to open in a new window, you can set the metaData like this:
 

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.mdx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.mdx
@@ -8,6 +8,7 @@
   - [Using provided data fetching util](#using-provided-data-fetching-util)
   - [Using provided data fetching hook (recommended)](#using-provided-data-fetching-hook-recommended)
   - [Hiding an icon from the action menu](#hiding-an-icon-from-the-action-menu)
+  - [Opening a route in a new window](#opening-a-route-in-a-new-window)
 - [Props](#props)
 - [Feedback](#feedback)
 - External Links
@@ -216,6 +217,181 @@ import { SuiteHeader } from 'carbon-addons-iot-react';
     return true;
   }}
 />;
+```
+
+## Opening a route in a new window
+
+The SuiteHeader and SideNav are very versatle. Application developers have control over the elements and metadata used to render a SideNav link or custom actions.
+All of the built-in actions in the SuiteHeader (Administation link, help, profile, or Application Switcher) can be opened in a new window by holding <kbd>⌘</kbd>+<kbd>Left-Click</kbd> (Mac) or <kbd>Ctrl</kbd>+<kbd>Left-Click</kbd> (Windows).
+
+For example, if you would like a link in the sideNav to open in a new window, you can set the metaData like this:
+
+```json
+{
+  "label": "Dashboards",
+  "href": "https://www.ibm.com",
+  "element": "a",
+  "target": "_blank",
+  "rel": "noopener noreferrer"
+}
+```
+
+If you want to use a button element, but also have the option of it opening in a new window, you can control that with the onClick handler.
+
+```jsx
+{
+  "label": "Dashboards",
+  "element": "button",
+  "onClick": (e) => {
+    // you'll need to check the current platform to confirm mac/windows
+    // and check the correct key
+    if (e.ctrlKey || e.metaKey) {
+      window.open('https://www.ibm.com', '_blank', 'noopener noreferrer')
+    } else {
+      window.location.href = 'https://www.ibm.com';
+    }
+  }
+}
+```
+
+Below is a full example of various BUTTON and ANCHOR tags used in both open in new window or same window scenarios.
+
+```jsx
+<SuiteHeader
+  suiteName={text('suiteName', 'Application Suite')}
+  appName={text('appName', 'Application Name')}
+  userDisplayName={text('userDisplayName', 'Admin User')}
+  username={text('username', 'adminuser')}
+  isAdminView={boolean('isAdminView', false)}
+  routes={object('routes', {
+    profile: 'https://www.ibm.com',
+    navigator: 'https://www.ibm.com',
+    admin: 'https://www.ibm.com',
+    logout: 'https://www.ibm.com',
+    whatsNew: 'https://www.ibm.com',
+    gettingStarted: 'https://www.ibm.com',
+    documentation: 'https://www.ibm.com',
+    requestEnhancement: 'https://www.ibm.com',
+    support: 'https://www.ibm.com',
+    about: 'https://www.ibm.com',
+    workspaceId: 'workspace1',
+    domain: 'ibm.com',
+  })}
+  applications={object('applications', [
+    {
+      id: 'monitor',
+      name: 'Monitor',
+      href: 'https://www.ibm.com',
+    },
+    {
+      id: 'health',
+      name: 'Health',
+      href: 'https://www.ibm.com',
+      isExternal: true,
+    },
+  ])}
+  sideNavProps={{
+    links: [
+      {
+        icon: Switcher24,
+        isEnabled: true,
+        metaData: {
+          tabIndex: 0,
+          label: 'Boards',
+          element: ({ children, ...rest }) => <div {...rest}>{children}</div>,
+          isActive: true,
+        },
+        linkContent: 'Boards',
+        childContent: [
+          {
+            metaData: {
+              label: 'Yet another link',
+              title: 'Yet another link',
+              element: 'button',
+              onClick: (e) => {
+                // do something else
+              },
+            },
+            content: 'Yet another link',
+          },
+        ],
+      },
+      {
+        isEnabled: true,
+        icon: Chip,
+        metaData: {
+          label: 'Devices',
+          href: 'https://www.ibm.com',
+          element: 'a',
+          target: '_blank',
+        },
+        linkContent: 'Devices',
+      },
+      {
+        isEnabled: true,
+        icon: Dashboard,
+        metaData: {
+          label: 'Dashboards',
+          href: 'https://www.ibm.com',
+          element: 'a',
+          target: '_blank',
+        },
+        linkContent: 'Dashboards',
+        childContent: [
+          {
+            metaData: {
+              label: 'Link 1',
+              title: 'Link 1',
+              element: 'button',
+              onClick: (e) => {
+                window.location.href = 'https://www.ibm.com';
+              },
+            },
+            content: 'Link 1',
+          },
+          {
+            metaData: {
+              label: 'Link 2',
+              title: 'Link 2',
+              element: 'a',
+              href: 'https://www.ibm.com',
+            },
+            content: 'Link 2',
+          },
+        ],
+      },
+      {
+        isEnabled: true,
+        icon: Group,
+        metaData: {
+          label: 'Members',
+          element: 'button',
+        },
+        linkContent: 'Members',
+        childContent: [
+          {
+            metaData: {
+              label: 'Yet another link',
+              title: 'Yet another link',
+              element: 'button',
+              onClick: (e) => {
+                // you'll need to check the current platform to confirm mac/windows
+                // and check the correct key
+                if (e.ctrlKey || e.metaKey) {
+                  window.open('https://www.ibm.com', '_blank', 'noopener noreferrer');
+                } else {
+                  window.location.href = 'https://www.ibm.com';
+                }
+              },
+            },
+            content: 'Link 3',
+            isActive: true,
+          },
+        ],
+      },
+    ],
+  }}
+/>
 ```
 
 ## Props

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
@@ -937,4 +937,94 @@ describe('SuiteHeader', () => {
     expect(onKeyDown).toHaveBeenCalled();
     jest.resetAllMocks();
   });
+
+  describe('opening in new window', () => {
+    let fakeUserAgent = '';
+    beforeAll(() => {
+      const { userAgent } = global.navigator;
+      Object.defineProperty(global.navigator, 'userAgent', {
+        get() {
+          return fakeUserAgent === '' ? userAgent : fakeUserAgent;
+        },
+      });
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+      fakeUserAgent = '';
+    });
+
+    it('should open built-in routes in new window when holding cmd', async () => {
+      const onRouteChange = jest.fn().mockImplementation(() => true);
+      fakeUserAgent = 'Mac';
+      render(<SuiteHeader {...commonProps} onRouteChange={onRouteChange} />);
+      await userEvent.click(screen.getByLabelText('Administration'), { metaKey: true });
+      expect(onRouteChange).toHaveBeenCalledWith('NAVIGATOR', 'https://www.ibm.com');
+      expect(window.open).toHaveBeenCalledWith(
+        'https://www.ibm.com',
+        '_blank',
+        'noopener noreferrer'
+      );
+    });
+
+    it('should open built-in routes in new window when holding ctrl', async () => {
+      const onRouteChange = jest.fn().mockImplementation(() => true);
+      fakeUserAgent = 'Win';
+      render(<SuiteHeader {...commonProps} onRouteChange={onRouteChange} />);
+      await userEvent.click(screen.getByLabelText('Administration'), { ctrlKey: true });
+      expect(onRouteChange).toHaveBeenCalledWith('NAVIGATOR', 'https://www.ibm.com');
+      expect(window.open).toHaveBeenLastCalledWith(
+        'https://www.ibm.com',
+        '_blank',
+        'noopener noreferrer'
+      );
+      expect(window.open).toHaveBeenCalledTimes(1);
+      userEvent.click(screen.getByRole('menuitem', { name: 'user' }));
+      await userEvent.click(screen.getByRole('button', { name: 'Manage profile' }), {
+        ctrlKey: true,
+      });
+      expect(window.open).toHaveBeenLastCalledWith(
+        'https://www.ibm.com',
+        '_blank',
+        'noopener noreferrer'
+      );
+      expect(window.open).toHaveBeenCalledTimes(2);
+
+      userEvent.click(screen.getByRole('menuitem', { name: 'Help' }));
+      await userEvent.click(screen.getByTitle('About'), { ctrlKey: true });
+      expect(window.open).toHaveBeenLastCalledWith(
+        'https://www.ibm.com',
+        '_blank',
+        'noopener noreferrer'
+      );
+      expect(window.open).toHaveBeenCalledTimes(3);
+
+      userEvent.click(screen.getByRole('button', { name: 'AppSwitcher' }));
+      await userEvent.click(screen.getByText('All applications'), { ctrlKey: true });
+      expect(window.open).toHaveBeenLastCalledWith(
+        'https://www.ibm.com',
+        '_blank',
+        'noopener noreferrer'
+      );
+      expect(window.open).toHaveBeenCalledTimes(4);
+
+      userEvent.click(screen.getByRole('button', { name: 'AppSwitcher' }));
+      await userEvent.click(screen.getByText('Monitor'), { ctrlKey: true });
+      expect(window.open).toHaveBeenLastCalledWith(
+        'https://www.ibm.com',
+        '_blank',
+        'noopener noreferrer'
+      );
+      expect(window.open).toHaveBeenCalledTimes(5);
+
+      userEvent.click(screen.getByRole('button', { name: 'AppSwitcher' }));
+      await userEvent.click(screen.getByText('Health'), { ctrlKey: true });
+      expect(window.open).toHaveBeenLastCalledWith(
+        'https://www.ibm.com',
+        '_blank',
+        'noopener noreferrer'
+      );
+      expect(window.open).toHaveBeenCalledTimes(6);
+    });
+  });
 });

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
@@ -15,28 +15,28 @@ const commonProps = {
   isAdminView: true,
   onRouteChange: async () => true,
   routes: {
-    profile: 'https://www.ibm.com',
-    navigator: 'https://www.ibm.com',
-    admin: 'https://www.ibm.com',
-    logout: 'https://www.ibm.com',
-    logoutInactivity: 'https://www.ibm.com',
-    whatsNew: 'https://www.ibm.com',
-    gettingStarted: 'https://www.ibm.com',
-    documentation: 'https://www.ibm.com',
-    requestEnhancement: 'https://www.ibm.com',
-    support: 'https://www.ibm.com',
-    about: 'https://www.ibm.com',
+    profile: 'https://www.ibm.com/profile',
+    navigator: 'https://www.ibm.com/navigator',
+    admin: 'https://www.ibm.com/admin',
+    logout: 'https://www.ibm.com/logout',
+    logoutInactivity: 'https://www.ibm.com/inactivity',
+    whatsNew: 'https://www.ibm.com/whatsnew',
+    gettingStarted: 'https://www.ibm.com/gettingstarted',
+    documentation: 'https://www.ibm.com/documentation',
+    requestEnhancement: 'https://www.ibm.com/request',
+    support: 'https://www.ibm.com/support',
+    about: 'https://www.ibm.com/about',
   },
   applications: [
     {
       id: 'monitor',
       name: 'Monitor',
-      href: 'https://www.ibm.com',
+      href: 'https://www.ibm.com/monitor',
     },
     {
       id: 'health',
       name: 'Health',
-      href: 'https://www.ibm.com',
+      href: 'https://www.ibm.com/health',
       isExternal: true,
     },
   ],
@@ -494,14 +494,14 @@ describe('SuiteHeader', () => {
     render(<SuiteHeader {...commonProps} onRouteChange={onRouteChange} />);
     userEvent.click(screen.getByRole('menuitem', { name: 'user' }));
     await userEvent.click(screen.getByRole('button', { name: 'Manage profile' }));
-    expect(onRouteChange).toHaveBeenCalledWith('PROFILE', 'https://www.ibm.com');
+    expect(onRouteChange).toHaveBeenCalledWith('PROFILE', commonProps.routes.profile);
     expect(window.location.href).toEqual(originalHref);
 
     onRouteChange.mockImplementation(() => true);
     userEvent.click(screen.getByRole('menuitem', { name: 'user' }));
     await userEvent.click(screen.getByRole('button', { name: 'Manage profile' }));
-    expect(onRouteChange).toHaveBeenCalledWith('PROFILE', 'https://www.ibm.com');
-    expect(window.location.href).toBe('https://www.ibm.com');
+    expect(onRouteChange).toHaveBeenCalledWith('PROFILE', commonProps.routes.profile);
+    expect(window.location.href).toBe(commonProps.routes.profile);
   });
 
   it('should handle keyboard navigation for actionItems and panel links', async () => {
@@ -959,9 +959,9 @@ describe('SuiteHeader', () => {
       fakeUserAgent = 'Mac';
       render(<SuiteHeader {...commonProps} onRouteChange={onRouteChange} />);
       await userEvent.click(screen.getByLabelText('Administration'), { metaKey: true });
-      expect(onRouteChange).toHaveBeenCalledWith('NAVIGATOR', 'https://www.ibm.com');
+      expect(onRouteChange).toHaveBeenCalledWith('NAVIGATOR', commonProps.routes.navigator);
       expect(window.open).toHaveBeenCalledWith(
-        'https://www.ibm.com',
+        commonProps.routes.navigator,
         '_blank',
         'noopener noreferrer'
       );
@@ -972,9 +972,9 @@ describe('SuiteHeader', () => {
       fakeUserAgent = 'Win';
       render(<SuiteHeader {...commonProps} onRouteChange={onRouteChange} />);
       await userEvent.click(screen.getByLabelText('Administration'), { ctrlKey: true });
-      expect(onRouteChange).toHaveBeenCalledWith('NAVIGATOR', 'https://www.ibm.com');
+      expect(onRouteChange).toHaveBeenCalledWith('NAVIGATOR', commonProps.routes.navigator);
       expect(window.open).toHaveBeenLastCalledWith(
-        'https://www.ibm.com',
+        commonProps.routes.navigator,
         '_blank',
         'noopener noreferrer'
       );
@@ -984,7 +984,7 @@ describe('SuiteHeader', () => {
         ctrlKey: true,
       });
       expect(window.open).toHaveBeenLastCalledWith(
-        'https://www.ibm.com',
+        commonProps.routes.profile,
         '_blank',
         'noopener noreferrer'
       );
@@ -993,7 +993,7 @@ describe('SuiteHeader', () => {
       userEvent.click(screen.getByRole('menuitem', { name: 'Help' }));
       await userEvent.click(screen.getByTitle('About'), { ctrlKey: true });
       expect(window.open).toHaveBeenLastCalledWith(
-        'https://www.ibm.com',
+        commonProps.routes.about,
         '_blank',
         'noopener noreferrer'
       );
@@ -1002,7 +1002,7 @@ describe('SuiteHeader', () => {
       userEvent.click(screen.getByRole('button', { name: 'AppSwitcher' }));
       await userEvent.click(screen.getByText('All applications'), { ctrlKey: true });
       expect(window.open).toHaveBeenLastCalledWith(
-        'https://www.ibm.com',
+        commonProps.routes.navigator,
         '_blank',
         'noopener noreferrer'
       );
@@ -1011,7 +1011,7 @@ describe('SuiteHeader', () => {
       userEvent.click(screen.getByRole('button', { name: 'AppSwitcher' }));
       await userEvent.click(screen.getByText('Monitor'), { ctrlKey: true });
       expect(window.open).toHaveBeenLastCalledWith(
-        'https://www.ibm.com',
+        commonProps.applications[0].href,
         '_blank',
         'noopener noreferrer'
       );
@@ -1020,7 +1020,7 @@ describe('SuiteHeader', () => {
       userEvent.click(screen.getByRole('button', { name: 'AppSwitcher' }));
       await userEvent.click(screen.getByText('Health'), { ctrlKey: true });
       expect(window.open).toHaveBeenLastCalledWith(
-        'https://www.ibm.com',
+        commonProps.applications[1].href,
         '_blank',
         'noopener noreferrer'
       );

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
@@ -9,7 +9,10 @@ import { ButtonSkeleton } from 'carbon-components-react';
 import { settings } from '../../../constants/Settings';
 import Button from '../../Button';
 import { SkeletonText } from '../../SkeletonText';
-import SuiteHeader, { SuiteHeaderApplicationPropTypes } from '../SuiteHeader';
+import SuiteHeader, {
+  SuiteHeaderApplicationPropTypes,
+  shouldOpenInNewWindow,
+} from '../SuiteHeader';
 import { handleSpecificKeyDown } from '../../../utils/componentUtilityFunctions';
 
 const defaultProps = {
@@ -58,12 +61,13 @@ const SuiteHeaderAppSwitcher = ({
     : null;
 
   const handleRouteChange = useCallback(
-    ({ href, id, isExternal }) => async () => {
+    ({ href, id, isExternal }) => async (e) => {
+      const newWindow = shouldOpenInNewWindow(e);
       const result = await onRouteChange(SuiteHeader.ROUTE_TYPES.APPLICATION, href, {
         appId: id,
       });
       if (result) {
-        if (isExternal) {
+        if (isExternal || newWindow) {
           window.open(href, '_blank', 'noopener noreferrer');
         } else {
           window.location.href = href;
@@ -73,12 +77,20 @@ const SuiteHeaderAppSwitcher = ({
     [onRouteChange]
   );
 
-  const handleAllApplicationRoute = useCallback(async () => {
-    const result = await onRouteChange(SuiteHeader.ROUTE_TYPES.NAVIGATOR, allApplicationsLink);
-    if (result) {
-      window.location.href = allApplicationsLink;
-    }
-  }, [allApplicationsLink, onRouteChange]);
+  const handleAllApplicationRoute = useCallback(
+    async (e) => {
+      const newWindow = shouldOpenInNewWindow(e);
+      const result = await onRouteChange(SuiteHeader.ROUTE_TYPES.NAVIGATOR, allApplicationsLink);
+      if (result) {
+        if (newWindow) {
+          window.open(allApplicationsLink, '_blank', 'noopener noreferrer');
+        } else {
+          window.location.href = allApplicationsLink;
+        }
+      }
+    },
+    [allApplicationsLink, onRouteChange]
+  );
 
   return (
     <ul data-testid={testId} className={baseClassName}>


### PR DESCRIPTION
Closes #2852 

**Summary**

- Makes it possible to open SuiteHeader links by holding cmd+click or ctrl+click.

**Change List (commits, features, bugs, etc)**

- Adds cmd+click / ctrl+click checking to all built-in SuiteHeader links
- Updates docs to make to more clear how this behavior can be controlled on the application side
- added tests for coverage

**Acceptance Test (how to verify the PR)**

- holding cmd+click (mac) or ctrl+click (win) should open all SuiteHeader links (Administation, Manage Profile, Help, All Applications, Monitor, Health, etc) in a new window.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- links still open in same window when not hold ctrl or cmd.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
