### PR TITLE
chore(table): remove isSortable prop where inappropriate

### DIFF
--- a/packages/react/src/components/Table/StatefulTable.test.jsx
+++ b/packages/react/src/components/Table/StatefulTable.test.jsx
@@ -190,7 +190,6 @@ describe('stateful table with real reducer', () => {
         }}
         secondaryTitle={`Row count: ${initialState.data.length}`}
         actions={mockActions}
-        isSortable
         options={{
           ...initialState.options,
           hasFilter: 'onKeyPress',
@@ -284,7 +283,6 @@ describe('stateful table with real reducer', () => {
         }}
         secondaryTitle={`Row count: ${initialState.data.length}`}
         actions={mockActions}
-        isSortable
         options={{
           ...initialState.options,
           hasFilter: 'onKeyPress',

--- a/packages/react/src/components/Table/Table.story.jsx
+++ b/packages/react/src/components/Table/Table.story.jsx
@@ -1283,7 +1283,6 @@ export const TableExampleWithCreateSaveViews = () => {
             },
           },
         }}
-        isSortable
         options={{
           ...baseState.options,
           hasResize: true,

--- a/packages/react/src/components/Table/Table.test.jsx
+++ b/packages/react/src/components/Table/Table.test.jsx
@@ -953,9 +953,7 @@ describe('Table', () => {
       },
     };
 
-    const { rerender } = render(
-      <Table {...initialState} {...additionalProps} isSortable i18n={i18nTest} />
-    );
+    const { rerender } = render(<Table {...initialState} {...additionalProps} i18n={i18nTest} />);
 
     expect(screen.getAllByLabelText(i18nTest.overflowMenuAria)[0]).toBeInTheDocument();
     expect(screen.getAllByLabelText(i18nTest.clickToExpandAria)[0]).toBeInTheDocument();
@@ -1067,7 +1065,7 @@ describe('Table', () => {
       },
     };
 
-    const { rerender } = render(<Table {...initialState} {...additionalProps} isSortable />);
+    const { rerender } = render(<Table {...initialState} {...additionalProps} />);
 
     expect(screen.getByText(i18nDefault.itemsSelected(2))).toBeInTheDocument();
     expect(screen.getByText(i18nDefault.pageRange(1, 10))).toBeInTheDocument();
@@ -1075,7 +1073,7 @@ describe('Table', () => {
     expect(screen.getByText(i18nDefault.rowCountInHeader(100))).toBeInTheDocument();
 
     additionalProps.view.table.selectedIds = ['row-1'];
-    rerender(<Table {...initialState} {...additionalProps} isSortable />);
+    rerender(<Table {...initialState} {...additionalProps} />);
     expect(screen.getByText(i18nDefault.itemSelected(1))).toBeInTheDocument();
   });
 
@@ -1102,7 +1100,7 @@ describe('Table', () => {
     };
 
     const { rerender } = render(
-      <Table {...initialState} {...additionalProps} isSortable i18n={i18nFunctions} />
+      <Table {...initialState} {...additionalProps} i18n={i18nFunctions} />
     );
     expect(screen.getByText(i18nFunctions.itemsSelected(2))).toBeInTheDocument();
     expect(screen.getByText(i18nFunctions.pageRange(1, 10))).toBeInTheDocument();
@@ -1110,7 +1108,7 @@ describe('Table', () => {
     expect(screen.getByText(i18nFunctions.rowCountInHeader(100))).toBeInTheDocument();
 
     additionalProps.view.table.selectedIds = ['row-1'];
-    rerender(<Table {...initialState} {...additionalProps} isSortable i18n={i18nFunctions} />);
+    rerender(<Table {...initialState} {...additionalProps} i18n={i18nFunctions} />);
     expect(screen.getByText(i18nFunctions.itemSelected(1))).toBeInTheDocument();
   });
 

--- a/packages/react/src/components/Table/__snapshots__/Table.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/Table.story.storyshot
@@ -29196,7 +29196,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           className="bx--data-table-content"
         >
           <table
-            className="bx--data-table iot--data-table--resize iot--data-table--fixed iot--data-table--row-actions bx--data-table--lg bx--data-table--sort bx--data-table--no-border"
+            className="bx--data-table iot--data-table--resize iot--data-table--fixed iot--data-table--row-actions bx--data-table--lg bx--data-table--no-border"
             data-testid="table"
             id="table"
             title={null}


### PR DESCRIPTION
Closes #2962 

**Summary**

- removes extraneous uses of isSortable in stories/tests where not appropriate.

**Change List (commits, features, bugs, etc)**

- updated stories, tests, snapshots

**Acceptance Test (how to verify the PR)**

- isSortable should not appear as knobs in stories
- or in tests except where necessary

**Regression Test (how to make sure this PR doesn't break old functionality)**

- n/a

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
