### PR TITLE
fix(suite-header): replace javascript urls

### DIFF
--- a/packages/react/src/components/Card/__snapshots__/Card.story.storyshot
+++ b/packages/react/src/components/Card/__snapshots__/Card.story.storyshot
@@ -192,7 +192,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
           }
         >
           <section
-            aria-label="data table toolbar"
+            aria-label="Custom Card Title Toolbar"
             className="bx--table-toolbar"
             data-testid="my table-table-toolbar"
           >

--- a/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -1594,7 +1594,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   data-testid="table-for-card-alert-table1-table-container"
                 >
                   <section
-                    aria-label="data table toolbar"
+                    aria-label="Alerts Toolbar"
                     className="bx--table-toolbar"
                     data-testid="table-for-card-alert-table1-table-toolbar"
                   >
@@ -4539,7 +4539,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   data-testid="table-for-card-alert-table1-table-container"
                 >
                   <section
-                    aria-label="data table toolbar"
+                    aria-label="Alerts Toolbar"
                     className="bx--table-toolbar"
                     data-testid="table-for-card-alert-table1-table-toolbar"
                   >
@@ -7519,7 +7519,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   data-testid="table-for-card-alert-table1-table-container"
                 >
                   <section
-                    aria-label="data table toolbar"
+                    aria-label="Alerts Toolbar"
                     className="bx--table-toolbar"
                     data-testid="table-for-card-alert-table1-table-toolbar"
                   >
@@ -9593,7 +9593,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   data-testid="table-for-card-expandedcard-table-container"
                 >
                   <section
-                    aria-label="data table toolbar"
+                    aria-label="Expanded card Toolbar"
                     className="bx--table-toolbar"
                     data-testid="table-for-card-expandedcard-table-toolbar"
                   >
@@ -13125,7 +13125,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   data-testid="table-for-card-alert-table1-table-container"
                 >
                   <section
-                    aria-label="data table toolbar"
+                    aria-label="Alerts Toolbar"
                     className="bx--table-toolbar"
                     data-testid="table-for-card-alert-table1-table-toolbar"
                   >
@@ -30602,7 +30602,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   data-testid="table-for-card-alert-table1-table-container"
                 >
                   <section
-                    aria-label="data table toolbar"
+                    aria-label="Alerts Toolbar"
                     className="bx--table-toolbar"
                     data-testid="table-for-card-alert-table1-table-toolbar"
                   >

--- a/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
@@ -2104,7 +2104,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
               data-testid="table-for-card-tableCard-table-container"
             >
               <section
-                aria-label="data table toolbar"
+                aria-label="TableCard - LARGE Toolbar"
                 className="bx--table-toolbar"
                 data-testid="table-for-card-tableCard-table-toolbar"
               >

--- a/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -627,7 +627,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         data-testid="table-for-card-Table-table-container"
                       >
                         <section
-                          aria-label="data table toolbar"
+                          aria-label="Table card Toolbar"
                           className="bx--table-toolbar"
                           data-testid="table-for-card-Table-table-toolbar"
                         >
@@ -19913,7 +19913,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       data-testid="table-for-card-Table-table-container"
                     >
                       <section
-                        aria-label="data table toolbar"
+                        aria-label="Table card Toolbar"
                         className="bx--table-toolbar"
                         data-testid="table-for-card-Table-table-toolbar"
                       >

--- a/packages/react/src/components/RuleBuilder/__snapshots__/RuleBuilder.story.storyshot
+++ b/packages/react/src/components/RuleBuilder/__snapshots__/RuleBuilder.story.storyshot
@@ -847,7 +847,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     data-testid="edit-table-table-container"
                   >
                     <section
-                      aria-label="data table toolbar"
+                      aria-label="Editor access Toolbar"
                       className="bx--table-toolbar"
                       data-testid="edit-table-table-toolbar"
                     >
@@ -1362,7 +1362,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     data-testid="read-table-table-container"
                   >
                     <section
-                      aria-label="data table toolbar"
+                      aria-label="Read only access Toolbar"
                       className="bx--table-toolbar"
                       data-testid="read-table-table-toolbar"
                     >
@@ -5463,7 +5463,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     data-testid="edit-table-table-container"
                   >
                     <section
-                      aria-label="data table toolbar"
+                      aria-label="Editor access Toolbar"
                       className="bx--table-toolbar"
                       data-testid="edit-table-table-toolbar"
                     >
@@ -5742,7 +5742,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     data-testid="read-table-table-container"
                   >
                     <section
-                      aria-label="data table toolbar"
+                      aria-label="Read only access Toolbar"
                       className="bx--table-toolbar"
                       data-testid="read-table-table-toolbar"
                     >

