### PR TITLE
fix(hierarchy-list): uncheck children when parent unchecked

### DIFF
--- a/packages/react/src/components/List/HierarchyList/HierarchyList.jsx
+++ b/packages/react/src/components/List/HierarchyList/HierarchyList.jsx
@@ -288,7 +288,9 @@ const HierarchyList = ({
 
   const setSelected = (id, parentId = null) => {
     if (editingStyle) {
-      setEditModeSelectedIds(handleEditModeSelect(items, editModeSelectedIds, id, parentId));
+      setEditModeSelectedIds(
+        handleEditModeSelect(items, editModeSelectedIds, id, parentId, lockedIds)
+      );
     } else if (selectedIds.includes(id) && hasDeselection) {
       setSelectedIds(selectedIds.filter((item) => item !== id));
       // else, no-op because the item can't be deselected

--- a/packages/react/src/components/List/HierarchyList/HierarchyList.test.jsx
+++ b/packages/react/src/components/List/HierarchyList/HierarchyList.test.jsx
@@ -830,6 +830,48 @@ describe('HierarchyList', () => {
     ).toHaveAttribute('draggable');
   });
 
+  it('should uncheck children when the parent is unchecked.', () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <HierarchyList
+        items={items}
+        title="Hierarchy List"
+        editingStyle={EditingStyle.MultipleNesting}
+        onSelect={onSelect}
+      />
+    );
+
+    userEvent.click(screen.getByTestId('Atlanta Braves-checkbox'));
+    expect(onSelect).toHaveBeenCalled();
+    expect(screen.getByText('10 items selected')).toBeVisible();
+    userEvent.click(screen.getByTestId('Atlanta Braves-checkbox'));
+    expect(onSelect).toHaveBeenCalled();
+    expect(screen.queryByText('10 items selected')).toBeNull();
+    expect(container.querySelectorAll('input[checked]').length).toBe(0);
+  });
+
+  it('should not selected a locked row when parent selected', () => {
+    const onSelect = jest.fn();
+    render(
+      <HierarchyList
+        items={items}
+        title="Hierarchy List"
+        editingStyle={EditingStyle.MultipleNesting}
+        lockedIds={['Atlanta Braves_Dansby Swanson']}
+        defaultExpandedIds={['Atlanta Braves']}
+        onSelect={onSelect}
+      />
+    );
+
+    userEvent.click(screen.getByTestId('Atlanta Braves-checkbox'));
+    expect(onSelect).toHaveBeenCalled();
+    expect(screen.getByText('9 items selected')).toBeVisible();
+    userEvent.click(screen.getByTestId('Atlanta Braves-checkbox'));
+    expect(onSelect).toHaveBeenCalled();
+    expect(screen.queryByText('9 items selected')).toBeNull();
+    expect(screen.getByTestId('Atlanta Braves_Dansby Swanson-checkbox')).not.toBeChecked();
+  });
+
   describe('isVirtualList', () => {
     beforeEach(() => {
       jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => ({
@@ -855,6 +897,50 @@ describe('HierarchyList', () => {
 
       expect(screen.getByText('Page 2')).toBeVisible();
       expect(screen.getByText('Item 9')).toBeVisible();
+    });
+
+    it('should uncheck children when the parent is unchecked.', () => {
+      const onSelect = jest.fn();
+      const { container } = render(
+        <HierarchyList
+          items={items}
+          title="Hierarchy List"
+          editingStyle={EditingStyle.MultipleNesting}
+          onSelect={onSelect}
+          isVirtualList
+        />
+      );
+
+      userEvent.click(screen.getByTestId('Atlanta Braves-checkbox'));
+      expect(onSelect).toHaveBeenCalled();
+      expect(screen.getByText('10 items selected')).toBeVisible();
+      userEvent.click(screen.getByTestId('Atlanta Braves-checkbox'));
+      expect(onSelect).toHaveBeenCalled();
+      expect(screen.queryByText('10 items selected')).toBeNull();
+      expect(container.querySelectorAll('input[checked]').length).toBe(0);
+    });
+
+    it('should not selected a locked row when parent selected', () => {
+      const onSelect = jest.fn();
+      render(
+        <HierarchyList
+          items={items}
+          title="Hierarchy List"
+          editingStyle={EditingStyle.MultipleNesting}
+          lockedIds={['Atlanta Braves_Dansby Swanson']}
+          defaultExpandedIds={['Atlanta Braves']}
+          onSelect={onSelect}
+          isVirtualList
+        />
+      );
+
+      userEvent.click(screen.getByTestId('Atlanta Braves-checkbox'));
+      expect(onSelect).toHaveBeenCalled();
+      expect(screen.getByText('9 items selected')).toBeVisible();
+      userEvent.click(screen.getByTestId('Atlanta Braves-checkbox'));
+      expect(onSelect).toHaveBeenCalled();
+      expect(screen.queryByText('9 items selected')).toBeNull();
+      expect(screen.getByTestId('Atlanta Braves_Dansby Swanson-checkbox')).not.toBeChecked();
     });
   });
 

--- a/packages/react/src/components/List/ListContent/ListContent.jsx
+++ b/packages/react/src/components/List/ListContent/ListContent.jsx
@@ -167,7 +167,15 @@ const ListContent = ({
                 name={item.value}
                 data-testid={`${item.id}-checkbox`}
                 labelText=""
-                onClick={() => handleSelect(item.id, parentId)}
+                onClick={(evt) => {
+                  // after the carbon upgrade to 10.47 this event
+                  // is being fired twice, once on the label and once on the
+                  // input, so filtering out the LABEL event here and only firing on
+                  // the input.
+                  if (evt.target.tagName === 'INPUT' && !isLocked) {
+                    handleSelect(item.id, parentId);
+                  }
+                }}
                 checked={isSelected}
                 disabled={isLocked}
                 indeterminate={isIndeterminate}

--- a/packages/react/src/components/List/ListContent/ListContent.jsx
+++ b/packages/react/src/components/List/ListContent/ListContent.jsx
@@ -167,15 +167,7 @@ const ListContent = ({
                 name={item.value}
                 data-testid={`${item.id}-checkbox`}
                 labelText=""
-                onClick={(evt) => {
-                  // after the carbon upgrade to 10.47 this event
-                  // is being fired twice, once on the label and once on the
-                  // input, so filtering out the LABEL event here and only firing on
-                  // the input.
-                  if (evt.target.tagName === 'INPUT' && !isLocked) {
-                    handleSelect(item.id, parentId);
-                  }
-                }}
+                onChange={() => handleSelect(item.id, parentId)}
                 checked={isSelected}
                 disabled={isLocked}
                 indeterminate={isIndeterminate}

--- a/packages/react/src/utils/DragAndDropUtils.jsx
+++ b/packages/react/src/utils/DragAndDropUtils.jsx
@@ -111,12 +111,14 @@ export const moveItemsInList = (items, dragIds, dropId, location) => {
  * Returns every child id from the ListItem and their children's ids
  * @param {ListItem} listItem
  */
-const getAllChildIds = (listItem) => {
+const getAllChildIds = (listItem, lockedIds) => {
   let childIds = [];
 
   if (listItem.children) {
     listItem.children.forEach((child) => {
-      childIds.push(child.id);
+      if (!lockedIds.includes(child.id)) {
+        childIds.push(child.id);
+      }
 
       childIds = [...childIds, ...getAllChildIds(child)];
     });
@@ -132,21 +134,32 @@ const getAllChildIds = (listItem) => {
  * @param {string} id the id of an item that has been selected or deselected
  * @param {string} parentId the parent id of the selected or deselected item - if unselected, the parent is also unselected
  */
-export const handleEditModeSelect = (list, currentSelection, id, parentId) => {
+export const handleEditModeSelect = (list, currentSelection, id, parentId, lockedIds) => {
   let newSelection = [];
 
   if (currentSelection.filter((editId) => editId === id).length > 0) {
-    newSelection = currentSelection.filter((selected) => selected !== id && selected !== parentId);
+    const selectedItem = list.find((item) => item.id === id);
+    const hasChildren = selectedItem?.children?.length > 0 ?? false;
+    const selectedItemChildrenIds = hasChildren
+      ? selectedItem.children.map((child) => child.id)
+      : [];
+    newSelection = currentSelection.filter((selected) => {
+      const notCurrentOrParent = selected !== id && selected !== parentId;
+
+      return hasChildren
+        ? !selectedItemChildrenIds.includes(selected) && notCurrentOrParent
+        : notCurrentOrParent;
+    });
   } else {
     list.forEach((editItem) => {
       if (editItem.id === id) {
         newSelection.push(id);
 
-        newSelection = [...newSelection, ...getAllChildIds(editItem)];
+        newSelection = [...newSelection, ...getAllChildIds(editItem, lockedIds)];
       } else if (editItem.children) {
         newSelection = [
           ...newSelection,
-          ...handleEditModeSelect(editItem.children, currentSelection, id, parentId),
+          ...handleEditModeSelect(editItem.children, currentSelection, id, parentId, lockedIds),
         ];
       }
 


### PR DESCRIPTION
Closes #3005 

**Summary**

- previously when a parent was selected and then unselected, all the children would remain checked. This fixes that.

**Change List (commits, features, bugs, etc)**

- fix onClick being called twice on label and input
- fix locked rows being selected when parent is checked
- fix children not being unselected when parent is unselected
- move the handleSelect call on the checkbox to onChange instead of onClick
- add tests to confirm

**Acceptance Test (how to verify the PR)**

1. https://deploy-preview-3064--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-hierarchylist--with-nested-reorder
2. check a parent
3. uncheck a parent
4. confirm children unselected

1. check a parent with a locked child
2. confirm locked child is not selected

**Regression Test (how to make sure this PR doesn't break old functionality)**

- no adverse effects on other hierarchylist stories

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
