### PR TITLE
fix(table): add skeleton column for nesting rows when lazy loading

### DIFF
--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -745,7 +745,7 @@ const Table = (props) => {
   const totalColumns =
     visibleColumns.length +
     (hasMultiSelect ? 1 : 0) +
-    (options.hasRowExpansion ? 1 : 0) +
+    (options.hasRowExpansion || options.hasRowNesting ? 1 : 0) +
     (options.hasRowActions ? 1 : 0) +
     (showExpanderColumn ? 1 : 0);
 

--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -745,7 +745,7 @@ const Table = (props) => {
   const totalColumns =
     visibleColumns.length +
     (hasMultiSelect ? 1 : 0) +
-    (options.hasRowExpansion || options.hasRowNesting ? 1 : 0) +
+    (options.hasRowExpansion ? 1 : 0) +
     (options.hasRowActions ? 1 : 0) +
     (showExpanderColumn ? 1 : 0);
 

--- a/packages/react/src/components/Table/Table.test.e2e.jsx
+++ b/packages/react/src/components/Table/Table.test.e2e.jsx
@@ -370,9 +370,9 @@ describe('Table visual regression tests', () => {
     // 50 for rows, 1 for header
     cy.get('tr').should('have.length', 51);
     cy.findAllByTestId(/lazy-row/i).should('have.length', 42);
-    cy.get('tr').eq(10).scrollIntoView({ duration: 500 });
+    cy.get('tr').eq(10).scrollIntoView({ duration: 1500 });
     cy.findAllByTestId(/lazy-row/i).should('have.length', 32);
-    cy.get('tr').last().scrollIntoView({ duration: 500 });
+    cy.get('tr').last().scrollIntoView({ duration: 1500 });
     cy.findAllByTestId(/lazy-row/i).should('have.length', 0);
 
     // reset back to default

--- a/packages/react/src/components/Table/TableBody/TableBodyRowRenderer.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRowRenderer.jsx
@@ -197,11 +197,15 @@ const TableBodyRowRenderer = (props) => {
         ref={rowVisibilityRef}
         data-testid={`${tableId}-lazy-row-${row.id}`}
       >
-        {[...Array(totalColumns)].map((c, colIndex) => (
+        {hasRowSelection === 'multi' ? <TableCell /> : null}
+        {hasRowExpansion || hasRowNesting ? <TableCell /> : null}
+        {columns.map((v, colIndex) => (
           <TableCell key={`empty-cell-${colIndex}`}>
             <SkeletonText />
           </TableCell>
         ))}
+        {showExpanderColumn ? <TableCell /> : null}
+        {hasRowActions ? <TableCell /> : null}
       </tr>
     );
   }

--- a/packages/react/src/components/Table/TableBody/TableBodyRowRenderer.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRowRenderer.jsx
@@ -198,7 +198,7 @@ const TableBodyRowRenderer = (props) => {
         data-testid={`${tableId}-lazy-row-${row.id}`}
       >
         {hasRowSelection === 'multi' ? <TableCell /> : null}
-        {hasRowExpansion ? <TableCell /> : null}
+        {hasRowExpansion || hasRowNesting ? <TableCell /> : null}
         {columns.map((v, colIndex) => (
           <TableCell key={`empty-cell-${colIndex}`}>
             <SkeletonText />

--- a/packages/react/src/components/Table/TableBody/TableBodyRowRenderer.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRowRenderer.jsx
@@ -197,15 +197,11 @@ const TableBodyRowRenderer = (props) => {
         ref={rowVisibilityRef}
         data-testid={`${tableId}-lazy-row-${row.id}`}
       >
-        {hasRowSelection === 'multi' ? <TableCell /> : null}
-        {hasRowExpansion || hasRowNesting ? <TableCell /> : null}
-        {columns.map((v, colIndex) => (
+        {[...Array(totalColumns)].map((c, colIndex) => (
           <TableCell key={`empty-cell-${colIndex}`}>
             <SkeletonText />
           </TableCell>
         ))}
-        {showExpanderColumn ? <TableCell /> : null}
-        {hasRowActions ? <TableCell /> : null}
       </tr>
     );
   }


### PR DESCRIPTION
Closes #3220 

**Summary**

- The placeholder skeleton column was missing when lazy loading with `hasNestedRows`. This fixes that.

**Change List (commits, features, bugs, etc)**

- add check for `hasRowNesting` when including skeleton columns

**Acceptance Test (how to verify the PR)**

- go the the basic table story
- turn on hasRowNesting
- turn on hasRowSelection to 'multi'
- turn on shouldLazyRender
- confirm the columns align with header and Object ID column isn't missing a skeleton

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
