### PR TITLE
style(valuecard): trend text should be grey instead of indicator color

### DIFF
--- a/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -845,7 +845,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                       data-testid="Card-attribute-0-secondary-value"
                       style={
                         Object {
-                          "--secondary-value-color": "#6F6F6F",
+                          "--secondary-value-color": "#6f6f6f",
                         }
                       }
                     >
@@ -1104,7 +1104,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                       data-testid="Card-attribute-0-secondary-value"
                       style={
                         Object {
-                          "--secondary-value-color": "#6F6F6F",
+                          "--secondary-value-color": "#6f6f6f",
                         }
                       }
                     >
@@ -3785,7 +3785,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                       data-testid="Card-attribute-0-secondary-value"
                       style={
                         Object {
-                          "--secondary-value-color": "#6F6F6F",
+                          "--secondary-value-color": "#6f6f6f",
                         }
                       }
                     >
@@ -4044,7 +4044,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                       data-testid="Card-attribute-0-secondary-value"
                       style={
                         Object {
-                          "--secondary-value-color": "#6F6F6F",
+                          "--secondary-value-color": "#6f6f6f",
                         }
                       }
                     >
@@ -6760,7 +6760,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                       data-testid="Card-attribute-0-secondary-value"
                       style={
                         Object {
-                          "--secondary-value-color": "#6F6F6F",
+                          "--secondary-value-color": "#6f6f6f",
                         }
                       }
                     >
@@ -7019,7 +7019,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                       data-testid="Card-attribute-0-secondary-value"
                       style={
                         Object {
-                          "--secondary-value-color": "#6F6F6F",
+                          "--secondary-value-color": "#6f6f6f",
                         }
                       }
                     >
@@ -12336,7 +12336,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                       data-testid="Card-attribute-0-secondary-value"
                       style={
                         Object {
-                          "--secondary-value-color": "#6F6F6F",
+                          "--secondary-value-color": "#6f6f6f",
                         }
                       }
                     >
@@ -12595,7 +12595,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                       data-testid="Card-attribute-0-secondary-value"
                       style={
                         Object {
-                          "--secondary-value-color": "#6F6F6F",
+                          "--secondary-value-color": "#6f6f6f",
                         }
                       }
                     >
@@ -16560,7 +16560,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -16693,7 +16693,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -17105,7 +17105,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -17238,7 +17238,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -20689,7 +20689,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -20822,7 +20822,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -22977,7 +22977,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -23110,7 +23110,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -25398,7 +25398,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -25477,7 +25477,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-1-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -25610,7 +25610,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -25792,7 +25792,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -25870,7 +25870,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-1-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -26076,7 +26076,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -26155,7 +26155,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-1-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -26288,7 +26288,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -26470,7 +26470,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -26548,7 +26548,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-1-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -27729,7 +27729,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-1-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -27808,7 +27808,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-2-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -28527,7 +28527,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-1-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -28606,7 +28606,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-2-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "#6F6F6F",
+                            "--secondary-value-color": "#6f6f6f",
                           }
                         }
                       >
@@ -29982,7 +29982,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                       data-testid="Card-attribute-0-secondary-value"
                       style={
                         Object {
-                          "--secondary-value-color": "#6F6F6F",
+                          "--secondary-value-color": "#6f6f6f",
                         }
                       }
                     >
@@ -30241,7 +30241,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                       data-testid="Card-attribute-0-secondary-value"
                       style={
                         Object {
-                          "--secondary-value-color": "#6F6F6F",
+                          "--secondary-value-color": "#6f6f6f",
                         }
                       }
                     >

--- a/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -845,7 +845,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                       data-testid="Card-attribute-0-secondary-value"
                       style={
                         Object {
-                          "--secondary-value-color": "green",
+                          "--secondary-value-color": "#6F6F6F",
                         }
                       }
                     >
@@ -853,7 +853,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         aria-label="trending up"
                         className="iot--value-card__attribute_trend-icon"
                         data-testid="Card-attribute-0-trending-up"
-                        fill="currentColor"
+                        fill="green"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -1104,7 +1104,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                       data-testid="Card-attribute-0-secondary-value"
                       style={
                         Object {
-                          "--secondary-value-color": "red",
+                          "--secondary-value-color": "#6F6F6F",
                         }
                       }
                     >
