### PR TITLE
feat(table): focus on first filterable column when filter row opened

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.jsx
+++ b/packages/react/src/components/ComboBox/ComboBox.jsx
@@ -52,232 +52,237 @@ const defaultProps = {
   horizontalDirection: 'end',
 };
 
-const ComboBox = ({
-  loading,
-  wrapperClassName,
-  closeButtonText,
-  editOptionText,
-  hasMultiValue,
-  onChange,
-  items,
-  className,
-  disabled,
-  id,
-  itemToString,
-  size,
-  onInputChange,
-  addToList,
-  helperText,
-  shouldFilterItem,
-  onBlur,
-  testId,
-  menuFitContent,
-  horizontalDirection,
-  ...rest
-}) => {
-  // Ref for the combobox input
-  const comboRef = React.createRef();
-  // Input value that is added to list
-  const [inputValue, setInputValue] = useState('');
-  // Array that populates list
-  const [listItems, setListItems] = useState(items);
-  // Array that populates tags
-  const [tagItems, setTagItems] = useState([]);
-  // Array that populates tags
-  const prevTagAndListCount = useRef(items.length + tagItems.length);
+const ComboBox = React.forwardRef(
+  (
+    {
+      loading,
+      wrapperClassName,
+      closeButtonText,
+      editOptionText,
+      hasMultiValue,
+      onChange,
+      items,
+      className,
+      disabled,
+      id,
+      itemToString,
+      size,
+      onInputChange,
+      addToList,
+      helperText,
+      shouldFilterItem,
+      onBlur,
+      testId,
+      menuFitContent,
+      horizontalDirection,
+      ...rest
+    },
+    ref
+  ) => {
+    // Ref for the combobox input
+    const comboRef = ref || React.createRef();
+    // Input value that is added to list
+    const [inputValue, setInputValue] = useState('');
+    // Array that populates list
+    const [listItems, setListItems] = useState(items);
+    // Array that populates tags
+    const [tagItems, setTagItems] = useState([]);
+    // Array that populates tags
+    const prevTagAndListCount = useRef(items.length + tagItems.length);
 
-  // Handle focus after adding new tags or list items
-  useEffect(() => {
-    const currentTagAndListCount = tagItems.length + listItems.length;
+    // Handle focus after adding new tags or list items
+    useEffect(() => {
+      const currentTagAndListCount = tagItems.length + listItems.length;
 
-    // only focus input if the tags or list have increased
-    if (prevTagAndListCount.current < currentTagAndListCount) {
-      comboRef.current.focus();
-    }
-
-    // Store the value for the next render
-    prevTagAndListCount.current = currentTagAndListCount;
-  }, [tagItems, listItems, comboRef]);
-
-  /**
-   * List to the blur event and trigger parent onBlur
-   * @param {event} e
-   */
-  const handleOnBlur = (e) => {
-    if (onBlur) {
-      onBlur(inputValue, e);
-    }
-  };
-
-  const handleOnClose = (e) => {
-    // Get close target's text
-    const closedValue = e.currentTarget.parentNode?.children[0]?.textContent;
-    // If there is a tag with the same value then remove from tag array
-    tagItems.forEach((item, idx) => {
-      if (itemToString(item) === closedValue) {
-        tagItems.splice(idx, 1);
-        setTagItems([...tagItems]);
+      // only focus input if the tags or list have increased
+      if (prevTagAndListCount.current < currentTagAndListCount) {
+        comboRef.current.focus();
       }
-    });
-    // Send new value to users onChange callback
-    onChange([...tagItems]);
-    // eslint-disable-next-line no-unused-expressions
-    e.currentTarget.parentNode?.parentNode?.parentNode?.firstChild?.children[0]?.children[1]?.focus();
-  };
 
-  const handleOnChange = ({ selectedItem: downShiftSelectedItem }) => {
-    const newItem =
-      downShiftSelectedItem &&
-      Object.keys(downShiftSelectedItem).reduce((acc, currentId) => {
-        const value = downShiftSelectedItem[currentId];
-        return {
-          ...acc,
-          [currentId]: typeof value === 'string' ? value.trim() : value,
-        };
-      }, {});
+      // Store the value for the next render
+      prevTagAndListCount.current = currentTagAndListCount;
+    }, [tagItems, listItems, comboRef]);
 
-    const currentValue = itemToString(newItem);
-    // Check that there is no existing tag
-    const hasNoExistingTag = tagItems.filter((x) => itemToString(x) === currentValue).length < 1;
-    // Check if value is part of items array
-    const isInList = listItems.filter((x) => itemToString(x).trim() === currentValue)[0];
-
-    if (hasMultiValue) {
-      // If tags array does not contain new value
-      if (newItem && hasNoExistingTag) {
-        // Add new value to tags array
-        setTagItems((inputValues) => [...inputValues, newItem]);
-        // pass the combobox value to user's onChange callback
-        onChange([...tagItems, newItem]);
+    /**
+     * List to the blur event and trigger parent onBlur
+     * @param {event} e
+     */
+    const handleOnBlur = (e) => {
+      if (onBlur) {
+        onBlur(inputValue, e);
       }
-    } else {
-      onChange(newItem);
-    }
+    };
 
-    if (
-      (addToList || hasMultiValue) &&
-      typeof newItem?.id === 'string' &&
-      newItem?.id.startsWith(`${iotPrefix}-input-`) &&
-      !isInList
-    ) {
-      // Add new item to items array
-      setListItems((currentList) => [newItem, ...currentList]);
-    }
-
-    setInputValue(null);
-  };
-
-  // If the input text doesn't match something in the list, the CarbonComboBox does not call the onChange handler
-  // https://github.com/carbon-design-system/carbon/issues/6613
-  const handleOnKeypress = (evt) => {
-    // Current value of input
-    const currentValue = comboRef.current.value.trim();
-    if (evt.key === keyboardKeys.ENTER && currentValue) {
-      const newItem = {
-        id: `${iotPrefix}-input-${currentValue.split(' ').join('-')}-${currentValue.length}`,
-        text: currentValue,
-      };
-      handleOnChange({ selectedItem: newItem });
-    }
-  };
-
-  const handleInputChange = (e) => {
-    const matchedItem = listItems.filter((x) => itemToString(x) === e)[0];
-    if ((onBlur || addToList || hasMultiValue) && e && e !== '' && !matchedItem) {
-      setInputValue({
-        id: `${iotPrefix}-input-${e.split(' ').join('-')}-${e.length}`,
-        text: e,
+    const handleOnClose = (e) => {
+      // Get close target's text
+      const closedValue = e.currentTarget.parentNode?.children[0]?.textContent;
+      // If there is a tag with the same value then remove from tag array
+      tagItems.forEach((item, idx) => {
+        if (itemToString(item) === closedValue) {
+          tagItems.splice(idx, 1);
+          setTagItems([...tagItems]);
+        }
       });
-    } else {
+      // Send new value to users onChange callback
+      onChange([...tagItems]);
+      // eslint-disable-next-line no-unused-expressions
+      e.currentTarget.parentNode?.parentNode?.parentNode?.firstChild?.children[0]?.children[1]?.focus();
+    };
+
+    const handleOnChange = ({ selectedItem: downShiftSelectedItem }) => {
+      const newItem =
+        downShiftSelectedItem &&
+        Object.keys(downShiftSelectedItem).reduce((acc, currentId) => {
+          const value = downShiftSelectedItem[currentId];
+          return {
+            ...acc,
+            [currentId]: typeof value === 'string' ? value.trim() : value,
+          };
+        }, {});
+
+      const currentValue = itemToString(newItem);
+      // Check that there is no existing tag
+      const hasNoExistingTag = tagItems.filter((x) => itemToString(x) === currentValue).length < 1;
+      // Check if value is part of items array
+      const isInList = listItems.filter((x) => itemToString(x).trim() === currentValue)[0];
+
+      if (hasMultiValue) {
+        // If tags array does not contain new value
+        if (newItem && hasNoExistingTag) {
+          // Add new value to tags array
+          setTagItems((inputValues) => [...inputValues, newItem]);
+          // pass the combobox value to user's onChange callback
+          onChange([...tagItems, newItem]);
+        }
+      } else {
+        onChange(newItem);
+      }
+
+      if (
+        (addToList || hasMultiValue) &&
+        typeof newItem?.id === 'string' &&
+        newItem?.id.startsWith(`${iotPrefix}-input-`) &&
+        !isInList
+      ) {
+        // Add new item to items array
+        setListItems((currentList) => [newItem, ...currentList]);
+      }
+
       setInputValue(null);
-    }
-    // Pass on to user callbacks
-    if (typeof onInputChange === 'function') {
-      onInputChange(e);
-    }
-  };
+    };
 
-  const combinedItems = useMemo(() => (inputValue ? [inputValue, ...listItems] : listItems), [
-    inputValue,
-    listItems,
-  ]);
+    // If the input text doesn't match something in the list, the CarbonComboBox does not call the onChange handler
+    // https://github.com/carbon-design-system/carbon/issues/6613
+    const handleOnKeypress = (evt) => {
+      // Current value of input
+      const currentValue = comboRef.current.value.trim();
+      if (evt.key === keyboardKeys.ENTER && currentValue) {
+        const newItem = {
+          id: `${iotPrefix}-input-${currentValue.split(' ').join('-')}-${currentValue.length}`,
+          text: currentValue,
+        };
+        handleOnChange({ selectedItem: newItem });
+      }
+    };
 
-  const shouldFilterItemForTags = ({
-    item,
-    itemToString: _itemToString,
-    inputValue: _inputValue,
-  }) => _itemToString(item)?.includes(_inputValue);
+    const handleInputChange = (e) => {
+      const matchedItem = listItems.filter((x) => itemToString(x) === e)[0];
+      if ((onBlur || addToList || hasMultiValue) && e && e !== '' && !matchedItem) {
+        setInputValue({
+          id: `${iotPrefix}-input-${e.split(' ').join('-')}-${e.length}`,
+          text: e,
+        });
+      } else {
+        setInputValue(null);
+      }
+      // Pass on to user callbacks
+      if (typeof onInputChange === 'function') {
+        onInputChange(e);
+      }
+    };
 
-  return (
-    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-    <div
-      className={classnames(`${iotPrefix}--combobox`, {
-        [wrapperClassName]: wrapperClassName,
-        [`${iotPrefix}--combobox-add`]: inputValue,
-        [`${iotPrefix}--combobox-size-${size}`]: size,
-        [`${iotPrefix}--combobox-helper-text`]: helperText,
-        [`${iotPrefix}--combobox__menu--fit-content`]: menuFitContent,
-        [`${iotPrefix}--combobox__menu--flip-horizontal`]: horizontalDirection === 'start',
-      })}
-      onKeyDown={handleOnKeypress}
-      onBlur={handleOnBlur}
-      data-testid={`${testId}-wrapper`}
-      data-edit-option-text={editOptionText}
-    >
-      <CarbonComboBox
-        data-testid={`${testId}-box`}
-        id={id}
-        key={`tags:${tagItems.length} listItems:${listItems.length}`}
-        size={size}
-        ref={comboRef}
-        items={combinedItems}
-        itemToString={itemToString}
-        onChange={handleOnChange}
-        onInputChange={handleInputChange}
-        className={classnames(className, `${iotPrefix}--combobox-input`)}
-        disabled={disabled || (loading !== undefined && loading !== false)}
-        helperText={helperText}
-        shouldFilterItem={hasMultiValue || addToList ? shouldFilterItemForTags : shouldFilterItem}
-        {...pick(
-          rest,
-          'ariaLabel',
-          'direction',
-          'downshiftProps',
-          'initialSelectedItem',
-          'invalid',
-          'invalidText',
-          'itemToElement',
-          'light',
-          'onToggleClick',
-          'placeholder',
-          'selectedItem',
-          'titleText',
-          'translateWithId',
-          'type',
-          'warn',
-          'warnText'
-        )}
-        {...filterValidAttributes(rest)}
-      />
-      {hasMultiValue ? (
-        <ul data-testid={`${testId}-tags`} className={`${iotPrefix}--combobox-tags`}>
-          {tagItems.map((item, idx) => (
-            <li key={`li-${item?.id}-${idx}`}>
-              <Tag
-                key={`tag-${item?.id}-${idx}`}
-                filter
-                onClose={(e) => handleOnClose(e)}
-                title={closeButtonText}
-              >
-                {itemToString(item)}
-              </Tag>
-            </li>
-          ))}
-        </ul>
-      ) : null}
-    </div>
-  );
-};
+    const combinedItems = useMemo(() => (inputValue ? [inputValue, ...listItems] : listItems), [
+      inputValue,
+      listItems,
+    ]);
+
+    const shouldFilterItemForTags = ({
+      item,
+      itemToString: _itemToString,
+      inputValue: _inputValue,
+    }) => _itemToString(item)?.includes(_inputValue);
+
+    return (
+      // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+      <div
+        className={classnames(`${iotPrefix}--combobox`, {
+          [wrapperClassName]: wrapperClassName,
+          [`${iotPrefix}--combobox-add`]: inputValue,
+          [`${iotPrefix}--combobox-size-${size}`]: size,
+          [`${iotPrefix}--combobox-helper-text`]: helperText,
+          [`${iotPrefix}--combobox__menu--fit-content`]: menuFitContent,
+          [`${iotPrefix}--combobox__menu--flip-horizontal`]: horizontalDirection === 'start',
+        })}
+        onKeyDown={handleOnKeypress}
+        onBlur={handleOnBlur}
+        data-testid={`${testId}-wrapper`}
+        data-edit-option-text={editOptionText}
+      >
+        <CarbonComboBox
+          data-testid={`${testId}-box`}
+          id={id}
+          key={`tags:${tagItems.length} listItems:${listItems.length}`}
+          size={size}
+          ref={comboRef}
+          items={combinedItems}
+          itemToString={itemToString}
+          onChange={handleOnChange}
+          onInputChange={handleInputChange}
+          className={classnames(className, `${iotPrefix}--combobox-input`)}
+          disabled={disabled || (loading !== undefined && loading !== false)}
+          helperText={helperText}
+          shouldFilterItem={hasMultiValue || addToList ? shouldFilterItemForTags : shouldFilterItem}
+          {...pick(
+            rest,
+            'ariaLabel',
+            'direction',
+            'downshiftProps',
+            'initialSelectedItem',
+            'invalid',
+            'invalidText',
+            'itemToElement',
+            'light',
+            'onToggleClick',
+            'placeholder',
+            'selectedItem',
+            'titleText',
+            'translateWithId',
+            'type',
+            'warn',
+            'warnText'
+          )}
+          {...filterValidAttributes(rest)}
+        />
+        {hasMultiValue ? (
+          <ul data-testid={`${testId}-tags`} className={`${iotPrefix}--combobox-tags`}>
+            {tagItems.map((item, idx) => (
+              <li key={`li-${item?.id}-${idx}`}>
+                <Tag
+                  key={`tag-${item?.id}-${idx}`}
+                  filter
+                  onClose={(e) => handleOnClose(e)}
+                  title={closeButtonText}
+                >
+                  {itemToString(item)}
+                </Tag>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    );
+  }
+);
 
 ComboBox.propTypes = propTypes;
 ComboBox.defaultProps = defaultProps;

--- a/packages/react/src/components/Table/StatefulTable.story.jsx
+++ b/packages/react/src/components/Table/StatefulTable.story.jsx
@@ -165,7 +165,7 @@ export const SimpleStatefulExample = () => {
               ...column,
               filter: {
                 ...column.filter,
-                isMultiselect: !!column.filter?.options,
+                isMultiselect: boolean('force MultiSelect filter', !!column.filter?.options),
               },
             };
           }

--- a/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
+++ b/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
@@ -149,10 +149,12 @@ class FilterHeaderRow extends Component {
     super(props);
 
     this.rowRef = React.createRef();
+    this.firstFilterableRef = React.createRef();
   }
 
   componentDidMount() {
     this.updateDropdownHeight();
+    this.updateFocus();
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -176,6 +178,22 @@ class FilterHeaderRow extends Component {
         this.setState({
           dropdownMaxHeight: `${height}px`,
         });
+      }
+    }
+  };
+
+  setFirstFilterableRef = (node) => {
+    if (!this.firstFilterableRef.current && node) {
+      this.firstFilterableRef.current = node;
+    }
+  };
+
+  updateFocus = () => {
+    if (this.firstFilterableRef.current) {
+      if (typeof this.firstFilterableRef.current.focus === 'function') {
+        this.firstFilterableRef.current.focus();
+      } else if (typeof this.firstFilterableRef.current.textInput.current.focus === 'function') {
+        this.firstFilterableRef.current.textInput.current.focus();
       }
     }
   };
@@ -266,6 +284,7 @@ class FilterHeaderRow extends Component {
             ) : column.options ? (
               column.isMultiselect ? (
                 <MultiSelect.Filterable
+                  ref={this.setFirstFilterableRef}
                   key={columnStateValue}
                   className={classnames(
                     `${iotPrefix}--filterheader-multiselect`,
@@ -306,6 +325,7 @@ class FilterHeaderRow extends Component {
                 />
               ) : (
                 <ComboBox
+                  ref={this.setFirstFilterableRef}
                   menuFitContent
                   horizontalDirection={isLastColumn ? 'start' : 'end'}
                   key={columnStateValue}
@@ -342,6 +362,7 @@ class FilterHeaderRow extends Component {
             ) : (
               <FormItem className={`${iotPrefix}--filter-header-row--form-item`}>
                 <TextInput
+                  ref={this.setFirstFilterableRef}
                   id={column.id}
                   labelText={column.id}
                   hideLabel

--- a/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.test.jsx
+++ b/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.test.jsx
@@ -668,6 +668,22 @@ describe('FilterHeaderRow', () => {
     expect(screen.getByPlaceholderText('col2')).not.toHaveFocus();
   });
 
+  it('should focus on first filterable text field when opened even if not first column', () => {
+    render(
+      <FilterHeaderRow
+        showExpanderColumn
+        {...commonFilterProps}
+        ordering={[{ columnId: 'col1' }, { columnId: 'col2' }]}
+        columns={[
+          { id: 'col1', isFilterable: false },
+          { id: 'col2', isFilterable: true, placeholderText: 'col2' },
+        ]}
+      />
+    );
+
+    expect(screen.getByPlaceholderText('col2')).toHaveFocus();
+  });
+
   it('should focus on first combobox field when opened', () => {
     render(
       <FilterHeaderRow

--- a/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.test.jsx
+++ b/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.test.jsx
@@ -650,4 +650,67 @@ describe('FilterHeaderRow', () => {
 
     expect(container).toBeEmptyDOMElement();
   });
+
+  it('should focus on first filterable text field when opened', () => {
+    render(
+      <FilterHeaderRow
+        showExpanderColumn
+        {...commonFilterProps}
+        ordering={[{ columnId: 'col1' }, { columnId: 'col2' }]}
+        columns={[
+          { id: 'col1', isFilterable: true, placeholderText: 'col1' },
+          { id: 'col2', isFilterable: true, placeholderText: 'col2' },
+        ]}
+      />
+    );
+
+    expect(screen.getByPlaceholderText('col1')).toHaveFocus();
+    expect(screen.getByPlaceholderText('col2')).not.toHaveFocus();
+  });
+
+  it('should focus on first combobox field when opened', () => {
+    render(
+      <FilterHeaderRow
+        showExpanderColumn
+        {...commonFilterProps}
+        ordering={[{ columnId: 'col1' }, { columnId: 'col2' }]}
+        columns={[
+          {
+            id: 'col1',
+            isFilterable: true,
+            placeholderText: 'col1',
+            isMultiselect: false,
+            options: [{ id: 'option-1', text: 'Option 1' }],
+          },
+          { id: 'col2', isFilterable: true, placeholderText: 'col2' },
+        ]}
+      />
+    );
+
+    expect(screen.getByPlaceholderText('col1')).toHaveFocus();
+    expect(screen.getByPlaceholderText('col2')).not.toHaveFocus();
+  });
+
+  it('should focus on first filterable multiselect field when opened', () => {
+    render(
+      <FilterHeaderRow
+        showExpanderColumn
+        {...commonFilterProps}
+        ordering={[{ columnId: 'col1' }, { columnId: 'col2' }]}
+        columns={[
+          {
+            id: 'col1',
+            isFilterable: true,
+            placeholderText: 'col1',
+            isMultiselect: true,
+            options: [{ id: 'option-1', text: 'Option 1' }],
+          },
+          { id: 'col2', isFilterable: true, placeholderText: 'col2' },
+        ]}
+      />
+    );
+
+    expect(screen.getByPlaceholderText('col1')).toHaveFocus();
+    expect(screen.getByPlaceholderText('col2')).not.toHaveFocus();
+  });
 });

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -22990,6 +22990,7 @@ Map {
     },
   },
   "ComboBox" => Object {
+    "$$typeof": Symbol(react.forward_ref),
     "defaultProps": Object {
       "addToList": false,
       "ariaLabel": "Choose an item",
@@ -23206,6 +23207,7 @@ Map {
         "type": "string",
       },
     },
+    "render": [Function],
   },
   "FlyoutMenu" => Object {
     "defaultProps": Object {


### PR DESCRIPTION
Closes #1340 

**Summary**

- adds refs to the FilterHeaderRow to apply focus to the first column when the FilterHeaderRow opens

**Change List (commits, features, bugs, etc)**

- adds forwardRef to ComboBox
- adds refs to FilterHeaderRow items
- checks type of first filterable column and focuses on it

**Acceptance Test (how to verify the PR)**

- open StatefulTable example
- turn on hasColumnSelection and hasFilter
- open filter row
- String column should be focused
- open column selection and move "Status" column to first position
- open Filters
- String column should still be focused
- Repeat moving Select column to first position
- Repeat moving Select column to first position and toggle "force MultiSelect filter" knob to true

**Regression Test (how to make sure this PR doesn't break old functionality)**

- ensure focus doesn't mess with any other FilterHeaderRow stories

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