--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -418,6 +418,7 @@ export const defaultProps = (baseProps) => ({
     itemSelected: 'item selected',
     rowCountInHeader: (totalRowCount) => `Results: ${totalRowCount}`,
     toggleAggregations: 'Toggle aggregations',
+    toolbarLabelAria: undefined,
     /** empty state */
     emptyMessage: 'There is no data',
     emptyMessageBody: '',
@@ -733,6 +734,7 @@ const Table = (props) => {
               downloadIconDescription: i18n.downloadIconDescription,
               rowCountInHeader: i18n.rowCountInHeader,
               toggleAggregations: i18n.toggleAggregations,
+              toolbarLabelAria: i18n.toolbarLabelAria,
             }}
             actions={{
               ...pick(

--- a/packages/react/src/components/Table/TablePropTypes.js
+++ b/packages/react/src/components/Table/TablePropTypes.js
@@ -174,6 +174,7 @@ export const I18NPropTypes = PropTypes.shape({
   closeMenuAria: PropTypes.string,
   clearSelectionAria: PropTypes.string,
   batchCancel: PropTypes.string,
+  toolbarLabelAria: PropTypes.string,
   itemsSelected: PropTypes.string,
   itemSelected: PropTypes.string,
   /** Row actions in table body */

--- a/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -75,6 +75,7 @@ const propTypes = {
     filterAscending: PropTypes.string,
     filterDescending: PropTypes.string,
     toggleAggregations: PropTypes.string,
+    toolbarLabelAria: PropTypes.string,
   }),
   /**
    * Action callbacks to update tableState
@@ -215,6 +216,7 @@ const TableToolbar = ({
       // TODO: remove deprecated 'testID' in v3
       data-testid={testID || testId}
       className={classnames(`${iotPrefix}--table-toolbar`, className)}
+      aria-label={i18n.toolbarLabelAria || secondaryTitle ? `${secondaryTitle} Toolbar` : undefined}
     >
       <TableBatchActions
         // TODO: remove deprecated 'testID' in v3

--- a/packages/react/src/components/Table/__snapshots__/StatefulTable.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/StatefulTable.story.storyshot
@@ -16,7 +16,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
       data-testid="table-table-container"
     >
       <section
-        aria-label="data table toolbar"
+        aria-label="Row count: 100 Toolbar"
         className="bx--table-toolbar"
         data-testid="table-table-toolbar"
       >
@@ -17561,7 +17561,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
       data-testid="table-table-container"
     >
       <section
-        aria-label="data table toolbar"
+        aria-label="Table with user view management Toolbar"
         className="bx--table-toolbar"
         data-testid="table-table-toolbar"
       >
@@ -22398,7 +22398,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
     data-testid="table-table-container"
   >
     <section
-      aria-label="data table toolbar"
+      aria-label="Row count: 100 Toolbar"
       className="bx--table-toolbar"
       data-testid="table-table-toolbar"
     >
@@ -43693,7 +43693,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
       data-testid="table-table-container"
     >
       <section
-        aria-label="data table toolbar"
+        aria-label="Row count: 100 Toolbar"
         className="bx--table-toolbar"
         data-testid="table-table-toolbar"
       >
@@ -48339,7 +48339,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
       data-testid="table-table-container"
     >
       <section
-        aria-label="data table toolbar"
+        aria-label="Row count: 100 Toolbar"
         className="bx--table-toolbar"
         data-testid="table-table-toolbar"
       >
@@ -52224,7 +52224,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
       data-testid="table-table-container"
     >
       <section
-        aria-label="data table toolbar"
+        aria-label="Row count: 100 Toolbar"
         className="bx--table-toolbar"
         data-testid="table-table-toolbar"
       >
@@ -84870,7 +84870,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
     }
   >
     <section
-      aria-label="data table toolbar"
+      aria-label="Row count: 100 Toolbar"
       className="bx--table-toolbar"
       data-testid="table-table-toolbar"
     >

--- a/packages/react/src/components/Table/__snapshots__/Table.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/Table.story.storyshot
@@ -10,7 +10,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
       data-testid="table-table-container"
     >
       <section
-        aria-label="data table toolbar"
+        aria-label="My editable table Toolbar"
         className="bx--table-toolbar"
         data-testid="table-table-toolbar"
       >
@@ -3755,7 +3755,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
       data-testid="table-table-container"
     >
       <section
-        aria-label="data table toolbar"
+        aria-label="Table with user view management Toolbar"
         className="bx--table-toolbar"
         data-testid="table-table-toolbar"
       >
@@ -8534,7 +8534,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
     data-testid="table-table-container"
   >
     <section
-      aria-label="data table toolbar"
+      aria-label="Basic \`dumb\` table Toolbar"
       className="bx--table-toolbar"
       data-testid="table-table-toolbar"
     >
@@ -87641,7 +87641,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
     data-testid="table-table-container"
   >
     <section
-      aria-label="data table toolbar"
+      aria-label="Row count: 100 Toolbar"
       className="bx--table-toolbar"
       data-testid="table-table-toolbar"
     >

--- a/packages/react/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/packages/react/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -37,7 +37,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           data-testid="table-for-card-table-list-table-container"
         >
           <section
-            aria-label="data table toolbar"
+            aria-label="Open Alerts Toolbar"
             className="bx--table-toolbar"
             data-testid="table-for-card-table-list-table-toolbar"
           >
@@ -1478,7 +1478,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           data-testid="table-for-card-table-list-table-container"
         >
           <section
-            aria-label="data table toolbar"
+            aria-label="Open Alerts Toolbar"
             className="bx--table-toolbar"
             data-testid="table-for-card-table-list-table-toolbar"
           >
@@ -2964,7 +2964,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           data-testid="table-for-card-table-list-table-container"
         >
           <section
-            aria-label="data table toolbar"
+            aria-label="Open Alerts Toolbar"
             className="bx--table-toolbar"
             data-testid="table-for-card-table-list-table-toolbar"
           >
@@ -4683,7 +4683,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           data-testid="table-for-card-undefined-table-container"
         >
           <section
-            aria-label="data table toolbar"
+            aria-label="Open Alerts Toolbar"
             className="bx--table-toolbar"
             data-testid="table-for-card-undefined-table-toolbar"
           >
@@ -5604,7 +5604,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           data-testid="table-for-card-table-list-table-container"
         >
           <section
-            aria-label="data table toolbar"
+            aria-label="Open Alerts 11112 Toolbar"
             className="bx--table-toolbar"
             data-testid="table-for-card-table-list-table-toolbar"
           >
@@ -6844,7 +6844,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           data-testid="table-for-card-table-list-table-container"
         >
           <section
-            aria-label="data table toolbar"
+            aria-label="Open Alerts Toolbar"
             className="bx--table-toolbar"
             data-testid="table-for-card-table-list-table-toolbar"
           >
@@ -9316,7 +9316,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           data-testid="table-for-card-table-list-table-container"
         >
           <section
-            aria-label="data table toolbar"
+            aria-label="Open Alerts Toolbar"
             className="bx--table-toolbar"
             data-testid="table-for-card-table-list-table-toolbar"
           >
@@ -11622,7 +11622,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           data-testid="table-for-card-table-list-table-container"
         >
           <section
-            aria-label="data table toolbar"
+            aria-label="Open Alerts Toolbar"
             className="bx--table-toolbar"
             data-testid="table-for-card-table-list-table-toolbar"
           >
@@ -13443,7 +13443,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           data-testid="table-for-card-table-list-table-container"
         >
           <section
-            aria-label="data table toolbar"
+            aria-label="Open Alerts Toolbar"
             className="bx--table-toolbar"
             data-testid="table-for-card-table-list-table-toolbar"
           >
@@ -15608,7 +15608,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           data-testid="table-for-card-table-list-table-container"
         >
           <section
-            aria-label="data table toolbar"
+            aria-label="Open Alerts Toolbar"
             className="bx--table-toolbar"
             data-testid="table-for-card-table-list-table-toolbar"
           >

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -395,6 +395,7 @@ Map {
         "selectRowAria": "Select row",
         "tableErrorStateTitle": "Unable to load the page",
         "toggleAggregations": "Toggle aggregations",
+        "toolbarLabelAria": undefined,
       },
       "id": null,
       "lightweight": false,
@@ -1041,6 +1042,9 @@ Map {
               "type": "string",
             },
             "toggleAggregations": Object {
+              "type": "string",
+            },
+            "toolbarLabelAria": Object {
               "type": "string",
             },
           },


### PR DESCRIPTION
Closes #2607
See #2860

**Summary**

Previously, aria-label could not be specified on TableToolbar, letting Carbon's TableToolbar default it to 'data table toolbar'
This the label should be unqiue, but with multiple Tables with toolbars, it would only ever be 'data table toolbar'

BREAKING CHANGE: TableToolbar with secondaryTitle will now default to using secondaryTitle in the aria-label.
To mitigate this change: set i18n.toolbarLabelAria to "data table toolbar"

**Change List (commits, features, bugs, etc)**

This change allows aria-label be be specified via the i18n prop as toolbarLabelAria
If secondaryTitle is used and no i18n.toolbarLabelAria is specified, it will default to using secondaryTitle within aria-label (appending ' Toolbar')
If no secondaryTitle nor i18n.toolbarLabelAria is specified, it will fallback to Carbon's TableToolbar default as it does now.

**Acceptance Test (how to verify the PR)**

- snapshots

**Regression Test (how to make sure this PR doesn't break old functionality)**

- snapshots

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
