### PR TITLE
fix(stateful-table): update reducer for rowEdit actions

### DIFF
--- a/packages/react/src/components/Table/Table.story.jsx
+++ b/packages/react/src/components/Table/Table.story.jsx
@@ -1327,6 +1327,8 @@ TableExampleWithCreateSaveViews.parameters = {
 };
 
 export const BasicTableWithFullRowEditExample = () => {
+  const selectedTableType = select('Type of Table', ['Table', 'StatefulTable'], 'Table');
+  const MyTable = selectedTableType === 'StatefulTable' ? StatefulTable : Table;
   const [showRowEditBar, setShowRowEditBar] = useState(false);
   const startingData = tableData.map((i) => ({
     ...i,
@@ -1363,12 +1365,17 @@ export const BasicTableWithFullRowEditExample = () => {
     setRowActionsState([]);
   };
   const onSaveRowEdit = () => {
-    setShowToast(true);
-    setPreviousData(currentData);
-    setCurrentData(rowEditedData);
-    setRowEditedData([]);
-    setShowRowEditBar(false);
-    setRowActionsState([]);
+    // because of the nature of rendering these buttons dynamically (and asyncronously via dispatch)
+    // in the StatefulTable we need to wrap these calls inside the setRowEditedData callback to ensure
+    // we're always working with the correctly updated data.
+    setRowEditedData((prev) => {
+      setShowToast(true);
+      setPreviousData(currentData);
+      setCurrentData(prev);
+      setShowRowEditBar(false);
+      setRowActionsState([]);
+      return [];
+    });
   };
   const onUndoRowEdit = () => {
     setCurrentData(previousData);
@@ -1458,7 +1465,7 @@ export const BasicTableWithFullRowEditExample = () => {
   return (
     <div>
       {showToast ? myToast : null}
-      <Table
+      <MyTable
         id="table"
         secondaryTitle="My editable table"
         size={select(

--- a/packages/react/src/components/Table/tableReducer.js
+++ b/packages/react/src/components/Table/tableReducer.js
@@ -525,6 +525,20 @@ export const tableReducer = (state = {}, action) => {
       const selectedAdvancedFilters = advancedFilters.filter((advFilter) =>
         selectedAdvancedFilterIds.includes(advFilter.filterId)
       );
+
+      const rowActionsFromState = get(state, 'view.table.rowActions', []);
+      const rowActionsFromProps = view?.table?.rowActions ?? [];
+      const rowActions = rowActionsFromState
+        // filter actions from state that have been removed from props
+        .filter(({ rowId }) => rowActionsFromProps.some((row) => row.rowId === rowId))
+        .concat(
+          // add actions from props that aren't in state
+          rowActionsFromProps.filter(({ rowId }) =>
+            rowActionsFromState.every((row) => row.rowId !== rowId)
+          )
+        );
+
+      const activeBar = view?.toolbar?.activeBar;
       return update(state, {
         data: {
           $set: updatedData,
@@ -537,6 +551,9 @@ export const tableReducer = (state = {}, action) => {
           toolbar: {
             initialDefaultSearch: { $set: initialDefaultSearch },
             search: { $set: searchFromState },
+            activeBar: {
+              $set: activeBar,
+            },
           },
           table: {
             ordering: { $set: ordering },
@@ -556,6 +573,9 @@ export const tableReducer = (state = {}, action) => {
                 rowCount: get(state, 'view.table.loadingState.rowCount') || 0,
                 columnCount: get(state, 'view.table.loadingState.columnCount') || 0,
               },
+            },
+            rowActions: {
+              $set: rowActions,
             },
             // Reset the selection to the previous values
             selectedIds: {

--- a/packages/react/src/components/Table/tableReducer.test.jsx
+++ b/packages/react/src/components/Table/tableReducer.test.jsx
@@ -550,6 +550,92 @@ describe('table reducer', () => {
       );
 
       expect(tableWithLoadingMoreDataComplete.view.table.loadingMoreIds).toHaveLength(2);
+
+      const addTableRowActionsFromProps = tableReducer(
+        initialState,
+        tableRegister({
+          view: {
+            table: { rowActions: [{ rowId: 'row-0', isEditMode: true }] },
+            toolbar: { activeBar: 'rowEdit' },
+          },
+        })
+      );
+
+      expect(addTableRowActionsFromProps.view.table.rowActions).toHaveLength(1);
+      expect(addTableRowActionsFromProps.view.table.rowActions).toEqual([
+        {
+          rowId: 'row-0',
+          isEditMode: true,
+        },
+      ]);
+      expect(addTableRowActionsFromProps.view.toolbar.activeBar).toEqual('rowEdit');
+
+      const addSecondTableRowActionsFromProps = tableReducer(
+        addTableRowActionsFromProps,
+        tableRegister({
+          view: {
+            table: {
+              rowActions: [
+                { rowId: 'row-0', isEditMode: true },
+                { rowId: 'row-1', isEditMode: true },
+              ],
+            },
+            toolbar: { activeBar: 'rowEdit' },
+          },
+        })
+      );
+
+      expect(addSecondTableRowActionsFromProps.view.table.rowActions).toHaveLength(2);
+      expect(addSecondTableRowActionsFromProps.view.table.rowActions).toEqual([
+        {
+          rowId: 'row-0',
+          isEditMode: true,
+        },
+        {
+          rowId: 'row-1',
+          isEditMode: true,
+        },
+      ]);
+      expect(addSecondTableRowActionsFromProps.view.toolbar.activeBar).toEqual('rowEdit');
+
+      const removeOneTableRowActionsFromProps = tableReducer(
+        addTableRowActionsFromProps,
+        tableRegister({
+          view: {
+            table: {
+              rowActions: [{ rowId: 'row-1', isEditMode: true }],
+            },
+            toolbar: { activeBar: 'rowEdit' },
+          },
+        })
+      );
+
+      expect(removeOneTableRowActionsFromProps.view.table.rowActions).toHaveLength(1);
+      expect(removeOneTableRowActionsFromProps.view.table.rowActions).toEqual([
+        {
+          rowId: 'row-1',
+          isEditMode: true,
+        },
+      ]);
+      expect(removeOneTableRowActionsFromProps.view.toolbar.activeBar).toEqual('rowEdit');
+
+      const turnOffRowEditActiveBar = tableReducer(
+        removeOneTableRowActionsFromProps,
+        tableRegister({
+          view: {
+            toolbar: {
+              activeBar: undefined,
+            },
+            table: {
+              rowActions: [],
+            },
+          },
+        })
+      );
+
+      expect(turnOffRowEditActiveBar.view.table.rowActions).toHaveLength(0);
+      expect(turnOffRowEditActiveBar.view.table.rowActions).toEqual([]);
+      expect(turnOffRowEditActiveBar.view.toolbar.activeBar).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Closes #2985 

**Summary**

- updates the reducer for the StatefulTable to properly handle changes to rowActions or activeBar.

**Change List (commits, features, bugs, etc)**

- update rowEdit example story to be able to choose StatefulTable
- fix StatefulTable reducer to handle changes to rowActions
- add tests to confirm

**Acceptance Test (how to verify the PR)**

- go to [Table with full rowEdit example story](https://deploy-preview-3018--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table-table--basic-table-with-full-row-edit-example)
- change to StatefulTable
- edit various single rows and save and/or cancel
- rows should flip from editable to normal state
- data should be updated correctly on save
- repeat using the full table edit button in the top toolbar

**Regression Test (how to make sure this PR doesn't break old functionality)**

- ensure other row actions aren't effected in other stories

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
