### PR TITLE
fix(table): add rownesting in total columns calc

### DIFF
--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -745,7 +745,7 @@ const Table = (props) => {
   const totalColumns =
     visibleColumns.length +
     (hasMultiSelect ? 1 : 0) +
-    (options.hasRowExpansion ? 1 : 0) +
+    (options.hasRowExpansion || options.hasRowNesting ? 1 : 0) +
     (options.hasRowActions ? 1 : 0) +
     (showExpanderColumn ? 1 : 0);
 

--- a/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
+++ b/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
@@ -69,6 +69,7 @@ class FilterHeaderRow extends Component {
     tableOptions: PropTypes.shape({
       hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
       hasRowExpansion: PropTypes.bool,
+      hasRowNesting: PropTypes.bool,
       hasRowActions: PropTypes.bool,
     }),
     /** filter can be hidden by the user but filters will still apply to the table */
@@ -245,7 +246,7 @@ class FilterHeaderRow extends Component {
       ordering,
       clearFilterText,
       filterText,
-      tableOptions: { hasRowSelection, hasRowExpansion, hasRowActions },
+      tableOptions: { hasRowSelection, hasRowExpansion, hasRowNesting, hasRowActions },
       isVisible,
       lightweight,
       isDisabled,
@@ -265,7 +266,7 @@ class FilterHeaderRow extends Component {
         {hasRowSelection === 'multi' ? (
           <TableHeader className={`${iotPrefix}--filter-header-row--header`} ref={this.rowRef} />
         ) : null}
-        {hasRowExpansion ? (
+        {hasRowExpansion || hasRowNesting ? (
           <TableHeader className={`${iotPrefix}--filter-header-row--header`} />
         ) : null}
         {visibleColumns.map((c, i) => {

--- a/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.test.jsx
+++ b/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.test.jsx
@@ -587,6 +587,27 @@ describe('FilterHeaderRow', () => {
     expect(container.querySelectorAll('th')).toHaveLength(4);
   });
 
+  it('should display an extra header when hasRowNesting', () => {
+    const { container } = render(
+      <FilterHeaderRow
+        showExpanderColumn
+        {...commonFilterProps}
+        ordering={[{ columnId: 'col1' }, { columnId: 'col2' }]}
+        columns={[
+          { id: 'col1', isFilterable: true },
+          { id: 'col2', isFilterable: true },
+        ]}
+        tableOptions={{
+          hasRowSelection: 'single',
+          hasRowNesting: true,
+        }}
+        isVisible
+      />
+    );
+
+    expect(container.querySelectorAll('th')).toHaveLength(4);
+  });
+
   it('should display an extra header when hasRowActions', () => {
     const { container } = render(
       <FilterHeaderRow


### PR DESCRIPTION
Closes #3210

**Summary**
Fix for keeping filter columns aligned when using options.hasRowNesting

**Change List (commits, features, bugs, etc)**
- Updated FilterHeaderRow to handle options.hasRowNesting
- Added unit test
- Fixed options.hasRowNesting that was missing when calculating `totalColumns` in the table. This was not the fix needed for this issue, but it will solve other bugs not yet reported in `ErrorTable` and `EmptyTable`. Other use of `totalColumns` is unaffected from what I could tell.

**Acceptance Test (how to verify the PR)**

1. Go to https://deploy-preview-3235--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table-table--basic-dumb-table
2. Select StatefulTable in knob Stable Type of Table
3. Make sure knob `options.hasRowNesting` is true
4. Make sure the filters are showing
5. Verify that the filters are aligned with the column headers

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Verify that the other table stories using row nesting is working as expected

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
