### PR TITLE
fix(list-story): fix clearing search in story

### DIFF
--- a/packages/react/src/components/List/List.story.jsx
+++ b/packages/react/src/components/List/List.story.jsx
@@ -158,8 +158,7 @@ export const BasicSingleColumnWithSearch = () => {
               content: { value: key },
             }))
             .filter(
-              ({ id }) =>
-                searchValue === null || id.toLowerCase().includes(searchValue?.toLowerCase())
+              ({ id }) => !searchValue || id.toLowerCase().includes(searchValue?.toLowerCase())
             )}
           isLoading={boolean('isLoading', false)}
           search={{


### PR DESCRIPTION
Closes #2949 

**Summary**

- fixes the clear search `x` by properly checking the state of the value returned in the onChange handler. Since the `List` is stateless, this is just an error in the story not an issue with the component.

**Change List (commits, features, bugs, etc)**

- fix story

**Acceptance Test (how to verify the PR)**

- Go to [list with search story](https://deploy-preview-3019--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-list--basic-single-column-with-search)
- type `a`
- click `x` to clear search
- ensure list resets

**Regression Test (how to make sure this PR doesn't break old functionality)**

- n/a

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
