### PR TITLE
fix(header): add isSideNavExpanded prop to fix aria-label for button

### DIFF
--- a/packages/react/src/components/Header/Header.jsx
+++ b/packages/react/src/components/Header/Header.jsx
@@ -51,6 +51,8 @@ const propTypes = {
   testId: PropTypes.string,
   /** Returns true, if the icon should be shown. (actionItem) => {} */
   isActionItemVisible: PropTypes.func,
+  /** allows setting aria-label on side-nav menu button correctly */
+  isSideNavExpanded: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -70,6 +72,7 @@ const defaultProps = {
   },
   testId: 'header',
   isActionItemVisible: () => true,
+  isSideNavExpanded: false,
 };
 
 /**
@@ -91,6 +94,7 @@ const Header = ({
   i18n,
   testId,
   isActionItemVisible,
+  isSideNavExpanded,
 }) => {
   const mergedI18n = { ...defaultProps.i18n, ...i18n };
   const theShortAppName = shortAppName || appName;
@@ -126,7 +130,7 @@ const Header = ({
       {hasSideNav && (
         <HeaderMenuButton
           data-testid={`${testId}-menu-button`}
-          aria-label={mergedI18n.openMenu}
+          aria-label={isSideNavExpanded ? mergedI18n.closeMenu : mergedI18n.openMenu}
           onClick={onClickSideNavExpand}
         />
       )}

--- a/packages/react/src/components/Header/Header.test.jsx
+++ b/packages/react/src/components/Header/Header.test.jsx
@@ -331,4 +331,22 @@ describe('Header', () => {
     render(<Header {...HeaderPropsWithoutOnClick} actionItems={[]} />);
     expect(screen.getByText('IBM')).toBeVisible();
   });
+  it('should change side-nav menu button label when isSideNavExpanded change', () => {
+    const { rerender } = render(<Header {...HeaderPropsWithoutOnClick} isSideNavExpanded />);
+    expect(screen.getByLabelText('Close menu')).toBeVisible();
+    rerender(<Header {...HeaderPropsWithoutOnClick} isSideNavExpanded={false} />);
+    expect(screen.getByLabelText('Open menu')).toBeVisible();
+    rerender(
+      <Header
+        {...HeaderPropsWithoutOnClick}
+        isSideNavExpanded={false}
+        i18n={{ openMenu: '__open__' }}
+      />
+    );
+    expect(screen.getByLabelText('__open__')).toBeVisible();
+    rerender(
+      <Header {...HeaderPropsWithoutOnClick} isSideNavExpanded i18n={{ closeMenu: '__close__' }} />
+    );
+    expect(screen.getByLabelText('__close__')).toBeVisible();
+  });
 });

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -10024,6 +10024,7 @@ Map {
         "openMenu": "Open menu",
       },
       "isActionItemVisible": [Function],
+      "isSideNavExpanded": false,
       "onClickSideNavExpand": null,
       "prefix": "IBM",
       "skipto": "#main-content",
@@ -10134,6 +10135,9 @@ Map {
       },
       "isActionItemVisible": Object {
         "type": "func",
+      },
+      "isSideNavExpanded": Object {
+        "type": "bool",
       },
       "onClickSideNavExpand": Object {
         "type": "func",


### PR DESCRIPTION
Closes #1675 

**Summary**

- adds isSideNavExpanded prop to header so that the aria-label on the menu button can be updated when the nav opens and closes

**Change List (commits, features, bugs, etc)**

- add isSideNavExpanded prop
- add tests

**Acceptance Test (how to verify the PR)**

- check the [side nav ](https://deploy-preview-3137--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-sidenav--side-nav-component) stories
- hover over the side-nav menu button
- should show 'Open menu'
- click to open menu
- hover over the side-nav menu button
- should show 'Close menu'

**Regression Test (how to make sure this PR doesn't break old functionality)**

- n/a

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
