### PR TITLE
fix(bar-chart-card): add prop warning for unsupported sizes

### DIFF
--- a/packages/react/src/components/BarChartCard/BarChartCard.test.jsx
+++ b/packages/react/src/components/BarChartCard/BarChartCard.test.jsx
@@ -1,13 +1,11 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import '@testing-library/jest-dom/extend-expect';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fileDownload from 'js-file-download';
 
-import Table from '../Table/Table';
 import { barChartData } from '../../utils/barChartDataSample';
-import { BAR_CHART_LAYOUTS, BAR_CHART_TYPES } from '../../constants/LayoutConstants';
+import { CARD_SIZES, BAR_CHART_LAYOUTS, BAR_CHART_TYPES } from '../../constants/LayoutConstants';
 
 import BarChartCard from './BarChartCard';
 import * as barChartUtils from './barChartUtils';
@@ -51,23 +49,23 @@ describe('BarChartCard', () => {
   });
 
   it('does not show bar chart when loading', () => {
-    const wrapper = mount(<BarChartCard {...barChartCardProps} isLoading />);
-    expect(wrapper.find('#mock-bar-chart-simple')).toHaveLength(0);
+    const { container } = render(<BarChartCard {...barChartCardProps} isLoading />);
+    expect(container.querySelectorAll('#mock-bar-chart-simple')).toHaveLength(0);
   });
 
   it('does not show bar chart when empty data', () => {
-    const wrapper = mount(
+    const { container } = render(
       <BarChartCard
         {...barChartCardProps}
         values={barChartData.quarters.filter((q) => q.quarter === 'NOT_VALID')}
       />
     );
-    expect(wrapper.find('#mock-bar-chart-simple')).toHaveLength(0);
+    expect(container.querySelectorAll('#mock-bar-chart-simple')).toHaveLength(0);
   });
 
   it('shows table when isExpanded', () => {
-    const wrapper = mount(<BarChartCard {...barChartCardProps} isExpanded />);
-    expect(wrapper.find(Table)).toHaveLength(1);
+    const { container } = render(<BarChartCard {...barChartCardProps} isExpanded />);
+    expect(container.querySelectorAll('#BarChartCard-table')).toHaveLength(1);
   });
 
   it('onCsvDownload should fire when download button is clicked', async () => {
@@ -85,7 +83,7 @@ describe('BarChartCard', () => {
   });
 
   it('shows groupedBarChart on grouped data', () => {
-    const wrapper = mount(
+    const { container } = render(
       <BarChartCard
         {...barChartCardProps}
         content={{
@@ -108,11 +106,11 @@ describe('BarChartCard', () => {
         values={barChartData.quarters.filter((a) => a.quarter === '2020-Q1')}
       />
     );
-    expect(wrapper.find('#mock-bar-chart-grouped')).toHaveLength(1);
+    expect(container.querySelectorAll('#mock-bar-chart-grouped')).toHaveLength(1);
   });
 
   it('shows stackedBarChart', () => {
-    const wrapper = mount(
+    const { container } = render(
       <BarChartCard
         {...barChartCardProps}
         content={{
@@ -135,11 +133,11 @@ describe('BarChartCard', () => {
         values={barChartData.quarters.filter((a) => a.quarter === '2020-Q3')}
       />
     );
-    expect(wrapper.find('#mock-bar-chart-stacked')).toHaveLength(1);
+    expect(container.querySelectorAll('#mock-bar-chart-stacked')).toHaveLength(1);
   });
 
   it('shows a timeSeries chart', () => {
-    const wrapper = mount(
+    const { container } = render(
       <BarChartCard
         {...barChartCardProps}
         content={{
@@ -157,11 +155,11 @@ describe('BarChartCard', () => {
         values={barChartData.timestamps.filter((t) => t.city === 'Amsterdam')}
       />
     );
-    expect(wrapper.find('#mock-bar-chart-stacked')).toHaveLength(1);
+    expect(container.querySelectorAll('#mock-bar-chart-stacked')).toHaveLength(1);
   });
 
   it('shows a horizontal chart', () => {
-    const wrapper = mount(
+    const { container } = render(
       <BarChartCard
         {...barChartCardProps}
         content={{
@@ -185,7 +183,7 @@ describe('BarChartCard', () => {
         values={barChartData.quarters.filter((a) => a.quarter === '2020-Q1')}
       />
     );
-    expect(wrapper.find('#mock-bar-chart-grouped')).toHaveLength(1);
+    expect(container.querySelectorAll('#mock-bar-chart-grouped')).toHaveLength(1);
   });
 
   it('i18n string test', () => {
@@ -220,6 +218,22 @@ describe('BarChartCard', () => {
       undefined,
       'city',
       undefined
+    );
+    jest.resetAllMocks();
+  });
+  it('should throw a prop warning when using an unsupported size', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { rerender } = render(<BarChartCard {...barChartCardProps} size={CARD_SIZES.SMALL} />);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('`BarChartCard` prop `size` cannot be `SMALL`')
+    );
+    rerender(<BarChartCard {...barChartCardProps} size={CARD_SIZES.SMALLWIDE} />);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('`BarChartCard` prop `size` cannot be `SMALLWIDE`')
+    );
+    rerender(<BarChartCard {...barChartCardProps} size={CARD_SIZES.SMALLFULL} />);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('`BarChartCard` prop `size` cannot be `SMALLFULL`')
     );
     jest.resetAllMocks();
   });

--- a/packages/react/src/constants/CardPropTypes.js
+++ b/packages/react/src/constants/CardPropTypes.js
@@ -270,9 +270,13 @@ export const BarChartCardPropTypes = {
       );
     }
     // If the size
-    if (props[propName] === CARD_SIZES.SMALL || props[propName] === CARD_SIZES.SMALLWIDE) {
+    if (
+      props[propName] === CARD_SIZES.SMALL ||
+      props[propName] === CARD_SIZES.SMALLWIDE ||
+      props[propName] === CARD_SIZES.SMALLFULL
+    ) {
       error = new Error(
-        `Deprecation notice: \`${componentName}\` prop \`${propName}\` cannot be \`SMALL\` || \`SMALLWIDE\` as the charts will not render correctly. Minimum size is \`MEDIUM\``
+        `Deprecation notice: \`${componentName}\` prop \`${propName}\` cannot be \`${props[propName]}\` as the charts will not render correctly. Minimum size is \`MEDIUM\``
       );
     }
     return error;


### PR DESCRIPTION
Closes #2885 

**Summary**

- adds console warning to SMALLFULL BarChartCards

**Change List (commits, features, bugs, etc)**

- add prop warnings and tests

**Acceptance Test (how to verify the PR)**

- BarChartCards of SMALLFULL size should throw prop warnings

**Regression Test (how to make sure this PR doesn't break old functionality)**

- n/a

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
