### PR TITLE
fix(page-title-bar): chrome upgrade(?) causes cypress test to fail

### DIFF
--- a/packages/react/src/components/PageTitleBar/PageTItleBar.test.e2e.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTItleBar.test.e2e.jsx
@@ -27,7 +27,13 @@ describe('PageTitleBar', () => {
       .should('have.class', 'page-title-bar--dynamic--during')
       .should('not.have.class', 'page-title-bar--dynamic--after')
       .should('not.have.class', 'page-title-bar--dynamic--before')
-      .should('have.attr', 'style', '--header-offset:48px; --scroll-transition-progress:0.2;');
+      .should(($el) => {
+        const scrollProgress = Number.parseFloat(
+          $el[0].style.getPropertyValue('--scroll-transition-progress')
+        ).toPrecision(1);
+
+        expect(scrollProgress).to.equal('0.2');
+      });
 
     cy.scrollTo(0, 200);
     cy.findByTestId('page-title-bar')


### PR DESCRIPTION
Closes #2909

**Summary**

- update e2e test to account for minor precision differences in PageTitleBar scroll checking.

**Change List (commits, features, bugs, etc)**

- round scroll check to tenths place.

**Acceptance Test (how to verify the PR)**

- test pass

**Regression Test (how to make sure this PR doesn't break old functionality)**

- n/a

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
