### PR TITLE
fix(hierarchy-list): reset pagination and search when data changes

### DIFF
--- a/packages/react/src/components/List/HierarchyList/HierarchyList.jsx
+++ b/packages/react/src/components/List/HierarchyList/HierarchyList.jsx
@@ -258,6 +258,8 @@ const HierarchyList = ({
   useEffect(() => {
     if (!isEqual(items, previousItems)) {
       setFilteredItems(items);
+      setSearchValue('');
+      setCurrentPageNumber(1);
     }
   }, [items, previousItems]);
 

--- a/packages/react/src/components/List/HierarchyList/HierarchyList.story.jsx
+++ b/packages/react/src/components/List/HierarchyList/HierarchyList.story.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
-import { text, select, boolean, object } from '@storybook/addon-knobs';
+import { text, select, boolean, object, number } from '@storybook/addon-knobs';
 import { Add16 } from '@carbon/icons-react';
 import { OverflowMenu, OverflowMenuItem } from 'carbon-components-react';
 
@@ -468,7 +468,7 @@ export const WithLargeNumberOfItems = () => (
     <HierarchyList
       title={text('Title', 'Big List')}
       isFullHeight={boolean('isFullHeight', false)}
-      items={[...Array(1000)].map((_, i) => ({
+      items={[...Array(number('number of items to render', 1000))].map((_, i) => ({
         id: `item-${i}`,
         content: {
           value: `Item ${i}`,

--- a/packages/react/src/components/List/HierarchyList/HierarchyList.test.jsx
+++ b/packages/react/src/components/List/HierarchyList/HierarchyList.test.jsx
@@ -840,4 +840,31 @@ describe('HierarchyList', () => {
 
     expect(screen.getByText('A CUSTOM EMPTY NODE')).toBeVisible();
   });
+
+  it('should reset pagination and search when data changes', () => {
+    const { rerender } = render(
+      <HierarchyList items={getListItems(100)} hasSearch title="Changing List" pageSize="sm" />
+    );
+
+    userEvent.type(screen.getByPlaceholderText('Enter a value'), '5');
+    expect(screen.getByTitle('Item 5')).toBeVisible();
+    expect(screen.getByTitle('Item 15')).toBeVisible();
+    expect(screen.getByTitle('Item 25')).toBeVisible();
+    expect(screen.getByTitle('Item 35')).toBeVisible();
+    expect(screen.getByTitle('Item 45')).toBeVisible();
+    userEvent.click(screen.getByRole('button', { name: 'Next page' }));
+    expect(screen.getByText('Page 2')).toBeVisible();
+    expect(screen.getByTitle('Item 50')).toBeVisible();
+    expect(screen.getByTitle('Item 51')).toBeVisible();
+    expect(screen.getByTitle('Item 52')).toBeVisible();
+    expect(screen.getByTitle('Item 53')).toBeVisible();
+    expect(screen.getByTitle('Item 54')).toBeVisible();
+    rerender(<HierarchyList items={getListItems(50)} title="Changing List" pageSize="sm" />);
+    expect(screen.getByText('Page 1')).toBeVisible();
+    expect(screen.getByTitle('Item 1')).toBeVisible();
+    expect(screen.getByTitle('Item 2')).toBeVisible();
+    expect(screen.getByTitle('Item 3')).toBeVisible();
+    expect(screen.getByTitle('Item 4')).toBeVisible();
+    expect(screen.getByTitle('Item 5')).toBeVisible();
+  });
 });


### PR DESCRIPTION
Closes #1849 

**Summary**

- resets the pagination and search props when the data in the list changes

**Change List (commits, features, bugs, etc)**

- add resets to useEffect when data changes
- add tests to confirm
- add knob to large list story to show in storybook

**Acceptance Test (how to verify the PR)**

- go to the hierarchylist with large list story
- search for '5'
- go to the next page
- change number of items knob
- HierarchyList should reset back to no search and page 1

**Regression Test (how to make sure this PR doesn't break old functionality)**

- confirm other HierarchyList stories are unaffected

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
