### PR TITLE
chore(list-builder): fix story for complex nesting add users/groups

### DIFF
--- a/packages/react/src/components/ListBuilder/ListBuilder.story.jsx
+++ b/packages/react/src/components/ListBuilder/ListBuilder.story.jsx
@@ -249,7 +249,9 @@ export const ComplexNestedExample = () => {
   };
 
   const handleAdd = (row) => {
-    setSelectedUsers([row].concat(...selectedUsers));
+    const userIdsInRow = row.users ? row.users.map(({ id }) => id) : [row.id];
+    const filteredSelectedUsers = selectedUsers.filter(({ id }) => !userIdsInRow.includes(id));
+    setSelectedUsers([row].concat(...filteredSelectedUsers));
   };
 
   const displayAllUsersList = (unmodifiedUsers, selection = []) => {


### PR DESCRIPTION
Closes #3099 

**Summary**

- simple update to the ListBuilder complex story to filter individual users when adding a group that contains that user.

**Acceptance Test (how to verify the PR)**

1. Go to [listbuilder--complex-nested-example](https://deploy-preview-3135--carbon-addons-iot-react.netlify.app/?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-listbuilder--complex-nested-example)
2. Click on the expand "Roles" button
3. Click on the expand "Roles One" button
4. Select item "Misha Knappenberger"
5. Select the whole group "Roles One"
6. Notice how "Misha Knappenberger" was now removed and only appears in Role One

**Regression Test (how to make sure this PR doesn't break old functionality)**

- n/a

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
