### PR TITLE
fix(table): remove state management of aggregations from table component

### DIFF
--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useRef, useCallback, useEffect } from 'react';
+import React, { useMemo, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import merge from 'lodash/merge';
 import pick from 'lodash/pick';
@@ -386,10 +386,7 @@ export const defaultProps = (baseProps) => ({
       onApplyAdvancedFilter: defaultFunction('actions.toolbar.onApplyAdvancedFilter'),
       onChangeAdvancedFilter: defaultFunction('actions.toolbar.onChangeAdvancedFilter'),
       onToggleAdvancedFilter: defaultFunction('actions.toolbar.onToggleAdvancedFilter'),
-      // TODO: removed to mimic the current state of consumers in the wild
-      // since they won't be adding this prop to any of their components
-      // can be readded in V3.
-      // onToggleAggregations: defaultFunction('actions.toolbar.onToggleAggregations'),
+      onToggleAggregations: defaultFunction('actions.toolbar.onToggleAggregations'),
     },
     table: {
       onChangeSort: defaultFunction('actions.table.onChangeSort'),
@@ -631,32 +628,8 @@ const Table = (props) => {
   const getColumnNumbers = (tableData, columnId) =>
     tableData.map((row) => row.values[columnId]).filter((value) => Number.isFinite(value));
 
-  /**
-   * All of this was written incorrectly the first time, and needs to be removed in v3. However,
-   * to maintain backwards compatibility for a minor release the state management is left in
-   * the Table here, and a useEffect is added. If the onToggleAggregations callback is not supplied
-   * by the consumer we manage the aggregations state here in the table, but if it is provided,
-   * we push the management of the aggregations.isHidden prop to the consumer to manage. Once
-   * we move to v3. The useState, useCallback, and useEffects can all be removed and just call
-   * the onToggleAggregations from the actions.toolbar prop.
-   */
-  const [hideAggregations, setHideAggregations] = useState(!options.hasAggregations);
-  const statefulOnToggleAggregations = useCallback(() => setHideAggregations((prev) => !prev), [
-    setHideAggregations,
-  ]);
-
-  useEffect(() => {
-    if (!actions.toolbar.onToggleAggregations) {
-      setHideAggregations(!options.hasAggregations);
-    }
-  }, [actions.toolbar.onToggleAggregations, options.hasAggregations]);
-
-  const onToggleAggregations = actions.toolbar.onToggleAggregations
-    ? actions.toolbar.onToggleAggregations
-    : statefulOnToggleAggregations;
-
   const aggregationsAreHidden =
-    aggregationsProp?.isHidden !== undefined ? aggregationsProp.isHidden : hideAggregations;
+    aggregationsProp?.isHidden !== undefined ? aggregationsProp.isHidden : false;
 
   const aggregations = useMemo(() => {
     return options.hasAggregations && aggregationsProp.columns
@@ -781,7 +754,7 @@ const Table = (props) => {
                 'onRemoveAdvancedFilter',
                 'onToggleAdvancedFilter'
               ),
-              onToggleAggregations,
+              onToggleAggregations: actions.toolbar.onToggleAggregations,
               onApplySearch: (value) => {
                 searchValue.current = value;
                 if (actions.toolbar?.onApplySearch) {

--- a/packages/react/src/components/Table/Table.story.jsx
+++ b/packages/react/src/components/Table/Table.story.jsx
@@ -412,10 +412,7 @@ export const tableActions = {
     onChangeAdvancedFilter: action('onChangeAdvancedFilter'),
     onApplyAdvancedFilter: action('onApplyAdvancedFilter'),
     onToggleAdvancedFilter: action('onToggleAdvancedFilter'),
-    // TODO: removed to mimic the current state of consumers in the wild
-    // since they won't be adding this prop to any of their components
-    // can be readded in V3.
-    // onToggleAggregations: action('onToggleAggregations'),
+    onToggleAggregations: action('onToggleAggregations'),
   },
   table: {
     onRowClicked: action('onRowClicked'),

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -334,6 +334,7 @@ Map {
           "onRemoveAdvancedFilter": [Function],
           "onShowRowEdit": [Function],
           "onToggleAdvancedFilter": [Function],
+          "onToggleAggregations": [Function],
           "onToggleColumnSelection": [Function],
           "onToggleFilter": [Function],
         },


### PR DESCRIPTION
Closes #2434

### Merging into V3

**Summary**

- cleans up the state management of aggregations that was in the basic table.

**Change List (commits, features, bugs, etc)**

- add onToggleAggregations callback to actions/defaults.
- remove all the useEffects, useStates, etc

**Acceptance Test (how to verify the PR)**

- table should no longer automatically manage state for aggregations, but the user should supply the `isHidden` prop to toggle it on/off.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- this is a breaking change for v3.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
