### PR TITLE
fix(table): add deprecated table size props and warning

### DIFF
--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -7,6 +7,7 @@ import { Table as CarbonTable, TableContainer, Tag } from 'carbon-components-rea
 import uniqueId from 'lodash/uniqueId';
 import classnames from 'classnames';
 import { useLangDirection } from 'use-lang-direction';
+import warning from 'warning';
 
 import { defaultFunction } from '../../utils/componentUtilityFunctions';
 import { settings } from '../../constants/Settings';
@@ -117,7 +118,16 @@ const propTypes = {
   }),
 
   /** Size prop from Carbon to shrink row height (and header height in some instances) */
-  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),
+  size: function checkProps(props, propName, componentName) {
+    if (['compact', 'short', 'normal', 'tall'].includes(props[propName])) {
+      warning(
+        false,
+        `The value \`${props[propName]}\` has been deprecated for the ` +
+          `\`${propName}\` prop on the ${componentName} component. It will be removed in the next major ` +
+          `release. Please use 'xs', 'sm', 'md', 'lg', or 'xl' instead.`
+      );
+    }
+  },
 
   /** Initial state of the table, should be updated via a local state wrapper component implementation or via a central store/redux see StatefulTable component for an example */
   view: PropTypes.shape({

--- a/packages/react/src/components/Table/Table.test.jsx
+++ b/packages/react/src/components/Table/Table.test.jsx
@@ -2304,4 +2304,45 @@ describe('Table', () => {
     expect(screen.getByTitle('String')).toBeVisible();
     expect(screen.getByTitle('Date')).toBeVisible();
   });
+
+  it('should show a deprecation warning for old size props', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { rerender } = render(
+      <Table id="loading-table" columns={tableColumns} data={tableData} size="compact" />
+    );
+    expect(console.error).toHaveBeenLastCalledWith(
+      expect.stringContaining(
+        'The value `compact` has been deprecated for the `size` prop on the Table component.'
+      )
+    );
+    rerender(<Table id="loading-table" columns={tableColumns} data={tableData} size="short" />);
+    expect(console.error).toHaveBeenLastCalledWith(
+      expect.stringContaining(
+        'The value `short` has been deprecated for the `size` prop on the Table component.'
+      )
+    );
+    rerender(<Table id="loading-table" columns={tableColumns} data={tableData} size="normal" />);
+    expect(console.error).toHaveBeenLastCalledWith(
+      expect.stringContaining(
+        'The value `normal` has been deprecated for the `size` prop on the Table component.'
+      )
+    );
+    rerender(<Table id="loading-table" columns={tableColumns} data={tableData} size="tall" />);
+    expect(console.error).toHaveBeenLastCalledWith(
+      expect.stringContaining(
+        'The value `tall` has been deprecated for the `size` prop on the Table component.'
+      )
+    );
+    rerender(
+      <Table id="loading-table" columns={tableColumns} data={tableData} size="unsupported" />
+    );
+    expect(console.error).toHaveBeenLastCalledWith(
+      expect.stringContaining(
+        'Failed prop type: Invalid prop `size` of value `unsupported` supplied to `Table`'
+      )
+    );
+    jest.clearAllMocks();
+    rerender(<Table id="loading-table" columns={tableColumns} data={tableData} size="lg" />);
+    expect(console.error).not.toHaveBeenCalled();
+  });
 });

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -1253,18 +1253,7 @@ Map {
       "secondaryTitle": Object {
         "type": "string",
       },
-      "size": Object {
-        "args": Array [
-          Array [
-            "xs",
-            "sm",
-            "md",
-            "lg",
-            "xl",
-          ],
-        ],
-        "type": "oneOf",
-      },
+      "size": [Function],
       "stickyHeader": [Function],
       "testId": Object {
         "type": "string",


### PR DESCRIPTION
Closes #2895 

**Summary**

- Added the old table size props and a deprecation warning for them

**Change List (commits, features, bugs, etc)**

- add deprecated props and warning
- add tests to confirm

**Acceptance Test (how to verify the PR)**

- tests pass

**Regression Test (how to make sure this PR doesn't break old functionality)**

- table still functions as expected

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
