### PR TITLE
3044 menu button style audit button variations

### DIFF
--- a/packages/react/src/components/Button/_button.scss
+++ b/packages/react/src/components/Button/_button.scss
@@ -73,8 +73,12 @@
     right: initial;
   }
 
+  // The padding $spacing-05 was added globally to all ghost button sizes at some point,
+  // but it should probably only be applied to the default size so we have added exceptions here
+  // once we found they were needed in order not to break any existing functionality.
+  // For Carbon v.11 when the button sizes are adjusted we should look over this.
   .#{$iot-prefix}--btn.#{$prefix}--btn--ghost {
-    &:not(.#{$prefix}--btn--sm.#{$prefix}--btn--icon-only) {
+    &:not(.#{$prefix}--btn--sm.#{$prefix}--btn--icon-only):not(.#{$prefix}--btn--md.#{$prefix}--btn--icon-only) {
       padding-left: $spacing-05;
       padding-right: $spacing-05;
     }

--- a/packages/react/src/components/Button/_button.scss
+++ b/packages/react/src/components/Button/_button.scss
@@ -76,9 +76,10 @@
   // The padding $spacing-05 was added globally to all ghost button sizes at some point,
   // but it should probably only be applied to the default size so we have added exceptions here
   // once we found they were needed in order not to break any existing functionality.
-  // For Carbon v.11 when the button sizes are adjusted we should look over this.
+  // For Carbon v.11 when the button sizes are adjusted we should take the oportunity to
+  // see if we can remove this global ghost padding.
   .#{$iot-prefix}--btn.#{$prefix}--btn--ghost {
-    &:not(.#{$prefix}--btn--sm.#{$prefix}--btn--icon-only):not(.#{$prefix}--btn--md.#{$prefix}--btn--icon-only) {
+    &:not(.#{$prefix}--btn--sm.#{$prefix}--btn--icon-only):not(.#{$iot-prefix}--menu-button__trigger) {
       padding-left: $spacing-05;
       padding-right: $spacing-05;
     }

--- a/packages/react/src/components/MenuButton/MenuButton.jsx
+++ b/packages/react/src/components/MenuButton/MenuButton.jsx
@@ -72,6 +72,11 @@ const propTypes = {
   },
 
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+
+  /**
+   * The size of the button and the dropdown items
+   */
+  size: PropTypes.oneOf(['sm', 'md', 'default']),
 };
 
 const defaultProps = {
@@ -82,6 +87,7 @@ const defaultProps = {
   closeIconDescription: 'close menu button',
   renderOpenIcon: ChevronDown16,
   renderCloseIcon: ChevronUp16,
+  size: 'default',
 };
 
 const MenuButton = ({
@@ -95,6 +101,7 @@ const MenuButton = ({
   renderOpenIcon,
   renderCloseIcon,
   children,
+  size: buttonSize,
 }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [position, setPosition] = useState({ x: 0, y: 0 });
@@ -111,7 +118,7 @@ const MenuButton = ({
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [label, langDir, onPrimaryActionClick, isMenuOpen]);
+  }, [label, langDir, onPrimaryActionClick, isMenuOpen, buttonSize]);
 
   /**
    * This is a hacky work-around, because the current Menu (7.42.1) won't allow us
@@ -200,6 +207,8 @@ const MenuButton = ({
     [children, handleChildClick]
   );
 
+  const menuSize = buttonSize === 'default' ? 'lg' : buttonSize;
+
   const ButtonComponent =
     typeof onPrimaryActionClick === 'function' && label ? SplitMenuButton : SingleMenuButton;
   return (
@@ -219,8 +228,9 @@ const MenuButton = ({
         label={label}
         // TODO: remove deprecated 'testID' in v3.
         testId={testID || testId}
+        size={buttonSize}
       />
-      <Menu open={isMenuOpen} {...position}>
+      <Menu size={menuSize} open={isMenuOpen} {...position}>
         {contextMenuItems}
       </Menu>
     </div>

--- a/packages/react/src/components/MenuButton/MenuButton.jsx
+++ b/packages/react/src/components/MenuButton/MenuButton.jsx
@@ -238,7 +238,12 @@ const MenuButton = ({
         size={buttonSize}
         kind={kind}
       />
-      <Menu size={menuSize} open={isMenuOpen} {...position}>
+      <Menu
+        className={`${iotPrefix}--menu-button__menu`}
+        size={menuSize}
+        open={isMenuOpen}
+        {...position}
+      >
         {contextMenuItems}
       </Menu>
     </div>

--- a/packages/react/src/components/MenuButton/MenuButton.jsx
+++ b/packages/react/src/components/MenuButton/MenuButton.jsx
@@ -77,6 +77,11 @@ const propTypes = {
    * The size of the button and the dropdown items
    */
   size: PropTypes.oneOf(['sm', 'md', 'default']),
+
+  /**
+   * The kind of button
+   */
+  kind: PropTypes.oneOf(['primary', 'secondary', 'tertiary', 'ghost']),
 };
 
 const defaultProps = {
@@ -88,6 +93,7 @@ const defaultProps = {
   renderOpenIcon: ChevronDown16,
   renderCloseIcon: ChevronUp16,
   size: 'default',
+  kind: 'primary',
 };
 
 const MenuButton = ({
@@ -102,6 +108,7 @@ const MenuButton = ({
   renderCloseIcon,
   children,
   size: buttonSize,
+  kind,
 }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [position, setPosition] = useState({ x: 0, y: 0 });
@@ -229,6 +236,7 @@ const MenuButton = ({
         // TODO: remove deprecated 'testID' in v3.
         testId={testID || testId}
         size={buttonSize}
+        kind={kind}
       />
       <Menu size={menuSize} open={isMenuOpen} {...position}>
         {contextMenuItems}

--- a/packages/react/src/components/MenuButton/MenuButton.jsx
+++ b/packages/react/src/components/MenuButton/MenuButton.jsx
@@ -233,7 +233,7 @@ const MenuButton = ({
     [`${iotPrefix}--menu-button--flip-x`]: flippedX,
     [`${iotPrefix}--menu-button--opens-horizontally`]: opensHorizontally,
   };
-  const showShadowBlocker = buttonKind === GHOST && isMenuOpen;
+  const showShadowBlocker = buttonKind === GHOST && isMenuOpen && !label;
   const shadowBlocker = showShadowBlocker ? (
     <div
       style={{ [`--menu-height`]: `${menuHeight}px` }}

--- a/packages/react/src/components/MenuButton/MenuButton.story.jsx
+++ b/packages/react/src/components/MenuButton/MenuButton.story.jsx
@@ -52,12 +52,17 @@ export const menuItems = [
 ];
 
 const sizes = ['sm', 'md', 'default'];
+const kinds = ['primary', 'secondary', 'tertiary', 'ghost'];
 
 export const Experimental = () => <StoryNotice componentName="MenuButton" experimental />;
 Experimental.storyName = experimentalStoryTitle;
 
 const SingleButton = () => (
-  <MenuButton size={select('Button size (size)', sizes, 'default')} label="Actions">
+  <MenuButton
+    size={select('Button size (size)', sizes, 'default')}
+    kind={select('Button kind (kind)', kinds, 'primary')}
+    label="Actions"
+  >
     {menuItems}
   </MenuButton>
 );
@@ -76,6 +81,11 @@ SingleMenuButton.storyName = 'menu button';
 const SplitButton = () => (
   <MenuButton
     size={select('Button size (size)', sizes, 'default')}
+    kind={select(
+      'Button kind (kind)',
+      kinds.filter((kind) => kind !== 'ghost'),
+      'primary'
+    )}
     onPrimaryActionClick={action('onPrimaryActionClick')}
     label="Create"
   >

--- a/packages/react/src/components/MenuButton/MenuButton.story.jsx
+++ b/packages/react/src/components/MenuButton/MenuButton.story.jsx
@@ -21,9 +21,7 @@ export const menuItems = [
     initialChecked={false}
     onChange={action('Publish')}
   />,
-  <MenuDivider key="div-1" />,
   <MenuItem key="duplicate" renderIcon={Copy16} label="Duplicate" onClick={action('Duplicate')} />,
-  <MenuDivider key="div-2" />,
   <MenuItem key="share" label="Share with">
     <MenuRadioGroup
       label="Shared with"
@@ -32,7 +30,6 @@ export const menuItems = [
       onChange={action('Share')}
     />
   </MenuItem>,
-  <MenuDivider key="div-3" />,
   <MenuItem key="export" label="Export">
     <MenuItem label="CSV" onClick={action('Export CSV')} />
     <MenuItem label="JSON" onClick={action('Export JSON')} />
@@ -42,7 +39,7 @@ export const menuItems = [
     label={<span title="You must have proper credentials to use this option.">Disabled</span>}
     disabled
   />,
-  <MenuDivider key="div-4" />,
+  <MenuDivider key="div-1" />,
   <MenuItem
     key="delete"
     label="Delete"
@@ -54,10 +51,17 @@ export const menuItems = [
   />,
 ];
 
+const sizes = ['sm', 'md', 'default'];
+
 export const Experimental = () => <StoryNotice componentName="MenuButton" experimental />;
 Experimental.storyName = experimentalStoryTitle;
 
-const SingleButton = () => <MenuButton label="Actions">{menuItems}</MenuButton>;
+const SingleButton = () => (
+  <MenuButton size={select('Button size (size)', sizes, 'default')} label="Actions">
+    {menuItems}
+  </MenuButton>
+);
+
 /**
  * If no primary action is given, but has a label we assume it's a single menu button.
  */
@@ -70,7 +74,11 @@ SingleMenuButton.storyName = 'menu button';
  */
 
 const SplitButton = () => (
-  <MenuButton onPrimaryActionClick={action('onPrimaryActionClick')} label="Create">
+  <MenuButton
+    size={select('Button size (size)', sizes, 'default')}
+    onPrimaryActionClick={action('onPrimaryActionClick')}
+    label="Create"
+  >
     {menuItems}
   </MenuButton>
 );

--- a/packages/react/src/components/MenuButton/MenuButton.story.jsx
+++ b/packages/react/src/components/MenuButton/MenuButton.story.jsx
@@ -101,7 +101,11 @@ SplitMenuButton.storyName = 'split menu button';
  * if no label is given then it assumes it's an icon only menu.
  */
 const IconOnlyButton = () => (
-  <MenuButton renderOpenIcon={OverflowMenuVertical16} renderCloseIcon={OverflowMenuVertical16}>
+  <MenuButton
+    size={select('Button size (size)', sizes, 'default')}
+    renderOpenIcon={OverflowMenuVertical16}
+    renderCloseIcon={OverflowMenuVertical16}
+  >
     {menuItems}
   </MenuButton>
 );

--- a/packages/react/src/components/MenuButton/MenuButton.test.jsx
+++ b/packages/react/src/components/MenuButton/MenuButton.test.jsx
@@ -202,6 +202,135 @@ describe('MenuButton', () => {
     expect(screen.getAllByRole('menu')[0]).not.toHaveClass(`${prefix}--menu--lg`);
   });
 
+  it('should render the correct default kind for buttons', () => {
+    // Single button
+    const { rerender } = render(<MenuButton label="Create">{menuItems}</MenuButton>);
+    expect(screen.getByRole('button', { name: 'Create' })).toHaveClass(`${prefix}--btn--primary`);
+
+    // Split button
+    rerender(
+      <MenuButton onPrimaryActionClick={() => {}} label="Create">
+        {menuItems}
+      </MenuButton>
+    );
+    expect(screen.getByRole('button', { name: 'Create' })).toHaveClass(`${prefix}--btn--primary`);
+    expect(screen.getByRole('button', { name: 'open menu button' })).toHaveClass(
+      `${prefix}--btn--primary`
+    );
+
+    // Icon only button
+    rerender(<MenuButton renderOpenIcon={ChevronDown16}>{menuItems}</MenuButton>);
+    expect(screen.getByRole('button')).toHaveClass(`${prefix}--btn--ghost`);
+  });
+
+  it('should render primary kind for single button and split button', () => {
+    // Single button
+    const { rerender } = render(<MenuButton label="Create">{menuItems}</MenuButton>);
+    expect(screen.getByRole('button', { name: 'Create' })).toHaveClass(`${prefix}--btn--primary`);
+
+    // Split button
+    rerender(
+      <MenuButton onPrimaryActionClick={() => {}} label="Create">
+        {menuItems}
+      </MenuButton>
+    );
+    expect(screen.getByRole('button', { name: 'Create' })).toHaveClass(`${prefix}--btn--primary`);
+    expect(screen.getByRole('button', { name: 'open menu button' })).toHaveClass(
+      `${prefix}--btn--primary`
+    );
+
+    // Icon only button is always ghost
+    rerender(<MenuButton renderOpenIcon={ChevronDown16}>{menuItems}</MenuButton>);
+    expect(screen.getByRole('button')).toHaveClass(`${prefix}--btn--ghost`);
+  });
+
+  it('should render seondary kind for single button and split button', () => {
+    // Single button
+    const { rerender } = render(
+      <MenuButton kind="secondary" label="Create">
+        {menuItems}
+      </MenuButton>
+    );
+    expect(screen.getByRole('button', { name: 'Create' })).toHaveClass(`${prefix}--btn--secondary`);
+
+    // Split button
+    rerender(
+      <MenuButton kind="secondary" onPrimaryActionClick={() => {}} label="Create">
+        {menuItems}
+      </MenuButton>
+    );
+    expect(screen.getByRole('button', { name: 'Create' })).toHaveClass(`${prefix}--btn--secondary`);
+    expect(screen.getByRole('button', { name: 'open menu button' })).toHaveClass(
+      `${prefix}--btn--secondary`
+    );
+
+    // Icon only button is always ghost
+    rerender(
+      <MenuButton kind="secondary" renderOpenIcon={ChevronDown16}>
+        {menuItems}
+      </MenuButton>
+    );
+    expect(screen.getByRole('button')).toHaveClass(`${prefix}--btn--ghost`);
+  });
+
+  it('should render tertiary kind for single button and split button', () => {
+    // Single button
+    const { rerender } = render(
+      <MenuButton kind="tertiary" label="Create">
+        {menuItems}
+      </MenuButton>
+    );
+    expect(screen.getByRole('button', { name: 'Create' })).toHaveClass(`${prefix}--btn--tertiary`);
+
+    // Split button
+    rerender(
+      <MenuButton kind="tertiary" onPrimaryActionClick={() => {}} label="Create">
+        {menuItems}
+      </MenuButton>
+    );
+    expect(screen.getByRole('button', { name: 'Create' })).toHaveClass(`${prefix}--btn--tertiary`);
+    expect(screen.getByRole('button', { name: 'open menu button' })).toHaveClass(
+      `${prefix}--btn--tertiary`
+    );
+
+    // Icon only button is always ghost
+    rerender(
+      <MenuButton kind="tertiary" renderOpenIcon={ChevronDown16}>
+        {menuItems}
+      </MenuButton>
+    );
+    expect(screen.getByRole('button')).toHaveClass(`${prefix}--btn--ghost`);
+  });
+
+  it('should render ghost kind for single button, split button & icon button', () => {
+    // Single button
+    const { rerender } = render(
+      <MenuButton kind="ghost" label="Create">
+        {menuItems}
+      </MenuButton>
+    );
+    expect(screen.getByRole('button', { name: 'Create' })).toHaveClass(`${prefix}--btn--ghost`);
+
+    // Split button
+    rerender(
+      <MenuButton kind="ghost" onPrimaryActionClick={() => {}} label="Create">
+        {menuItems}
+      </MenuButton>
+    );
+    expect(screen.getByRole('button', { name: 'Create' })).toHaveClass(`${prefix}--btn--ghost`);
+    expect(screen.getByRole('button', { name: 'open menu button' })).toHaveClass(
+      `${prefix}--btn--ghost`
+    );
+
+    // Icon only button is always ghost
+    rerender(
+      <MenuButton kind="ghost" renderOpenIcon={ChevronDown16}>
+        {menuItems}
+      </MenuButton>
+    );
+    expect(screen.getByRole('button')).toHaveClass(`${prefix}--btn--ghost`);
+  });
+
   it('should be open the menu when clicking the button in single button mode', () => {
     render(<MenuButton label="Create">{menuItems}</MenuButton>);
 

--- a/packages/react/src/components/MenuButton/MenuButton.test.jsx
+++ b/packages/react/src/components/MenuButton/MenuButton.test.jsx
@@ -302,7 +302,7 @@ describe('MenuButton', () => {
     expect(screen.getByRole('button')).toHaveClass(`${prefix}--btn--ghost`);
   });
 
-  it('should render ghost kind for single button, split button & icon button', () => {
+  it('should render ghost kind for single button & icon button', () => {
     // Single button
     const { rerender } = render(
       <MenuButton kind="ghost" label="Create">
@@ -310,17 +310,6 @@ describe('MenuButton', () => {
       </MenuButton>
     );
     expect(screen.getByRole('button', { name: 'Create' })).toHaveClass(`${prefix}--btn--ghost`);
-
-    // Split button
-    rerender(
-      <MenuButton kind="ghost" onPrimaryActionClick={() => {}} label="Create">
-        {menuItems}
-      </MenuButton>
-    );
-    expect(screen.getByRole('button', { name: 'Create' })).toHaveClass(`${prefix}--btn--ghost`);
-    expect(screen.getByRole('button', { name: 'open menu button' })).toHaveClass(
-      `${prefix}--btn--ghost`
-    );
 
     // Icon only button is always ghost
     rerender(

--- a/packages/react/src/components/MenuButton/MenuButton.test.jsx
+++ b/packages/react/src/components/MenuButton/MenuButton.test.jsx
@@ -135,6 +135,73 @@ describe('MenuButton', () => {
     expect(create).toBeCalled();
   });
 
+  it('should use default size for buttons and menu items', () => {
+    render(<MenuButton label="Create">{menuItems}</MenuButton>);
+
+    // The "default" size does not have a specific class, so we make sure that the
+    // other size classed have not been added.
+    expect(screen.getByRole('button', { name: 'Create' })).not.toHaveClass(`${prefix}--btn--sm`);
+    expect(screen.getByRole('button', { name: 'Create' })).not.toHaveClass(`${prefix}--btn--md`);
+    expect(screen.getByRole('button', { name: 'Create' })).not.toHaveClass(`${prefix}--btn--lg`);
+    expect(screen.getByRole('button', { name: 'Create' })).not.toHaveClass(`${prefix}--btn--xl`);
+
+    userEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    // The menu will by default get the size lg which mathces the size "default" of
+    // the triggering button
+    expect(screen.getAllByRole('menu')[0]).toHaveClass(`${prefix}--menu--lg`);
+  });
+
+  it('should render the correct sizes for buttons and menu items for size "default"', () => {
+    render(
+      <MenuButton size="default" label="Create">
+        {menuItems}
+      </MenuButton>
+    );
+
+    // The "default" size does not have a specific class, so we make sure that the
+    // other size classed have not been added.
+    expect(screen.getByRole('button', { name: 'Create' })).not.toHaveClass(`${prefix}--btn--sm`);
+    expect(screen.getByRole('button', { name: 'Create' })).not.toHaveClass(`${prefix}--btn--md`);
+    expect(screen.getByRole('button', { name: 'Create' })).not.toHaveClass(`${prefix}--btn--lg`);
+    expect(screen.getByRole('button', { name: 'Create' })).not.toHaveClass(`${prefix}--btn--xl`);
+
+    userEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    // The menu will by default get the size lg which mathces the size "default" of
+    // the triggering button
+    expect(screen.getAllByRole('menu')[0]).toHaveClass(`${prefix}--menu--lg`);
+  });
+
+  it('should render the correct sizes for buttons and menu items for size "md"', () => {
+    render(
+      <MenuButton size="md" label="Create">
+        {menuItems}
+      </MenuButton>
+    );
+
+    expect(screen.getByRole('button', { name: 'Create' })).toHaveClass(`${prefix}--btn--md`);
+
+    userEvent.click(screen.getByRole('button', { name: 'Create' }));
+    expect(screen.getAllByRole('menu')[0]).toHaveClass(`${prefix}--menu--md`);
+  });
+
+  it('should render the correct sizes for buttons and menu items for size "sm"', () => {
+    render(
+      <MenuButton size="sm" label="Create">
+        {menuItems}
+      </MenuButton>
+    );
+
+    expect(screen.getByRole('button', { name: 'Create' })).toHaveClass(`${prefix}--btn--sm`);
+
+    userEvent.click(screen.getByRole('button', { name: 'Create' }));
+    // The size "sm" will not get an explicit class, so we check that the other classes
+    // are not present
+    expect(screen.getAllByRole('menu')[0]).not.toHaveClass(`${prefix}--menu--md`);
+    expect(screen.getAllByRole('menu')[0]).not.toHaveClass(`${prefix}--menu--lg`);
+  });
+
   it('should be open the menu when clicking the button in single button mode', () => {
     render(<MenuButton label="Create">{menuItems}</MenuButton>);
 

--- a/packages/react/src/components/MenuButton/MenuButton.test.jsx
+++ b/packages/react/src/components/MenuButton/MenuButton.test.jsx
@@ -168,7 +168,7 @@ describe('MenuButton', () => {
 
     userEvent.click(screen.getByRole('button', { name: 'Create' }));
 
-    // The menu will by default get the size lg which mathces the size "default" of
+    // The menu will by default get the size lg which matches the size "default" of
     // the triggering button
     expect(screen.getAllByRole('menu')[0]).toHaveClass(`${prefix}--menu--lg`);
   });
@@ -416,6 +416,217 @@ describe('MenuButton', () => {
         `Failed prop type: The prop \`iconDescription\` is marked as required in \`ForwardRef\`, but its value is \`null\`.`
       )
     );
+  });
+
+  describe('getShadowBlockerConfig', () => {
+    const MENU_HEIGHT = 236;
+    beforeEach(() => {
+      Object.defineProperty(document.body, 'clientWidth', {
+        writable: true,
+        value: 1024,
+      });
+      Object.defineProperty(document.body, 'clientHeight', {
+        writable: true,
+        value: 768,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(document.body, 'clientWidth', {
+        writable: true,
+        value: 0,
+      });
+      Object.defineProperty(document.body, 'clientHeight', {
+        writable: true,
+        value: 0,
+      });
+    });
+
+    it('get the correct height of the menu', () => {
+      const button = generateMenuButton({
+        bottom: 747,
+        height: 48,
+        left: 930,
+        right: 978,
+        top: 699,
+        width: 48,
+        x: 930,
+        y: 699,
+      });
+
+      const { menuHeight } = MenuButtonUtils.getShadowBlockerConfig({ current: button });
+      expect(menuHeight).toEqual(MENU_HEIGHT);
+    });
+
+    it('should set openHorizontally when menu overflows to both top and bottom', () => {
+      Object.defineProperty(document.body, 'clientWidth', {
+        writable: true,
+        value: 1024,
+      });
+      Object.defineProperty(document.body, 'clientHeight', {
+        writable: true,
+        value: 384,
+      });
+
+      const button = generateMenuButton({
+        bottom: 816,
+        height: 48,
+        left: 912.984375,
+        right: 960.984375,
+        top: 200,
+        width: 48,
+        x: 912.984375,
+        y: 768,
+      });
+
+      const { flippedX, flippedY, opensHorizontally } = MenuButtonUtils.getShadowBlockerConfig({
+        current: button,
+      });
+
+      expect(flippedX).toEqual(false);
+      expect(flippedY).toEqual(true);
+      expect(opensHorizontally).toEqual(true);
+    });
+
+    it('should generate correct config when overflow is right', () => {
+      const button = generateMenuButton({
+        bottom: 456,
+        height: 48,
+        left: 912.984375,
+        right: 960.984375,
+        top: 408,
+        width: 48,
+        x: 912.984375,
+        y: 408,
+      });
+
+      const { flippedX, flippedY, opensHorizontally } = MenuButtonUtils.getShadowBlockerConfig({
+        current: button,
+      });
+      expect(flippedX).toEqual(false);
+      expect(flippedY).toEqual(true);
+      expect(opensHorizontally).toEqual(false);
+    });
+
+    it('should generate correct config when overflow is top-right', () => {
+      const button = generateMenuButton({
+        bottom: 96,
+        height: 48,
+        left: 912.984375,
+        right: 960.984375,
+        top: 48,
+        width: 48,
+        x: 912.984375,
+        y: 48,
+      });
+
+      const { flippedX, flippedY, opensHorizontally } = MenuButtonUtils.getShadowBlockerConfig({
+        current: button,
+      });
+      expect(flippedX).toEqual(false);
+      expect(flippedY).toEqual(true);
+      expect(opensHorizontally).toEqual(false);
+    });
+
+    it('should generate correct config when overflow is top', () => {
+      const button = generateMenuButton({
+        bottom: 96,
+        height: 48,
+        left: 480.484375,
+        right: 528.484375,
+        top: 48,
+        width: 48,
+        x: 480.484375,
+        y: 48,
+      });
+
+      const { flippedX, flippedY, opensHorizontally } = MenuButtonUtils.getShadowBlockerConfig({
+        current: button,
+      });
+      expect(flippedX).toEqual(false);
+      expect(flippedY).toEqual(false);
+      expect(opensHorizontally).toEqual(false);
+    });
+
+    it('should generate correct config when there is no overflow in any direction', () => {
+      const button = generateMenuButton({
+        bottom: 456,
+        height: 48,
+        left: 480.484375,
+        right: 528.484375,
+        top: 408,
+        width: 48,
+        x: 480.484375,
+        y: 408,
+      });
+
+      const { flippedX, flippedY, opensHorizontally } = MenuButtonUtils.getShadowBlockerConfig({
+        current: button,
+      });
+      expect(flippedX).toEqual(false);
+      expect(flippedY).toEqual(false);
+      expect(opensHorizontally).toEqual(false);
+    });
+
+    it('should generate correct config when overflow is left', () => {
+      const button = generateMenuButton({
+        bottom: 456,
+        height: 48,
+        left: 48,
+        right: 96,
+        top: 408,
+        width: 48,
+        x: 48,
+        y: 408,
+      });
+
+      const { flippedX, flippedY, opensHorizontally } = MenuButtonUtils.getShadowBlockerConfig({
+        current: button,
+      });
+      expect(flippedX).toEqual(false);
+      expect(flippedY).toEqual(false);
+      expect(opensHorizontally).toEqual(false);
+    });
+
+    it('should generate correct config when overflow is top-left', () => {
+      const button = generateMenuButton({
+        bottom: 96,
+        height: 48,
+        left: 48,
+        right: 96,
+        top: 48,
+        width: 48,
+        x: 48,
+        y: 48,
+      });
+
+      const { flippedX, flippedY, opensHorizontally } = MenuButtonUtils.getShadowBlockerConfig({
+        current: button,
+      });
+      expect(flippedX).toEqual(false);
+      expect(flippedY).toEqual(false);
+      expect(opensHorizontally).toEqual(false);
+    });
+
+    it('should generate correct config when overflow is bottom-left', () => {
+      const button = generateMenuButton({
+        bottom: 816,
+        height: 48,
+        left: 48,
+        right: 96,
+        top: 768,
+        width: 48,
+        x: 48,
+        y: 768,
+      });
+
+      const { flippedX, flippedY, opensHorizontally } = MenuButtonUtils.getShadowBlockerConfig({
+        current: button,
+      });
+      expect(flippedX).toEqual(true);
+      expect(flippedY).toEqual(false);
+      expect(opensHorizontally).toEqual(false);
+    });
   });
 
   describe('getMenuPosition', () => {

--- a/packages/react/src/components/MenuButton/SingleMenuButton.jsx
+++ b/packages/react/src/components/MenuButton/SingleMenuButton.jsx
@@ -32,6 +32,11 @@ const propTypes = {
   iconDescription: PropTypes.string.isRequired,
 
   testId: PropTypes.string.isRequired,
+
+  /**
+   * The size of the button and the dropdown items
+   */
+  size: PropTypes.oneOf(['sm', 'md', 'default']).isRequired,
 };
 
 const defaultProps = {
@@ -42,7 +47,15 @@ const defaultProps = {
 
 export const SingleMenuButton = React.forwardRef(
   (
-    { onSecondaryActionClick, onPrimaryActionClick, label, iconDescription, renderIcon, testId },
+    {
+      onSecondaryActionClick,
+      onPrimaryActionClick,
+      label,
+      iconDescription,
+      renderIcon,
+      testId,
+      size,
+    },
     ref
   ) => {
     return (
@@ -55,6 +68,7 @@ export const SingleMenuButton = React.forwardRef(
         hasIconOnly={!label}
         kind={!label ? 'ghost' : 'primary'}
         testId={label ? `${testId}-single` : `${testId}-icon`}
+        size={size}
       >
         {label}
       </Button>

--- a/packages/react/src/components/MenuButton/SingleMenuButton.jsx
+++ b/packages/react/src/components/MenuButton/SingleMenuButton.jsx
@@ -37,6 +37,11 @@ const propTypes = {
    * The size of the button and the dropdown items
    */
   size: PropTypes.oneOf(['sm', 'md', 'default']).isRequired,
+
+  /**
+   * The kind of button
+   */
+  kind: PropTypes.oneOf(['primary', 'secondary', 'tertiary', 'ghost']).isRequired,
 };
 
 const defaultProps = {
@@ -55,6 +60,7 @@ export const SingleMenuButton = React.forwardRef(
       renderIcon,
       testId,
       size,
+      kind,
     },
     ref
   ) => {
@@ -66,7 +72,7 @@ export const SingleMenuButton = React.forwardRef(
         iconDescription={iconDescription}
         renderIcon={renderIcon}
         hasIconOnly={!label}
-        kind={!label ? 'ghost' : 'primary'}
+        kind={!label ? 'ghost' : kind}
         testId={label ? `${testId}-single` : `${testId}-icon`}
         size={size}
       >

--- a/packages/react/src/components/MenuButton/SingleMenuButton.jsx
+++ b/packages/react/src/components/MenuButton/SingleMenuButton.jsx
@@ -39,7 +39,7 @@ const propTypes = {
   size: PropTypes.oneOf(['sm', 'md', 'default']).isRequired,
 
   /**
-   * The kind of button
+   * The kind of button to render
    */
   kind: PropTypes.oneOf(['primary', 'secondary', 'tertiary', 'ghost']).isRequired,
 };
@@ -72,7 +72,7 @@ export const SingleMenuButton = React.forwardRef(
         iconDescription={iconDescription}
         renderIcon={renderIcon}
         hasIconOnly={!label}
-        kind={!label ? 'ghost' : kind}
+        kind={kind}
         testId={label ? `${testId}-single` : `${testId}-icon`}
         size={size}
       >

--- a/packages/react/src/components/MenuButton/SplitMenuButton.jsx
+++ b/packages/react/src/components/MenuButton/SplitMenuButton.jsx
@@ -42,6 +42,11 @@ const propTypes = {
    * The size of the button and the dropdown items
    */
   size: PropTypes.oneOf(['sm', 'md', 'default']).isRequired,
+
+  /**
+   * The kind of button to render
+   */
+  kind: PropTypes.oneOf(['primary', 'secondary', 'tertiary']).isRequired,
 };
 
 export const SplitMenuButton = React.forwardRef(
@@ -54,6 +59,7 @@ export const SplitMenuButton = React.forwardRef(
       onSecondaryActionClick,
       size,
       testId,
+      kind,
     },
     ref
   ) => {
@@ -64,6 +70,7 @@ export const SplitMenuButton = React.forwardRef(
           onClick={onPrimaryActionClick}
           testId={`${testId}-primary`}
           size={size}
+          kind={kind}
         >
           {label}
         </Button>
@@ -79,6 +86,7 @@ export const SplitMenuButton = React.forwardRef(
           onClick={onSecondaryActionClick}
           testId={`${testId}-secondary`}
           size={size}
+          kind={kind}
         />
       </>
     );

--- a/packages/react/src/components/MenuButton/SplitMenuButton.jsx
+++ b/packages/react/src/components/MenuButton/SplitMenuButton.jsx
@@ -37,11 +37,24 @@ const propTypes = {
    * be read by screen readers
    */
   iconDescription: PropTypes.string.isRequired,
+
+  /**
+   * The size of the button and the dropdown items
+   */
+  size: PropTypes.oneOf(['sm', 'md', 'default']).isRequired,
 };
 
 export const SplitMenuButton = React.forwardRef(
   (
-    { label, iconDescription, renderIcon, onPrimaryActionClick, onSecondaryActionClick, testId },
+    {
+      label,
+      iconDescription,
+      renderIcon,
+      onPrimaryActionClick,
+      onSecondaryActionClick,
+      size,
+      testId,
+    },
     ref
   ) => {
     return (
@@ -50,6 +63,7 @@ export const SplitMenuButton = React.forwardRef(
           className={classnames(`${iotPrefix}--menu-button__primary`)}
           onClick={onPrimaryActionClick}
           testId={`${testId}-primary`}
+          size={size}
         >
           {label}
         </Button>
@@ -64,6 +78,7 @@ export const SplitMenuButton = React.forwardRef(
           renderIcon={renderIcon}
           onClick={onSecondaryActionClick}
           testId={`${testId}-secondary`}
+          size={size}
         />
       </>
     );

--- a/packages/react/src/components/MenuButton/_menu-button-shadow-blocker.scss
+++ b/packages/react/src/components/MenuButton/_menu-button-shadow-blocker.scss
@@ -1,0 +1,192 @@
+@import '../../globals/vars';
+
+$size-sm: rem(32px);
+$size-md: rem(40px);
+$size-lg: rem(48px);
+$shadow-blocker-height: rem(8px);
+$shadow-blocker-border-width: rem(1px);
+
+@mixin shadow-blocker-element {
+  position: absolute;
+  display: block;
+  height: calc(#{$shadow-blocker-height} - #{$shadow-blocker-border-width});
+}
+
+// COVER THE SHADOW WITH A NEW DIV
+// We add a new div on a higher z-index in order to cover the shadow of the menu.
+.#{$iot-prefix}--menu-button--icon-only.#{$prefix}--menu--open {
+  .#{$iot-prefix}--menu__shadow-blocker {
+    @include shadow-blocker-element;
+    top: calc((-#{$shadow-blocker-height}) + #{$shadow-blocker-border-width});
+    left: 0;
+    width: $size-sm; // small is the default size
+    background-color: $ui-01;
+    border-bottom: $shadow-blocker-border-width solid $ui-01;
+
+    &--flip-y {
+      left: unset;
+      right: 0;
+    }
+
+    &--flip-x {
+      left: unset;
+      top: var(--menu-height);
+    }
+
+    html[dir='rtl'] & {
+      &:not(.#{$iot-prefix}--menu__shadow-blocker--opens-horizontally) {
+        left: 0;
+      }
+    }
+
+    &--md {
+      width: $size-md;
+    }
+    &--lg {
+      width: $size-lg;
+    }
+
+    // The menu is attached to the side (instead of above or below)
+    &--opens-horizontally {
+      $width: calc(#{$shadow-blocker-height} - #{$shadow-blocker-border-width});
+
+      top: 0;
+      height: $size-sm; // small is the default size
+      width: $width;
+      left: calc((#{$width}) * (-1));
+      border-bottom: none;
+      border-right: $shadow-blocker-border-width solid $ui-01;
+
+      &.#{$iot-prefix}--menu__shadow-blocker--flip-y {
+        right: calc((#{$width}) * (-1));
+        left: unset;
+        border-right: none;
+        border-left: $shadow-blocker-border-width solid $ui-01;
+      }
+
+      &.#{$iot-prefix}--menu__shadow-blocker--md {
+        height: $size-md;
+        width: $width;
+      }
+      &.#{$iot-prefix}--menu__shadow-blocker--lg {
+        height: $size-lg;
+        width: $width;
+      }
+    }
+  }
+
+  // If the menu has focus it has a blue border and that one needs to
+  // be restored since it is covered by the shadow-blocker
+  &:focus .#{$iot-prefix}--menu__shadow-blocker {
+    border-bottom: $shadow-blocker-border-width solid $focus;
+    &--flip-x {
+      border-bottom-color: $ui-01;
+      border-top: $shadow-blocker-border-width solid $focus;
+    }
+    &--opens-horizontally {
+      border-bottom: none;
+      border-right: $shadow-blocker-border-width solid $focus;
+      &.#{$iot-prefix}--menu__shadow-blocker--flip-y {
+        border-right: none;
+        border-left: $shadow-blocker-border-width solid $focus;
+      }
+    }
+  }
+}
+
+// RESTORE THE BLUE FOCUS BORDER OF THE BUTTON
+// This needed to make sure the blue focus border of the actual button is not covered by the element
+// introduced to cover the shadow of the menu. This style has to be placed on the button since the menu
+// does not know when the button has focus.
+.#{$iot-prefix}--menu-button--open {
+  .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--btn--ghost:focus:not(:active) {
+    @function calculate-width($size) {
+      @return calc(#{$size} - (2 * #{$shadow-blocker-border-width}));
+    }
+    @function calculate-top($size) {
+      @return calc(#{$size} - #{$shadow-blocker-height} - #{$shadow-blocker-border-width});
+    }
+
+    &::after {
+      @include shadow-blocker-element;
+      width: calculate-width($size-lg); // large is the default
+      top: calculate-top($size-lg); // large is the default
+      content: '';
+      left: calc(#{$shadow-blocker-border-width} * (-1));
+      background-color: transparent;
+      z-index: 9001; // z-index of the menu is 9000
+      border: none;
+      border-bottom: $shadow-blocker-border-width solid $focus;
+      border-left: $shadow-blocker-border-width solid $focus;
+      border-right: $shadow-blocker-border-width solid $focus;
+      // We need to unset some properties added by other styling also using ::after
+      // e.g. the ones from tooltip__trigger
+      border-radius: 0;
+      transform: none;
+      box-shadow: none;
+      padding: 0;
+    }
+    &.#{$prefix}--btn--md::after {
+      width: calculate-width($size-md);
+      top: calculate-top($size-md);
+    }
+    &.#{$prefix}--btn--sm::after {
+      width: calculate-width($size-sm);
+      top: calculate-top($size-sm);
+    }
+  }
+
+  &.#{$iot-prefix}--menu-button--flip-x
+    .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--btn--ghost:focus:not(:active)::after {
+    top: (-$shadow-blocker-border-width);
+    border-top: $shadow-blocker-border-width solid $focus;
+    border-bottom: 0;
+  }
+
+  // The menu is attached to the side (instead of above or below)
+  &.#{$iot-prefix}--menu-button--opens-horizontally {
+    .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--btn--ghost:focus:not(:active) {
+      @function calculate-middle($size) {
+        @return calc(
+          ((#{$size} - #{$shadow-blocker-height}) / 2) - #{$shadow-blocker-border-width}
+        );
+      }
+
+      &::after {
+        transform: rotate(-90deg);
+        top: calculate-middle($size-lg);
+        left: calculate-middle($size-lg);
+      }
+
+      &.#{$prefix}--btn--md::after {
+        top: calculate-middle($size-md);
+        left: calculate-middle($size-md);
+      }
+      &.#{$prefix}--btn--sm::after {
+        top: calculate-middle($size-sm);
+        left: calculate-middle($size-sm);
+      }
+    }
+
+    &.#{$iot-prefix}--menu-button--flip-y {
+      .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--btn--ghost:focus:not(:active) {
+        @function calculate-negative-middle($size) {
+          @return calc(
+            (((#{$size} - #{$shadow-blocker-height}) / 2) + #{$shadow-blocker-border-width}) * (-1)
+          );
+        }
+
+        &::after {
+          transform: rotate(90deg);
+          left: calculate-negative-middle($size-lg);
+        }
+        &.#{$prefix}--btn--md::after {
+          left: calculate-negative-middle($size-md);
+        }
+        &.#{$prefix}--btn--sm::after {
+          left: calculate-negative-middle($size-sm);
+        }
+      }
+    }
+  }
+}

--- a/packages/react/src/components/MenuButton/_menu-button.scss
+++ b/packages/react/src/components/MenuButton/_menu-button.scss
@@ -1,5 +1,6 @@
 @import '~carbon-components/scss/components/menu/menu';
 @import '../../globals/vars';
+@import './menu-button-shadow-blocker';
 
 .#{$iot-prefix}--menu-button {
   .#{$iot-prefix}--menu-button__primary + .#{$iot-prefix}--menu-button__secondary {

--- a/packages/react/src/components/MenuButton/_menu-button.scss
+++ b/packages/react/src/components/MenuButton/_menu-button.scss
@@ -36,6 +36,13 @@
   }
 }
 
+.#{$iot-prefix}--menu-button__menu {
+  padding: 0;
+  .#{$prefix}--menu-divider {
+    margin: 0;
+  }
+}
+
 .#{$prefix}--menu.#{$prefix}--menu--open.#{$prefix}--menu--root {
   opacity: var(--iot-menu-button-menu-opacity);
 }

--- a/packages/react/src/components/MenuButton/_menu-button.scss
+++ b/packages/react/src/components/MenuButton/_menu-button.scss
@@ -39,13 +39,13 @@
   opacity: var(--iot-menu-button-menu-opacity);
 }
 
-html[dir='rtl'] .#{$iot-prefix}--menu-button {
-  .#{$prefix}--context-menu-option__icon {
+html[dir='rtl'] .#{$iot-prefix}--menu-button__menu {
+  .#{$prefix}--menu-option__icon {
     margin-right: 0;
     margin-left: $spacing-03;
   }
 
-  .#{$prefix}--context-menu-option__info {
+  .#{$prefix}--menu-option__info {
     margin-left: 0;
     margin-right: $spacing-05;
     transform: rotate(180deg);

--- a/packages/react/src/components/MenuButton/_menu-button.scss
+++ b/packages/react/src/components/MenuButton/_menu-button.scss
@@ -12,7 +12,20 @@
 
   &--open {
     .#{$iot-prefix}--menu-button__trigger {
-      background-color: $active-primary;
+      &.#{$prefix}--btn--primary {
+        background-color: $active-primary;
+      }
+      &.#{$prefix}--btn--secondary {
+        background-color: $active-secondary;
+      }
+      &.#{$prefix}--btn--tertiary {
+        background-color: $active-tertiary;
+        color: $text-04;
+      }
+      &.#{$prefix}--btn--ghost {
+        background-color: $active-ui; // There is no $active-ghost sass variable
+        color: $link-02;
+      }
     }
 
     .#{$prefix}--btn--ghost.#{$prefix}--btn--icon-only {

--- a/packages/react/src/components/MenuButton/utils.js
+++ b/packages/react/src/components/MenuButton/utils.js
@@ -1,20 +1,61 @@
 import { settings } from '../../constants/Settings';
 
 const { prefix } = settings;
-export const getMenuPosition = ({ label, buttonRef, onPrimaryActionClick, langDir }) => {
-  const isSplitButton = label && typeof onPrimaryActionClick === 'function';
+
+const getBoundingClientRects = (buttonRef, isSplitButton) => {
   const buttonRect = buttonRef.current.getBoundingClientRect();
   const primaryButtonRect = isSplitButton
     ? buttonRef?.current?.previousSibling?.getBoundingClientRect()
     : null;
-  const node =
-    buttonRef.current?.nextSibling ??
-    document.querySelector(`.${prefix}--menu.${prefix}--menu--open.${prefix}--menu--root`);
-  const menuRect = node?.getBoundingClientRect();
   // Once the menuButton can accept a target for the react portal, we can
   // use this method again once the menu is placed within the same div as the
   // button.
   // const menuRect = buttonRef.current.nextSibling?.getBoundingClientRect();
+  const node =
+    buttonRef.current?.nextSibling ??
+    document.querySelector(`.${prefix}--menu.${prefix}--menu--open.${prefix}--menu--root`);
+  const menuRect = node?.getBoundingClientRect();
+
+  return { buttonRect, primaryButtonRect, menuRect };
+};
+
+const getMenuDimensions = (menuRect) => ({
+  menuHeight: menuRect?.height ?? 0,
+  menuWidth: menuRect?.width ?? 0,
+});
+
+const getOverflow = (menuRect, buttonRect) => {
+  const windowWidth = window.innerWidth || document.documentElement.clientWidth;
+  const windowHeight = window.innerHeight || document.documentElement.clientHeight;
+  const { menuHeight, menuWidth } = getMenuDimensions(menuRect);
+  const offTop = buttonRect.top - menuHeight < 0;
+  const offLeft = buttonRect.left - menuWidth < 0;
+  const offRight = buttonRect.right + menuWidth > windowWidth;
+  const offBottom = buttonRect.bottom + menuHeight > windowHeight;
+  const T = offTop ? 'top' : '';
+  const R = offRight ? 'right' : '';
+  const B = offBottom ? 'bottom' : '';
+  const L = offLeft ? 'left' : '';
+
+  return [T, R, B, L].filter(Boolean).join('-');
+};
+
+export const getShadowBlockerConfig = (buttonRef) => {
+  const { buttonRect, menuRect } = getBoundingClientRects(buttonRef);
+  const { menuHeight } = getMenuDimensions(menuRect);
+  const overflow = getOverflow(menuRect, buttonRect);
+  const flippedX = overflow?.includes('bottom') && !overflow?.includes('top');
+  const flippedY = overflow?.includes('right');
+  const opensHorizontally = overflow?.includes('top') && overflow?.includes('bottom');
+  return { menuHeight, flippedX, flippedY, opensHorizontally };
+};
+
+export const getMenuPosition = ({ label, buttonRef, onPrimaryActionClick, langDir }) => {
+  const isSplitButton = label && typeof onPrimaryActionClick === 'function';
+  const { buttonRect, primaryButtonRect, menuRect } = getBoundingClientRects(
+    buttonRef,
+    isSplitButton
+  );
   const isRtl = langDir === 'rtl';
   const { x: buttonX, y: buttonY, width: buttonWidth, height: buttonHeight } = buttonRect;
   const { clientHeight: bodyHeight } = document.body;
@@ -27,20 +68,8 @@ export const getMenuPosition = ({ label, buttonRef, onPrimaryActionClick, langDi
   let y = buttonY + buttonHeight;
   let x = isSplitButton ? buttonX + primaryButtonWidth : buttonX;
 
-  const windowWidth = window.innerWidth || document.documentElement.clientWidth;
-  const windowHeight = window.innerHeight || document.documentElement.clientHeight;
-  const menuHeight = menuRect?.height ?? 0;
-  const menuWidth = menuRect?.width ?? 0;
-  const offTop = buttonRect.top - menuHeight < 0;
-  const offLeft = buttonRect.left - menuWidth < 0;
-  const offRight = buttonRect.right + menuWidth > windowWidth;
-  const offBottom = buttonRect.bottom + menuHeight > windowHeight;
-  const T = offTop ? 'top' : '';
-  const R = offRight ? 'right' : '';
-  const B = offBottom ? 'bottom' : '';
-  const L = offLeft ? 'left' : '';
-
-  const overflow = [T, R, B, L].filter(Boolean).join('-');
+  const { menuHeight, menuWidth } = getMenuDimensions(menuRect);
+  const overflow = getOverflow(menuRect, buttonRect);
 
   /* istanbul ignore else */
   if (menuRect) {

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -27097,6 +27097,7 @@ Map {
   "MenuButton" => Object {
     "defaultProps": Object {
       "closeIconDescription": "close menu button",
+      "kind": "primary",
       "label": null,
       "onPrimaryActionClick": null,
       "openIconDescription": "open menu button",
@@ -27108,6 +27109,7 @@ Map {
         "$$typeof": Symbol(react.forward_ref),
         "render": [Function],
       },
+      "size": "default",
       "testId": "menu-button",
     },
     "propTypes": Object {
@@ -27131,6 +27133,17 @@ Map {
         "type": "oneOfType",
       },
       "closeIconDescription": [Function],
+      "kind": Object {
+        "args": Array [
+          Array [
+            "primary",
+            "secondary",
+            "tertiary",
+            "ghost",
+          ],
+        ],
+        "type": "oneOf",
+      },
       "label": Object {
         "type": "string",
       },
@@ -27163,6 +27176,16 @@ Map {
           ],
         ],
         "type": "oneOfType",
+      },
+      "size": Object {
+        "args": Array [
+          Array [
+            "sm",
+            "md",
+            "default",
+          ],
+        ],
+        "type": "oneOf",
       },
       "testID": [Function],
       "testId": Object {


### PR DESCRIPTION
Closes #3044

**Summary**
Fixed the styling remarks from #3044 and also fixed some additional RTL issued. In order to understand the changes it is easiest to go through the commits one by one.

**Change List (commits, features, bugs, etc)**

1. Fixed button and menu item sizes according to the spec  + unit tests
2. Added button variations (kind) according to the spec + unit tests
3. Fixed the shadow from the menu that was incorrectly dropping in the button (complex fix needed) + unit tests
4. Fixed additional RTL issues


**Acceptance Test (how to verify the PR)**
Start by reading the spec.

1. Go to https://deploy-preview-3185--carbon-addons-iot-react.netlify.app?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-menubutton--single-menu-button and use the size knob to verify that the sizes renders according to spec. Note, we use "default" instead of large until carbon v.11

2.  Repeat step 1 for https://deploy-preview-3185--carbon-addons-iot-react.netlify.app?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-menubutton--split-menu-button and https://deploy-preview-3185--carbon-addons-iot-react.netlify.app?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-menubutton--icon-only-menu-button

3. Verify that https://deploy-preview-3185--carbon-addons-iot-react.netlify.app?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-menubutton--single-menu-button renders the different kinds of buttons available in the kind knob and that the button and the menu looks as expected. Compare to the spec.

4. Verify that https://deploy-preview-3185--carbon-addons-iot-react.netlify.app?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-menubutton--split-menu-button renders the different kinds of buttons available in the kind knob and that the button and the menu looks as expected. Compare to the spec.

5.  Go to https://deploy-preview-3185--carbon-addons-iot-react.netlify.app?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-menubutton--auto-positioning-example and for all COMBINATIONS of positions, sizes and RTL-mode for the IconOnlyButton verify that: 
a) the shadow from the menu does not fall on the button (for any state of interaction)
b) the blue focus border of the menu is intact
c) the blue focus border of the button is intact (to test this click the button to open the menu and then press down on the button with the mouse again but move the cursor outside the button before releasing)


**Regression Test (how to make sure this PR doesn't break old functionality)**

- All stories work as before except for the changes described by the spec.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
