### PR TITLE
fix(list): fix styles to keep secondaryValue aligned when overflowing

### DIFF
--- a/packages/react/src/components/List/HierarchyList/HierarchyList.story.jsx
+++ b/packages/react/src/components/List/HierarchyList/HierarchyList.story.jsx
@@ -471,9 +471,14 @@ export const WithLargeNumberOfItems = () => (
       items={[...Array(1000)].map((_, i) => ({
         id: `item-${i}`,
         content: {
-          value: i === 20 ? `Item ${i} `.repeat(i + 1 * 10) : `Item ${i}`,
+          value:
+            i === 20
+              ? `Item ${i} that has an extra long label that will definitely be truncated`
+              : `Item ${i}`,
           secondaryValue:
-            i === 10 ? `Item ${i} Subvalue `.repeat(i + 1 * 10) : `Item ${i} Subvalue`,
+            i === 10
+              ? `Item ${i} that has an extra long label that will definitely be truncated`
+              : `Item ${i} Subvalue`,
         },
       }))}
       editingStyle={EditingStyle.Single}

--- a/packages/react/src/components/List/HierarchyList/HierarchyList.story.jsx
+++ b/packages/react/src/components/List/HierarchyList/HierarchyList.story.jsx
@@ -471,7 +471,9 @@ export const WithLargeNumberOfItems = () => (
       items={[...Array(1000)].map((_, i) => ({
         id: `item-${i}`,
         content: {
-          value: `Item ${i}`,
+          value: i === 20 ? `Item ${i} `.repeat(i + 1 * 10) : `Item ${i}`,
+          secondaryValue:
+            i === 10 ? `Item ${i} Subvalue `.repeat(i + 1 * 10) : `Item ${i} Subvalue`,
         },
       }))}
       editingStyle={EditingStyle.Single}

--- a/packages/react/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
+++ b/packages/react/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
@@ -7007,7 +7007,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                   onChange={[Function]}
                   tabIndex={0}
                   type="radio"
-                  value="Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 "
+                  value="Item 20 that has an extra long label that will definitely be truncated"
                 />
                 <label
                   className="bx--radio-button__label"
@@ -7019,7 +7019,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                   <span
                     className="bx--visually-hidden"
                   >
-                    Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 
+                    Item 20 that has an extra long label that will definitely be truncated
                   </span>
                 </label>
               </div>
@@ -7033,7 +7033,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                 <div
                   className="iot--hierarchy-list-bulk-modal--list-item-value"
                 >
-                  Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 
+                  Item 20 that has an extra long label that will definitely be truncated
                 </div>
               </div>
             </div>

--- a/packages/react/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
+++ b/packages/react/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
@@ -7007,7 +7007,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                   onChange={[Function]}
                   tabIndex={0}
                   type="radio"
-                  value="Item 20"
+                  value="Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 "
                 />
                 <label
                   className="bx--radio-button__label"
@@ -7019,7 +7019,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                   <span
                     className="bx--visually-hidden"
                   >
-                    Item 20
+                    Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 
                   </span>
                 </label>
               </div>
@@ -7033,7 +7033,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                 <div
                   className="iot--hierarchy-list-bulk-modal--list-item-value"
                 >
-                  Item 20
+                  Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 Item 20 
                 </div>
               </div>
             </div>
@@ -50334,6 +50334,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                       >
                         Item 0
                       </div>
+                      <div
+                        className="iot--list-item--content--values--value"
+                        title="Item 0 Subvalue"
+                      >
+                        Item 0 Subvalue
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -50400,6 +50406,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                       >
                         Item 1
                       </div>
+                      <div
+                        className="iot--list-item--content--values--value"
+                        title="Item 1 Subvalue"
+                      >
+                        Item 1 Subvalue
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -50465,6 +50477,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/H
                         title="Item 2"
                       >
                         Item 2
+                      </div>
+                      <div
+                        className="iot--list-item--content--values--value"
+                        title="Item 2 Subvalue"
+                      >
+                        Item 2 Subvalue
                       </div>
                     </div>
                   </div>

--- a/packages/react/src/components/List/ListItem/_list-item.scss
+++ b/packages/react/src/components/List/ListItem/_list-item.scss
@@ -160,6 +160,7 @@
     width: 100%;
     height: 100%;
     align-items: center;
+    min-width: 0;
     &__large {
       align-items: flex-start;
     }
@@ -190,7 +191,6 @@
       }
       &--value {
         flex: 1;
-
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;


### PR DESCRIPTION
Closes #2939 

**Summary**

- small style fix to prevent the flexbox from creeping up in size and causing the secondaryValue to be out of alignment

**Change List (commits, features, bugs, etc)**

- add min-width to css

**Acceptance Test (how to verify the PR)**

- in the [HierarchyList with large number of items story](https://deploy-preview-3024--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-hierarchylist--with-large-number-of-items)
- item 10 secondary value should be aligned and overflow with ellipsis
- item 20 primary value should be aligned and overflow with ellipsis

**Regression Test (how to make sure this PR doesn't break old functionality)**

- scan List stories to make sure it doesn't cause adverse effects

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
