### PR TITLE
fix(table): hide 'toggle aggregations' when toolbar disabled

### DIFF
--- a/packages/react/src/components/Table/Table.story.jsx
+++ b/packages/react/src/components/Table/Table.story.jsx
@@ -682,6 +682,7 @@ export const BasicDumbTable = () => {
         },
         toolbar: {
           activeBar: hasColumnSelection || hasColumnSelectionConfig ? 'column' : undefined,
+          isDisabled: boolean('Disable the table toolbar (view.toolbar.isDisabled)', false),
         },
         table: {
           loadingState: {

--- a/packages/react/src/components/Table/Table.test.jsx
+++ b/packages/react/src/components/Table/Table.test.jsx
@@ -2301,7 +2301,10 @@ describe('Table', () => {
     expect(console.error).not.toHaveBeenCalled();
   });
 
-  it('should not show toggle aggregations when toolbar is disabled', () => {
+  it('should not show toggle aggregations when toolbar is disabled', async () => {
+    jest
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(() => ({ width: 100, height: 100 }));
     const { rerender } = render(
       <Table
         columns={tableColumns}
@@ -2331,7 +2334,10 @@ describe('Table', () => {
       />
     );
 
-    expect(screen.queryByLabelText('open and close list of options')).toBeNull();
+    userEvent.click(screen.getByRole('button', { name: 'open and close list of options' }));
+    const toggleButton = screen.getByRole('menuitem', { name: 'Toggle aggregations' });
+    expect(toggleButton).toBeVisible();
+    expect(toggleButton).toBeDisabled();
     expect(screen.getByText('Total:')).toBeVisible();
 
     rerender(
@@ -2362,6 +2368,10 @@ describe('Table', () => {
         }}
       />
     );
-    expect(screen.getByRole('button', { name: 'open and close list of options' })).toBeVisible();
+    userEvent.click(screen.getByRole('button', { name: 'open and close list of options' }));
+    expect(toggleButton).toBeVisible();
+    expect(toggleButton).not.toBeDisabled();
+    expect(screen.getByText('Total:')).toBeVisible();
+    jest.resetAllMocks();
   });
 });

--- a/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -391,7 +391,7 @@ const TableToolbar = ({
               disabled={isDisabled}
             />
           ) : null}
-          {hasAggregations && !isDisabled ? (
+          {hasAggregations ? (
             <OverflowMenu
               className={`${iotPrefix}--table-toolbar-aggregations__overflow-menu`}
               direction="bottom"
@@ -409,6 +409,7 @@ const TableToolbar = ({
                 // When passing the event directly to the storybook action it throws an iframe access
                 // error. This might a temporary issue and can be removed later.
                 onClick={() => onToggleAggregations()}
+                disabled={isDisabled}
               />
             </OverflowMenu>
           ) : null}


### PR DESCRIPTION
Closes #2857 

**Summary**

- Previously, the "Toggle Aggregations" overflow menu option would remain active if the toolbar was disabled. This PR fixes that.

**Change List (commits, features, bugs, etc)**

- hide Toggle Aggregations overflow menu in TableToolbar if toolbar is disabled.
- add tests to confirm

**Acceptance Test (how to verify the PR)**

- go to a table story with aggregations, and turn off the toolbar.
- confirm the aggregations stay visible, but the toolbar option to turn them off is disabled.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- aggregations still work as expected when toolbar is turned off/on

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
