### PR TITLE
fix(table): fix proptype on TableToolbar, too

### DIFF
--- a/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -27,11 +27,11 @@ import {
   TableSearchPropTypes,
   defaultI18NPropTypes,
   ActiveTableToolbarPropType,
-  TableRowPropTypes,
   TableColumnsPropTypes,
   TableFiltersPropType,
   TableOrderingPropType,
   TableToolbarActionsPropType,
+  TableRowsPropTypes,
 } from '../TablePropTypes';
 import {
   handleSpecificKeyDown,
@@ -165,7 +165,7 @@ const propTypes = {
     toolbarActions: TableToolbarActionsPropType,
   }).isRequired,
   /** Row value data for the body of the table */
-  data: TableRowPropTypes.isRequired,
+  data: TableRowsPropTypes.isRequired,
 
   // TODO: remove deprecated 'testID' in v3
   // eslint-disable-next-line react/require-default-props

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -4139,140 +4139,145 @@ Map {
       "data": Object {
         "args": Array [
           Object {
-            "children": Object {
-              "args": Array [
-                Array [
-                  Object {
-                    "type": "array",
-                  },
-                ],
-              ],
-              "type": "oneOfType",
-            },
-            "hasLoadMore": Object {
-              "type": "bool",
-            },
-            "id": Object {
-              "isRequired": true,
-              "type": "string",
-            },
-            "isSelectable": Object {
-              "type": "bool",
-            },
-            "rowActions": Object {
-              "args": Array [
-                Object {
+            "args": Array [
+              Object {
+                "children": Object {
+                  "args": Array [
+                    Array [
+                      Object {
+                        "type": "array",
+                      },
+                    ],
+                  ],
+                  "type": "oneOfType",
+                },
+                "hasLoadMore": Object {
+                  "type": "bool",
+                },
+                "id": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+                "isSelectable": Object {
+                  "type": "bool",
+                },
+                "rowActions": Object {
                   "args": Array [
                     Object {
-                      "disabled": Object {
-                        "type": "bool",
-                      },
-                      "hasDivider": Object {
-                        "type": "bool",
-                      },
-                      "id": Object {
-                        "isRequired": true,
-                        "type": "string",
-                      },
-                      "isDelete": Object {
-                        "type": "bool",
-                      },
-                      "isEdit": Object {
-                        "type": "bool",
-                      },
-                      "isOverflow": Object {
-                        "type": "bool",
-                      },
-                      "labelText": Object {
-                        "type": "string",
-                      },
-                      "renderIcon": Object {
-                        "args": Array [
-                          Array [
-                            Object {
-                              "args": Array [
+                      "args": Array [
+                        Object {
+                          "disabled": Object {
+                            "type": "bool",
+                          },
+                          "hasDivider": Object {
+                            "type": "bool",
+                          },
+                          "id": Object {
+                            "isRequired": true,
+                            "type": "string",
+                          },
+                          "isDelete": Object {
+                            "type": "bool",
+                          },
+                          "isEdit": Object {
+                            "type": "bool",
+                          },
+                          "isOverflow": Object {
+                            "type": "bool",
+                          },
+                          "labelText": Object {
+                            "type": "string",
+                          },
+                          "renderIcon": Object {
+                            "args": Array [
+                              Array [
                                 Object {
-                                  "height": Object {
-                                    "type": "string",
-                                  },
-                                  "svgData": Object {
-                                    "args": Array [
-                                      Object {
-                                        "type": Object {
-                                          "args": Array [
-                                            Array [
-                                              "svg",
-                                            ],
-                                          ],
-                                          "type": "oneOf",
-                                        },
+                                  "args": Array [
+                                    Object {
+                                      "height": Object {
+                                        "type": "string",
                                       },
+                                      "svgData": Object {
+                                        "args": Array [
+                                          Object {
+                                            "type": Object {
+                                              "args": Array [
+                                                Array [
+                                                  "svg",
+                                                ],
+                                              ],
+                                              "type": "oneOf",
+                                            },
+                                          },
+                                        ],
+                                        "isRequired": true,
+                                        "type": "shape",
+                                      },
+                                      "viewBox": Object {
+                                        "isRequired": true,
+                                        "type": "string",
+                                      },
+                                      "width": Object {
+                                        "type": "string",
+                                      },
+                                    },
+                                  ],
+                                  "type": "shape",
+                                },
+                                Object {
+                                  "args": Array [
+                                    Array [
+                                      "caretUp",
+                                      "caretDown",
+                                      "edit",
+                                      "close",
+                                      "checkmark",
+                                      "warning",
+                                      "arrowUp",
+                                      "arrowDown",
+                                      "user",
+                                      "info",
+                                      "help",
                                     ],
-                                    "isRequired": true,
-                                    "type": "shape",
-                                  },
-                                  "viewBox": Object {
-                                    "isRequired": true,
-                                    "type": "string",
-                                  },
-                                  "width": Object {
-                                    "type": "string",
-                                  },
+                                  ],
+                                  "type": "oneOf",
+                                },
+                                Object {
+                                  "type": "node",
+                                },
+                                Object {
+                                  "type": "object",
+                                },
+                                Object {
+                                  "type": "func",
                                 },
                               ],
-                              "type": "shape",
-                            },
-                            Object {
-                              "args": Array [
-                                Array [
-                                  "caretUp",
-                                  "caretDown",
-                                  "edit",
-                                  "close",
-                                  "checkmark",
-                                  "warning",
-                                  "arrowUp",
-                                  "arrowDown",
-                                  "user",
-                                  "info",
-                                  "help",
-                                ],
-                              ],
-                              "type": "oneOf",
-                            },
-                            Object {
-                              "type": "node",
-                            },
-                            Object {
-                              "type": "object",
-                            },
-                            Object {
-                              "type": "func",
-                            },
-                          ],
-                        ],
-                        "type": "oneOfType",
-                      },
+                            ],
+                            "type": "oneOfType",
+                          },
+                        },
+                      ],
+                      "type": "shape",
                     },
                   ],
-                  "type": "shape",
+                  "type": "arrayOf",
                 },
-              ],
-              "type": "arrayOf",
-            },
-            "values": Object {
-              "args": Array [
-                Object {
-                  "type": "any",
+                "values": Object {
+                  "args": Array [
+                    Object {
+                      "type": "any",
+                    },
+                  ],
+                  "isRequired": true,
+                  "type": "objectOf",
                 },
-              ],
-              "isRequired": true,
-              "type": "objectOf",
-            },
+              },
+            ],
+            "type": "shape",
           },
         ],
         "isRequired": true,
-        "type": "shape",
+        "type": "arrayOf",
       },
       "i18n": Object {
         "args": Array [


### PR DESCRIPTION
Closes #

**Summary**

- Small proptype fix, same as Bjorn's [PR here](https://github.com/carbon-design-system/carbon-addons-iot-react/pull/3222), but also updates it in the TableToolbar

**Change List (commits, features, bugs, etc)**

- TableToolbar proptype fix.

**Acceptance Test (how to verify the PR)**

- no proptype warning in storybook

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
