### PR TITLE
feat(timeseries): allow users to turn off totals

### DIFF
--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -166,6 +166,8 @@ const TimeSeriesCardPropTypes = {
   },
   /** tooltip format pattern that follows the dayjs formatting patterns */
   tooltipDateFormatPattern: PropTypes.string,
+  /** should the tooltip total the line chart values? */
+  tooltipShowTotals: PropTypes.bool,
   // TODO: remove deprecated 'testID' in v3
   // eslint-disable-next-line react/require-default-props
   testID: deprecate(
@@ -203,6 +205,7 @@ const defaultProps = {
   showTimeInGMT: false,
   domainRange: null,
   tooltipDateFormatPattern: 'L HH:mm:ss',
+  tooltipShowTotals: true,
 };
 
 const TimeSeriesCard = ({
@@ -222,6 +225,7 @@ const TimeSeriesCard = ({
   isLoading,
   domainRange,
   tooltipDateFormatPattern,
+  tooltipShowTotals,
   showTimeInGMT,
   // TODO: remove deprecated 'testID' in v3
   testID,
@@ -476,6 +480,7 @@ const TimeSeriesCard = ({
       },
       containerResizable: true,
       tooltip: {
+        showTotal: tooltipShowTotals,
         truncation: {
           type: 'none',
         },
@@ -531,6 +536,7 @@ const TimeSeriesCard = ({
       isEditable,
       showLegend,
       truncation,
+      tooltipShowTotals,
       mergedI18n.tooltipGroupLabel,
       mergedI18n.alertDetected,
       handleStrokeColor,

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
@@ -150,6 +150,7 @@ export const MultiLineIntervalDataChoices = () => {
         title={text('title', 'Temperature, Humidity, eCount, and Pressure')}
         isLoading={boolean('isLoading', false)}
         isExpanded={boolean('isExpanded', false)}
+        tooltipShowTotals={boolean('tooltipShowTotals', true)}
         content={{
           series: [
             {

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -15900,6 +15900,7 @@ Map {
       "showTimeInGMT": false,
       "size": "MEDIUM",
       "tooltipDateFormatPattern": "L HH:mm:ss",
+      "tooltipShowTotals": true,
       "values": Array [],
     },
     "propTypes": Object {
@@ -17081,6 +17082,9 @@ Map {
       },
       "tooltipDateFormatPattern": Object {
         "type": "string",
+      },
+      "tooltipShowTotals": Object {
+        "type": "bool",
       },
       "values": Object {
         "args": Array [


### PR DESCRIPTION
Closes #

**Summary**

- Small feature here to add a property that allows consumers of the Line Chart to turn off the auto totalling in a graph

**Change List (commits, features, bugs, etc)**

- feat(TimeSeriesCard): take a showTooltipTotals prop to control the Carbon Charts feature

**Acceptance Test (how to verify the PR)**

- Verify in the multiple line story you can turn off an on tooltip totals using the prop
- http://127.0.0.1:3000/?path=/story/1-watson-iot-%E2%9A%A0%EF%B8%8F-timeseriescard--multi-line-interval-data-choices
- Off 
- 
![image](https://user-images.githubusercontent.com/6663002/139331453-9df61d20-922e-4c1c-8291-c66cce1596d5.png)


**Regression Test (how to make sure this PR doesn't break old functionality)**

- Make sure the default line chart shows totals
- On
- 
![image](https://user-images.githubusercontent.com/6663002/139331495-234a5654-0c99-41ff-b215-1f29513cbc08.png)


<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