@@ -1112,7 +1112,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         aria-label="trending down"
                         className="iot--value-card__attribute_trend-icon"
                         data-testid="Card-attribute-0-trending-down"
-                        fill="currentColor"
+                        fill="red"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -3785,7 +3785,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                       data-testid="Card-attribute-0-secondary-value"
                       style={
                         Object {
-                          "--secondary-value-color": "green",
+                          "--secondary-value-color": "#6F6F6F",
                         }
                       }
                     >
@@ -3793,7 +3793,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         aria-label="trending up"
                         className="iot--value-card__attribute_trend-icon"
                         data-testid="Card-attribute-0-trending-up"
-                        fill="currentColor"
+                        fill="green"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -4044,7 +4044,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                       data-testid="Card-attribute-0-secondary-value"
                       style={
                         Object {
-                          "--secondary-value-color": "red",
+                          "--secondary-value-color": "#6F6F6F",
                         }
                       }
                     >
@@ -4052,7 +4052,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         aria-label="trending down"
                         className="iot--value-card__attribute_trend-icon"
                         data-testid="Card-attribute-0-trending-down"
-                        fill="currentColor"
+                        fill="red"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -6760,7 +6760,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                       data-testid="Card-attribute-0-secondary-value"
                       style={
                         Object {
-                          "--secondary-value-color": "green",
+                          "--secondary-value-color": "#6F6F6F",
                         }
                       }
                     >
@@ -6768,7 +6768,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         aria-label="trending up"
                         className="iot--value-card__attribute_trend-icon"
                         data-testid="Card-attribute-0-trending-up"
-                        fill="currentColor"
+                        fill="green"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -7019,7 +7019,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                       data-testid="Card-attribute-0-secondary-value"
                       style={
                         Object {
-                          "--secondary-value-color": "red",
+                          "--secondary-value-color": "#6F6F6F",
                         }
                       }
                     >
@@ -7027,7 +7027,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         aria-label="trending down"
                         className="iot--value-card__attribute_trend-icon"
                         data-testid="Card-attribute-0-trending-down"
-                        fill="currentColor"
+                        fill="red"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -12336,7 +12336,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                       data-testid="Card-attribute-0-secondary-value"
                       style={
                         Object {
-                          "--secondary-value-color": "green",
+                          "--secondary-value-color": "#6F6F6F",
                         }
                       }
                     >
@@ -12344,7 +12344,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         aria-label="trending up"
                         className="iot--value-card__attribute_trend-icon"
                         data-testid="Card-attribute-0-trending-up"
-                        fill="currentColor"
+                        fill="green"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -12595,7 +12595,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                       data-testid="Card-attribute-0-secondary-value"
                       style={
                         Object {
-                          "--secondary-value-color": "red",
+                          "--secondary-value-color": "#6F6F6F",
                         }
                       }
                     >
@@ -12603,7 +12603,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         aria-label="trending down"
                         className="iot--value-card__attribute_trend-icon"
                         data-testid="Card-attribute-0-trending-down"
