### PR TITLE
fix(table-view-dropdown): fix [Object object] showing in title

### DIFF
--- a/packages/react/src/components/Table/TableViewDropdown/TableViewDropdown.jsx
+++ b/packages/react/src/components/Table/TableViewDropdown/TableViewDropdown.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Dropdown } from 'carbon-components-react';
 import { Settings16 } from '@carbon/icons-react';
@@ -6,6 +6,7 @@ import withSize from 'react-sizeme';
 
 import { settings } from '../../../constants/Settings';
 import { OverridePropTypes } from '../../../constants/SharedPropTypes';
+import { useDropdownTitleFixer } from '../../IconDropdown/dropdownHooks';
 
 import TableViewItemPropType from './TableViewItemPropTypes';
 import TableViewDropdownItem from './TableViewDropdownItem';
@@ -13,7 +14,7 @@ import TableViewDropdownItem from './TableViewDropdownItem';
 const { iotPrefix } = settings;
 
 const propTypes = {
-  /** Set to true if the user has modfied filters etc since the view was loaded */
+  /** Set to true if the user has modified filters etc since the view was loaded */
   selectedViewEdited: PropTypes.bool,
   /** The id of the view that is currently selected */
   selectedViewId: PropTypes.string,
@@ -41,7 +42,7 @@ const propTypes = {
     /** Callback for when the current view is changed by the user */
     onChangeView: PropTypes.func,
   }).isRequired,
-  /** Used to overide the internal components and props of the TableViewDropdown */
+  /** Used to override the internal components and props of the TableViewDropdown */
   overrides: PropTypes.shape({
     dropdown: OverridePropTypes,
     dropdownItem: OverridePropTypes,
@@ -103,7 +104,7 @@ const TableViewDropdown = ({
       icon: Settings16,
     };
     // Save changes button show only appear if the view has been edited and the current view is not 'View all'
-    // 'View all' is equivalent to a "default view", which would not be able to get resaved. The user should supply
+    // 'View all' is equivalent to a "default view", which would not be able to get re-saved. The user should supply
     // their own default views that can be changed if they would like that functionality
     const dialogItems =
       selectedViewEdited && selectedViewId && selectedViewId !== 'view-all'
@@ -129,6 +130,15 @@ const TableViewDropdown = ({
   const mySelectedItem = allItems.find((item) => item.id === selectedViewId) || viewAllItem;
   const MyDropDown = overrides?.dropdown?.component || Dropdown;
   const MyTableViewDropDownItem = overrides?.dropdownItem?.component || TableViewDropdownItem;
+  const [dropdownRef, updateTitle] = useDropdownTitleFixer();
+
+  useEffect(() => {
+    if (mySelectedItem?.text && dropdownRef?.current) {
+      updateTitle(
+        selectedViewEdited ? `${mySelectedItem.text} - ${i18n.edited}` : mySelectedItem.text
+      );
+    }
+  }, [dropdownRef, i18n.edited, mySelectedItem, selectedViewEdited, updateTitle]);
 
   const onSelectionChange = (change) => {
     const item = change.selectedItem;
@@ -147,6 +157,7 @@ const TableViewDropdown = ({
         return (
           <div className={`${iotPrefix}--view-dropdown__container`} style={style}>
             <MyDropDown
+              ref={dropdownRef}
               label={i18n.tableViewMenu}
               data-testid={testID}
               selectedItem={mySelectedItem}


### PR DESCRIPTION
Closes #2423 

**Summary**

- Fixes the `[Object object]` being shown in the browser title tooltip of the TableViewDropdown. This is a stop-gap fix until https://github.com/carbon-design-system/carbon/pull/10188 is released and we can update and incorporate it. 

**Change List (commits, features, bugs, etc)**

- uses the custom hook to manually set the title of the selected item to overcome the `itemToString` hacks we're using to show an element in the dropdown.

**Acceptance Test (how to verify the PR)**

- in the [table with create save view management story](https://deploy-preview-3126--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table-table--table-example-with-create-save-views)
- hover over various points on the dropdown
- the title should match the text shown in the center of the dropdown.
- A few hover point examples:
<img width="327" alt="Screen Shot 2021-12-09 at 5 22 43 AM" src="https://user-images.githubusercontent.com/609466/145378811-fb80805d-54f4-4598-aa4d-af359e167a94.png">

Note: hovering over the down chevron should display "Open menu"

**Regression Test (how to make sure this PR doesn't break old functionality)**

- n/a

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
