### PR TITLE
feat(usescrollintoview): hook for infinite loading functionality

### DIFF
--- a/packages/react/src/hooks/useScrollIntoViewCallback.jsx
+++ b/packages/react/src/hooks/useScrollIntoViewCallback.jsx
@@ -1,0 +1,48 @@
+import { useRef, useCallback, useEffect } from 'react';
+
+/**
+ *
+ * @param {Function} callback - required callback function to call when intersecting
+ * @param {Boolean} loading - optional loading boolean to return without setting up observer
+ * @returns {Object} scrollItemRef
+ * @example const { scrollItemRef } = useScrollIntoViewCallback(callback, loading);
+ */
+export default function useScrollIntoViewCallback(callback, loading) {
+  const observer = useRef();
+  useEffect(
+    () => () => {
+      // Disconnect from any old observers
+      if (observer.current) {
+        observer.current.disconnect();
+      }
+    },
+    []
+  );
+
+  const scrollItemRef = useCallback(
+    (node) => {
+      // If loading just return
+      if (loading) {
+        return;
+      }
+      // Disconnect from any old observers
+      if (observer.current) {
+        observer.current.disconnect();
+      }
+      // Create a new observer
+      observer.current = new IntersectionObserver((entries) => {
+        // If scrollItemRef is in veiwport call callback function
+        if (entries[0].isIntersecting) {
+          callback();
+        }
+      });
+      // Once component mounts tell our observer to observe it
+      if (node && observer.current) {
+        observer.current.observe(node);
+      }
+    },
+    [loading, callback]
+  );
+
+  return { scrollItemRef };
+}

--- a/packages/react/src/hooks/useScrollIntoViewCallback.test.e2e.jsx
+++ b/packages/react/src/hooks/useScrollIntoViewCallback.test.e2e.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { mount } from '@cypress/react';
+
+import useScrollIntoViewCallback from './useScrollIntoViewCallback';
+
+describe('useScrollIntoViewCallback', () => {
+  it('should call the provided callback when the last item is scrolled into view', () => {
+    // eslint-disable-next-line react/prop-types
+    function TestComponent({ callback }) {
+      const { scrollItemRef } = useScrollIntoViewCallback(callback);
+      const ids = Array(20)
+        .fill()
+        .map(() => Math.random());
+      const items = Array.from(ids).map((e, i) => {
+        return i === 19 ? (
+          <li data-testid="last" ref={scrollItemRef} key={e}>
+            last
+          </li>
+        ) : (
+          <li key={e}>e</li>
+        );
+      });
+
+      return <ul>{items}</ul>;
+    }
+    const callbackStub = cy.stub();
+    mount(<TestComponent callback={callbackStub} />);
+
+    expect(callbackStub).to.not.be.called;
+    cy.findByTestId('last')
+      .scrollIntoView()
+      .should(() => {
+        expect(callbackStub).to.be.called;
+      });
+  });
+
+  it('should return without calling the callback if loading equals true', () => {
+    // eslint-disable-next-line react/prop-types
+    function TestComponent({ callback }) {
+      const { scrollItemRef } = useScrollIntoViewCallback(callback, true);
+      const ids = Array(20)
+        .fill()
+        .map(() => Math.random());
+      const items = Array.from(ids).map((e, i) => {
+        return i === 19 ? (
+          <li data-testid="last" ref={scrollItemRef} key={e}>
+            last
+          </li>
+        ) : (
+          <li key={e}>e</li>
+        );
+      });
+
+      return <ul>{items}</ul>;
+    }
+    const callbackStub = cy.stub();
+    mount(<TestComponent callback={callbackStub} />);
+
+    expect(callbackStub).to.not.be.called;
+    cy.findByTestId('last')
+      .scrollIntoView()
+      .should(() => {
+        expect(callbackStub).to.not.be.called;
+      });
+  });
+});


### PR DESCRIPTION
Closes #3054

**Summary**

This PR adds a custom hook for creating an intersection observer that can be placed on items in a list in order to implement infinite scrolling. 

**Change List (commits, features, bugs, etc)**

- created useScrollIntoViewCallback.jsx and associated test

**Acceptance Test (how to verify the PR)**

- tests should pass

