### PR TITLE
fix(table): don't display native title when using tooltip in header

### DIFF
--- a/packages/react/src/components/Table/StatefulTable.story.jsx
+++ b/packages/react/src/components/Table/StatefulTable.story.jsx
@@ -174,7 +174,11 @@ export const SimpleStatefulExample = () => {
         .map((col, i) => ({
           ...col,
           width: demoInitialColumnSizes ? (i % 2 === 0 ? '100px' : '200px') : undefined,
-          tooltip: demoColumnTooltips ? `A tooltip for ${col.name} here` : undefined,
+          tooltip: demoColumnTooltips
+            ? col.id === 'select'
+              ? `This tooltip displays extra information about the select box. You can choose from a variety of options. Pick one today!`
+              : `A tooltip for ${col.name} here`
+            : undefined,
         }))}
       columnGroups={object('Column groups definition (columnGroups)', [
         {

--- a/packages/react/src/components/Table/TableCellRenderer/TableCellRenderer.jsx
+++ b/packages/react/src/components/Table/TableCellRenderer/TableCellRenderer.jsx
@@ -131,7 +131,9 @@ const TableCellRenderer = ({
     <span
       className={myClasses}
       title={
-        typeof children === 'number' && locale
+        useTooltip || tooltip
+          ? undefined
+          : typeof children === 'number' && locale
           ? children.toLocaleString(locale, { maximumFractionDigits: 20 })
           : children
       }
@@ -142,7 +144,7 @@ const TableCellRenderer = ({
         : children}
     </span>
   ) : typeof children === 'boolean' ? ( // handle booleans
-    <span className={myClasses} title={children.toString()}>
+    <span className={myClasses} title={useTooltip || tooltip ? undefined : children.toString()}>
       {children.toString()}
     </span>
   ) : typeof children === 'object' && !React.isValidElement(children) ? null : (

--- a/packages/react/src/components/Table/TableCellRenderer/TableCellRenderer.test.jsx
+++ b/packages/react/src/components/Table/TableCellRenderer/TableCellRenderer.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { settings } from '../../../constants/Settings';
 
@@ -114,7 +114,7 @@ describe('TableCellRenderer', () => {
     setOffsetWidth(10);
     setScrollWidth(20);
 
-    const { container } = render(
+    const { container, rerender } = render(
       <TableCellRenderer wrapText="never" truncateCellText>
         {cellText}
       </TableCellRenderer>
@@ -125,14 +125,14 @@ describe('TableCellRenderer', () => {
 
     setOffsetWidth(20);
     setScrollWidth(10);
-    const wrapper2 = mount(
+    rerender(
       <TableCellRenderer wrapText="never" truncateCellText>
         {cellText}
       </TableCellRenderer>
     );
-    expect(wrapper2.find(`.${prefix}--tooltip__label`)).toHaveLength(0);
-    expect(wrapper2.find(`.${iotPrefix}--table__cell-text--truncate`)).toHaveLength(1);
-    expect(wrapper2.find(`.${iotPrefix}--table__cell-text--no-wrap`)).toHaveLength(1);
+    expect(container.querySelectorAll(`.${prefix}--tooltip__label`)).toHaveLength(0);
+    expect(container.querySelectorAll(`.${iotPrefix}--table__cell-text--truncate`)).toHaveLength(1);
+    expect(container.querySelectorAll(`.${iotPrefix}--table__cell-text--no-wrap`)).toHaveLength(1);
 
     setOffsetWidth(0);
     setScrollWidth(0);
@@ -261,6 +261,54 @@ describe('TableCellRenderer', () => {
       expect(console.error).not.toHaveBeenCalled();
       expect(renderDataFunction).toHaveBeenCalled();
       expect(screen.getByText('124556')).toBeDefined();
+    });
+
+    it('should render a tooltip and display it on focus when one is given', () => {
+      render(
+        <TableCellRenderer
+          wrapText="never"
+          truncateCellText
+          locale="en"
+          tooltip="This is a test tooltip"
+        >
+          Select
+        </TableCellRenderer>
+      );
+
+      expect(screen.getByText('Select')).toBeVisible();
+      expect(screen.getByRole('tooltip')).toBeDefined();
+      expect(screen.getByRole('button', { name: 'Select' })).not.toHaveClass(
+        `${prefix}--tooltip--visible`
+      );
+      expect(document.body).toHaveFocus();
+      userEvent.tab();
+      expect(screen.getByRole('button', { name: 'Select' })).toHaveFocus();
+      expect(screen.getByRole('button', { name: 'Select' })).toHaveClass(
+        `${prefix}--tooltip--visible`
+      );
+    });
+
+    it('should render a tooltip and display it on hover when one is given', () => {
+      render(
+        <TableCellRenderer
+          wrapText="never"
+          truncateCellText
+          locale="en"
+          tooltip="This is a test tooltip"
+        >
+          Select
+        </TableCellRenderer>
+      );
+
+      expect(screen.getByText('Select')).toBeVisible();
+      expect(screen.getByRole('tooltip')).toBeDefined();
+      expect(screen.getByRole('button', { name: 'Select' })).not.toHaveClass(
+        `${prefix}--tooltip--visible`
+      );
+      userEvent.hover(screen.getByText('Select'));
+      expect(screen.getByRole('button', { name: 'Select' })).toHaveClass(
+        `${prefix}--tooltip--visible`
+      );
     });
   });
 });

--- a/packages/react/src/components/Table/__snapshots__/StatefulTable.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/StatefulTable.story.storyshot
@@ -21484,7 +21484,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     >
                       <span
                         className=""
-                        title="Select"
                       >
                         Select
                       </span>


### PR DESCRIPTION
Closes #2937 

**Summary**

- We had previously added definition tooltips to column headers, but there was a minor issue of the native browser title appearing on hover. This fixes that and adds some test cases.

**Change List (commits, features, bugs, etc)**

- set `title` prop to undefined when using tooltips in column headers
- add test cases
- remove old enzyme test
- add long text block example to Stateful example story

**Acceptance Test (how to verify the PR)**

- ensure native browser tooltip doesn't appear when hovering over a tooltip title in column headers

**Regression Test (how to make sure this PR doesn't break old functionality)**

- ensure titles still work without tooltips
- tooltips still function as expected

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
