### PR TITLE
2839 time picker spinner improved keyboard input and added error state

### DIFF
--- a/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
@@ -310,8 +310,8 @@ const DateTimePicker = ({
   const [isTooltipOpen, setIsTooltipOpen] = useState(false);
   const [relativeLastNumberInvalid, setRelativeLastNumberInvalid] = useState(false);
   const [relativeToTimeInvalid, setRelativeToTimeInvalid] = useState(false);
-  const [absolutStartTimeInvalid, setAbsolutStartTimeInvalid] = useState(false);
-  const [absolutEndTimeInvalid, setAbsolutEndTimeInvalid] = useState(false);
+  const [absoluteStartTimeInvalid, setAbsoluteStartTimeInvalid] = useState(false);
+  const [absoluteEndTimeInvalid, setAbsoluteEndTimeInvalid] = useState(false);
 
   // Refs
   const [datePickerElem, setDatePickerElem] = useState(null);
@@ -817,11 +817,11 @@ const DateTimePicker = ({
 
   // on change functions that trigger a absolute value update
   const onAbsoluteStartTimeChange = (pickerValue, evt, meta) => {
-    setAbsolutStartTimeInvalid(meta.invalid);
+    setAbsoluteStartTimeInvalid(meta.invalid);
     changeAbsolutePropertyValue('startTime', pickerValue);
   };
   const onAbsoluteEndTimeChange = (pickerValue, evt, meta) => {
-    setAbsolutEndTimeInvalid(meta.invalid);
+    setAbsoluteEndTimeInvalid(meta.invalid);
     changeAbsolutePropertyValue('endTime', pickerValue);
   };
 
@@ -829,7 +829,7 @@ const DateTimePicker = ({
     ? renderPresetTooltipText(currentValue)
     : getIntervalValue();
 
-  const disbableRelativeApply =
+  const disableRelativeApply =
     isCustomRange &&
     customRangeKind === PICKER_KINDS.RELATIVE &&
     (relativeLastNumberInvalid || relativeToTimeInvalid);
@@ -837,9 +837,9 @@ const DateTimePicker = ({
   const disbableAbsoluteApply =
     isCustomRange &&
     customRangeKind === PICKER_KINDS.ABSOLUTE &&
-    (absolutStartTimeInvalid || absolutEndTimeInvalid);
+    (absoluteStartTimeInvalid || absoluteEndTimeInvalid);
 
-  const disableApply = disbableRelativeApply || disbableAbsoluteApply;
+  const disableApply = disableRelativeApply || disbableAbsoluteApply;
 
   /**
    * Shows and hides the tooltip with the humanValue (Relative) or full-range (Absolute) when
@@ -1131,7 +1131,7 @@ const DateTimePicker = ({
                         <div className={`${iotPrefix}--date-time-picker__fields-wrapper`}>
                           <TimePickerSpinner
                             id={`${id}-start-time`}
-                            invalid={absolutStartTimeInvalid}
+                            invalid={absoluteStartTimeInvalid}
                             labelText={strings.startTimeLabel}
                             value={absoluteValue ? absoluteValue.startTime : '00:00'}
                             i18n={i18n}
@@ -1142,7 +1142,7 @@ const DateTimePicker = ({
                           />
                           <TimePickerSpinner
                             id={`${id}-end-time`}
-                            invalid={absolutEndTimeInvalid}
+                            invalid={absoluteEndTimeInvalid}
                             labelText={strings.endTimeLabel}
                             value={absoluteValue ? absoluteValue.endTime : '00:00'}
                             i18n={i18n}

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
@@ -309,6 +309,9 @@ const DateTimePicker = ({
   const [focusOnFirstField, setFocusOnFirstField] = useState(true);
   const [isTooltipOpen, setIsTooltipOpen] = useState(false);
   const [relativeLastNumberInvalid, setRelativeLastNumberInvalid] = useState(false);
+  const [relativeToTimeInvalid, setRelativeToTimeInvalid] = useState(false);
+  const [absolutStartTimeInvalid, setAbsolutStartTimeInvalid] = useState(false);
+  const [absolutEndTimeInvalid, setAbsolutEndTimeInvalid] = useState(false);
 
   // Refs
   const [datePickerElem, setDatePickerElem] = useState(null);
@@ -800,7 +803,8 @@ const DateTimePicker = ({
   const onRelativeToWhenChange = (event) => {
     changeRelativePropertyValue('relativeToWhen', event.currentTarget.value);
   };
-  const onRelativeToTimeChange = (pickerValue) => {
+  const onRelativeToTimeChange = (pickerValue, evt, meta) => {
+    setRelativeToTimeInvalid(meta.invalid);
     changeRelativePropertyValue('relativeToTime', pickerValue);
   };
 
@@ -812,16 +816,30 @@ const DateTimePicker = ({
   };
 
   // on change functions that trigger a absolute value update
-  const onAbsoluteStartTimeChange = (pickerValue) => {
+  const onAbsoluteStartTimeChange = (pickerValue, evt, meta) => {
+    setAbsolutStartTimeInvalid(meta.invalid);
     changeAbsolutePropertyValue('startTime', pickerValue);
   };
-  const onAbsoluteEndTimeChange = (pickerValue) => {
+  const onAbsoluteEndTimeChange = (pickerValue, evt, meta) => {
+    setAbsolutEndTimeInvalid(meta.invalid);
     changeAbsolutePropertyValue('endTime', pickerValue);
   };
 
   const tooltipValue = renderPresetTooltipText
     ? renderPresetTooltipText(currentValue)
     : getIntervalValue();
+
+  const disbableRelativeApply =
+    isCustomRange &&
+    customRangeKind === PICKER_KINDS.RELATIVE &&
+    (relativeLastNumberInvalid || relativeToTimeInvalid);
+
+  const disbableAbsoluteApply =
+    isCustomRange &&
+    customRangeKind === PICKER_KINDS.ABSOLUTE &&
+    (absolutStartTimeInvalid || absolutEndTimeInvalid);
+
+  const disableApply = disbableRelativeApply || disbableAbsoluteApply;
 
   /**
    * Shows and hides the tooltip with the humanValue (Relative) or full-range (Absolute) when
@@ -1065,7 +1083,9 @@ const DateTimePicker = ({
                         </Select>
                         {hasTimeInput ? (
                           <TimePickerSpinner
+                            key={`${id}-relative-to-time`}
                             id={`${id}-relative-to-time`}
+                            invalid={relativeToTimeInvalid}
                             value={relativeValue ? relativeValue.relativeToTime : ''}
                             i18n={i18n}
                             light
@@ -1111,6 +1131,7 @@ const DateTimePicker = ({
                         <div className={`${iotPrefix}--date-time-picker__fields-wrapper`}>
                           <TimePickerSpinner
                             id={`${id}-start-time`}
+                            invalid={absolutStartTimeInvalid}
                             labelText={strings.startTimeLabel}
                             value={absoluteValue ? absoluteValue.startTime : '00:00'}
                             i18n={i18n}
@@ -1121,6 +1142,7 @@ const DateTimePicker = ({
                           />
                           <TimePickerSpinner
                             id={`${id}-end-time`}
+                            invalid={absolutEndTimeInvalid}
                             labelText={strings.endTimeLabel}
                             value={absoluteValue ? absoluteValue.endTime : '00:00'}
                             i18n={i18n}
@@ -1173,11 +1195,7 @@ const DateTimePicker = ({
               /* using on onKeyUp b/c something is preventing onKeyDown from firing with 'Enter' when the calendar is displayed */
               onKeyUp={handleSpecificKeyDown(['Enter', ' '], onApplyClick)}
               size="field"
-              disabled={
-                isCustomRange &&
-                customRangeKind === PICKER_KINDS.RELATIVE &&
-                relativeLastNumberInvalid
-              }
+              disabled={disableApply}
             >
               {strings.applyBtnLabel}
             </Button>

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
@@ -834,12 +834,12 @@ const DateTimePicker = ({
     customRangeKind === PICKER_KINDS.RELATIVE &&
     (relativeLastNumberInvalid || relativeToTimeInvalid);
 
-  const disbableAbsoluteApply =
+  const disableAbsoluteApply =
     isCustomRange &&
     customRangeKind === PICKER_KINDS.ABSOLUTE &&
     (absoluteStartTimeInvalid || absoluteEndTimeInvalid);
 
-  const disableApply = disableRelativeApply || disbableAbsoluteApply;
+  const disableApply = disableRelativeApply || disableAbsoluteApply;
 
   /**
    * Shows and hides the tooltip with the humanValue (Relative) or full-range (Absolute) when

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.test.e2e.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.test.e2e.jsx
@@ -50,6 +50,48 @@ describe('DateTimePicker', () => {
       });
   });
 
+  it('should disable apply button when absolute TimePickerSpinner inputs are invalid ', () => {
+    const { i18n } = DateTimePicker.defaultProps;
+    const onApply = cy.stub();
+    const onCancel = cy.stub();
+    mount(
+      <DateTimePicker
+        onApply={onApply}
+        onCancel={onCancel}
+        id="picker-test"
+        hasTimeInput
+        defaultValue={{
+          timeRangeKind: PICKER_KINDS.ABSOLUTE,
+          timeRangeValue: {
+            start: new Date(2021, 7, 1, 12, 34, 0),
+            end: new Date(2021, 7, 6, 10, 49, 0),
+          },
+        }}
+      />
+    );
+
+    cy.findByText('2021-08-01 12:34 to 2021-08-06 10:49').should('be.visible').click();
+
+    cy.findByLabelText(i18n.startTimeLabel).type(
+      '{backspace}{backspace}{backspace}{backspace}{backspace}91:35'
+    );
+    cy.findByText(i18n.applyBtnLabel).should('be.disabled');
+
+    cy.findByLabelText(i18n.startTimeLabel).type(
+      '{backspace}{backspace}{backspace}{backspace}{backspace}11:35'
+    );
+    cy.findByText(i18n.applyBtnLabel).should('not.be.disabled');
+
+    cy.findByLabelText(i18n.endTimeLabel).type(
+      '{backspace}{backspace}{backspace}{backspace}{backspace}11:61'
+    );
+    cy.findByText(i18n.applyBtnLabel).should('be.disabled');
+
+    // set time to 11:00
+    cy.findByLabelText(i18n.endTimeLabel).type('{backspace}{backspace}00');
+    cy.findByText(i18n.applyBtnLabel).should('not.be.disabled');
+  });
+
   it('should be able to navigate by keyboard', () => {
     const onApply = cy.stub();
     const onCancel = cy.stub();

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
@@ -651,4 +651,32 @@ describe('DateTimePicker', () => {
     expect(numberInput).toBeInvalid();
     expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
   });
+
+  it('should disable apply button when relative TimePickerSpinner input is invalid', () => {
+    const { i18n } = DateTimePicker.defaultProps;
+    render(<DateTimePicker {...dateTimePickerProps} id="picker-test" />);
+    jest.runAllTimers();
+
+    userEvent.click(screen.getByTestId('date-time-picker__field'));
+    userEvent.click(screen.queryByText(DateTimePicker.defaultProps.i18n.customRangeLinkLabel));
+    const applyBytton = screen.getByRole('button', { name: i18n.applyBtnLabel });
+    expect(applyBytton).toBeEnabled();
+    const relativeToTime = screen.getByPlaceholderText('hh:mm');
+    expect(relativeToTime).toBeValid();
+
+    // set time to 1
+    userEvent.type(relativeToTime, '1');
+    expect(relativeToTime).toBeInvalid();
+    expect(applyBytton).toBeDisabled();
+
+    // set time to 11:11
+    userEvent.type(relativeToTime, '1:11');
+    expect(relativeToTime).toBeValid();
+    expect(applyBytton).toBeEnabled();
+
+    // set time to 11:61
+    userEvent.type(relativeToTime, '{backspace}{backspace}61');
+    expect(relativeToTime).toBeInvalid();
+    expect(applyBytton).toBeDisabled();
+  });
 });

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
@@ -45,6 +45,8 @@ describe('DateTimePicker', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
   });
 
   beforeAll(() => {

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
@@ -283,6 +283,9 @@ const DateTimePicker = ({
   const [relativeValue, setRelativeValue] = useState(null);
   const [absoluteValue, setAbsoluteValue] = useState(null);
   const [focusOnFirstField, setFocusOnFirstField] = useState(true);
+  const [relativeToTimeInvalid, setRelativeToTimeInvalid] = useState(false);
+  const [absolutStartTimeInvalid, setAbsolutStartTimeInvalid] = useState(false);
+  const [absolutEndTimeInvalid, setAbsolutEndTimeInvalid] = useState(false);
 
   // Refs
   const [datePickerElem, setDatePickerElem] = useState(null);
@@ -617,7 +620,8 @@ const DateTimePicker = ({
   const onRelativeToWhenChange = (event) => {
     changeRelativePropertyValue('relativeToWhen', event.currentTarget.value);
   };
-  const onRelativeToTimeChange = (pickerValue) => {
+  const onRelativeToTimeChange = (pickerValue, evt, meta) => {
+    setRelativeToTimeInvalid(meta.invalid);
     changeRelativePropertyValue('relativeToTime', pickerValue);
   };
 
@@ -629,16 +633,28 @@ const DateTimePicker = ({
   };
 
   // on change functions that trigger a absolute value update
-  const onAbsoluteStartTimeChange = (pickerValue) => {
+  const onAbsoluteStartTimeChange = (pickerValue, evt, meta) => {
+    setAbsolutStartTimeInvalid(meta.invalid);
     changeAbsolutePropertyValue('startTime', pickerValue);
   };
-  const onAbsoluteEndTimeChange = (pickerValue) => {
+  const onAbsoluteEndTimeChange = (pickerValue, evt, meta) => {
+    setAbsolutEndTimeInvalid(meta.invalid);
     changeAbsolutePropertyValue('endTime', pickerValue);
   };
 
   const tooltipValue = renderPresetTooltipText
     ? renderPresetTooltipText(currentValue)
     : getIntervalValue();
+
+  const disbableRelativeApply =
+    isCustomRange && customRangeKind === PICKER_KINDS.RELATIVE && relativeToTimeInvalid;
+
+  const disbableAbsoluteApply =
+    isCustomRange &&
+    customRangeKind === PICKER_KINDS.ABSOLUTE &&
+    (absolutStartTimeInvalid || absolutEndTimeInvalid);
+
+  const disableApply = disbableRelativeApply || disbableAbsoluteApply;
 
   // eslint-disable-next-line react/prop-types
   const CustomFooter = ({ setIsOpen }) => {
@@ -706,6 +722,7 @@ const DateTimePicker = ({
           size="field"
           {...others}
           onClick={onApplyClick}
+          disabled={disableApply}
         >
           {strings.applyBtnLabel}
         </Button>
@@ -932,6 +949,7 @@ const DateTimePicker = ({
                           {hasTimeInput ? (
                             <TimePickerSpinner
                               id={`${id}-relative-to-time`}
+                              invalid={relativeToTimeInvalid}
                               value={relativeValue ? relativeValue.relativeToTime : ''}
                               i18n={i18n}
                               onChange={onRelativeToTimeChange}
@@ -980,6 +998,7 @@ const DateTimePicker = ({
                           <div className={`${iotPrefix}--date-time-picker__fields-wrapper`}>
                             <TimePickerSpinner
                               id={`${id}-start-time`}
+                              invalid={absolutStartTimeInvalid}
                               labelText={strings.startTimeLabel}
                               value={absoluteValue ? absoluteValue.startTime : '00:00'}
                               i18n={i18n}
@@ -990,6 +1009,7 @@ const DateTimePicker = ({
                             />
                             <TimePickerSpinner
                               id={`${id}-end-time`}
+                              invalid={absolutEndTimeInvalid}
                               labelText={strings.endTimeLabel}
                               value={absoluteValue ? absoluteValue.endTime : '00:00'}
                               i18n={i18n}

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
@@ -284,8 +284,8 @@ const DateTimePicker = ({
   const [absoluteValue, setAbsoluteValue] = useState(null);
   const [focusOnFirstField, setFocusOnFirstField] = useState(true);
   const [relativeToTimeInvalid, setRelativeToTimeInvalid] = useState(false);
-  const [absolutStartTimeInvalid, setAbsolutStartTimeInvalid] = useState(false);
-  const [absolutEndTimeInvalid, setAbsolutEndTimeInvalid] = useState(false);
+  const [absoluteStartTimeInvalid, setAbsoluteStartTimeInvalid] = useState(false);
+  const [absoluteEndTimeInvalid, setAbsoluteEndTimeInvalid] = useState(false);
 
   // Refs
   const [datePickerElem, setDatePickerElem] = useState(null);
@@ -634,11 +634,11 @@ const DateTimePicker = ({
 
   // on change functions that trigger a absolute value update
   const onAbsoluteStartTimeChange = (pickerValue, evt, meta) => {
-    setAbsolutStartTimeInvalid(meta.invalid);
+    setAbsoluteStartTimeInvalid(meta.invalid);
     changeAbsolutePropertyValue('startTime', pickerValue);
   };
   const onAbsoluteEndTimeChange = (pickerValue, evt, meta) => {
-    setAbsolutEndTimeInvalid(meta.invalid);
+    setAbsoluteEndTimeInvalid(meta.invalid);
     changeAbsolutePropertyValue('endTime', pickerValue);
   };
 
@@ -646,15 +646,15 @@ const DateTimePicker = ({
     ? renderPresetTooltipText(currentValue)
     : getIntervalValue();
 
-  const disbableRelativeApply =
+  const disableRelativeApply =
     isCustomRange && customRangeKind === PICKER_KINDS.RELATIVE && relativeToTimeInvalid;
 
   const disbableAbsoluteApply =
     isCustomRange &&
     customRangeKind === PICKER_KINDS.ABSOLUTE &&
-    (absolutStartTimeInvalid || absolutEndTimeInvalid);
+    (absoluteStartTimeInvalid || absoluteEndTimeInvalid);
 
-  const disableApply = disbableRelativeApply || disbableAbsoluteApply;
+  const disableApply = disableRelativeApply || disbableAbsoluteApply;
 
   // eslint-disable-next-line react/prop-types
   const CustomFooter = ({ setIsOpen }) => {
@@ -998,7 +998,7 @@ const DateTimePicker = ({
                           <div className={`${iotPrefix}--date-time-picker__fields-wrapper`}>
                             <TimePickerSpinner
                               id={`${id}-start-time`}
-                              invalid={absolutStartTimeInvalid}
+                              invalid={absoluteStartTimeInvalid}
                               labelText={strings.startTimeLabel}
                               value={absoluteValue ? absoluteValue.startTime : '00:00'}
                               i18n={i18n}
@@ -1009,7 +1009,7 @@ const DateTimePicker = ({
                             />
                             <TimePickerSpinner
                               id={`${id}-end-time`}
-                              invalid={absolutEndTimeInvalid}
+                              invalid={absoluteEndTimeInvalid}
                               labelText={strings.endTimeLabel}
                               value={absoluteValue ? absoluteValue.endTime : '00:00'}
                               i18n={i18n}

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
@@ -649,12 +649,12 @@ const DateTimePicker = ({
   const disableRelativeApply =
     isCustomRange && customRangeKind === PICKER_KINDS.RELATIVE && relativeToTimeInvalid;
 
-  const disbableAbsoluteApply =
+  const disableAbsoluteApply =
     isCustomRange &&
     customRangeKind === PICKER_KINDS.ABSOLUTE &&
     (absoluteStartTimeInvalid || absoluteEndTimeInvalid);
 
-  const disableApply = disableRelativeApply || disbableAbsoluteApply;
+  const disableApply = disableRelativeApply || disableAbsoluteApply;
 
   // eslint-disable-next-line react/prop-types
   const CustomFooter = ({ setIsOpen }) => {

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.e2e.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.e2e.jsx
@@ -52,6 +52,69 @@ describe('DateTimePickerV2', () => {
       });
   });
 
+  it('should disable apply button when relative TimePickerSpinner input is invalid ', () => {
+    const { i18n } = DateTimePickerV2.defaultProps;
+    const onApply = cy.stub();
+    const onCancel = cy.stub();
+    mount(<DateTimePickerV2 onApply={onApply} onCancel={onCancel} id="picker-test" hasTimeInput />);
+
+    cy.findAllByLabelText('Calendar').eq(0).click();
+    cy.findByText('Custom Range').click();
+
+    cy.findByPlaceholderText('hh:mm').type('91:35');
+
+    cy.findByText(i18n.applyBtnLabel).should('be.disabled');
+
+    cy.findByPlaceholderText('hh:mm').type(
+      '{backspace}{backspace}{backspace}{backspace}{backspace}11:35'
+    );
+    cy.findByText(i18n.applyBtnLabel).should('not.be.disabled');
+  });
+
+  it('should disable apply button when absolute TimePickerSpinner inputs are invalid ', () => {
+    const { i18n } = DateTimePickerV2.defaultProps;
+    const onApply = cy.stub();
+    const onCancel = cy.stub();
+    mount(
+      <DateTimePickerV2
+        onApply={onApply}
+        onCancel={onCancel}
+        id="picker-test"
+        hasTimeInput
+        defaultValue={{
+          timeRangeKind: PICKER_KINDS.ABSOLUTE,
+          timeRangeValue: {
+            startDate: '2021-08-01',
+            startTime: '12:34',
+            endDate: '2021-08-06',
+            endTime: '10:49',
+          },
+        }}
+      />
+    );
+
+    cy.findByText('2021-08-01 12:34 to 2021-08-06 10:49').should('be.visible').click();
+
+    cy.findByLabelText(i18n.startTimeLabel).type(
+      '{backspace}{backspace}{backspace}{backspace}{backspace}91:35'
+    );
+    cy.findByText(i18n.applyBtnLabel).should('be.disabled');
+
+    cy.findByLabelText(i18n.startTimeLabel).type(
+      '{backspace}{backspace}{backspace}{backspace}{backspace}11:35'
+    );
+    cy.findByText(i18n.applyBtnLabel).should('not.be.disabled');
+
+    cy.findByLabelText(i18n.endTimeLabel).type(
+      '{backspace}{backspace}{backspace}{backspace}{backspace}11:61'
+    );
+    cy.findByText(i18n.applyBtnLabel).should('be.disabled');
+
+    // set time to 11:00
+    cy.findByLabelText(i18n.endTimeLabel).type('{backspace}{backspace}00');
+    cy.findByText(i18n.applyBtnLabel).should('not.be.disabled');
+  });
+
   it('should open the flyout when hitting enter', () => {
     const onApply = cy.stub();
     const onCancel = cy.stub();

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
@@ -38,8 +38,15 @@ const i18n = {
 };
 
 describe('DateTimePicker', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
   afterEach(() => {
     console.error.mockClear();
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
   });
 
   beforeAll(() => {

--- a/packages/react/src/components/DateTimePicker/_date-time-picker.scss
+++ b/packages/react/src/components/DateTimePicker/_date-time-picker.scss
@@ -166,7 +166,7 @@
 
         .#{$iot-prefix}--date-time-picker__fields-wrapper {
           display: flex;
-          align-items: flex-end;
+          align-items: flex-start;
 
           &--with-gap {
             gap: $spacing-05;

--- a/packages/react/src/components/DateTimePicker/_date-time-pickerv2.scss
+++ b/packages/react/src/components/DateTimePicker/_date-time-pickerv2.scss
@@ -160,7 +160,7 @@
 
   .#{$iot-prefix}--date-time-picker__fields-wrapper {
     display: flex;
-    align-items: flex-end;
+    align-items: flex-start;
 
     .#{$prefix}--label {
       margin-bottom: 0;

--- a/packages/react/src/components/TimePickerSpinner/TimePickerSpinner.jsx
+++ b/packages/react/src/components/TimePickerSpinner/TimePickerSpinner.jsx
@@ -24,7 +24,10 @@ const propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
   /** triggered on input click  */
   onClick: PropTypes.func,
-  /** triggered on value change  */
+  /** triggered on value change. Called with 3 parameters: newValue, event, meta
+   * The meta object has a property called invalid that is either true or false
+   * representing the validation status of the new input
+   */
   onChange: PropTypes.func,
   /** disable the input  */
   disabled: PropTypes.bool,

--- a/packages/react/src/components/TimePickerSpinner/TimePickerSpinner.jsx
+++ b/packages/react/src/components/TimePickerSpinner/TimePickerSpinner.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { TimePicker } from 'carbon-components-react';
 import { CaretDownGlyph, CaretUpGlyph } from '@carbon/icons-react';
 import classnames from 'classnames';
+import merge from 'lodash/merge';
 
 import { settings } from '../../constants/Settings';
 import { keyCodes } from '../../constants/KeyCodeConstants';
@@ -27,6 +28,8 @@ const propTypes = {
   onChange: PropTypes.func,
   /** disable the input  */
   disabled: PropTypes.bool,
+  /** will display invalidText when set to true */
+  invalid: PropTypes.bool,
   /** set a 12-hour timepicker instead of the default 24-hour  */
   is12hour: PropTypes.bool,
   /** the default selected timegroup (hours, minutes) */
@@ -52,6 +55,7 @@ const defaultProps = {
   onClick: null,
   onChange: null,
   disabled: false,
+  invalid: false,
   is12hour: false,
   defaultTimegroup: TIMEGROUPS.HOURS,
   i18n: {
@@ -73,12 +77,14 @@ const TimePickerSpinner = ({
   onClick,
   onChange,
   disabled,
+  invalid,
   is12hour,
   defaultTimegroup,
-  i18n,
+  i18n: i18nProp,
   testId,
   ...others
 }) => {
+  const i18n = merge({}, defaultProps.i18n, i18nProp);
   const [pickerValue, setPickerValue] = useState(value || '');
   const [currentTimeGroup, setCurrentTimeGroup] = useState(
     defaultTimegroup === TIMEGROUPS.MINUTES ? 1 : 0
@@ -90,6 +96,12 @@ const TimePickerSpinner = ({
   const [focusTarget, setFocusTarget] = useState(null);
 
   const timePickerRef = React.createRef();
+
+  const validate = (newValue) => {
+    const isValid12HoursRegex = /^(1[0-2]|0?[1-9]):[0-5][0-9]$/;
+    const isValid24HoursRegex = /^([01][0-9]|2[0-3]):([0-5][0-9])$/;
+    return !(is12hour ? isValid12HoursRegex.test(newValue) : isValid24HoursRegex.test(newValue));
+  };
 
   const handleArrowClick = (direction) => {
     const timeGroups = pickerValue.split(':');
@@ -109,7 +121,7 @@ const TimePickerSpinner = ({
     const newValue = timeGroups.join(':');
     setPickerValue(newValue);
     if (onChange) {
-      onChange(newValue);
+      onChange(newValue, null, { invalid: validate(newValue) });
     }
     window.setTimeout(() => {
       if (focusTarget) {
@@ -135,8 +147,20 @@ const TimePickerSpinner = ({
     } = e;
     setPickerValue(currentValue);
     if (onChange) {
-      onChange(currentValue, e);
+      onChange(currentValue, e, { invalid: validate(currentValue) });
     }
+  };
+
+  const preventNonAllowedKeyboardInput = (e) => {
+    const isNumberChar = /\d/.test(e.key);
+    const isOnlyColon = e.key === ':' && !e.currentTarget.value?.includes(':');
+
+    if (isNumberChar || isOnlyColon) {
+      return true;
+    }
+
+    e.preventDefault();
+    return false;
   };
 
   const onInputKeyDown = (e) => {
@@ -147,9 +171,18 @@ const TimePickerSpinner = ({
       case keyCodes.DOWN:
         setKeyUpOrDownPosition(target.selectionStart);
         break;
-      default:
+      case keyCodes.BACKSPACE:
+      case keyCodes.DELETE:
+      case keyCodes.TAB:
+      case keyCodes.END:
+      case keyCodes.HOME:
+      case keyCodes.LEFT:
+      case keyCodes.RIGHT:
         break;
+      default:
+        return preventNonAllowedKeyboardInput(e);
     }
+    return true;
   };
 
   const onInputBlur = (e) => {
@@ -235,6 +268,7 @@ const TimePickerSpinner = ({
         onBlur={onInputBlur}
         disabled={disabled}
         data-testid={testId}
+        invalid={invalid}
         {...others}
       >
         {children}

--- a/packages/react/src/components/TimePickerSpinner/TimePickerSpinner.story.jsx
+++ b/packages/react/src/components/TimePickerSpinner/TimePickerSpinner.story.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { boolean } from '@storybook/addon-knobs';
+import React, { createElement, useState } from 'react';
+import { boolean, text } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 import { spacing05 } from '@carbon/layout';
 
 import TimePickerSpinner, { TIMEGROUPS } from './TimePickerSpinner';
@@ -21,9 +22,11 @@ export const WithSpinner = () => {
         id="timepicker"
         value="19:33"
         aria-label="Pick a time"
-        disabled={boolean('Disable input', false)}
-        spinner={boolean('Enable spinner', true)}
-        is12hour={boolean('12-hour format', false)}
+        disabled={boolean('Disable input (disabled)', false)}
+        spinner={boolean('Enable spinner (spinner)', true)}
+        is12hour={boolean('12-hour format (is12hour)', false)}
+        invalid={boolean('Invalid value (invalid)', false)}
+        onChange={action('onChange')}
       />
     </div>
   );
@@ -40,9 +43,36 @@ export const DefaultTimeGroupToMinutes = () => {
         aria-label="Pick a time"
         spinner
         defaultTimegroup={TIMEGROUPS.MINUTES}
+        onChange={action('onChange')}
       />
     </div>
   );
 };
 
 DefaultTimeGroupToMinutes.storyName = 'Default timeGroup to minutes';
+
+export const WithStateForInputvalidation = () => {
+  const [invalid, setInvalid] = useState(false);
+
+  return (
+    <div style={{ margin: spacing05 + 4 }}>
+      <TimePickerSpinner
+        labelText={text('Label text (labelText)', 'My label')}
+        id="timepicker"
+        value="19:33"
+        aria-label="Pick a time"
+        disabled={boolean('Disable input (disabled)', false)}
+        spinner={boolean('Enable spinner (spinner)', true)}
+        invalid={invalid}
+        is12hour={boolean('12-hour format (is12hour)', false)}
+        invalidText={text('Invalid input text (i18n.invalidText)', 'A valid value is required')}
+        onChange={(newValue, evt, meta) => {
+          setInvalid(meta.invalid);
+          action('onChange')(newValue, evt, meta);
+        }}
+      />
+    </div>
+  );
+};
+WithStateForInputvalidation.storyName = 'With state for input validation';
+WithStateForInputvalidation.decorators = [createElement];

--- a/packages/react/src/components/TimePickerSpinner/TimePickerSpinner.test.jsx
+++ b/packages/react/src/components/TimePickerSpinner/TimePickerSpinner.test.jsx
@@ -334,4 +334,165 @@ describe('TimePickerSpinner', () => {
     userEvent.click(screen.getByLabelText(/decrement/i));
     expect(screen.getByLabelText('Pick a time')).toHaveValue('12:59');
   });
+
+  it('can have invalid state and default invalid text', () => {
+    render(<TimePickerSpinner id="timepickerspinner" value="42:00" invalid />);
+    expect(screen.getByText('Invalid time format.')).toBeVisible();
+  });
+
+  it('can have invalid state and custom invalid text', () => {
+    render(
+      <TimePickerSpinner
+        id="timepickerspinner"
+        value="42:00"
+        invalid
+        invalidText="my invalid text"
+      />
+    );
+    expect(screen.getByText('my invalid text')).toBeVisible();
+  });
+
+  it('adds validation result in onChange callback when using text input', () => {
+    let invalid;
+    const onChange = jest.fn().mockImplementation((time, evt, meta) => {
+      /* eslint-disable-next-line prefer-destructuring */
+      invalid = meta.invalid;
+    });
+    render(<TimePickerSpinner {...timePickerProps} spinner onChange={onChange} />);
+    const input = screen.getByLabelText('Pick a time');
+    userEvent.type(input, '25:34');
+    expect(invalid).toBeTruthy();
+    expect(onChange).toHaveBeenCalledTimes(5);
+
+    userEvent.clear(input);
+    expect(onChange).toHaveBeenCalledTimes(6);
+    expect(invalid).toBeTruthy();
+
+    userEvent.type(input, '11:34');
+    expect(invalid).toBeFalsy();
+    expect(onChange).toHaveBeenCalledTimes(11);
+
+    userEvent.clear(input);
+    userEvent.type(input, '11:61');
+    expect(onChange).toHaveBeenCalledTimes(17);
+    expect(invalid).toBeTruthy();
+
+    userEvent.type(input, '{backspace}{backspace}');
+    expect(onChange).toHaveBeenCalledTimes(19);
+    expect(invalid).toBeTruthy();
+
+    userEvent.type(input, '59');
+    expect(onChange).toHaveBeenCalledTimes(21);
+    expect(invalid).toBeFalsy();
+  });
+
+  it('adds validation result in onChange callback when using text input & 12 hours setting', () => {
+    let invalid;
+    let time;
+    const onChange = jest.fn().mockImplementation((newTime, evt, meta) => {
+      /* eslint-disable-next-line prefer-destructuring */
+      invalid = meta.invalid;
+      time = newTime;
+    });
+    render(<TimePickerSpinner {...timePickerProps} spinner onChange={onChange} is12hour />);
+    const input = screen.getByLabelText('Pick a time');
+    userEvent.type(input, '13:34');
+    expect(invalid).toBeTruthy();
+    expect(onChange).toHaveBeenCalledTimes(5);
+
+    userEvent.clear(input);
+    expect(onChange).toHaveBeenCalledTimes(6);
+    expect(invalid).toBeTruthy();
+
+    userEvent.type(input, '11:34');
+    expect(invalid).toBeFalsy();
+    expect(onChange).toHaveBeenCalledTimes(11);
+
+    userEvent.clear(input);
+    userEvent.type(input, '11:61');
+    expect(onChange).toHaveBeenCalledTimes(17);
+    expect(invalid).toBeTruthy();
+
+    userEvent.type(input, '{backspace}{backspace}');
+    expect(onChange).toHaveBeenCalledTimes(19);
+    expect(invalid).toBeTruthy();
+
+    userEvent.type(input, '59');
+    expect(onChange).toHaveBeenCalledTimes(21);
+    expect(time).toBe('11:59');
+    expect(invalid).toBeFalsy();
+  });
+
+  it('adds validation result in onChange callback when using spinner buttons', () => {
+    let invalid;
+    let time;
+    const onChange = jest.fn().mockImplementation((newTime, evt, meta) => {
+      /* eslint-disable-next-line prefer-destructuring */
+      invalid = meta.invalid;
+      time = newTime;
+    });
+    render(<TimePickerSpinner {...timePickerProps} spinner onChange={onChange} value="19:78" />);
+    userEvent.click(screen.queryByRole('button', { name: /Increment hours/i }));
+    expect(invalid).toBeTruthy();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(time).toBe('20:78');
+
+    // Increasing or decreasing the minutes with the spinner buttons will reset the minutes to a valid 00
+    const input = screen.getByLabelText('Pick a time');
+    userEvent.type(input, '{end}');
+
+    userEvent.click(screen.queryByRole('button', { name: /Increment minutes/i }));
+    expect(invalid).toBeFalsy();
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(time).toBe('20:00');
+
+    userEvent.click(screen.queryByRole('button', { name: /Increment minutes/i }));
+    expect(invalid).toBeFalsy();
+    expect(onChange).toHaveBeenCalledTimes(3);
+    expect(time).toBe('20:01');
+  });
+
+  it('adds validation result in onChange callback when using spinner buttons & 12 hours setting', () => {
+    let invalid;
+    let time;
+    const onChange = jest.fn().mockImplementation((newTime, evt, meta) => {
+      /* eslint-disable-next-line prefer-destructuring */
+      invalid = meta.invalid;
+      time = newTime;
+    });
+    render(
+      <TimePickerSpinner {...timePickerProps} spinner onChange={onChange} value="7:78" is12hour />
+    );
+    userEvent.click(screen.queryByRole('button', { name: /Increment hours/i }));
+    expect(invalid).toBeTruthy();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(time).toBe('08:78');
+
+    // Increasing or decreasing the minutes with the spinner buttons will reset the minutes to a valid 00
+    const input = screen.getByLabelText('Pick a time');
+    userEvent.type(input, '{end}');
+
+    userEvent.click(screen.queryByRole('button', { name: /Increment minutes/i }));
+    expect(invalid).toBeFalsy();
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(time).toBe('08:00');
+
+    userEvent.click(screen.queryByRole('button', { name: /Increment minutes/i }));
+    expect(invalid).toBeFalsy();
+    expect(onChange).toHaveBeenCalledTimes(3);
+    expect(time).toBe('08:01');
+  });
+
+  it('only allows numbers and : as input', () => {
+    render(<TimePickerSpinner {...timePickerProps} spinner />);
+
+    const input = screen.getByLabelText('Pick a time');
+    userEvent.type(input, 'ababJKD');
+
+    expect(timePickerProps.onChange).not.toHaveBeenCalled();
+
+    userEvent.type(input, 'a:?12Ö!');
+    expect(input.value).toEqual(':12');
+    expect(timePickerProps.onChange).toHaveBeenCalledTimes(3);
+  });
 });

--- a/packages/react/src/components/TimePickerSpinner/__snapshots__/TimePickerSpinner.story.storyshot
+++ b/packages/react/src/components/TimePickerSpinner/__snapshots__/TimePickerSpinner.story.storyshot
@@ -229,3 +229,124 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
   </div>
 </div>
 `;
+
+exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/TimePickerSpinner With state for input validation 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "margin": "1rem4",
+      }
+    }
+  >
+    <div
+      className="iot--time-picker__wrapper iot--time-picker__wrapper--with-spinner"
+      data-testid="time-picker-spinner-wrapper"
+    >
+      <div
+        className="bx--form-item"
+      >
+        <label
+          className="bx--label"
+          htmlFor="timepicker"
+        >
+          My label
+        </label>
+        <div
+          className="bx--time-picker"
+        >
+          <div
+            className="bx--time-picker__input"
+          >
+            <input
+              aria-label="Pick a time"
+              className="bx--time-picker__input-field bx--text-input"
+              data-testid="time-picker-spinner"
+              disabled={false}
+              id="timepicker"
+              maxLength={5}
+              onBlur={[Function]}
+              onChange={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              pattern="(1[012]|[1-9]):[0-5][0-9](\\\\s)?"
+              placeholder="hh:mm"
+              type="text"
+              value="19:33"
+            />
+          </div>
+          <div
+            className="iot--time-picker__controls"
+          >
+            <button
+              aria-atomic="true"
+              aria-label="Increment hours"
+              aria-live="polite"
+              className="iot--time-picker__controls--btn up-icon"
+              data-testid="time-picker-spinner-up-button"
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              title="Increment hours"
+              type="button"
+            >
+              <svg
+                aria-hidden={true}
+                className="up-icon"
+                fill="currentColor"
+                focusable="false"
+                height={4}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 8 4"
+                width={8}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0 4L4 0 8 4z"
+                />
+              </svg>
+            </button>
+            <button
+              aria-atomic="true"
+              aria-label="Decrement hours"
+              aria-live="polite"
+              className="iot--time-picker__controls--btn down-icon"
+              data-testid="time-picker-spinner-down-button"
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              title="Decrement hours"
+              type="button"
+            >
+              <svg
+                aria-hidden={true}
+                className="down-icon"
+                fill="currentColor"
+                focusable="false"
+                height={4}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 8 4"
+                width={8}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 0L4 4 0 0z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/react/src/components/TimePickerSpinner/_time-picker-spinner.scss
+++ b/packages/react/src/components/TimePickerSpinner/_time-picker-spinner.scss
@@ -17,16 +17,26 @@
   }
 
   &.#{$iot-prefix}--time-picker__wrapper--show-underline {
+    .bx--time-picker--invalid .bx--time-picker__input:before {
+      bottom: 1.6rem;
+    }
     .bx--time-picker__input:before {
       content: '__';
       position: absolute;
       bottom: 0.365rem;
       left: 1rem;
     }
+
     &.#{$iot-prefix}--time-picker__wrapper--show-underline-minutes {
       .bx--time-picker__input:before {
         left: 2.7rem;
       }
+    }
+  }
+
+  .bx--time-picker--invalid {
+    .#{$iot-prefix}--time-picker__controls {
+      bottom: calc(#{$spacing-06} - #{$spacing-01});
     }
   }
 

--- a/packages/react/src/constants/KeyCodeConstants.js
+++ b/packages/react/src/constants/KeyCodeConstants.js
@@ -1,4 +1,6 @@
 export const keyCodes = {
+  BACKSPACE: 8,
+  DELETE: 46,
   TAB: 9,
   ENTER: 13,
   ESCAPE: 27,

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -6513,6 +6513,7 @@ Map {
         "increment": "Increment",
         "minutes": "minutes",
       },
+      "invalid": false,
       "is12hour": false,
       "onChange": null,
       "onClick": null,
@@ -6589,6 +6590,9 @@ Map {
           },
         ],
         "type": "shape",
+      },
+      "invalid": Object {
+        "type": "bool",
       },
       "is12hour": Object {
         "type": "bool",


### PR DESCRIPTION
Closes #2839 
Improved keyboard input and added a validation state to the onChangeCallback for the TimePickerSpinner.

It turned our that completely preventing all illegal input without crippling the normal UX (text selection, cut, paste, tab focus etc) would be near impossible. So I made the TimePickerSpinner play well with the invalid prop and added the calculated validation result to the onChange callback so that it could be lifted to the parent component. Hence this is an optional built-in validation that still allow for external validation, or none, to be used.

**Change List (commits, features, bugs, etc)**
TimePickerSpinner
- added validation and adjusted scss
- kept a small part of the initial effort in preventing invalid input, i.e. to only allow numbers and one colon
- fixed old bx-prefix in scss
- fixed story knobs
- added new story
- added default i18n prop merge (turned out it was not needed for my changes but I left it in there)
- added unit tests

DateTimePicker/DateTimePicker2
- fix to disable apply button when there are invalid values in the TimePickerSpinner
- fixed issue in DateTimePicker where the timepickerspinner values from relative spilled over to absolute and the other way around.
- added new unit test and e2e tests
- added restore faketimer to tests 

As a note I also created the following new issues:
https://github.com/carbon-design-system/carbon-addons-iot-react/issues/2899
https://github.com/carbon-design-system/carbon-addons-iot-react/issues/2893
https://github.com/carbon-design-system/carbon-addons-iot-react/issues/2877

**Acceptance Test (how to verify the PR)**
- Verify that new [TimeSpinnerPicker](https://deploy-preview-XXXXX--carbon-addons-iot-react.netlify.app?path=/story/1-watson-iot-timepickerspinner--with-state-for-inputvalidation) story shows a validation error when an incorrect time is added. It should work for both 12 and 24 hours 

- Verify that it is not possible to, as an end user, enter an invalid time in the TimePickerSpinners we have in the DateTimePicker and DateTimePicker2 without getting the Apply button disabled. Also verify that the the UI with the validation error present looks ok.

**Regression Test (how to make sure this PR doesn't break old functionality)**
- Verify that the old TimeSpinnerPicker stories work as expected
- Verify that the DateTimePicker and DateTimePicker2 stories work as expected

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
