### PR TITLE
fix(overflow-menu): increase width of the spacer to match button width

### DIFF
--- a/packages/react/src/components/OverflowMenu/_overflow-menu.scss
+++ b/packages/react/src/components/OverflowMenu/_overflow-menu.scss
@@ -3,3 +3,9 @@
 button.#{$prefix}--overflow-menu {
   background: none;
 }
+
+.#{$prefix}--overflow-menu-options[data-floating-menu-direction] {
+  &:after {
+    width: $spacing-09;
+  }
+}

--- a/packages/react/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
+++ b/packages/react/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { DataTable, OverflowMenu, OverflowMenuItem, Loading } from 'carbon-components-react';
+import { DataTable, Loading } from 'carbon-components-react';
 import classnames from 'classnames';
 import omit from 'lodash/omit';
 
@@ -8,6 +8,8 @@ import Button from '../../../Button';
 import { settings } from '../../../../constants/Settings';
 import { RowActionPropTypes, RowActionErrorPropTypes } from '../../TablePropTypes';
 import icons from '../../../../utils/bundledIcons';
+import { OverflowMenu } from '../../../OverflowMenu';
+import { OverflowMenuItem } from '../../../OverflowMenuItem';
 
 import RowActionsError from './RowActionsError';
 
@@ -183,6 +185,7 @@ class RowActionsCell extends React.Component {
                     onClose={this.handleClose}
                     className={`${iotPrefix}--row-actions-cell--overflow-menu`}
                     selectorPrimaryFocus={`.${iotPrefix}--action-overflow-item--initialFocus`}
+                    useAutoPositioning
                   >
                     {overflowActions.map((action, actionIndex) => (
                       <OverflowMenuItem

--- a/packages/react/src/hooks/usePopoverPositioning.jsx
+++ b/packages/react/src/hooks/usePopoverPositioning.jsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { useLangDirection } from 'use-lang-direction';
+
 /**
  * This is used as the callback for menuOffset on Tooltips, OverflowMenus, and FlyoutMenus.
  * That callback returns the underlying FloatingMenu element, direction, trigger element, and flipped
@@ -70,6 +72,7 @@ export const usePopoverPositioning = ({
   const [adjustedFlipped, setAdjustedFlipped] = React.useState();
   const [{ flyoutAlignment }, setDirections] = React.useState({});
   const previousDirection = React.useRef();
+  const langDir = useLangDirection();
 
   React.useEffect(() => {
     previousDirection.current = direction;
@@ -105,7 +108,6 @@ export const usePopoverPositioning = ({
         : buttonElement.getBoundingClientRect();
       const windowWidth = window.innerWidth || document.documentElement.clientWidth;
       const directionChange = `${previousDirection.current}->${adjustedDirection}`;
-
       if (previousDirection.current !== adjustedDirection && flyoutAlignment) {
         switch (directionChange) {
           default:
@@ -114,6 +116,12 @@ export const usePopoverPositioning = ({
               left: tooltipRect.x - buttonRect.x,
             };
         }
+      }
+
+      let left = 0;
+
+      if (langDir === 'rtl' && isOverflowMenu) {
+        left = -16;
       }
 
       if (previousDirection.current !== adjustedDirection) {
@@ -132,17 +140,17 @@ export const usePopoverPositioning = ({
           default:
             return {
               top: 0,
-              left: 0,
+              left,
             };
         }
       }
 
       return {
         top: 0,
-        left: 0,
+        left,
       };
     },
-    [adjustedDirection, flyoutAlignment]
+    [adjustedDirection, flyoutAlignment, isOverflowMenu, langDir]
   );
 
   /**
@@ -252,6 +260,10 @@ export const usePopoverPositioning = ({
     (...args) => {
       const defaultOffset = getOffset(...args);
 
+      if (langDir === 'rtl' && isOverflowMenu) {
+        defaultOffset.left -= 16;
+      }
+
       if (!useAutoPositioning) {
         return defaultOffset;
       }
@@ -276,7 +288,7 @@ export const usePopoverPositioning = ({
           return defaultOffset;
       }
     },
-    [fixOverflow, getOffset, useAutoPositioning]
+    [fixOverflow, getOffset, isOverflowMenu, langDir, useAutoPositioning]
   );
 
   /**

--- a/packages/react/src/hooks/usePopoverPositioning.jsx
+++ b/packages/react/src/hooks/usePopoverPositioning.jsx
@@ -2,6 +2,11 @@ import * as React from 'react';
 import { useLangDirection } from 'use-lang-direction';
 
 /**
+ * constant override to fix the calculated result returned from getMenuOffset in carbon
+ */
+const RTL_OFFSET_FIX = 15;
+
+/**
  * This is used as the callback for menuOffset on Tooltips, OverflowMenus, and FlyoutMenus.
  * That callback returns the underlying FloatingMenu element, direction, trigger element, and flipped
  * prop. It grabs the window dimentions and bounds for the menu element and determines if it is
@@ -121,7 +126,7 @@ export const usePopoverPositioning = ({
       let left = 0;
 
       if (langDir === 'rtl' && isOverflowMenu) {
-        left = -15;
+        left -= RTL_OFFSET_FIX;
       }
 
       if (previousDirection.current !== adjustedDirection) {
@@ -261,7 +266,7 @@ export const usePopoverPositioning = ({
       const defaultOffset = getOffset(...args);
 
       if (langDir === 'rtl' && isOverflowMenu) {
-        defaultOffset.left -= 15;
+        defaultOffset.left -= RTL_OFFSET_FIX;
       }
 
       if (!useAutoPositioning) {

--- a/packages/react/src/hooks/usePopoverPositioning.jsx
+++ b/packages/react/src/hooks/usePopoverPositioning.jsx
@@ -121,7 +121,7 @@ export const usePopoverPositioning = ({
       let left = 0;
 
       if (langDir === 'rtl' && isOverflowMenu) {
-        left = -16;
+        left = -15;
       }
 
       if (previousDirection.current !== adjustedDirection) {
@@ -261,7 +261,7 @@ export const usePopoverPositioning = ({
       const defaultOffset = getOffset(...args);
 
       if (langDir === 'rtl' && isOverflowMenu) {
-        defaultOffset.left -= 16;
+        defaultOffset.left -= 15;
       }
 
       if (!useAutoPositioning) {


### PR DESCRIPTION
Closes #3013 #1885 

**Summary**

- The small spacer tab in the overflow menu wasn't quite long enough to fill the space leaving a small gap. This fixes that.

**Change List (commits, features, bugs, etc)**

- increase width of spacer tab to match button width

**Acceptance Test (how to verify the PR)**

- Go to [StatefulTable with row action](https://deploy-preview-3031--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table-statefultable--stateful-example-with-expansion-max-pages-and-column-resize) or [OverflowMenu stories](https://deploy-preview-3031--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-overflowmenu--basic)
- open the overflow menu
- the spacer tab should match the width of the button

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Check other stories using overflow menu (in RTL) to confirm the fixes don't break anything
- https://deploy-preview-3031--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table-table--table-example-with-create-save-views
- https://deploy-preview-3031--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table-table--basic-table-with-full-row-edit-example
- https://deploy-preview-3031--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-overflowmenu--basic

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
