### PR TITLE
fix(hierarchy-list): don't reset selected items on drag and drop

### DIFF
--- a/packages/react/src/components/List/HierarchyList/HierarchyList.jsx
+++ b/packages/react/src/components/List/HierarchyList/HierarchyList.jsx
@@ -313,31 +313,28 @@ const HierarchyList = ({
     cancelMoveClicked();
   };
 
-  useEffect(
-    () => {
-      // Expand the parent elements of the defaultSelectedId
-      if (defaultSelectedId) {
-        const tempFilteredItems = searchForNestedItemIds(
-          itemsStrippedOfNodeElements,
-          defaultSelectedId
-        );
-        const tempExpandedIds = [...expandedIds];
-        // Expand the categories that have found results
-        tempFilteredItems.forEach((categoryItem) => {
-          tempExpandedIds.push(categoryItem.id);
-        });
-        setExpandedIds(tempExpandedIds);
-
-        /* istanbul ignore else */
-        if (!isEqual(selectedIds, [defaultSelectedId])) {
-          // If the defaultSelectedId prop is updated from the outside, we need to use it
-          setSelected(defaultSelectedId);
-        }
-      }
-    },
+  useEffect(() => {
+    // Expand the parent elements of the defaultSelectedId
+    if (defaultSelectedId) {
+      const tempFilteredItems = searchForNestedItemIds(
+        itemsStrippedOfNodeElements,
+        defaultSelectedId
+      );
+      const tempExpandedIds = [...expandedIds];
+      // Expand the categories that have found results
+      tempFilteredItems.forEach((categoryItem) => {
+        tempExpandedIds.push(categoryItem.id);
+      });
+      setExpandedIds(tempExpandedIds);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [defaultSelectedId, itemsStrippedOfNodeElements]
-  );
+  }, [defaultSelectedId, itemsStrippedOfNodeElements]);
+
+  useEffect(() => {
+    // If the defaultSelectedId prop is updated from the outside, we need to use it
+    setSelected(defaultSelectedId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultSelectedId]);
 
   const numberOfItems = filteredItems.length;
   let rowsPerPage;


### PR DESCRIPTION
Closes #3042 

**Summary**

- when dragging and dropping selected items in a hierarchylist this was triggering a useEffect that was reseting the to the `defaultSelectedIds` prop.

**Change List (commits, features, bugs, etc)**

- create new useEffect for only `defaultSelectedIds`

**Acceptance Test (how to verify the PR)**

1. http://localhost:3000/?path=/story/1-watson-iot-hierarchylist--with-nested-reorder
2. turn on `multiple-nesting`
3. select two items (you'll have to click on the checkbox and then hit space bar (until the other PR is merged https://github.com/carbon-design-system/carbon-addons-iot-react/pull/3064)
4. drag these items around the list
5. when you drop all the selected items should still be selected

**Regression Test (how to make sure this PR doesn't break old functionality)**

- check other hierarchy list stories for issues related to defaultSelectedIds

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
