### PR TITLE
3194 storybook knobs are leaking into all stories

### DIFF
--- a/packages/react/src/components/Dashboard/Dashboard.story.jsx
+++ b/packages/react/src/components/Dashboard/Dashboard.story.jsx
@@ -450,7 +450,7 @@ export const originalCards = [
   },
 ];
 
-const commonDashboardProps = {
+const getCommonDashboardProps = () => ({
   title: text('title', 'Munich Building'),
   cards: originalCards,
   lastUpdated: new Date('2019-10-22T00:00:00').toUTCString(),
@@ -463,7 +463,7 @@ const commonDashboardProps = {
   onFetchData: (card) => {
     return new Promise((resolve) => setTimeout(() => resolve(card), 5000));
   },
-};
+});
 
 export default {
   title: '1 - Watson IoT/🚫 Dashboard',
@@ -476,7 +476,7 @@ Deprecated.storyName = deprecatedStoryTitle;
 export const BasicDashboard = () => {
   return (
     <FullWidthWrapper>
-      <Dashboard {...commonDashboardProps} isLoading={boolean('isLoading', false)} />
+      <Dashboard {...getCommonDashboardProps()} isLoading={boolean('isLoading', false)} />
     </FullWidthWrapper>
   );
 };
@@ -504,7 +504,7 @@ BasicDashboard.parameters = {
 export const BasicWithoutLastUpdatedHeader = () => {
   return (
     <FullWidthWrapper>
-      <Dashboard {...commonDashboardProps} hasLastUpdated={false} />
+      <Dashboard {...getCommonDashboardProps()} hasLastUpdated={false} />
     </FullWidthWrapper>
   );
 };
@@ -515,7 +515,7 @@ export const CustomActions = () => {
   return (
     <FullWidthWrapper>
       <Dashboard
-        {...commonDashboardProps}
+        {...getCommonDashboardProps()}
         actions={[{ id: 'edit', labelText: 'Edit', icon: 'edit' }]}
         onDashboardAction={action('onDashboardAction')}
       />
@@ -529,7 +529,7 @@ export const Sidebar = () => {
   return (
     <FullWidthWrapper>
       <Dashboard
-        {...commonDashboardProps}
+        {...getCommonDashboardProps()}
         sidebar={
           <div style={{ width: 300 }}>
             <h1>Sidebar content</h1>
@@ -548,7 +548,7 @@ export const I18NLabels = () => {
   return (
     <FullWidthWrapper>
       <Dashboard
-        {...commonDashboardProps}
+        {...getCommonDashboardProps()}
         i18n={{
           lastUpdatedLabel: text('lastUpdatedLabel', 'Last updated: '),
           noDataLabel: text('noDataLabel', 'No data is available for this time range.'),

--- a/packages/react/src/components/GaugeCard/GaugeCard.story.jsx
+++ b/packages/react/src/components/GaugeCard/GaugeCard.story.jsx
@@ -10,7 +10,7 @@ import { getCardMinSize } from '../../utils/componentUtilityFunctions';
 
 import GaugeCard from './GaugeCard';
 
-const content = {
+const getContent = () => ({
   gauges: [
     {
       dataSourceId: 'usage',
@@ -48,7 +48,7 @@ const content = {
       ],
     },
   ],
-};
+});
 
 export default {
   title: '1 - Watson IoT/GaugeCard',
@@ -79,7 +79,7 @@ export const Basic = () => {
           usage: number('Gauge value', 81),
           usageTrend: '12%',
         }}
-        content={content}
+        content={getContent()}
       />
     </div>
   );
@@ -250,7 +250,7 @@ export const BasicWithExpand = () => {
         availableActions={{
           expand: true,
         }}
-        content={content}
+        content={getContent()}
         onCardAction={action('Expand button clicked')}
       />
     </div>

--- a/packages/react/src/components/ImageCard/HotspotContent.story.jsx
+++ b/packages/react/src/components/ImageCard/HotspotContent.story.jsx
@@ -6,7 +6,7 @@ import { red60 } from '@carbon/colors';
 
 import HotspotContent from './HotspotContent';
 
-const mockValues = object('values', { temperature: 35.35, humidity: 99 });
+const getMockValues = () => object('values', { temperature: 35.35, humidity: 99 });
 
 export default {
   title: '1 - Watson IoT/HotspotContent',
@@ -24,7 +24,7 @@ export const Basic = () => {
       <HotspotContent
         title={text('title', 'Hotspot title')}
         description={text('description', 'description')}
-        values={mockValues}
+        values={getMockValues()}
         attributes={object('attributes', [
           { dataSourceId: 'temperature', label: 'Temperature' },
           { dataSourceId: 'humidity', label: 'Humidity' },
@@ -42,7 +42,7 @@ export const BasicWithUnitsAndPrecision = () => {
       <HotspotContent
         title={text('title', 'Hotspot title')}
         description={text('description', 'description')}
-        values={mockValues}
+        values={getMockValues()}
         attributes={object('attributes', [
           {
             dataSourceId: 'temperature',
@@ -70,7 +70,7 @@ export const WithThresholds = () => {
       <HotspotContent
         title={text('title', 'Hotspot title')}
         description={text('description', 'description')}
-        values={mockValues}
+        values={getMockValues()}
         attributes={object('attributes', [
           {
             dataSourceId: 'temperature',
@@ -119,7 +119,7 @@ export const Locale = () => {
       <HotspotContent
         title={text('title', 'Hotspot title')}
         description={text('description', 'description')}
-        values={mockValues}
+        values={getMockValues()}
         attributes={object('attributes', [
           {
             dataSourceId: 'temperature',

--- a/packages/react/src/components/Table/Table.story.jsx
+++ b/packages/react/src/components/Table/Table.story.jsx
@@ -510,11 +510,6 @@ export const initialState = {
     hasColumnSelection: true,
     shouldExpandOnRowClick: false,
     hasRowEdit: true,
-    wrapCellText: select(
-      'Choose how text should wrap witin columns (options.wrapCellText)',
-      selectTextWrapping,
-      'always'
-    ),
   },
   view: {
     filters: [

--- a/packages/react/src/components/TileGallery/TileGallery.story.jsx
+++ b/packages/react/src/components/TileGallery/TileGallery.story.jsx
@@ -31,7 +31,7 @@ const overflowComponent = (
   </OverflowMenu>
 );
 
-export const content = (
+const getContent = () => (
   <Fragment>
     <TileGallerySection
       title={select('Select with/without section', { Title: 'Section 1', None: null }, 'Title')}
@@ -149,7 +149,7 @@ export default {
     component: TileGallery,
   },
 
-  excludeStories: ['content', 'galleryData'],
+  excludeStories: ['galleryData'],
 };
 
 export const _StatefulTileGallery = () => (
@@ -167,7 +167,7 @@ _StatefulTileGallery.storyName = 'Stateful TileGallery';
 
 export const BasicExample = () => (
   <FullWidthWrapper>
-    <TileGallery>{content}</TileGallery>
+    <TileGallery>{getContent()}</TileGallery>
   </FullWidthWrapper>
 );
 
@@ -207,7 +207,7 @@ export const _TileGalleryViewSwitcher = () => <TileGalleryViewSwitcher />;
 _TileGalleryViewSwitcher.storyName = 'TileGalleryViewSwitcher';
 
 export const TileGallerySectionWithTileGalleryItemGrid = () => (
-  <FullWidthWrapper>{content}</FullWidthWrapper>
+  <FullWidthWrapper>{getContent()}</FullWidthWrapper>
 );
 
 TileGallerySectionWithTileGalleryItemGrid.storyName =


### PR DESCRIPTION
Closes #3194

**Summary**
Fixed stories that had knobs that were "leaking" into the other stories. The problem was that there were knobs defined in objects in the the storybook global scope outside the exported stories. Transformed the objects into functions.

**Change List (commits, features, bugs, etc)**
- Transformed the objects into functions.


**Acceptance Test (how to verify the PR)**

1. Go to https://deploy-preview-3197--carbon-addons-iot-react.netlify.app?path=/story/0-overview-getting-started--about-storybook and make sure there no knobs are appearing.

**Regression Test (how to make sure this PR doesn't break old functionality)**
1. Go through the stories for GaugeCard, HotspotContent, Table and TileGallery and make sure they work as before.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
