### PR TITLE
fix(page-title-bar): fix header top margin and height in condensed mode

### DIFF
--- a/packages/react/src/components/OverflowMenu/_overflow-menu.scss
+++ b/packages/react/src/components/OverflowMenu/_overflow-menu.scss
@@ -3,3 +3,9 @@
 button.#{$prefix}--overflow-menu {
   background: none;
 }
+
+.#{$prefix}--overflow-menu-options[data-floating-menu-direction] {
+  &:after {
+    width: $spacing-09;
+  }
+}

--- a/packages/react/src/components/PageTitleBar/PageTItleBar.test.e2e.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTItleBar.test.e2e.jsx
@@ -17,9 +17,10 @@ describe('PageTitleBar', () => {
     );
 
     cy.findByTestId('page-title-bar')
+      .should('have.class', 'page-title-bar--dynamic')
+      .should('have.class', 'page-title-bar--dynamic--before')
       .should('not.have.class', 'page-title-bar--dynamic--during')
       .should('not.have.class', 'page-title-bar--dynamic--after')
-      .should('not.have.class', 'page-title-bar--dynamic--before')
       .should('have.attr', 'style', '--header-offset:48px; --scroll-transition-progress:0;');
 
     cy.scrollTo(0, 118);

--- a/packages/react/src/components/PageTitleBar/_page-title-bar.scss
+++ b/packages/react/src/components/PageTitleBar/_page-title-bar.scss
@@ -152,7 +152,7 @@
     flex-direction: row;
     align-items: center;
     padding: $spacing-04 0 $spacing-02 $spacing-07;
-    max-height: clamp(0rem, #{$spacing-07}, #{$spacing-08});
+    max-height: $spacing-07;
     white-space: nowrap;
 
     [dir='rtl'] & {

--- a/packages/react/src/components/PageTitleBar/_page-title-bar.scss
+++ b/packages/react/src/components/PageTitleBar/_page-title-bar.scss
@@ -164,7 +164,6 @@
       overflow: hidden;
       transition: all $duration--fast-02;
       border-bottom: 1px solid transparent;
-      margin-bottom: -1px;
     }
 
     .page-title-bar--dynamic--during &,

--- a/packages/react/src/components/PageTitleBar/_page-title-bar.scss
+++ b/packages/react/src/components/PageTitleBar/_page-title-bar.scss
@@ -152,7 +152,7 @@
     flex-direction: row;
     align-items: center;
     padding: $spacing-04 0 $spacing-02 $spacing-07;
-    max-height: clamp(0rem, $spacing-02, $spacing-08);
+    max-height: clamp(0rem, #{$spacing-07}, #{$spacing-08});
     white-space: nowrap;
 
     [dir='rtl'] & {
@@ -172,6 +172,7 @@
       padding-bottom: $spacing-04;
       transition: all $duration--fast-02;
       z-index: 900;
+      max-height: $spacing-08;
     }
 
     .page-title-bar--condensed-static & {
@@ -179,6 +180,7 @@
       grid-area: title;
       padding-bottom: $spacing-04;
       z-index: 1000;
+      max-height: $spacing-08;
     }
 
     > nav {


### PR DESCRIPTION
Closes #3012 

**Summary**

- fixes the max height for a couple situations with the PageTitleBar

**Change List (commits, features, bugs, etc)**

- fix max height of base breadcrumbs
- fix max height of condensed mode
- fix max height of dynamic mode

**Acceptance Test (how to verify the PR)**

- check the [base story](https://deploy-preview-3033--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-pagetitlebar--base) and confirm the breadcrumbs are 32px tall (include padding)
- check the [with dynamic breadcrumbs actions and content story](https://deploy-preview-3033--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-pagetitlebar--with-dynamic-scrolling)
- scroll down to condense the header, confirm it's 40px tall and the buttons are even with the bottom
- check the [condensed with primary + secondary buttons story](https://deploy-preview-3033--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-pagetitlebar--with-condensed-header)
- scroll down to condense the header
- confirm the header is 40px tall and the buttons are even with the bottom

**Regression Test (how to make sure this PR doesn't break old functionality)**

- check other PageTitleBar stories for regressions

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
