### PR TITLE
3046 suite header design recon

### DIFF
--- a/packages/react/src/components/CardCodeEditor/CardCodeEditor.test.e2e.jsx
+++ b/packages/react/src/components/CardCodeEditor/CardCodeEditor.test.e2e.jsx
@@ -38,6 +38,7 @@ describe('CardCodeEditor loaded editor test', () => {
     );
     cy.findByTitle(/Copy to clipboard/)
       .should('be.visible')
+      .click()
       .realClick()
       .then(() => {
         expect(onCopy).to.be.called;

--- a/packages/react/src/components/Header/_header.scss
+++ b/packages/react/src/components/Header/_header.scss
@@ -19,6 +19,7 @@ $hoverBgColor: #2c2c2c;
     padding-left: $spacing-03;
     min-width: 150px;
     display: inline-flex;
+    align-items: center;
 
     > span.#{$prefix}--header__name--prefix {
       white-space: nowrap;
@@ -125,6 +126,11 @@ $hoverBgColor: #2c2c2c;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
+  min-height: $spacing-06;
+
+  .#{$prefix}--tag {
+    margin: 0;
+  }
 }
 
 .#{$prefix}--overflow-menu {

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.story.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.story.jsx
@@ -354,7 +354,7 @@ export const HeaderWithExtraContent = () => {
     <SuiteHeader
       suiteName="Application Suite"
       appName="Application Name"
-      extraContent={<Tag>Admin Mode</Tag>}
+      extraContent={<Tag size="sm">Admin Mode</Tag>}
       userDisplayName="Admin User"
       username="adminuser"
       routes={{

--- a/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
@@ -1861,7 +1861,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
             className="iot--suite-header-subtitle"
           >
             <div
-              className="bx--tag"
+              className="bx--tag bx--tag--sm"
               disabled={null}
               id="tag-28"
             >


### PR DESCRIPTION
Closes #3046 

**Summary**

- sets a min-height on the subtitle area, and switches to using a small tag without a margin.

**Change List (commits, features, bugs, etc)**

- use the small size tag
- remove the margin
- set min-height on subtitle area

**Acceptance Test (how to verify the PR)**

- when switching from default story to Header with extra content story, the text and tag should not move and always be aligned. The dividing bar between "IBM Application Suite" and "Application Name" should remain the same length

**Regression Test (how to make sure this PR doesn't break old functionality)**

- n/a

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
