### PR TITLE
fix(table): add hidden prop to row action

### DIFF
--- a/packages/react/src/components/Table/StatefulTable.story.jsx
+++ b/packages/react/src/components/Table/StatefulTable.story.jsx
@@ -156,14 +156,31 @@ export const SimpleStatefulExample = () => {
       id="table"
       key={`table${demoInitialColumnSizes}`}
       {...initialState}
-      data={initialState.data.slice(
-        0,
-        select(
-          'number of data items in table',
-          [initialState.data.length, 50, 20, 5],
-          initialState.data.length
+      data={initialState.data
+        .slice(
+          0,
+          select(
+            'number of data items in table',
+            [initialState.data.length, 50, 20, 5],
+            initialState.data.length
+          )
         )
-      )}
+        .map((row, index) => ({
+          ...row,
+          rowActions:
+            index === 1
+              ? [
+                  {
+                    id: 'Add',
+                    iconDescription: 'Add',
+                    labelText: 'Add',
+                    isOverflow: false,
+                    hasDivider: true,
+                    hidden: true,
+                  },
+                ]
+              : row.rowActions,
+        }))}
       actions={tableActions}
       columns={initialState.columns
         .map((column) => {

--- a/packages/react/src/components/Table/Table.story.jsx
+++ b/packages/react/src/components/Table/Table.story.jsx
@@ -472,6 +472,18 @@ export const initialState = {
         disabled: true,
       },
       {
+        id: 'hiddenOverflow',
+        labelText: 'Hidden overflow',
+        isOverflow: true,
+        hidden: true,
+      },
+      {
+        id: 'hidden',
+        labelText: 'Hidden',
+        isOverflow: false,
+        hidden: true,
+      },
+      {
         id: 'Add',
         renderIcon: Add,
         iconDescription: 'Add',

--- a/packages/react/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
+++ b/packages/react/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
@@ -118,7 +118,8 @@ class RowActionsCell extends React.Component {
       size,
     } = this.props;
     const { isOpen } = this.state;
-    const overflowActions = actions ? actions.filter((action) => action.isOverflow) : [];
+    const visibleActions = actions ? actions.filter((action) => !action.hidden) : [];
+    const overflowActions = visibleActions.filter((action) => action.isOverflow);
     const hasOverflow = overflowActions.length > 0;
     const firstSelectableItemIndex = overflowActions.findIndex((action) => !action.disabled);
 
@@ -158,7 +159,7 @@ class RowActionsCell extends React.Component {
               </Fragment>
             ) : (
               <Fragment>
-                {actions
+                {visibleActions
                   .filter((action) => !action.isOverflow)
                   .map(({ id: actionId, labelText, iconDescription, ...others }) => (
                     <Button

--- a/packages/react/src/components/Table/TableBody/RowActionsCell/RowActionsCell.test.jsx
+++ b/packages/react/src/components/Table/TableBody/RowActionsCell/RowActionsCell.test.jsx
@@ -95,6 +95,59 @@ describe('RowActionsCell', () => {
     expect(screen.queryByText(action.labelText)).toBeTruthy();
   });
 
+  it('still renders action cell and container when all actions are hidden', () => {
+    const tableRow = document.createElement('tr');
+    const actions = [
+      {
+        id: 'hidden',
+        labelText: 'hidden',
+        hidden: true,
+      },
+      {
+        id: 'hidden2',
+        labelText: 'Hidden 2',
+        isOverflow: true,
+        hidden: true,
+      },
+    ];
+    render(<RowActionsCell {...commonRowActionsProps} actions={actions} />, {
+      container: document.body.appendChild(tableRow),
+    });
+
+    expect(screen.getByTestId('row-action-container-background')).toBeVisible();
+  });
+
+  it('does not render hidden actions', () => {
+    const tableRow = document.createElement('tr');
+    const actions = [
+      {
+        id: 'hiddenEdit',
+        renderIcon: 'edit',
+        iconDescription: 'Edit stuff',
+        labelText: 'Hidden Edit icon label',
+        hidden: true,
+      },
+      {
+        id: 'visible',
+        labelText: 'Visible action button',
+      },
+      {
+        id: 'hidden2',
+        labelText: 'Hidden 2',
+        hidden: true,
+      },
+    ];
+    render(<RowActionsCell {...commonRowActionsProps} actions={actions} />, {
+      container: document.body.appendChild(tableRow),
+    });
+
+    expect(screen.queryByText('Hidden Edit icon label')).toBeNull();
+
+    expect(screen.getByText('Visible action button')).toBeVisible();
+
+    expect(screen.queryByText('Hidden 2')).toBeNull();
+  });
+
   describe('RowActionsError', () => {
     it('should show errors and be dismissable when onClearError is given', () => {
       const tableRow = document.createElement('tr');
@@ -328,6 +381,91 @@ describe('RowActionsCell', () => {
       expect(
         screen.getByTestId('tableId-rowId-row-actions-cell-overflow-menu-item-edit')
       ).toBeVisible();
+    });
+
+    it('does not render hidden overflow actions', () => {
+      const tableRow = document.createElement('tr');
+      const actions = [
+        {
+          id: 'hiddenEdit',
+          renderIcon: 'edit',
+          iconDescription: 'Edit stuff',
+          labelText: 'Hidden Edit icon label',
+          isOverflow: true,
+          hidden: true,
+        },
+        {
+          id: 'visible',
+          labelText: 'Visible',
+          isOverflow: true,
+        },
+        {
+          id: 'hidden2',
+          labelText: 'Hidden 2',
+          isOverflow: true,
+          hidden: true,
+        },
+      ];
+      render(<RowActionsCell {...commonRowActionsProps} actions={actions} />, {
+        container: document.body.appendChild(tableRow),
+      });
+
+      userEvent.click(
+        screen.getByRole('button', {
+          name: RowActionsCell.defaultProps.overflowMenuAria,
+        })
+      );
+
+      expect(screen.queryByLabelText('Hidden Edit icon label', { selector: 'svg' })).toBeNull();
+      expect(
+        screen.queryByTestId('tableId-rowId-row-actions-cell-overflow-menu-item-hiddenEdit')
+      ).toBeNull();
+
+      expect(
+        screen.getByTestId('tableId-rowId-row-actions-cell-overflow-menu-item-visible')
+      ).toBeVisible();
+
+      expect(
+        screen.queryByTestId('tableId-rowId-row-actions-cell-overflow-menu-item-hidden2')
+      ).toBeNull();
+    });
+
+    it('does not render overflow button if all actions are hidden', () => {
+      const tableRow = document.createElement('tr');
+      const actions = [
+        {
+          id: 'initiallyVisible',
+          labelText: 'Initially visible',
+          isOverflow: true,
+          hidden: false,
+        },
+        {
+          id: 'hidden2',
+          labelText: 'Hidden 2',
+          isOverflow: true,
+          hidden: true,
+        },
+      ];
+      const { rerender } = render(<RowActionsCell {...commonRowActionsProps} actions={actions} />, {
+        container: document.body.appendChild(tableRow),
+      });
+
+      expect(
+        screen.queryByRole('button', {
+          name: RowActionsCell.defaultProps.overflowMenuAria,
+        })
+      ).toBeVisible();
+
+      actions[0].hidden = true;
+      rerender(<RowActionsCell {...commonRowActionsProps} actions={actions} />, {
+        container: document.body.appendChild(tableRow),
+      });
+
+      expect(
+        screen.queryByRole('button', {
+          name: RowActionsCell.defaultProps.overflowMenuAria,
+        })
+      ).toBeNull();
     });
   });
 });

--- a/packages/react/src/components/Table/TablePropTypes.js
+++ b/packages/react/src/components/Table/TablePropTypes.js
@@ -22,6 +22,7 @@ export const RowActionPropTypes = PropTypes.arrayOf(
       PropTypes.func,
     ]),
     disabled: PropTypes.bool,
+    hidden: PropTypes.bool,
     labelText: PropTypes.string,
     /** Action should go into the overflow menu, not be rendered inline in the row */
     isOverflow: PropTypes.bool,

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -1050,6 +1050,9 @@ Map {
                           "hasDivider": Object {
                             "type": "bool",
                           },
+                          "hidden": Object {
+                            "type": "bool",
+                          },
                           "id": Object {
                             "isRequired": true,
                             "type": "string",
@@ -3257,6 +3260,9 @@ Map {
                           "hasDivider": Object {
                             "type": "bool",
                           },
+                          "hidden": Object {
+                            "type": "bool",
+                          },
                           "id": Object {
                             "isRequired": true,
                             "type": "string",
@@ -4170,6 +4176,9 @@ Map {
                             "type": "bool",
                           },
                           "hasDivider": Object {
+                            "type": "bool",
+                          },
+                          "hidden": Object {
                             "type": "bool",
                           },
                           "id": Object {


### PR DESCRIPTION
Closes #3208

**Summary**
Adds hidden prop to Table rowActions

**Change List (commits, features, bugs, etc)**
- Adds hidden prop and proptype to Table rowActions
- Update Table story example data to include a hidden action and a hidden overflow action
- Update `SimpleStatefulExample` to include a row where all actions are hidden
- Write unit tests

**Acceptance Test (how to verify the PR)**
1. Go to https://deploy-preview-3238--carbon-addons-iot-react.netlify.app?path=/story/1-watson-iot-table-statefultable--simple-stateful-example
2. Enable knob hasRowActions
3. Verify that the second row is not showing any row actions at all
4. Verify that there are no actions named "Hidden" visible
5. Verify that there are no overflow actions named "Hidden overflow" visible

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Make sure the other Table stories with actions work as expected

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
