### PR TITLE
fix(stateful-table): handle resetting pagination when necessary

### DIFF
--- a/packages/react/src/components/Table/StatefulTable.story.jsx
+++ b/packages/react/src/components/Table/StatefulTable.story.jsx
@@ -157,6 +157,14 @@ export const SimpleStatefulExample = () => {
       id="table"
       key={`table${demoInitialColumnSizes}`}
       {...initialState}
+      data={initialState.data.slice(
+        0,
+        select(
+          'number of data items in table',
+          [initialState.data.length, 50, 20, 5],
+          initialState.data.length
+        )
+      )}
       actions={tableActions}
       columns={initialState.columns
         .map((column) => {

--- a/packages/react/src/components/Table/tableReducer.js
+++ b/packages/react/src/components/Table/tableReducer.js
@@ -493,7 +493,7 @@ export const tableReducer = (state = {}, action) => {
         }) ?? [];
 
       const { view, totalItems, hasUserViewManagement } = action.payload;
-      const { pageSize, pageSizes } = get(view, 'pagination') || {};
+      const { pageSize, pageSizes, page } = get(view, 'pagination') || {};
       const paginationFromState = get(state, 'view.pagination');
       const initialDefaultSearch =
         get(view, 'toolbar.search.defaultValue') || get(view, 'toolbar.search.value');
@@ -513,14 +513,13 @@ export const tableReducer = (state = {}, action) => {
 
       const nextPageSize = paginationFromState.pageSize || pageSize;
       const nextTotalItems = totalItems || updatedData.length;
-      const currentPage = get(state, 'view.pagination.page');
-
+      const nextPage = page || 1;
       const pagination = get(state, 'view.pagination')
         ? {
             totalItems: { $set: nextTotalItems },
             pageSize: { $set: nextPageSize },
             pageSizes: { $set: pageSizes },
-            page: { $set: nextPageSize * currentPage > nextTotalItems ? 1 : currentPage },
+            page: { $set: nextPage },
           }
         : {};
 

--- a/packages/react/src/components/Table/tableReducer.js
+++ b/packages/react/src/components/Table/tableReducer.js
@@ -511,11 +511,16 @@ export const tableReducer = (state = {}, action) => {
         ? searchFromState?.defaultValue
         : searchFromState?.value;
 
+      const nextPageSize = paginationFromState.pageSize || pageSize;
+      const nextTotalItems = totalItems || updatedData.length;
+      const currentPage = get(state, 'view.pagination.page');
+
       const pagination = get(state, 'view.pagination')
         ? {
-            totalItems: { $set: totalItems || updatedData.length },
-            pageSize: { $set: paginationFromState.pageSize || pageSize },
+            totalItems: { $set: nextTotalItems },
+            pageSize: { $set: nextPageSize },
             pageSizes: { $set: pageSizes },
+            page: { $set: nextPageSize * currentPage > nextTotalItems ? 1 : currentPage },
           }
         : {};
 

--- a/packages/react/src/components/Table/tableReducer.test.jsx
+++ b/packages/react/src/components/Table/tableReducer.test.jsx
@@ -448,6 +448,7 @@ describe('table reducer', () => {
 
       expect(tableWithDataSizeChanges.view.pagination).toEqual({
         pageSize: 10,
+        pageSizes: undefined,
         page: 1,
         totalItems: 100,
       });
@@ -483,7 +484,8 @@ describe('table reducer', () => {
       expect(increaseDataLength.data.length).toEqual(100);
       expect(increaseDataLength.view.pagination).toEqual({
         pageSize: 3,
-        page: 3,
+        page: 1,
+        pageSizes: undefined,
         totalItems: 100,
       });
 

--- a/packages/react/src/components/Table/tableReducer.test.jsx
+++ b/packages/react/src/components/Table/tableReducer.test.jsx
@@ -441,6 +441,52 @@ describe('table reducer', () => {
       expect(newTableSingleWithExpandedRow.view.table.expandedIds).toEqual(['row-2']);
     });
     it('REGISTER_TABLE', () => {
+      const tableWithDataSizeChanges = tableReducer(
+        initialState,
+        tableRegister({ view: { table: { pagination: { pageSize: 10 } } } })
+      );
+
+      expect(tableWithDataSizeChanges.view.pagination).toEqual({
+        pageSize: 10,
+        page: 1,
+        totalItems: 100,
+      });
+      const changePagesState = tableReducer(
+        tableWithDataSizeChanges,
+        tablePageChange({ page: 3, pageSize: 10 })
+      );
+      expect(changePagesState.data.length).toEqual(100);
+      expect(changePagesState.view.pagination.page).toEqual(3);
+
+      const reduceDataLength = tableReducer(
+        changePagesState,
+        tableRegister({ data: changePagesState.data.slice(0, 10) })
+      );
+      expect(reduceDataLength.data.length).toEqual(10);
+      expect(reduceDataLength.view.pagination.page).toEqual(1);
+
+      const changePageSizeState = tableReducer(reduceDataLength, tablePageChange({ pageSize: 3 }));
+      expect(changePageSizeState.data.length).toEqual(10);
+      expect(changePageSizeState.view.pagination.page).toEqual(1);
+
+      const movePageState = tableReducer(
+        changePageSizeState,
+        tablePageChange({ page: 3, pageSize: 3 })
+      );
+      expect(movePageState.data.length).toEqual(10);
+      expect(movePageState.view.pagination.page).toEqual(3);
+
+      const increaseDataLength = tableReducer(
+        movePageState,
+        tableRegister({ data: changePagesState.data })
+      );
+      expect(increaseDataLength.data.length).toEqual(100);
+      expect(increaseDataLength.view.pagination).toEqual({
+        pageSize: 3,
+        page: 3,
+        totalItems: 100,
+      });
+
       // Data should be filtered once table registers
       expect(initialState.view.table.filteredData).toBeUndefined();
       const tableWithFilteredData = tableReducer(


### PR DESCRIPTION
Closes #2971 

**Summary**

- Fixes the StatefulTable reducer to update the current page in situations where the number of data items is less than what the currently selected page is able to display

**Change List (commits, features, bugs, etc)**

- add knob to stateful table example story to display `n` number of items
- update reducer to check current page against number of items and pageSize
- add tests to confirm

**Acceptance Test (how to verify the PR)**

- on the [StatefulTable example story](https://deploy-preview-3022--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table-statefultable--simple-stateful-example)
- turn on pagination
- change to page 3
- change number of items to 5
- check that page reset to page 1
- repeat with various combinations of pageSize, page, and number of items

**Regression Test (how to make sure this PR doesn't break old functionality)**

- check other pagination related StatefulTable stories for errors.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
