### PR TITLE
fix(pie-chart-card): show prop-type error for SMALLFULL

### DIFF
--- a/packages/react/src/components/PieChartCard/PieChartCard.test.jsx
+++ b/packages/react/src/components/PieChartCard/PieChartCard.test.jsx
@@ -379,4 +379,22 @@ describe('PieChartCard', () => {
     expect(firstSlice).toHaveClass('hovered');
     expect(screen.getByText('custom-tooltip-test')).toBeVisible();
   });
+
+  it('should throw a prop warnings with an unsupported size', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { testID, ...props } = pieChartCardProps;
+    const { rerender } = render(<PieChartCard {...props} size={CARD_SIZES.SMALL} />);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(`PieChartCard does not support card size ${CARD_SIZES.SMALL}`)
+    );
+    rerender(<PieChartCard {...props} size={CARD_SIZES.SMALLWIDE} />);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(`PieChartCard does not support card size ${CARD_SIZES.SMALLWIDE}`)
+    );
+    rerender(<PieChartCard {...props} size={CARD_SIZES.SMALLFULL} />);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(`PieChartCard does not support card size ${CARD_SIZES.SMALLFULL}`)
+    );
+    jest.resetAllMocks();
+  });
 });

--- a/packages/react/src/utils/cardUtilityFunctions.js
+++ b/packages/react/src/utils/cardUtilityFunctions.js
@@ -309,13 +309,15 @@ export const chartValueFormatter = (value, size, unit, locale, precision) => {
 export const increaseSmallCardSize = (size, cardName) => {
   if (__DEV__) {
     warning(
-      size !== CARD_SIZES.SMALL && size !== CARD_SIZES.SMALLWIDE,
+      size !== CARD_SIZES.SMALL && size !== CARD_SIZES.SMALLWIDE && size !== CARD_SIZES.SMALLFULL,
       `${cardName} does not support card size ${size}`
     );
   }
   return size === CARD_SIZES.SMALL
     ? CARD_SIZES.MEDIUM
     : size === CARD_SIZES.SMALLWIDE
+    ? CARD_SIZES.MEDIUMWIDE
+    : size === CARD_SIZES.SMALLFULL
     ? CARD_SIZES.MEDIUMWIDE
     : size;
 };


### PR DESCRIPTION
Closes #2883 

**Summary**

- shows a prop type error for SMALLFULL size same as SMALL and SMALLWIDE

**Change List (commits, features, bugs, etc)**

- add warning for SMALLFULL
- add tests to confirm

**Acceptance Test (how to verify the PR)**

- tests pass
- SMALLFULL PieChartCards show prop-type warning

**Regression Test (how to make sure this PR doesn't break old functionality)**

- n/a

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
