### PR TITLE
fix(simple-list): rtl padding with actions in row

### DIFF
--- a/packages/react/src/components/List/ListItem/_list-item.scss
+++ b/packages/react/src/components/List/ListItem/_list-item.scss
@@ -207,7 +207,13 @@
         text-overflow: ellipsis;
         padding-right: $spacing-09;
         &__with-actions {
-          padding-right: $spacing-07; // save room for the action button
+          // save room for the action button
+          padding-right: $spacing-08;
+
+          [dir='rtl'] & {
+            padding-right: 0;
+            padding-left: $spacing-08;
+          }
         }
         &__large {
           color: $text-05;

--- a/packages/react/src/components/List/SimpleList/SimpleList.story.jsx
+++ b/packages/react/src/components/List/SimpleList/SimpleList.story.jsx
@@ -45,7 +45,12 @@ export const getListItemsWithActions = (num) =>
     .map((i, idx) => ({
       id: (idx + 1).toString(),
       content: {
-        value: `Item ${idx + 1}`,
+        value:
+          idx === 0
+            ? `Item ${
+                idx + 1
+              } with a very long title that should truncate before it hits the edge of the list`
+            : `Item ${idx + 1}`,
         rowActions,
       },
     }));
@@ -56,7 +61,12 @@ const getListItemsWithOverflowMenu = (num) =>
     .map((i, idx) => ({
       id: (idx + 1).toString(),
       content: {
-        value: `Item ${idx + 1}`,
+        value:
+          idx === 0
+            ? `Item ${
+                idx + 1
+              } with a very long title that should truncate before it hits the action icons`
+            : `Item ${idx + 1}`,
         rowActions: rowActionsOverFlowMenu,
       },
     }));
@@ -67,7 +77,12 @@ const getFatRowListItems = (num) =>
     .map((i, idx) => ({
       id: (idx + 1).toString(),
       content: {
-        value: `Item ${idx + 1}`,
+        value:
+          idx === 0
+            ? `Item ${
+                idx + 1
+              } with a very long title that should truncate before it hits the edge of the list`
+            : `Item ${idx + 1}`,
         secondaryValue: `This is a description or some secondary bit of data for Item ${idx + 100}`,
         rowActions: [],
       },
@@ -79,7 +94,12 @@ const getFatRowListItemsWithActions = (num) =>
     .map((i, idx) => ({
       id: (idx + 1).toString(),
       content: {
-        value: `Item ${idx + 1}`,
+        value:
+          idx === 0
+            ? `Item ${
+                idx + 1
+              } with a very long title that should truncate before it hits the edge of the list`
+            : `Item ${idx + 1}`,
         secondaryValue: `This is a description or some secondary bit of data for Item ${idx + 100}`,
         rowActions,
       },
@@ -91,7 +111,12 @@ const getFatRowListItemsWithOverflowMenu = (num) =>
     .map((i, idx) => ({
       id: (idx + 1).toString(),
       content: {
-        value: `Item ${idx + 1}`,
+        value:
+          idx === 0
+            ? `Item ${
+                idx + 1
+              } with a very long title that should truncate before it hits the edge of the list`
+            : `Item ${idx + 1}`,
         secondaryValue: `This is a description or some secondary bit of data for Item ${idx + 100}`,
         rowActions: rowActionsOverFlowMenu,
       },

--- a/packages/react/src/components/List/SimpleList/__snapshots__/SimpleList.story.storyshot
+++ b/packages/react/src/components/List/SimpleList/__snapshots__/SimpleList.story.storyshot
@@ -1122,9 +1122,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 >
                   <div
                     className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Item 1"
+                    title="Item 1 with a very long title that should truncate before it hits the edge of the list"
                   >
-                    Item 1
+                    Item 1 with a very long title that should truncate before it hits the edge of the list
                   </div>
                   <div
                     className="iot--list-item--content--row-actions"
@@ -1763,9 +1763,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 >
                   <div
                     className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Item 1"
+                    title="Item 1 with a very long title that should truncate before it hits the edge of the list"
                   >
-                    Item 1
+                    Item 1 with a very long title that should truncate before it hits the edge of the list
                   </div>
                   <div
                     className="iot--list-item--content--row-actions"
@@ -2802,9 +2802,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 >
                   <div
                     className="iot--list-item--content--values--value"
-                    title="Item 1"
+                    title="Item 1 with a very long title that should truncate before it hits the edge of the list"
                   >
-                    Item 1
+                    Item 1 with a very long title that should truncate before it hits the edge of the list
                   </div>
                 </div>
                 <div
@@ -3238,9 +3238,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 >
                   <div
                     className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Item 1"
+                    title="Item 1 with a very long title that should truncate before it hits the edge of the list"
                   >
-                    Item 1
+                    Item 1 with a very long title that should truncate before it hits the edge of the list
                   </div>
                   <div
                     className="iot--list-item--content--row-actions"
@@ -3849,9 +3849,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
                 >
                   <div
                     className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
-                    title="Item 1"
+                    title="Item 1 with a very long title that should truncate before it hits the action icons"
                   >
-                    Item 1
+                    Item 1 with a very long title that should truncate before it hits the action icons
                   </div>
                   <div
                     className="iot--list-item--content--row-actions"


### PR DESCRIPTION
Closes #3069 

**Summary**

- simple rtl padding fix for lists with actions in RTL

**Change List (commits, features, bugs, etc)**

- rtl padding

**Acceptance Test (how to verify the PR)**

- on the simple list with large row and multiple actions story
- switch to RTL
- confirm right edge of title aligns with list title at top
- confirm left edge of title truncates and does not overlap with action buttons

**Regression Test (how to make sure this PR doesn't break old functionality)**

- n/a

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
