### PR TITLE
fix(table): pass size to overflow menu in row actions

### DIFF
--- a/packages/react/src/components/DataTable/_data-table.scss
+++ b/packages/react/src/components/DataTable/_data-table.scss
@@ -80,7 +80,7 @@ html[dir='rtl'] {
     }
   }
 
-  // override padding on chexkbox cells, so that it aligns with cell content in tables with xl size prop
+  // override padding on checkbox cells, so that it aligns with cell content in tables with xl size prop
   &.#{$prefix}--data-table--xl {
     .#{$prefix}--checkbox-table-cell {
       padding-top: $spacing-05;

--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -561,6 +561,7 @@ const Table = (props) => {
     tooltip,
     error,
     testId,
+    size,
     ...others
   } = merge({}, defaultProps(props), props);
 
@@ -956,10 +957,12 @@ const Table = (props) => {
               options.hasResize && !options.useAutoTableLayoutForResize,
             [`${iotPrefix}--data-table--row-actions`]: options.hasRowActions,
           })}
+          size={size}
           {...others}
         >
           {columns.length ? (
             <TableHead
+              size={size}
               {...others}
               i18n={i18n}
               lightweight={lightweight}
@@ -1092,6 +1095,7 @@ const Table = (props) => {
                 // TODO: remove 'id' in v3.
                 testId={`${id || testId}-table-body`}
                 showExpanderColumn={showExpanderColumn}
+                size={size}
               />
             ) : (
               <EmptyTable

--- a/packages/react/src/components/Table/Table.test.jsx
+++ b/packages/react/src/components/Table/Table.test.jsx
@@ -113,7 +113,7 @@ describe('Table', () => {
     const { rerender } = render(
       <Table
         columns={tableColumns}
-        data={tableData.slice(0, 1)}
+        data={[tableData[0]]}
         expandedData={expandedData}
         actions={mockActions}
         options={{
@@ -159,7 +159,7 @@ describe('Table', () => {
     rerender(
       <Table
         columns={tableColumns}
-        data={tableData.slice(0, 1)}
+        data={[tableData[0]]}
         expandedData={expandedData}
         actions={mockActions}
         options={{
@@ -216,7 +216,7 @@ describe('Table', () => {
     const wrapper = mount(
       <Table
         columns={tableColumns}
-        data={tableData}
+        data={[tableData[0]]}
         expandedData={expandedData}
         actions={mockActions}
         options={options}
@@ -231,7 +231,7 @@ describe('Table', () => {
     const wrapper = mount(
       <Table
         columns={tableColumns}
-        data={tableData}
+        data={tableData.slice(0, 2)}
         actions={mockActions}
         options={options}
         view={view}
@@ -245,7 +245,7 @@ describe('Table', () => {
     const wrapper = mount(
       <Table
         columns={tableColumns}
-        data={tableData}
+        data={[tableData[0]]}
         actions={mockActions}
         options={options}
         view={view}
@@ -388,7 +388,7 @@ describe('Table', () => {
     render(
       <Table
         columns={tableColumns}
-        data={tableData}
+        data={[tableData[0]]}
         actions={mockActions}
         options={options}
         view={view}
@@ -497,7 +497,7 @@ describe('Table', () => {
     const wrapper = mount(
       <Table
         columns={tableColumns}
-        data={tableData}
+        data={[tableData[0]]}
         actions={mockActions}
         options={{
           hasSearch: true,
@@ -532,7 +532,7 @@ describe('Table', () => {
     render(
       <Table
         columns={tableColumns}
-        data={tableData}
+        data={[tableData[0]]}
         actions={mockActions}
         options={{
           hasSearch: true,
@@ -577,7 +577,7 @@ describe('Table', () => {
     render(
       <Table
         columns={tableColumns}
-        data={tableData}
+        data={[tableData[0]]}
         actions={mockActions}
         options={{
           hasSearch: true,
@@ -703,18 +703,22 @@ describe('Table', () => {
     const id = 'TableId3';
     // Should render correctly by default even if no lang attribute exist
     const { unmount, rerender, baseElement } = render(
-      <Table id={id} columns={tableColumns} data={[tableData[0]]} options={options} />
+      <Table id={id} columns={tableColumns} data={[tableData[0]]} options={options} size="xs" />
     );
     await fireEvent.click(screen.getByTestId(`${id}-row-0-row-actions-cell-overflow`));
     await waitFor(() => {
       // the menu is rendered via a portal outside of the container/screen
       expect(baseElement.querySelector('ul[role="menu"][class*=overflow-menu]')).toHaveClass(
-        `${prefix}--overflow-menu--flip`
+        `${prefix}--overflow-menu--flip`,
+        // should render a sm overflow menu for `xs` table rows
+        `${prefix}--overflow-menu-options--sm`
       );
     });
     document.documentElement.setAttribute('dir', 'rtl');
 
-    rerender(<Table id={id} columns={tableColumns} data={[tableData[1]]} options={options} />);
+    rerender(
+      <Table id={id} columns={tableColumns} data={[tableData[1]]} options={options} size="sm" />
+    );
     await fireEvent.click(screen.getByTestId(`${id}-row-1-row-actions-cell-overflow`));
     await waitFor(() => {
       // the menu is rendered via a portal outside of the container/screen
@@ -1382,7 +1386,7 @@ describe('Table', () => {
           ...col,
           width: '100px',
         }))}
-        data={tableData}
+        data={[tableData[0]]}
       />
     );
 
@@ -1395,7 +1399,7 @@ describe('Table', () => {
           width: '100px',
           overflowMenuItems: overflowData,
         }))}
-        data={tableData}
+        data={[tableData[0]]}
       />
     );
 
@@ -1847,7 +1851,7 @@ describe('Table', () => {
         <Table
           id={tableTestId}
           columns={tableColumns}
-          data={tableData}
+          data={tableData.slice(0, 5)}
           options={{ hasAggregations: true }}
           view={{
             aggregations: { columns: [{ id: columnId }] },
@@ -1857,7 +1861,7 @@ describe('Table', () => {
 
       expect(
         screen.getByTestId(`${tableTestId}-${tableFootTestId}-${columnId}`).textContent
-      ).toEqual('2470');
+      ).toEqual('30');
     });
 
     it('shows aggregation for specified columns using custom aggregation function', () => {
@@ -1872,7 +1876,7 @@ describe('Table', () => {
         <Table
           id="test"
           columns={tableColumns}
-          data={tableData}
+          data={tableData.slice(0, 5)}
           tooltip="this is a tooltip"
           options={{ hasAggregations: true }}
           actions={{
@@ -1898,7 +1902,7 @@ describe('Table', () => {
 
       expect(
         screen.getByTestId(`${tableTestId}-${tableFootTestId}-${columnId}`).textContent
-      ).toEqual('2471');
+      ).toEqual('31');
       expect(sumFunction).toHaveBeenCalled();
 
       const overflow = screen.getByTestId('table-head--overflow');
@@ -1945,7 +1949,7 @@ describe('Table', () => {
         <Table
           id="test"
           columns={tableColumns}
-          data={tableData}
+          data={[tableData[0]]}
           options={{ hasFilter: true, hasAdvancedFilter: true }}
         />
       );
@@ -1964,7 +1968,7 @@ describe('Table', () => {
         <Table
           id="test"
           columns={tableColumns}
-          data={tableData}
+          data={[tableData[0]]}
           options={{ hasAdvancedFilter: 'true' }}
         />
       );
@@ -1980,7 +1984,7 @@ describe('Table', () => {
         <Table
           id="test"
           columns={tableColumns}
-          data={tableData}
+          data={[tableData[0]]}
           actions={{
             toolbar: {
               onToggleAdvancedFilter: handleToggleFilters,
@@ -2006,7 +2010,7 @@ describe('Table', () => {
         <Table
           id="test"
           columns={tableColumns}
-          data={tableData}
+          data={[tableData[0]]}
           actions={{
             toolbar: {
               onApplyAdvancedFilter: handleApplyFilter,
@@ -2052,7 +2056,7 @@ describe('Table', () => {
         <Table
           id="test"
           columns={tableColumns}
-          data={tableData}
+          data={[tableData[0]]}
           actions={{
             toolbar: {
               onApplyAdvancedFilter: handleApplyFilter,
@@ -2085,7 +2089,7 @@ describe('Table', () => {
         <Table
           id="test"
           columns={tableColumns}
-          data={tableData}
+          data={[tableData[0]]}
           actions={{
             toolbar: {
               onApplyAdvancedFilter: handleApplyFilter,
@@ -2196,7 +2200,7 @@ describe('Table', () => {
         <Table
           id="test"
           columns={tableColumns}
-          data={tableData}
+          data={[tableData[0]]}
           actions={{
             toolbar: {
               onApplyAdvancedFilter: handleApplyFilter,
@@ -2315,7 +2319,7 @@ describe('Table', () => {
       <Table
         id="loading-table"
         columns={tableColumns}
-        data={tableData}
+        data={tableData.slice(0, 5)}
         view={{ table: { loadingState: { isLoading: false, rowCount: 10, columnCount: 3 } } }}
       />
     );
@@ -2323,8 +2327,8 @@ describe('Table', () => {
       container.querySelectorAll(`.${iotPrefix}--table-skeleton-with-headers--table-row`)
     ).toHaveLength(0);
 
-    // 20 rows plus the header
-    expect(container.querySelectorAll('tr')).toHaveLength(21);
+    // 5 rows plus the header
+    expect(container.querySelectorAll('tr')).toHaveLength(6);
     expect(screen.getByTitle('String')).toBeVisible();
     expect(screen.getByTitle('Date')).toBeVisible();
   });
@@ -2358,7 +2362,7 @@ describe('Table', () => {
   it('should show a deprecation warning for old size props', () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
     const { rerender } = render(
-      <Table id="loading-table" columns={tableColumns} data={tableData} size="compact" />
+      <Table id="loading-table" columns={tableColumns} data={[tableData[0]]} size="compact" />
     );
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining(
@@ -2370,7 +2374,9 @@ describe('Table', () => {
         'The value `compact` has been deprecated for the `size` prop on the TableHead component.'
       )
     );
-    rerender(<Table id="loading-table" columns={tableColumns} data={tableData} size="short" />);
+    rerender(
+      <Table id="loading-table" columns={tableColumns} data={[tableData[0]]} size="short" />
+    );
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining(
         'The value `short` has been deprecated for the `size` prop on the Table component.'
@@ -2381,7 +2387,9 @@ describe('Table', () => {
         'The value `short` has been deprecated for the `size` prop on the TableHead component.'
       )
     );
-    rerender(<Table id="loading-table" columns={tableColumns} data={tableData} size="normal" />);
+    rerender(
+      <Table id="loading-table" columns={tableColumns} data={[tableData[0]]} size="normal" />
+    );
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining(
         'The value `normal` has been deprecated for the `size` prop on the Table component.'
@@ -2392,7 +2400,7 @@ describe('Table', () => {
         'The value `normal` has been deprecated for the `size` prop on the TableHead component.'
       )
     );
-    rerender(<Table id="loading-table" columns={tableColumns} data={tableData} size="tall" />);
+    rerender(<Table id="loading-table" columns={tableColumns} data={[tableData[0]]} size="tall" />);
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining(
         'The value `tall` has been deprecated for the `size` prop on the Table component.'
@@ -2404,7 +2412,7 @@ describe('Table', () => {
       )
     );
     rerender(
-      <Table id="loading-table" columns={tableColumns} data={tableData} size="unsupported" />
+      <Table id="loading-table" columns={tableColumns} data={[tableData[0]]} size="unsupported" />
     );
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining(
@@ -2412,7 +2420,7 @@ describe('Table', () => {
       )
     );
     jest.clearAllMocks();
-    rerender(<Table id="loading-table" columns={tableColumns} data={tableData} size="lg" />);
+    rerender(<Table id="loading-table" columns={tableColumns} data={[tableData[0]]} size="lg" />);
     expect(console.error).not.toHaveBeenCalled();
   });
 
@@ -2510,7 +2518,7 @@ describe('Table', () => {
     const { rerender } = render(
       <Table
         columns={tableColumns}
-        data={tableData.slice(0, 1)}
+        data={[tableData[0]]}
         expandedData={expandedData}
         actions={mockActions}
         options={{
@@ -2545,7 +2553,7 @@ describe('Table', () => {
     rerender(
       <Table
         columns={tableColumns}
-        data={tableData.slice(0, 1)}
+        data={[tableData[0]]}
         expandedData={expandedData}
         actions={mockActions}
         options={{
@@ -2665,7 +2673,7 @@ describe('Table', () => {
       render(
         <Table
           columns={tableColumns}
-          data={tableData.slice(0, 1)}
+          data={[tableData[0]]}
           expandedData={expandedData}
           actions={merge(mockActions, { toolbar: { onApplyToolbarAction } })}
           options={{
@@ -2721,7 +2729,7 @@ describe('Table', () => {
       render(
         <Table
           columns={tableColumns}
-          data={tableData.slice(0, 1)}
+          data={[tableData[0]]}
           expandedData={expandedData}
           actions={merge(mockActions, { toolbar: { onApplyToolbarAction } })}
           options={{
@@ -2775,7 +2783,7 @@ describe('Table', () => {
       render(
         <Table
           columns={tableColumns}
-          data={tableData.slice(0, 1)}
+          data={[tableData[0]]}
           expandedData={expandedData}
           actions={merge(mockActions, { toolbar: { onApplyToolbarAction } })}
           options={{
@@ -2836,7 +2844,7 @@ describe('Table', () => {
         <Table
           testId="icon-render"
           columns={tableColumns}
-          data={tableData.slice(0, 1)}
+          data={[tableData[0]]}
           expandedData={expandedData}
           actions={merge(mockActions, { toolbar: { onApplyToolbarAction } })}
           options={{

--- a/packages/react/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
+++ b/packages/react/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
@@ -51,6 +51,10 @@ const propTypes = {
    * Direction of document. Passed in at Table
    */
   langDir: PropTypes.oneOf(['ltr', 'rtl']),
+  /**
+   * the size passed to the table to set row height
+   */
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),
 };
 
 const defaultProps = {
@@ -65,6 +69,7 @@ const defaultProps = {
   showSingleRowEditButtons: false,
   singleRowEditButtons: null,
   langDir: 'ltr',
+  size: undefined,
 };
 
 class RowActionsCell extends React.Component {
@@ -110,6 +115,7 @@ class RowActionsCell extends React.Component {
       showSingleRowEditButtons,
       singleRowEditButtons,
       langDir,
+      size,
     } = this.props;
     const { isOpen } = this.state;
     const overflowActions = actions ? actions.filter((action) => action.isOverflow) : [];
@@ -180,6 +186,8 @@ class RowActionsCell extends React.Component {
                     iconDescription={overflowMenuAria}
                     onOpen={this.handleOpen}
                     onClose={this.handleClose}
+                    // compact or xs rows need the `sm` overflow menu, everything else is default (md)
+                    size={['compact', 'xs'].includes(size) ? 'sm' : undefined}
                     className={`${iotPrefix}--row-actions-cell--overflow-menu`}
                     selectorPrimaryFocus={`.${iotPrefix}--action-overflow-item--initialFocus`}
                     useAutoPositioning

--- a/packages/react/src/components/Table/TableBody/TableBody.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBody.jsx
@@ -98,6 +98,10 @@ const propTypes = {
   loadingMoreIds: PropTypes.arrayOf(PropTypes.string),
   /** use white-space: pre; css when true */
   preserveCellWhiteSpace: PropTypes.bool,
+  /**
+   * the size passed to the table to set row height
+   */
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),
 };
 
 const defaultProps = {
@@ -131,6 +135,7 @@ const defaultProps = {
   inProgressText: 'In progress',
   dismissText: 'Dismiss',
   actionFailedText: 'Action failed',
+  size: undefined,
 };
 
 const TableBody = ({
@@ -171,6 +176,7 @@ const TableBody = ({
   testId,
   showExpanderColumn,
   preserveCellWhiteSpace,
+  size,
 }) => {
   // Need to merge the ordering and the columns since the columns have the renderer function
   const orderingMap = useMemo(
@@ -316,6 +322,7 @@ const TableBody = ({
         rowActions={row.rowActions}
         values={row.values}
         showExpanderColumn={showExpanderColumn}
+        size={size}
       />
     ) : (
       <TableBodyLoadMoreRow

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -122,6 +122,10 @@ const propTypes = {
   langDir: PropTypes.oneOf(['ltr', 'rtl']),
   /** shows an additional column that can expand/shrink as the table is resized  */
   showExpanderColumn: PropTypes.bool,
+  /**
+   * the size passed to the table to set row height
+   */
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),
 };
 
 const defaultProps = {
@@ -150,6 +154,7 @@ const defaultProps = {
   langDir: 'ltr',
   locale: 'en',
   isSelectable: undefined,
+  size: undefined,
 };
 
 const StyledTableRow = styled(({ isSelectable, isEditMode, ...others }) => (
@@ -426,6 +431,7 @@ const TableBodyRow = ({
   singleRowEditMode,
   singleRowEditButtons,
   showExpanderColumn,
+  size,
 }) => {
   const isEditMode = rowEditMode || singleRowEditMode;
   const singleSelectionIndicatorWidth = hasRowSelection === 'single' ? 0 : 5;
@@ -542,6 +548,7 @@ const TableBodyRow = ({
           dismissText={dismissText}
           rowActionsError={rowActionsError}
           onClearError={onClearRowError ? () => onClearRowError(id) : null}
+          size={size}
         />
       ) : nestingLevel > 0 && hasRowActions ? (
         <TableCell key={`${tableId}-${id}-row-actions-cell`} />

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -2897,6 +2897,7 @@ Map {
       "shouldLazyRender": false,
       "showExpanderColumn": false,
       "singleRowEditButtons": null,
+      "size": undefined,
       "testId": "",
       "totalColumns": 0,
     },
@@ -3384,6 +3385,18 @@ Map {
       },
       "singleRowEditButtons": Object {
         "type": "element",
+      },
+      "size": Object {
+        "args": Array [
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ],
+        ],
+        "type": "oneOf",
       },
       "tableId": Object {
         "isRequired": true,


### PR DESCRIPTION
Closes #3111 

**Summary**

- passes the `size` prop down through the table so that the overflow menu can be passed the appropriate size.

**Change List (commits, features, bugs, etc)**

- pass size prop down
- add className test to existing test
- speed up Table.test.jsx by only rendering the minimum number of rows needed to meet the requirements of the tests.

**Acceptance Test (how to verify the PR)**

- on the ?path=/story/1-watson-iot-table-statefultable--stateful-example-with-row-nesting-and-fixed-columns story
- change size to `xs`
- open overflow menu in row
- confirm visuals match

**Regression Test (how to make sure this PR doesn't break old functionality)**

- check other sizes to confirm no negative impacts

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
