### PR TITLE
fix(date-time-picker): add start/end to proptypes

### DIFF
--- a/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
@@ -99,6 +99,10 @@ const propTypes = {
       timeRangeValue: PropTypes.exact({
         startDate: PropTypes.string.isRequired,
         startTime: PropTypes.string.isRequired,
+        /** Can be a full parseable DateTime string or a Date object */
+        start: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
+        /** Can be a full parseable DateTime string or a Date object */
+        end: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
         endDate: PropTypes.string.isRequired,
         endTime: PropTypes.string.isRequired,
       }).isRequired,

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
@@ -274,7 +274,10 @@ describe('DateTimePicker', () => {
     const wrapper = mount(
       <DateTimePicker
         {...dateTimePickerProps}
-        defaultValue={PRESET_VALUES[1]}
+        defaultValue={{
+          timeRangeKind: PICKER_KINDS.PRESET,
+          timeRangeValue: PRESET_VALUES[1],
+        }}
         showRelativeOption={false}
       />
     );

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
@@ -57,6 +57,10 @@ export const DateTimePickerDefaultValuePropTypes = PropTypes.oneOfType([
     timeRangeValue: PropTypes.exact({
       startDate: PropTypes.string.isRequired,
       startTime: PropTypes.string.isRequired,
+      /** Can be a full parseable DateTime string or a Date object */
+      start: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
+      /** Can be a full parseable DateTime string or a Date object */
+      end: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
       endDate: PropTypes.string.isRequired,
       endTime: PropTypes.string.isRequired,
     }).isRequired,

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
@@ -275,7 +275,10 @@ describe('DateTimePicker', () => {
     const wrapper = mount(
       <DateTimePicker
         {...dateTimePickerProps}
-        defaultValue={PRESET_VALUES[1]}
+        defaultValue={{
+          timeRangeKind: PICKER_KINDS.PRESET,
+          timeRangeValue: PRESET_VALUES[1],
+        }}
         showRelativeOption={false}
       />
     );

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -6395,6 +6395,22 @@ Map {
                         "timeRangeValue": Object {
                           "args": Array [
                             Object {
+                              "end": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
+                              },
                               "endDate": Object {
                                 "isRequired": true,
                                 "type": "string",
@@ -6402,6 +6418,22 @@ Map {
                               "endTime": Object {
                                 "isRequired": true,
                                 "type": "string",
+                              },
+                              "start": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
                               },
                               "startDate": Object {
                                 "isRequired": true,
@@ -6883,6 +6915,22 @@ Map {
                   "timeRangeValue": Object {
                     "args": Array [
                       Object {
+                        "end": Object {
+                          "args": Array [
+                            Array [
+                              Object {
+                                "type": "string",
+                              },
+                              Object {
+                                "args": Array [
+                                  [Function],
+                                ],
+                                "type": "instanceOf",
+                              },
+                            ],
+                          ],
+                          "type": "oneOfType",
+                        },
                         "endDate": Object {
                           "isRequired": true,
                           "type": "string",
@@ -6890,6 +6938,22 @@ Map {
                         "endTime": Object {
                           "isRequired": true,
                           "type": "string",
+                        },
+                        "start": Object {
+                          "args": Array [
+                            Array [
+                              Object {
+                                "type": "string",
+                              },
+                              Object {
+                                "args": Array [
+                                  [Function],
+                                ],
+                                "type": "instanceOf",
+                              },
+                            ],
+                          ],
+                          "type": "oneOfType",
                         },
                         "startDate": Object {
                           "isRequired": true,
@@ -7298,6 +7362,22 @@ Map {
                   "timeRangeValue": Object {
                     "args": Array [
                       Object {
+                        "end": Object {
+                          "args": Array [
+                            Array [
+                              Object {
+                                "type": "string",
+                              },
+                              Object {
+                                "args": Array [
+                                  [Function],
+                                ],
+                                "type": "instanceOf",
+                              },
+                            ],
+                          ],
+                          "type": "oneOfType",
+                        },
                         "endDate": Object {
                           "isRequired": true,
                           "type": "string",
@@ -7305,6 +7385,22 @@ Map {
                         "endTime": Object {
                           "isRequired": true,
                           "type": "string",
+                        },
+                        "start": Object {
+                          "args": Array [
+                            Array [
+                              Object {
+                                "type": "string",
+                              },
+                              Object {
+                                "args": Array [
+                                  [Function],
+                                ],
+                                "type": "instanceOf",
+                              },
+                            ],
+                          ],
+                          "type": "oneOfType",
                         },
                         "startDate": Object {
                           "isRequired": true,
@@ -12766,6 +12862,22 @@ Map {
                         "timeRangeValue": Object {
                           "args": Array [
                             Object {
+                              "end": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
+                              },
                               "endDate": Object {
                                 "isRequired": true,
                                 "type": "string",
@@ -12773,6 +12885,22 @@ Map {
                               "endTime": Object {
                                 "isRequired": true,
                                 "type": "string",
+                              },
+                              "start": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
                               },
                               "startDate": Object {
                                 "isRequired": true,
@@ -13804,6 +13932,22 @@ Map {
                         "timeRangeValue": Object {
                           "args": Array [
                             Object {
+                              "end": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
+                              },
                               "endDate": Object {
                                 "isRequired": true,
                                 "type": "string",
@@ -13811,6 +13955,22 @@ Map {
                               "endTime": Object {
                                 "isRequired": true,
                                 "type": "string",
+                              },
+                              "start": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
                               },
                               "startDate": Object {
                                 "isRequired": true,
@@ -14927,6 +15087,22 @@ Map {
                         "timeRangeValue": Object {
                           "args": Array [
                             Object {
+                              "end": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
+                              },
                               "endDate": Object {
                                 "isRequired": true,
                                 "type": "string",
@@ -14934,6 +15110,22 @@ Map {
                               "endTime": Object {
                                 "isRequired": true,
                                 "type": "string",
+                              },
+                              "start": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
                               },
                               "startDate": Object {
                                 "isRequired": true,
@@ -16079,6 +16271,22 @@ Map {
                         "timeRangeValue": Object {
                           "args": Array [
                             Object {
+                              "end": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
+                              },
                               "endDate": Object {
                                 "isRequired": true,
                                 "type": "string",
@@ -16086,6 +16294,22 @@ Map {
                               "endTime": Object {
                                 "isRequired": true,
                                 "type": "string",
+                              },
+                              "start": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
                               },
                               "startDate": Object {
                                 "isRequired": true,
@@ -17065,6 +17289,22 @@ Map {
                         "timeRangeValue": Object {
                           "args": Array [
                             Object {
+                              "end": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
+                              },
                               "endDate": Object {
                                 "isRequired": true,
                                 "type": "string",
@@ -17072,6 +17312,22 @@ Map {
                               "endTime": Object {
                                 "isRequired": true,
                                 "type": "string",
+                              },
+                              "start": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
                               },
                               "startDate": Object {
                                 "isRequired": true,
@@ -18142,6 +18398,22 @@ Map {
                         "timeRangeValue": Object {
                           "args": Array [
                             Object {
+                              "end": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
+                              },
                               "endDate": Object {
                                 "isRequired": true,
                                 "type": "string",
@@ -18149,6 +18421,22 @@ Map {
                               "endTime": Object {
                                 "isRequired": true,
                                 "type": "string",
+                              },
+                              "start": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
                               },
                               "startDate": Object {
                                 "isRequired": true,
@@ -19245,6 +19533,22 @@ Map {
                         "timeRangeValue": Object {
                           "args": Array [
                             Object {
+                              "end": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
+                              },
                               "endDate": Object {
                                 "isRequired": true,
                                 "type": "string",
@@ -19252,6 +19556,22 @@ Map {
                               "endTime": Object {
                                 "isRequired": true,
                                 "type": "string",
+                              },
+                              "start": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
                               },
                               "startDate": Object {
                                 "isRequired": true,
@@ -20185,6 +20505,22 @@ Map {
                         "timeRangeValue": Object {
                           "args": Array [
                             Object {
+                              "end": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
+                              },
                               "endDate": Object {
                                 "isRequired": true,
                                 "type": "string",
@@ -20192,6 +20528,22 @@ Map {
                               "endTime": Object {
                                 "isRequired": true,
                                 "type": "string",
+                              },
+                              "start": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
                               },
                               "startDate": Object {
                                 "isRequired": true,
@@ -23799,6 +24151,22 @@ Map {
                         "timeRangeValue": Object {
                           "args": Array [
                             Object {
+                              "end": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
+                              },
                               "endDate": Object {
                                 "isRequired": true,
                                 "type": "string",
@@ -23806,6 +24174,22 @@ Map {
                               "endTime": Object {
                                 "isRequired": true,
                                 "type": "string",
+                              },
+                              "start": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
                               },
                               "startDate": Object {
                                 "isRequired": true,
@@ -25289,6 +25673,22 @@ Map {
                         "timeRangeValue": Object {
                           "args": Array [
                             Object {
+                              "end": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
+                              },
                               "endDate": Object {
                                 "isRequired": true,
                                 "type": "string",
@@ -25296,6 +25696,22 @@ Map {
                               "endTime": Object {
                                 "isRequired": true,
                                 "type": "string",
+                              },
+                              "start": Object {
+                                "args": Array [
+                                  Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "args": Array [
+                                        [Function],
+                                      ],
+                                      "type": "instanceOf",
+                                    },
+                                  ],
+                                ],
+                                "type": "oneOfType",
                               },
                               "startDate": Object {
                                 "isRequired": true,


### PR DESCRIPTION
Closes #2899 

**Summary**

- adds `start` / `end` to `absolute` proptypes and fixes one bad defaultValue in a test.

**Change List (commits, features, bugs, etc)**

- update proptypes
- fix test

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
