### PR TITLE
fix(table): aggregation column placement

### DIFF
--- a/packages/react/src/components/Table/StatefulTable.story.jsx
+++ b/packages/react/src/components/Table/StatefulTable.story.jsx
@@ -65,6 +65,11 @@ export const StatefulTableWithNestedRowItems = (props) => {
           ]
         : undefined,
   }));
+
+  const hasAggregations = boolean(
+    'Aggregates column values and displays in a footer row (options.hasAggregations)',
+    false
+  );
   return (
     <div style={{ width: select('table container width', ['auto', '300px', '800px'], 'auto') }}>
       <MyTable
@@ -83,6 +88,7 @@ export const StatefulTableWithNestedRowItems = (props) => {
         )}
         options={{
           ...initialState.options,
+          hasAggregations,
           hasRowNesting: true,
           hasFilter: true,
           hasResize: true,
@@ -94,6 +100,18 @@ export const StatefulTableWithNestedRowItems = (props) => {
         }}
         view={{
           ...initialState.view,
+          aggregations: hasAggregations
+            ? {
+                label: 'Total:',
+                columns: [
+                  {
+                    id: 'number',
+                    align: 'center',
+                    isSortable: false,
+                  },
+                ],
+              }
+            : undefined,
           filters: [],
           toolbar: {
             activeBar: null,

--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -1001,7 +1001,13 @@ const Table = (props) => {
           {options.hasAggregations && !aggregationsAreHidden ? (
             <TableFoot
               options={{
-                ...pick(options, 'hasRowSelection', 'hasRowExpansion', 'hasRowActions'),
+                ...pick(
+                  options,
+                  'hasRowSelection',
+                  'hasRowExpansion',
+                  'hasRowActions',
+                  'hasRowNesting'
+                ),
               }}
               tableState={{
                 aggregations,

--- a/packages/react/src/components/Table/TableFoot/TableFoot.jsx
+++ b/packages/react/src/components/Table/TableFoot/TableFoot.jsx
@@ -59,7 +59,8 @@ const TableFoot = ({
 
   const hasMultiSelect = hasRowSelection === 'multi';
   const hasExpandOrNest = hasRowExpansion || hasRowNesting;
-  const colSpan = hasExpandOrNest || hasMultiSelect ? 2 : 1;
+  const labelColSpan =
+    hasMultiSelect && hasExpandOrNest ? 3 : hasExpandOrNest || hasMultiSelect ? 2 : 1;
 
   return (
     <tfoot className={`${iotPrefix}-table-foot`} data-testid={testId}>
@@ -76,13 +77,10 @@ const TableFoot = ({
                 className={`${iotPrefix}-table-foot--label`}
                 data-testid={cellTestId}
                 key={cellKey}
-                colSpan={colSpan}
+                colSpan={labelColSpan}
               >
                 {aggregations.label}
               </TableCell>
-              {colSpan === 2 && hasMultiSelect && hasExpandOrNest ? (
-                <TableCell key="spacer-cell" />
-              ) : null}
             </Fragment>
           ) : aggregated ? (
             <Fragment key={`aggregated-cell-fragment-${index}`}>

--- a/packages/react/src/components/Table/TableFoot/TableFoot.jsx
+++ b/packages/react/src/components/Table/TableFoot/TableFoot.jsx
@@ -72,16 +72,14 @@ const TableFoot = ({
           const cellKey = `${orderedCol.columnId}${index}`;
 
           return isLabelCell ? (
-            <Fragment key="label-cell-fragment">
-              <TableCell
-                className={`${iotPrefix}-table-foot--label`}
-                data-testid={cellTestId}
-                key={cellKey}
-                colSpan={labelColSpan}
-              >
-                {aggregations.label}
-              </TableCell>
-            </Fragment>
+            <TableCell
+              className={`${iotPrefix}-table-foot--label`}
+              data-testid={cellTestId}
+              key={cellKey}
+              colSpan={labelColSpan}
+            >
+              {aggregations.label}
+            </TableCell>
           ) : aggregated ? (
             <Fragment key={`aggregated-cell-fragment-${index}`}>
               {index === 0 && (hasMultiSelect || hasExpandOrNest) ? (

--- a/packages/react/src/components/Table/TableFoot/TableFoot.jsx
+++ b/packages/react/src/components/Table/TableFoot/TableFoot.jsx
@@ -85,20 +85,25 @@ const TableFoot = ({
               ) : null}
             </Fragment>
           ) : aggregated ? (
-            <TableCell
-              className={classnames({
-                [`${iotPrefix}-table-foot--value`]: true,
-                'data-table-end': aggregated.align === 'end',
-                'data-table-start': !aggregated.align || aggregated.align === 'start',
-                'data-table-center': aggregated.align === 'center',
-                [`${iotPrefix}-table-foot--value__sortable`]: aggregated.isSortable,
-              })}
-              align={aggregated.align ? aggregated.align : undefined}
-              data-testid={cellTestId}
-              key={cellKey}
-            >
-              {aggregated.value}
-            </TableCell>
+            <Fragment key={`aggregated-cell-fragment-${index}`}>
+              {index === 0 && (hasMultiSelect || hasExpandOrNest) ? (
+                <TableCell colSpan={hasMultiSelect && hasExpandOrNest ? 2 : 1} />
+              ) : null}
+              <TableCell
+                className={classnames({
+                  [`${iotPrefix}-table-foot--value`]: true,
+                  'data-table-end': aggregated.align === 'end',
+                  'data-table-start': !aggregated.align || aggregated.align === 'start',
+                  'data-table-center': aggregated.align === 'center',
+                  [`${iotPrefix}-table-foot--value__sortable`]: aggregated.isSortable,
+                })}
+                align={aggregated.align ? aggregated.align : undefined}
+                data-testid={cellTestId}
+                key={cellKey}
+              >
+                {aggregated.value}
+              </TableCell>
+            </Fragment>
           ) : (
             <TableCell data-testid={cellTestId} key={cellKey}>
               &nbsp;

--- a/packages/react/src/components/Table/TableFoot/TableFoot.test.jsx
+++ b/packages/react/src/components/Table/TableFoot/TableFoot.test.jsx
@@ -214,7 +214,7 @@ describe('TableFoot', () => {
     expect(screen.getByTestId(firstColumnTestId).textContent).toEqual(label);
     expect(screen.getByTestId(thirdColumnTestId).textContent).toEqual('10');
     expect(container.querySelectorAll('tr').length).toEqual(1);
-    expect(container.querySelectorAll('td').length).toEqual(6);
+    expect(container.querySelectorAll('td').length).toEqual(5);
   });
 
   it('has the correct classes for alignment and sorting', () => {
@@ -290,8 +290,8 @@ describe('TableFoot', () => {
       </table>
     );
 
-    expect(screen.getByText('Total')).toHaveAttribute('colspan', '2');
-    expect(container.querySelectorAll('td')).toHaveLength(5);
+    expect(screen.getByText('Total')).toHaveAttribute('colspan', '3');
+    expect(container.querySelectorAll('td')).toHaveLength(4);
     rerender(
       <table>
         <TableFoot
@@ -316,8 +316,8 @@ describe('TableFoot', () => {
       </table>
     );
 
-    expect(screen.getByText('Total')).toHaveAttribute('colspan', '2');
-    expect(container.querySelectorAll('td')).toHaveLength(5);
+    expect(screen.getByText('Total')).toHaveAttribute('colspan', '3');
+    expect(container.querySelectorAll('td')).toHaveLength(4);
     rerender(
       <table>
         <TableFoot
@@ -342,8 +342,8 @@ describe('TableFoot', () => {
       </table>
     );
 
-    expect(screen.getByText('Total')).toHaveAttribute('colspan', '2');
-    expect(container.querySelectorAll('td')).toHaveLength(5);
+    expect(screen.getByText('Total')).toHaveAttribute('colspan', '3');
+    expect(container.querySelectorAll('td')).toHaveLength(4);
     rerender(
       <table>
         <TableFoot

--- a/packages/react/src/components/Table/TableFoot/TableFoot.test.jsx
+++ b/packages/react/src/components/Table/TableFoot/TableFoot.test.jsx
@@ -191,7 +191,7 @@ describe('TableFoot', () => {
     );
 
     expect(container.querySelectorAll('tr').length).toEqual(1);
-    expect(container.querySelectorAll('td').length).toEqual(4);
+    expect(container.querySelectorAll('td').length).toEqual(2);
     rerender(
       <table>
         <TableFoot
@@ -214,7 +214,7 @@ describe('TableFoot', () => {
     expect(screen.getByTestId(firstColumnTestId).textContent).toEqual(label);
     expect(screen.getByTestId(thirdColumnTestId).textContent).toEqual('10');
     expect(container.querySelectorAll('tr').length).toEqual(1);
-    expect(container.querySelectorAll('td').length).toEqual(7);
+    expect(container.querySelectorAll('td').length).toEqual(6);
   });
 
   it('has the correct classes for alignment and sorting', () => {
@@ -260,5 +260,219 @@ describe('TableFoot', () => {
 
     const dColumnTotalCell = screen.getByTestId(fourthColumnTestId);
     expect(dColumnTotalCell).toHaveClass('data-table-start');
+  });
+
+  it('should have the correct colSpan on label based on props', () => {
+    const tableFootTestId = 'table-foot';
+    const label = 'Total';
+
+    const { container, rerender } = render(
+      <table>
+        <TableFoot
+          testId={tableFootTestId}
+          options={{
+            hasRowActions: true,
+            hasRowExpansion: true,
+            hasRowNesting: true,
+            hasRowSelection: 'multi',
+          }}
+          tableState={{
+            aggregations: {
+              label,
+              columns: [
+                { id: 'c', value: '10', align: 'end', isSortable: true },
+                { id: 'd', value: '100' },
+              ],
+            },
+            ordering,
+          }}
+        />
+      </table>
+    );
+
+    expect(screen.getByText('Total')).toHaveAttribute('colspan', '2');
+    expect(container.querySelectorAll('td')).toHaveLength(5);
+    rerender(
+      <table>
+        <TableFoot
+          testId={tableFootTestId}
+          options={{
+            hasRowActions: true,
+            hasRowExpansion: true,
+            hasRowNesting: false,
+            hasRowSelection: 'multi',
+          }}
+          tableState={{
+            aggregations: {
+              label,
+              columns: [
+                { id: 'c', value: '10', align: 'end', isSortable: true },
+                { id: 'd', value: '100' },
+              ],
+            },
+            ordering,
+          }}
+        />
+      </table>
+    );
+
+    expect(screen.getByText('Total')).toHaveAttribute('colspan', '2');
+    expect(container.querySelectorAll('td')).toHaveLength(5);
+    rerender(
+      <table>
+        <TableFoot
+          testId={tableFootTestId}
+          options={{
+            hasRowActions: true,
+            hasRowExpansion: false,
+            hasRowNesting: true,
+            hasRowSelection: 'multi',
+          }}
+          tableState={{
+            aggregations: {
+              label,
+              columns: [
+                { id: 'c', value: '10', align: 'end', isSortable: true },
+                { id: 'd', value: '100' },
+              ],
+            },
+            ordering,
+          }}
+        />
+      </table>
+    );
+
+    expect(screen.getByText('Total')).toHaveAttribute('colspan', '2');
+    expect(container.querySelectorAll('td')).toHaveLength(5);
+    rerender(
+      <table>
+        <TableFoot
+          testId={tableFootTestId}
+          options={{
+            hasRowActions: true,
+            hasRowExpansion: false,
+            hasRowNesting: false,
+            hasRowSelection: 'multi',
+          }}
+          tableState={{
+            aggregations: {
+              label,
+              columns: [
+                { id: 'c', value: '10', align: 'end', isSortable: true },
+                { id: 'd', value: '100' },
+              ],
+            },
+            ordering,
+          }}
+        />
+      </table>
+    );
+
+    expect(screen.getByText('Total')).toHaveAttribute('colspan', '2');
+    expect(container.querySelectorAll('td')).toHaveLength(4);
+    rerender(
+      <table>
+        <TableFoot
+          testId={tableFootTestId}
+          options={{
+            hasRowActions: true,
+            hasRowExpansion: false,
+            hasRowNesting: false,
+            hasRowSelection: 'single',
+          }}
+          tableState={{
+            aggregations: {
+              label,
+              columns: [
+                { id: 'c', value: '10', align: 'end', isSortable: true },
+                { id: 'd', value: '100' },
+              ],
+            },
+            ordering,
+          }}
+        />
+      </table>
+    );
+
+    expect(screen.getByText('Total')).toHaveAttribute('colspan', '1');
+    expect(container.querySelectorAll('td')).toHaveLength(4);
+    rerender(
+      <table>
+        <TableFoot
+          testId={tableFootTestId}
+          options={{
+            hasRowActions: true,
+            hasRowExpansion: false,
+            hasRowNesting: false,
+            hasRowSelection: false,
+          }}
+          tableState={{
+            aggregations: {
+              label,
+              columns: [
+                { id: 'c', value: '10', align: 'end', isSortable: true },
+                { id: 'd', value: '100' },
+              ],
+            },
+            ordering,
+          }}
+        />
+      </table>
+    );
+
+    expect(screen.getByText('Total')).toHaveAttribute('colspan', '1');
+    expect(container.querySelectorAll('td')).toHaveLength(4);
+    rerender(
+      <table>
+        <TableFoot
+          testId={tableFootTestId}
+          options={{
+            hasRowActions: true,
+            hasRowExpansion: false,
+            hasRowNesting: true,
+            hasRowSelection: false,
+          }}
+          tableState={{
+            aggregations: {
+              label,
+              columns: [
+                { id: 'c', value: '10', align: 'end', isSortable: true },
+                { id: 'd', value: '100' },
+              ],
+            },
+            ordering,
+          }}
+        />
+      </table>
+    );
+
+    expect(screen.getByText('Total')).toHaveAttribute('colspan', '2');
+    expect(container.querySelectorAll('td')).toHaveLength(4);
+    rerender(
+      <table>
+        <TableFoot
+          testId={tableFootTestId}
+          options={{
+            hasRowActions: true,
+            hasRowExpansion: true,
+            hasRowNesting: true,
+            hasRowSelection: false,
+          }}
+          tableState={{
+            aggregations: {
+              label,
+              columns: [
+                { id: 'c', value: '10', align: 'end', isSortable: true },
+                { id: 'd', value: '100' },
+              ],
+            },
+            ordering,
+          }}
+        />
+      </table>
+    );
+
+    expect(screen.getByText('Total')).toHaveAttribute('colspan', '2');
+    expect(container.querySelectorAll('td')).toHaveLength(4);
   });
 });

--- a/packages/react/src/components/Table/TableFoot/TableFoot.test.jsx
+++ b/packages/react/src/components/Table/TableFoot/TableFoot.test.jsx
@@ -475,4 +475,65 @@ describe('TableFoot', () => {
     expect(screen.getByText('Total')).toHaveAttribute('colspan', '2');
     expect(container.querySelectorAll('td')).toHaveLength(4);
   });
+
+  it('should add a spacer cell when colSpan:2 and aggregation in first column', () => {
+    const tableFootTestId = 'table-foot';
+    const label = 'Total';
+    const { container } = render(
+      <table>
+        <TableFoot
+          testId={tableFootTestId}
+          options={{
+            hasRowActions: true,
+            hasRowExpansion: true,
+            hasRowNesting: true,
+            hasRowSelection: false,
+          }}
+          tableState={{
+            aggregations: {
+              label,
+              columns: [
+                { id: 'a', value: '300', align: 'center', isSortable: false },
+                { id: 'c', value: '10', align: 'end', isSortable: true },
+                { id: 'd', value: '100' },
+              ],
+            },
+            ordering,
+          }}
+        />
+      </table>
+    );
+
+    expect(container.querySelectorAll('td')).toHaveLength(5);
+  });
+  it('should add a not spacer cell when aggregation in first column with no nesting, expansion, or selection', () => {
+    const tableFootTestId = 'table-foot';
+    const label = 'Total';
+    const { container } = render(
+      <table>
+        <TableFoot
+          testId={tableFootTestId}
+          options={{
+            hasRowActions: true,
+            hasRowExpansion: false,
+            hasRowNesting: false,
+            hasRowSelection: false,
+          }}
+          tableState={{
+            aggregations: {
+              label,
+              columns: [
+                { id: 'a', value: '300', align: 'center', isSortable: false },
+                { id: 'c', value: '10', align: 'end', isSortable: true },
+                { id: 'd', value: '100' },
+              ],
+            },
+            ordering,
+          }}
+        />
+      </table>
+    );
+
+    expect(container.querySelectorAll('td')).toHaveLength(4);
+  });
 });

--- a/packages/react/src/components/Table/__snapshots__/StatefulTable.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/StatefulTable.story.storyshot
@@ -43266,9 +43266,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               data-testid="table-table-foot"
             >
               <tr>
-                <td />
                 <td
                   className="iot-table-foot--label"
+                  colSpan={2}
                   data-testid="table-table-foot-aggregation-string"
                 >
                   Total

--- a/packages/react/src/components/Table/__snapshots__/Table.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/Table.story.storyshot
@@ -23032,9 +23032,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             data-testid="table-table-foot"
           >
             <tr>
-              <td />
               <td
                 className="iot-table-foot--label"
+                colSpan={2}
                 data-testid="table-table-foot-aggregation-string"
               >
                 Total:
@@ -102791,9 +102791,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 data-testid="null-table-foot"
               >
                 <tr>
-                  <td />
                   <td
                     className="iot-table-foot--label"
+                    colSpan={2}
                     data-testid="null-table-foot-aggregation-string"
                   >
                     Total


### PR DESCRIPTION
Closes #2859 

**Summary**

- When using multiselect and nested rows at the same time, the aggregation label was in the wrong place. This fixes that by using colspan to position the label based on various prop combinations.

**Change List (commits, features, bugs, etc)**

- use colspan instead of cells to position label
- add tests to confirm

**Acceptance Test (how to verify the PR)**

- Go to [`basic dumb table` story](https://deploy-preview-2898--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table-table--basic-dumb-table)
- turn on pagination
- experiment with all combinations of `hasRowNesting`, `hasRowExpansion`, and `hasRowSelection`. The 'Total' label should also be aligned with the pagination below.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- aggregation placement is still correct on other aggregation stories/settings

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
