### PR TITLE
fix(date-time-picker): allow selecting ranges across months

### DIFF
--- a/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
@@ -539,20 +539,33 @@ const DateTimePicker = ({
     }
   }, [datePickerElem, focusOnFirstField]);
 
-  const onDatePickerChange = ([start, end]) => {
+  const onDatePickerChange = ([start, end], _, flatpickr) => {
+    if (
+      dayjs(absoluteValue.start).isSame(dayjs(start)) &&
+      dayjs(absoluteValue.end).isSame(dayjs(end))
+    ) {
+      return;
+    }
+
     const newAbsolute = { ...absoluteValue };
+    newAbsolute.start = start;
+    newAbsolute.startDate = dayjs(newAbsolute.start).format('MM/DD/YYYY');
+    const prevFocusOnFirstField = focusOnFirstField;
     if (end) {
       setFocusOnFirstField(!focusOnFirstField);
       newAbsolute.start = start;
       newAbsolute.startDate = dayjs(newAbsolute.start).format('MM/DD/YYYY');
       newAbsolute.end = end;
       newAbsolute.endDate = dayjs(newAbsolute.end).format('MM/DD/YYYY');
+      if (prevFocusOnFirstField) {
+        flatpickr.jumpToDate(newAbsolute.start);
+      } else {
+        flatpickr.jumpToDate(newAbsolute.end);
+      }
     } else {
       setFocusOnFirstField(false);
+      flatpickr.jumpToDate(newAbsolute.start);
     }
-
-    newAbsolute.start = start;
-    newAbsolute.startDate = dayjs(newAbsolute.start).format('MM/DD/YYYY');
 
     setAbsoluteValue(newAbsolute);
   };

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
@@ -722,6 +722,7 @@ describe('DateTimePicker', () => {
       code: 'ArrowDown',
     });
     expect(screen.getByText('Custom Range')).toHaveFocus();
+
     fireEvent.keyUp(screen.getByTestId(`date-time-picker__field`), {
       key: 'Escape',
       code: 'Escape',
@@ -729,5 +730,26 @@ describe('DateTimePicker', () => {
     expect(screen.getByRole('listbox')).not.toHaveClass(
       `${iotPrefix}--date-time-picker__menu-expanded`
     );
+  });
+
+  it('should allow keyboard navigation of absolute/relative types', () => {
+    render(<DateTimePicker {...dateTimePickerProps} id="picker-test" />);
+    userEvent.click(screen.getByTestId('date-time-picker__field'));
+    userEvent.click(screen.getByText('Custom Range'));
+    // relative → absolute
+    userEvent.type(screen.getByLabelText('Relative'), '{arrowright}');
+    expect(screen.getByLabelText('Absolute')).toBeChecked();
+
+    // absolute ← relative
+    userEvent.type(screen.getByLabelText('Absolute'), '{arrowleft}');
+    expect(screen.getByLabelText('Relative')).toBeChecked();
+
+    // relative ↑ absolute
+    userEvent.type(screen.getByLabelText('Relative'), '{arrowup}');
+    expect(screen.getByLabelText('Absolute')).toBeChecked();
+
+    // absolute ↓ relative
+    userEvent.type(screen.getByLabelText('Absolute'), '{arrowdown}');
+    expect(screen.getByLabelText('Relative')).toBeChecked();
   });
 });

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
@@ -684,4 +684,50 @@ describe('DateTimePicker', () => {
     expect(relativeToTime).toBeInvalid();
     expect(applyBytton).toBeDisabled();
   });
+
+  it('should close picker when escape is pressed', () => {
+    render(<DateTimePicker {...dateTimePickerProps} id="picker-test" />);
+    userEvent.click(screen.getByTestId('date-time-picker__field'));
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeVisible();
+    userEvent.click(screen.getByText('Last 6 hours'));
+    fireEvent.keyDown(screen.getByTestId('date-time-picker'), {
+      key: 'Escape',
+      code: 'Escape',
+    });
+    expect(screen.getByRole('listbox')).not.toHaveClass(
+      `${iotPrefix}--date-time-picker__menu-expanded`
+    );
+  });
+
+  it('should select a preset when hitting enter', () => {
+    render(<DateTimePicker {...dateTimePickerProps} id="picker-test" />);
+    userEvent.click(screen.getByTestId('date-time-picker__field'));
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeVisible();
+    const last6HoursLabel = screen.getByText('Last 6 hours');
+    fireEvent.keyDown(last6HoursLabel, {
+      key: 'Enter',
+      code: 'Enter',
+    });
+    expect(last6HoursLabel).toHaveClass(
+      `${iotPrefix}--date-time-picker__listitem--preset-selected`
+    );
+  });
+
+  it('should allow keyboard navigation of presets', () => {
+    render(<DateTimePicker {...dateTimePickerProps} id="picker-test" />);
+    userEvent.click(screen.getByTestId('date-time-picker__field'));
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeVisible();
+    fireEvent.keyUp(screen.getByTestId(`date-time-picker__field`), {
+      key: 'ArrowDown',
+      code: 'ArrowDown',
+    });
+    expect(screen.getByText('Custom Range')).toHaveFocus();
+    fireEvent.keyUp(screen.getByTestId(`date-time-picker__field`), {
+      key: 'Escape',
+      code: 'Escape',
+    });
+    expect(screen.getByRole('listbox')).not.toHaveClass(
+      `${iotPrefix}--date-time-picker__menu-expanded`
+    );
+  });
 });

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
@@ -714,13 +714,57 @@ describe('DateTimePicker', () => {
   });
 
   it('should allow keyboard navigation of presets', () => {
-    render(<DateTimePicker {...dateTimePickerProps} id="picker-test" />);
+    const { container } = render(<DateTimePicker {...dateTimePickerProps} id="picker-test" />);
     userEvent.click(screen.getByTestId('date-time-picker__field'));
     expect(screen.getByRole('button', { name: 'Apply' })).toBeVisible();
     fireEvent.keyUp(screen.getByTestId(`date-time-picker__field`), {
       key: 'ArrowDown',
       code: 'ArrowDown',
     });
+    expect(screen.getByText('Custom Range')).toHaveFocus();
+    fireEvent.keyDown(
+      container.querySelector(`.${iotPrefix}--date-time-picker__menu-scroll > div`),
+      {
+        key: 'ArrowDown',
+        code: 'ArrowDown',
+      }
+    );
+    expect(screen.getByText('Last 30 minutes', { selector: 'li' })).toHaveFocus();
+
+    fireEvent.keyDown(
+      container.querySelector(`.${iotPrefix}--date-time-picker__menu-scroll > div`),
+      {
+        key: 'ArrowUp',
+        code: 'ArrowUp',
+      }
+    );
+    expect(screen.getByText('Custom Range')).toHaveFocus();
+
+    fireEvent.keyDown(
+      container.querySelector(`.${iotPrefix}--date-time-picker__menu-scroll > div`),
+      {
+        key: 'ArrowRight',
+        code: 'ArrowRight',
+      }
+    );
+    expect(screen.getByText('Custom Range')).toHaveFocus();
+
+    fireEvent.keyDown(
+      container.querySelector(`.${iotPrefix}--date-time-picker__menu-scroll > div`),
+      {
+        key: 'ArrowUp',
+        code: 'ArrowUp',
+      }
+    );
+    expect(screen.getByText('Last 24 hours')).toHaveFocus();
+
+    fireEvent.keyDown(
+      container.querySelector(`.${iotPrefix}--date-time-picker__menu-scroll > div`),
+      {
+        key: 'ArrowDown',
+        code: 'ArrowDown',
+      }
+    );
     expect(screen.getByText('Custom Range')).toHaveFocus();
 
     fireEvent.keyUp(screen.getByTestId(`date-time-picker__field`), {

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
@@ -397,18 +397,33 @@ const DateTimePicker = ({
     }
   }, [datePickerElem, focusOnFirstField]);
 
-  const onDatePickerChange = ([start, end]) => {
+  const onDatePickerChange = ([start, end], _, flatpickr) => {
+    if (
+      dayjs(absoluteValue.start).isSame(dayjs(start)) &&
+      dayjs(absoluteValue.end).isSame(dayjs(end))
+    ) {
+      return;
+    }
+
     const newAbsolute = { ...absoluteValue };
+    newAbsolute.start = start;
+    newAbsolute.startDate = dayjs(newAbsolute.start).format('MM/DD/YYYY');
+    const prevFocusOnFirstField = focusOnFirstField;
     if (end) {
       setFocusOnFirstField(!focusOnFirstField);
       newAbsolute.start = start;
       newAbsolute.startDate = dayjs(newAbsolute.start).format('MM/DD/YYYY');
       newAbsolute.end = end;
       newAbsolute.endDate = dayjs(newAbsolute.end).format('MM/DD/YYYY');
+      if (prevFocusOnFirstField) {
+        flatpickr.jumpToDate(newAbsolute.start, true);
+      } else {
+        flatpickr.jumpToDate(newAbsolute.end, true);
+      }
+    } else {
+      setFocusOnFirstField(false);
+      flatpickr.jumpToDate(newAbsolute.start, true);
     }
-
-    newAbsolute.start = start;
-    newAbsolute.startDate = dayjs(newAbsolute.start).format('MM/DD/YYYY');
 
     setAbsoluteValue(newAbsolute);
   };

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
@@ -398,10 +398,28 @@ const DateTimePicker = ({
   }, [datePickerElem, focusOnFirstField]);
 
   const onDatePickerChange = ([start, end], _, flatpickr) => {
-    if (
+    const calendarInFocus = document?.activeElement?.closest(
+      `.${iotPrefix}--date-time-picker__datepicker`
+    );
+
+    const daysDidntChange =
       dayjs(absoluteValue.start).isSame(dayjs(start)) &&
-      dayjs(absoluteValue.end).isSame(dayjs(end))
-    ) {
+      dayjs(absoluteValue.end).isSame(dayjs(end));
+
+    if (daysDidntChange || !calendarInFocus) {
+      // jump back to start to fix bug where flatpickr will change the month to the start
+      // after it loses focus if you click outside the calendar
+      if (focusOnFirstField) {
+        flatpickr.jumpToDate(start);
+      } else {
+        flatpickr.jumpToDate(end);
+      }
+
+      // In some situations, when the calendar loses focus flatpickr is firing the onChange event
+      // again, but the dates reset to where both start and end are the same. This fixes that.
+      if (!calendarInFocus && dayjs(start).isSame(dayjs(end))) {
+        flatpickr.setDate([absoluteValue.start, absoluteValue.end]);
+      }
       return;
     }
 


### PR DESCRIPTION
Closes #3007 

**Summary**

- Fixes an issue where changing the month in the DateTimePicker when picking an absolute range would cause it to not show the correct month and lead to a confusing experience.

**Change List (commits, features, bugs, etc)**

- added checks to call flatpickr's `jumpToDate` function when selecting dates
- added tests to confirm for both DateTimePicker and DateTimePickerV2

**Acceptance Test (how to verify the PR)**

- go to https://deploy-preview-3015--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-datetime-picker--default
- Click "Last 30 minutes"
- Click "Custom Range"
- Click "Absolute"
- Click "Back arrow" to go back to a previous month
- Choose a date -- The month should still be the same month you were in...
- Click "Forward arrow" to go forward to a more recent month
- Choose a date -- The month should still be the same month you navigated to.
- Click "Apply"
- The chosen range should match what you entered
- Repeat with [DateTimePickerV2](https://deploy-preview-3015--carbon-addons-iot-react.netlify.app/?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-datetimepickerv2--default)

**Regression Test (how to make sure this PR doesn't break old functionality)**

- double check DateTimePicker and DateTimePickerV2 for adverse affects related to absolute ranges

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
