### PR TITLE
fix(pagetitlebar): child content component might be null

### DIFF
--- a/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
@@ -157,7 +157,8 @@ const PageTitleBar = ({
   */
   const hasTabs =
     titleBarContent?.type === Tabs ||
-    [].concat(titleBarContent?.props?.children ?? []).filter(({ type }) => type === Tabs).length;
+    [].concat(titleBarContent?.props?.children ?? []).filter((child) => child?.type === Tabs)
+      .length;
 
   const renderContentOutside =
     (hasTabs && headerMode === HEADER_MODES.DYNAMIC) ||


### PR DESCRIPTION
Closes #

**Summary**

- When some of the children components of the content prop of PageTitleBar were null (this is because they're conditional for us) a NPE was being thrown

**Change List (commits, features, bugs, etc)**

- Verify child isn't null before checking the type

**Acceptance Test (how to verify the PR)**

- View the code

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Verify the original fix is still preserved

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