-                        fill="currentColor"
+                        fill="red"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -16560,7 +16560,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "green",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -16568,7 +16568,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending up"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-0-trending-up"
-                          fill="currentColor"
+                          fill="green"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -16693,7 +16693,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "red",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -16701,7 +16701,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending down"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-0-trending-down"
-                          fill="currentColor"
+                          fill="red"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -17105,7 +17105,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "green",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -17113,7 +17113,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending up"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-0-trending-up"
-                          fill="currentColor"
+                          fill="green"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -17238,7 +17238,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "red",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -17246,7 +17246,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending down"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-0-trending-down"
-                          fill="currentColor"
+                          fill="red"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -20689,7 +20689,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "green",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -20697,7 +20697,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending up"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-0-trending-up"
-                          fill="currentColor"
+                          fill="green"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -20822,7 +20822,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "red",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -20830,7 +20830,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending down"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-0-trending-down"
-                          fill="currentColor"
+                          fill="red"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -22977,7 +22977,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "green",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -22985,7 +22985,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending up"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-0-trending-up"
-                          fill="currentColor"
+                          fill="green"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -23110,7 +23110,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "red",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -23118,7 +23118,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending down"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-0-trending-down"
-                          fill="currentColor"
+                          fill="red"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -25398,7 +25398,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "red",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -25406,7 +25406,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending down"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-0-trending-down"
-                          fill="currentColor"
+                          fill="red"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -25477,7 +25477,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-1-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "red",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -25485,7 +25485,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending down"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-1-trending-down"
-                          fill="currentColor"
+                          fill="red"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -25610,7 +25610,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "green",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -25618,7 +25618,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending up"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-0-trending-up"
-                          fill="currentColor"
+                          fill="green"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -25792,7 +25792,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "green",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -25800,7 +25800,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending up"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-0-trending-up"
-                          fill="currentColor"
+                          fill="green"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -25870,7 +25870,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-1-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "red",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -25878,7 +25878,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending down"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-1-trending-down"
-                          fill="currentColor"
+                          fill="red"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -26076,7 +26076,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "red",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -26084,7 +26084,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending down"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-0-trending-down"
-                          fill="currentColor"
+                          fill="red"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -26155,7 +26155,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-1-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "red",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -26163,7 +26163,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending down"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-1-trending-down"
-                          fill="currentColor"
+                          fill="red"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -26288,7 +26288,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "green",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -26296,7 +26296,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending up"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-0-trending-up"
-                          fill="currentColor"
+                          fill="green"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -26470,7 +26470,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-0-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "green",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -26478,7 +26478,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending up"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-0-trending-up"
-                          fill="currentColor"
+                          fill="green"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -26548,7 +26548,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-1-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "red",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -26556,7 +26556,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending down"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-1-trending-down"
-                          fill="currentColor"
+                          fill="red"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -27729,7 +27729,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-1-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "green",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -27737,7 +27737,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending up"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-1-trending-up"
-                          fill="currentColor"
+                          fill="green"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -27808,7 +27808,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-2-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "red",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -27816,7 +27816,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending down"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-2-trending-down"
-                          fill="currentColor"
+                          fill="red"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -28527,7 +28527,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-1-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "green",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -28535,7 +28535,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending up"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-1-trending-up"
-                          fill="currentColor"
+                          fill="green"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -28606,7 +28606,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         data-testid="Card-attribute-2-secondary-value"
                         style={
                           Object {
-                            "--secondary-value-color": "red",
+                            "--secondary-value-color": "#6F6F6F",
                           }
                         }
                       >
@@ -28614,7 +28614,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                           aria-label="trending down"
                           className="iot--value-card__attribute_trend-icon"
                           data-testid="Card-attribute-2-trending-down"
-                          fill="currentColor"
+                          fill="red"
                           focusable="false"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
@@ -29982,7 +29982,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                       data-testid="Card-attribute-0-secondary-value"
                       style={
                         Object {
-                          "--secondary-value-color": "green",
+                          "--secondary-value-color": "#6F6F6F",
                         }
                       }
                     >
@@ -29990,7 +29990,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         aria-label="trending up"
                         className="iot--value-card__attribute_trend-icon"
                         data-testid="Card-attribute-0-trending-up"
-                        fill="currentColor"
+                        fill="green"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -30241,7 +30241,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                       data-testid="Card-attribute-0-secondary-value"
                       style={
                         Object {
-                          "--secondary-value-color": "red",
+                          "--secondary-value-color": "#6F6F6F",
                         }
                       }
                     >
@@ -30249,7 +30249,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                         aria-label="trending down"
                         className="iot--value-card__attribute_trend-icon"
                         data-testid="Card-attribute-0-trending-down"
-                        fill="currentColor"
+                        fill="red"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"

--- a/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
@@ -783,7 +783,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                   data-testid="Card-attribute-0-secondary-value"
                   style={
                     Object {
-                      "--secondary-value-color": "red",
+                      "--secondary-value-color": "#6F6F6F",
                     }
                   }
                 >
@@ -791,7 +791,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                     aria-label="trending down"
                     className="iot--value-card__attribute_trend-icon"
                     data-testid="Card-attribute-0-trending-down"
-                    fill="currentColor"
+                    fill="red"
                     focusable="false"
                     height={16}
                     preserveAspectRatio="xMidYMid meet"

