### PR TITLE
chore(repo): initial action for updating `v3` on `next` changes

### DIFF
--- a/.github/workflows/update-v3.yml
+++ b/.github/workflows/update-v3.yml
@@ -1,0 +1,20 @@
+name: update v3 branch on next changes
+on:
+  push:
+    branches:
+      - next
+jobs:
+  update-v3:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: next
+      - name: Reset next branch
+        run: |
+          git fetch origin next:next
+          git reset --hard next
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          branch: v3

--- a/.github/workflows/update-v3.yml
+++ b/.github/workflows/update-v3.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Reset next branch
         run: |
           git fetch origin next:next
-          git reset --hard next
+          git merge origin/next
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:

--- a/.github/workflows/update-v3.yml
+++ b/.github/workflows/update-v3.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: next
+          ref: v3
       - name: Reset next branch
         run: |
           git fetch origin next:next
@@ -17,4 +17,4 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
-          branch: v3
+          branch: v3-upgrade


### PR DESCRIPTION
Closes #2969 

**Summary**

- first attempt at automating the creation of a PR to merge `next` into `v3`, each time `next` is updated. This helps prevent massive PRs and keeps `v3` up-to-date automatically. The problem is there's no good way to test this without doing it live that I'm aware of. 😕 

**Change List (commits, features, bugs, etc)**

- add new github action for creating a PR to merge next into v3.

**Acceptance Test (how to verify the PR)**

- when an update is made to next, a new PR to merge next into v3 should be created.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- all other actions proceed as expected.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
