### PR TITLE
fix bug for removing ID from JSON Editor

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditForm.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditForm.jsx
@@ -214,7 +214,7 @@ export const hideCardPropertiesForEditor = (card) => {
       : columns // TABLE CARD
       ? { ...card, content: { ...card.content, columns } }
       : card,
-    ['id', 'content.src', 'content.imgState', 'i18n', 'validateUploadedImage']
+    ['content.src', 'content.imgState', 'i18n', 'validateUploadedImage']
   );
 };
 


### PR DESCRIPTION
Closes ##3098
**Summary**

We need to show the ID in the JSON editor. Hiding this is inconsistent with the export feature 

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

1. edit any dashboard
2. edit any card
3. Click JSON Editor
4. The json will have the id field.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
