### PR TITLE
fix(image-card): prop error for unsupported size, attempt rendering img

### DIFF
--- a/packages/react/src/components/ImageCard/ImageCard.jsx
+++ b/packages/react/src/components/ImageCard/ImageCard.jsx
@@ -162,69 +162,65 @@ const ImageCard = ({
             { width, height } // eslint-disable-line react/prop-types
           ) => (
             <div className={`${iotPrefix}--image-card__wrapper`}>
-              {supportedSize ? (
-                isEditable && !imgContent.src ? (
-                  <ImageUploader
-                    onBrowseClick={onBrowseClick}
-                    width={width}
-                    height={height}
-                    maxFileSizeInBytes={maxFileSizeInBytes}
-                    onUpload={handleOnUpload}
-                    i18n={pick(
-                      mergedI18n,
-                      'dropContainerLabelText',
-                      'dropContainerDescText',
-                      'uploadByURLCancel',
-                      'uploadByURLButton',
-                      'browseImages',
-                      'insertUrl',
-                      'urlInput',
-                      'fileTooLarge',
-                      'errorTitle',
-                      'wrongFileType'
-                    )}
-                    hasInsertFromUrl={hasInsertFromUrl}
-                    validateUploadedImage={validateUploadedImage}
-                    // TODO: remove deprecated testID prop in v3.
-                    testId={`${testID || testId}-image-uploader`}
-                  />
-                ) : imgContent.src ? (
-                  <ImageHotspots
-                    // Key regen needed for stories that modifies the displayOption
-                    key={imgContent?.displayOption}
-                    {...imgContent}
-                    // Adjust for side padding of iot-image-card__wrapper + border of iot-card--wrapper
-                    width={width - (16 * 2 + 4)}
-                    // Adjust for bottom padding of iot-image-card__wrapper + border of iot-card--wrapper
-                    height={height - (16 + 4)}
-                    isExpanded={isExpanded}
-                    hotspots={hotspots}
-                    isHotspotDataLoading={isLoading}
-                    loadingHotspotsLabel={loadingDataLabel}
-                    renderIconByName={renderIconByName}
-                    locale={locale}
-                    i18n={pick(
-                      mergedI18n,
-                      'zoomIn',
-                      'zoomOut',
-                      'zoomToFit',
-                      'titlePlaceholderText',
-                      'titleEditableHintText'
-                    )}
-                    // TODO: remove deprecated testID prop in v3.
-                    testId={`${testID || testId}-image-hotspots`}
-                  />
-                ) : (
-                  <div
-                    // TODO: remove deprecated testID prop in v3.
-                    data-testid={`${testID || testId}-empty`}
-                    className={`${iotPrefix}--image-card__empty`}
-                  >
-                    <Image32 width={250} height={250} fill="gray" />
-                  </div>
-                )
+              {isEditable && !imgContent.src ? (
+                <ImageUploader
+                  onBrowseClick={onBrowseClick}
+                  width={width}
+                  height={height}
+                  maxFileSizeInBytes={maxFileSizeInBytes}
+                  onUpload={handleOnUpload}
+                  i18n={pick(
+                    mergedI18n,
+                    'dropContainerLabelText',
+                    'dropContainerDescText',
+                    'uploadByURLCancel',
+                    'uploadByURLButton',
+                    'browseImages',
+                    'insertUrl',
+                    'urlInput',
+                    'fileTooLarge',
+                    'errorTitle',
+                    'wrongFileType'
+                  )}
+                  hasInsertFromUrl={hasInsertFromUrl}
+                  validateUploadedImage={validateUploadedImage}
+                  // TODO: remove deprecated testID prop in v3.
+                  testId={`${testID || testId}-image-uploader`}
+                />
+              ) : imgContent.src ? (
+                <ImageHotspots
+                  // Key regen needed for stories that modifies the displayOption
+                  key={imgContent?.displayOption}
+                  {...imgContent}
+                  // Adjust for side padding of iot-image-card__wrapper + border of iot-card--wrapper
+                  width={width - (16 * 2 + 4)}
+                  // Adjust for bottom padding of iot-image-card__wrapper + border of iot-card--wrapper
+                  height={height - (16 + 4)}
+                  isExpanded={isExpanded}
+                  hotspots={hotspots}
+                  isHotspotDataLoading={isLoading}
+                  loadingHotspotsLabel={loadingDataLabel}
+                  renderIconByName={renderIconByName}
+                  locale={locale}
+                  i18n={pick(
+                    mergedI18n,
+                    'zoomIn',
+                    'zoomOut',
+                    'zoomToFit',
+                    'titlePlaceholderText',
+                    'titleEditableHintText'
+                  )}
+                  // TODO: remove deprecated testID prop in v3.
+                  testId={`${testID || testId}-image-hotspots`}
+                />
               ) : (
-                <p>Size not supported.</p>
+                <div
+                  // TODO: remove deprecated testID prop in v3.
+                  data-testid={`${testID || testId}-empty`}
+                  className={`${iotPrefix}--image-card__empty`}
+                >
+                  <Image32 width={250} height={250} fill="gray" />
+                </div>
               )}
             </div>
           )

--- a/packages/react/src/components/ImageCard/ImageCard.test.jsx
+++ b/packages/react/src/components/ImageCard/ImageCard.test.jsx
@@ -21,6 +21,7 @@ function stringToArrayBuffer(str) {
 
 describe('ImageCard', () => {
   it('should be selectable by testId or testID', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     const testID = 'IMAGE_CARD';
 
     const { rerender } = render(
@@ -28,6 +29,9 @@ describe('ImageCard', () => {
     );
 
     expect(screen.getByTestId(testID)).toBeDefined();
+    expect(console.error).toHaveBeenCalledWith(
+      `Warning: The 'testID' prop has been deprecated. Please use 'testId' instead.`
+    );
 
     const testId = 'image_card';
     rerender(<ImageCard content={{ src: landscape }} size={CARD_SIZES.LARGE} testID={testId} />);
@@ -40,12 +44,6 @@ describe('ImageCard', () => {
     rerender(<ImageCard content={{ src: '' }} size={CARD_SIZES.LARGE} testID={testId} />);
     expect(screen.getByTestId(testId)).toBeDefined();
     expect(screen.getByTestId(`${testId}-empty`)).toBeDefined();
-  });
-
-  it("should show 'size not supported' when an invalid size is given", () => {
-    render(<ImageCard content={{ src: landscape }} size={CARD_SIZES.SMALL} />);
-
-    expect(screen.getByText(/size not supported/gi)).toBeInTheDocument();
   });
 
   it('should show ImageUploader when editable and no image is given', () => {
@@ -673,5 +671,31 @@ describe('ImageCard', () => {
     expect(screen.queryByText(/fetch failed/gi)).toBeNull();
 
     global.fetch = undefined;
+  });
+
+  it('should throw a prop error when using an unsupported size', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { rerender } = render(<ImageCard content={{ src: landscape }} size={CARD_SIZES.SMALL} />);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('`ImageCard` prop `size` cannot be `SMALL`')
+    );
+
+    rerender(<ImageCard content={{ src: landscape }} size={CARD_SIZES.SMALLWIDE} />);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('`ImageCard` prop `size` cannot be `SMALLWIDE`')
+    );
+    rerender(<ImageCard content={{ src: landscape }} size={CARD_SIZES.SMALLFULL} />);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('`ImageCard` prop `size` cannot be `SMALLFULL`')
+    );
+    rerender(<ImageCard content={{ src: landscape }} size={CARD_SIZES.LARGETHIN} />);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('`ImageCard` prop `size` cannot be `LARGETHIN`')
+    );
+    jest.resetAllMocks();
   });
 });

--- a/packages/react/src/constants/CardPropTypes.js
+++ b/packages/react/src/constants/CardPropTypes.js
@@ -445,6 +445,28 @@ export const ImageCardPropTypes = {
   accept: PropTypes.arrayOf(PropTypes.string),
   /** callback that you can use to validate the image, if you return a message we will display it as an error */
   validateUploadedImage: PropTypes.func,
+  size: (props, propName, componentName) => {
+    let error;
+    if (!Object.keys(CARD_SIZES).includes(props[propName])) {
+      error = new Error(
+        `\`${componentName}\` prop \`${propName}\` must be one of ${Object.keys(CARD_SIZES).join(
+          ','
+        )}.`
+      );
+    }
+    // If the size
+    if (
+      props[propName] === CARD_SIZES.SMALL ||
+      props[propName] === CARD_SIZES.SMALLWIDE ||
+      props[propName] === CARD_SIZES.SMALLFULL ||
+      props[propName] === CARD_SIZES.LARGETHIN
+    ) {
+      error = new Error(
+        `Deprecation notice: \`${componentName}\` prop \`${propName}\` cannot be \`${props[propName]}\` as the lists will not render correctly. Minimum size is \`MEDIUM\``
+      );
+    }
+    return error;
+  },
 };
 
 export const GaugeCardPropTypes = {

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -16933,27 +16933,7 @@ Map {
         "type": "shape",
       },
       "showOverflow": [Function],
-      "size": Object {
-        "args": Array [
-          Array [
-            "XSMALL",
-            "XSMALLWIDE",
-            "TALL",
-            "WIDE",
-            "XLARGE",
-            "SMALL",
-            "SMALLWIDE",
-            "SMALLFULL",
-            "MEDIUMTHIN",
-            "MEDIUM",
-            "MEDIUMWIDE",
-            "LARGETHIN",
-            "LARGE",
-            "LARGEWIDE",
-          ],
-        ],
-        "type": "oneOf",
-      },
+      "size": [Function],
       "subtitle": Object {
         "type": "string",
       },


### PR DESCRIPTION
Closes #2886 

**Summary**

- Shows a prop-type warning for unsupported sizes and attempts to render the image instead of showing the "size not supported" text in the card.

**Change List (commits, features, bugs, etc)**

- add prop warnings for unsupported sizes
- add tests to confirm
- remove "size not supported" message in card

**Acceptance Test (how to verify the PR)**

- tests pass
- ImageCards should display a prop-type warning at SMALL, SMALLWIDE, SMALLFULL, and LARGETHIN sizes

**Regression Test (how to make sure this PR doesn't break old functionality)**

- confirm removing the "size not supported" text doesn't cause any adverse effects.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