--- a/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
@@ -783,7 +783,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                   data-testid="Card-attribute-0-secondary-value"
                   style={
                     Object {
-                      "--secondary-value-color": "#6F6F6F",
+                      "--secondary-value-color": "#6f6f6f",
                     }
                   }
                 >

--- a/packages/react/src/components/ValueCard/Attribute.jsx
+++ b/packages/react/src/components/ValueCard/Attribute.jsx
@@ -162,7 +162,7 @@ const Attribute = ({
             data-testid={`${testId}-secondary-value`}
             className={`${BEM_BASE}-secondary-value`}
             style={{
-              '--secondary-value-color': secondaryValue.color || '#777',
+              '--secondary-value-color': '#6F6F6F',
             }}
           >
             {secondaryValue.trend && secondaryValue.trend === 'up' ? (
@@ -170,12 +170,14 @@ const Attribute = ({
                 className={`${BEM_BASE}_trend-icon`}
                 aria-label="trending up"
                 data-testid={`${testId}-trending-up`}
+                fill={secondaryValue.color || '#6F6F6F'}
               />
             ) : secondaryValue.trend === 'down' ? (
               <CaretDown16
                 className={`${BEM_BASE}_trend-icon`}
                 aria-label="trending down"
                 data-testid={`${testId}-trending-down`}
+                fill={secondaryValue.color || '#6F6F6F'}
               />
             ) : null}
             {secondaryValue.value}

--- a/packages/react/src/components/ValueCard/Attribute.jsx
+++ b/packages/react/src/components/ValueCard/Attribute.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import isNil from 'lodash/isNil';
 import { CaretUp16, CaretDown16 } from '@carbon/icons-react';
 import classnames from 'classnames';
+import { gray60 } from '@carbon/colors';
 
 import { CARD_LAYOUTS } from '../../constants/LayoutConstants';
 import CardIcon from '../ImageCard/CardIcon';
@@ -162,7 +163,7 @@ const Attribute = ({
             data-testid={`${testId}-secondary-value`}
             className={`${BEM_BASE}-secondary-value`}
             style={{
-              '--secondary-value-color': '#6F6F6F',
+              '--secondary-value-color': gray60,
             }}
           >
             {secondaryValue.trend && secondaryValue.trend === 'up' ? (
@@ -170,14 +171,14 @@ const Attribute = ({
                 className={`${BEM_BASE}_trend-icon`}
                 aria-label="trending up"
                 data-testid={`${testId}-trending-up`}
-                fill={secondaryValue.color || '#6F6F6F'}
+                fill={secondaryValue.color || gray60}
               />
             ) : secondaryValue.trend === 'down' ? (
               <CaretDown16
                 className={`${BEM_BASE}_trend-icon`}
                 aria-label="trending down"
                 data-testid={`${testId}-trending-down`}
-                fill={secondaryValue.color || '#6F6F6F'}
+                fill={secondaryValue.color || gray60}
               />
             ) : null}
             {secondaryValue.value}

--- a/packages/react/src/components/ValueCard/Attribute.test.jsx
+++ b/packages/react/src/components/ValueCard/Attribute.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { gray60 } from '@carbon/colors';
 
 import Attribute from './Attribute';
 
@@ -24,10 +25,10 @@ const commonProps = {
   value: 89,
 };
 describe('Attribute', () => {
-  it('falls back to #6F6F6F when no secondaryValue.color given', () => {
+  it('falls back to gray60 when no secondaryValue.color given', () => {
     render(<Attribute {...commonProps} secondaryValue={{ trend: 'up', value: '22' }} />);
 
-    expect(screen.getByText('22')).toHaveStyle('--secondary-value-color:#6F6F6F');
+    expect(screen.getByText('22')).toHaveStyle(`--secondary-value-color:${gray60}`);
   });
 
   it('should match values less than or equal to a threshold', () => {

--- a/packages/react/src/components/ValueCard/Attribute.test.jsx
+++ b/packages/react/src/components/ValueCard/Attribute.test.jsx
@@ -24,10 +24,10 @@ const commonProps = {
   value: 89,
 };
 describe('Attribute', () => {
-  it('falls back to #777 when no secondaryValue.color given', () => {
+  it('falls back to #6F6F6F when no secondaryValue.color given', () => {
     render(<Attribute {...commonProps} secondaryValue={{ trend: 'up', value: '22' }} />);
 
-    expect(screen.getByText('22')).toHaveStyle('--secondary-value-color:#777');
+    expect(screen.getByText('22')).toHaveStyle('--secondary-value-color:#6F6F6F');
   });
 
   it('should match values less than or equal to a threshold', () => {

--- a/packages/react/src/components/ValueCard/ValueCard.test.jsx
+++ b/packages/react/src/components/ValueCard/ValueCard.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { gray60 } from '@carbon/colors';
 
 import { CARD_DATA_STATE, CARD_SIZES } from '../../constants/LayoutConstants';
 import { settings } from '../../constants/Settings';
@@ -189,6 +190,6 @@ describe('ValueCard', () => {
     const previewData = screen.getAllByText(PREVIEW_DATA);
     expect(previewData).toHaveLength(2);
     expect(previewData[1]).toHaveClass(`${iotPrefix}--value-card__attribute-secondary-value`);
-    expect(previewData[1]).toHaveStyle('--secondary-value-color:#6F6F6F');
+    expect(previewData[1]).toHaveStyle(`--secondary-value-color:${gray60}`);
   });
 });

--- a/packages/react/src/components/ValueCard/ValueCard.test.jsx
+++ b/packages/react/src/components/ValueCard/ValueCard.test.jsx
@@ -189,6 +189,6 @@ describe('ValueCard', () => {
     const previewData = screen.getAllByText(PREVIEW_DATA);
     expect(previewData).toHaveLength(2);
     expect(previewData[1]).toHaveClass(`${iotPrefix}--value-card__attribute-secondary-value`);
-    expect(previewData[1]).toHaveStyle('--secondary-value-color:red');
+    expect(previewData[1]).toHaveStyle('--secondary-value-color:#6F6F6F');
   });
 });

--- a/packages/react/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/packages/react/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -2469,7 +2469,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               data-testid="Card-attribute-0-secondary-value"
               style={
                 Object {
-                  "--secondary-value-color": "#6F6F6F",
+                  "--secondary-value-color": "#6f6f6f",
                 }
               }
             >

--- a/packages/react/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/packages/react/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -2469,7 +2469,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
               data-testid="Card-attribute-0-secondary-value"
               style={
                 Object {
-                  "--secondary-value-color": "red",
+                  "--secondary-value-color": "#6F6F6F",
                 }
               }
             >
@@ -2477,7 +2477,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
                 aria-label="trending down"
                 className="iot--value-card__attribute_trend-icon"
                 data-testid="Card-attribute-0-trending-down"
-                fill="currentColor"
+                fill="red"
                 focusable="false"
                 height={16}
                 preserveAspectRatio="xMidYMid meet"

--- a/packages/react/src/components/ValueCard/_attribute.scss
+++ b/packages/react/src/components/ValueCard/_attribute.scss
@@ -56,7 +56,7 @@
     height: $layout-01;
     display: flex;
     align-items: center;
-    font-size: 0.875rem;
+    font-size: 0.75rem;
     margin-bottom: $spacing-02;
     color: var(--secondary-value-color);
   }


### PR DESCRIPTION
Closes #2377

**Summary**

- The secondary-value-color in ValueCard should be grey(#6F6F6F), instead of the color of the ^ indicator.
- The indicator color when not specified will be display in #6F6F6F color.
- Font size of the secondary value is updated based on design https://ibm.invisionapp.com/d/main/#/console/15373465/319977464 

**Change List (commits, features, bugs, etc)**

- Changes done to Attribute component for secondary-value-color and font size changes in ValueCard.

**Acceptance Test (how to verify the PR)**

- Go to /?path=/story/1-watson-iot-valuecard--with-trends and verify that the secondary value is displayed in grey(#6F6F6F) whereas the trend indicator icon is displayed in the color as specified in the knob- content.attributes[0].secondaryValue.color

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Changes are related to style so go to /?path=/story/1-watson-iot-valuecard--with-trends and verify all functionalities which should work as before.

StoryBook: https://deploy-preview-2878--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-valuecard--with-trends

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
