### PR TITLE
fix(simple-list): adjust secondary value css to prevent cut-off

### DIFF
--- a/packages/react/src/components/List/ListItem/_list-item.scss
+++ b/packages/react/src/components/List/ListItem/_list-item.scss
@@ -208,11 +208,10 @@
         padding-right: $spacing-09;
         &__with-actions {
           padding-right: $spacing-07; // save room for the action button
-          width: $spacing-05;
         }
         &__large {
           color: $text-05;
-          white-space: wrap;
+          white-space: normal;
           height: rem(36px);
           overflow: hidden;
         }


### PR DESCRIPTION
Closes #3051 

**Summary**

- adjusts css for simple lists with large rows, secondary values, and actions.

**Change List (commits, features, bugs, etc)**

- change white-space and width css properties

**Acceptance Test (how to verify the PR)**

- secondary values should not be cut off in [this story](https://deploy-preview-3061--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-simplelist--large-row-list-with-multiple-actions). They should also wrap around to the next line if you add to them and make them super long.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- n/a

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
