### PR TITLE
fix(card-edit-form): fix threshold dropdown width

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/_card-edit-form.scss
+++ b/packages/react/src/components/CardEditor/CardEditForm/_card-edit-form.scss
@@ -179,7 +179,7 @@
     }
     &--item-dropdown {
       margin-right: $spacing-05;
-      max-width: 5rem;
+      max-width: 6rem;
     }
   }
 


### PR DESCRIPTION
Closes #3052 

**Summary**

- increases the max-width on the threshold items

**Change List (commits, features, bugs, etc)**

- increased max-width

**Acceptance Test (how to verify the PR)**

- confirm the [card edit form items](https://deploy-preview-3060--carbon-addons-iot-react.netlify.app/?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-cardeditor-cardeditformitems-thresholdformitem--example-with-initial-values) have the proper width

**Regression Test (how to make sure this PR doesn't break old functionality)**

- n/a

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
