### PR TITLE
fix(table): fix background gradient artifacting on rowActions open

### DIFF
--- a/packages/react/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
+++ b/packages/react/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
@@ -64,12 +64,13 @@
 .#{$iot-prefix}--row-actions-container__background--overflow-menu-open {
   opacity: 1;
   transition: opacity $duration--fast-02 motion(entrance, productive);
-  background: transparent;
 }
 
 .#{$prefix}--data-table tbody tr {
   &:not(:hover) .#{$iot-prefix}--row-actions-container__background--overflow-menu-open {
-    background: transparent;
+    // doesn't use the mixin above because safari has problems with 229 rgb values being rendered
+    // as transparent.
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0) 0, #{$ui-01} 16px);
   }
 
   &.#{$prefix}--data-table--selected:hover .#{$iot-prefix}--row-actions-container__background {

--- a/packages/react/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
+++ b/packages/react/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
@@ -64,11 +64,12 @@
 .#{$iot-prefix}--row-actions-container__background--overflow-menu-open {
   opacity: 1;
   transition: opacity $duration--fast-02 motion(entrance, productive);
+  background: transparent;
 }
 
 .#{$prefix}--data-table tbody tr {
   &:not(:hover) .#{$iot-prefix}--row-actions-container__background--overflow-menu-open {
-    @include backgroundGradient($ui-01);
+    background: transparent;
   }
 
   &.#{$prefix}--data-table--selected:hover .#{$iot-prefix}--row-actions-container__background {


### PR DESCRIPTION
Closes #3014 

**Summary**

- updates CSS to fix artifacting from background gradient on overflow items when rowAction overflow menus are open

**Change List (commits, features, bugs, etc)**

- css changes

**Acceptance Test (how to verify the PR)**

- go to [StatefulTable with row actions story](https://deploy-preview-3030--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table-statefultable--stateful-example-with-row-nesting-and-fixed-columns)
- hover first row
- click rowActions overflow menu
- move mouse off of row
- confirm there is no transition of a separate background gradient, but only that of the row

**Regression Test (how to make sure this PR doesn't break old functionality)**

- n/a

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
