### PR TITLE
fix(repo): change uuid imports to use uuid/v4

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo, useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Edit16, Subtract16 } from '@carbon/icons-react';
 import { omit, isEmpty } from 'lodash-es';
-import uuidv4 from 'uuid/v4';
+import * as uuid from 'uuid';
 import hash from 'object-hash';
 
 import { settings } from '../../../../../constants/Settings';
@@ -293,7 +293,7 @@ const DataSeriesFormItem = ({
             dataSourceId:
               itemWithMetaData?.destination === 'groupBy'
                 ? selectedItem.id
-                : `${selectedItem.id}_${uuidv4()}`,
+                : `${selectedItem.id}_${uuid.v4()}`,
           },
         ];
         // need to remove the category if the card is a stacked timeseries bar
@@ -502,7 +502,7 @@ const DataSeriesFormItem = ({
                   {
                     id: selectedItem,
                     ...(itemWithMetaData && { ...itemWithMetaData }),
-                    dataSourceId: `${selectedItem}_${uuidv4()}`,
+                    dataSourceId: `${selectedItem}_${uuid.v4()}`,
                   },
                 ],
                 cardConfig,

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo, useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Edit16, Subtract16 } from '@carbon/icons-react';
 import { omit, isEmpty } from 'lodash-es';
-import uuid from 'uuid';
+import uuidv4 from 'uuid/v4';
 import hash from 'object-hash';
 
 import { settings } from '../../../../../constants/Settings';
@@ -293,7 +293,7 @@ const DataSeriesFormItem = ({
             dataSourceId:
               itemWithMetaData?.destination === 'groupBy'
                 ? selectedItem.id
-                : `${selectedItem.id}_${uuid.v4()}`,
+                : `${selectedItem.id}_${uuidv4()}`,
           },
         ];
         // need to remove the category if the card is a stacked timeseries bar
@@ -502,7 +502,7 @@ const DataSeriesFormItem = ({
                   {
                     id: selectedItem,
                     ...(itemWithMetaData && { ...itemWithMetaData }),
-                    dataSourceId: `${selectedItem}_${uuid.v4()}`,
+                    dataSourceId: `${selectedItem}_${uuidv4()}`,
                   },
                 ],
                 cardConfig,

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { Edit16, Subtract16 } from '@carbon/icons-react';
 import { isEmpty, omit } from 'lodash-es';
-import uuidv4 from 'uuid/v4';
+import * as uuid from 'uuid';
 import hash from 'object-hash';
 
 import { settings } from '../../../../../constants/Settings';
@@ -201,7 +201,7 @@ const TableCardFormContent = ({
           dataSourceId:
             itemWithMetaData?.destination === 'groupBy'
               ? selectedItem.id
-              : `${selectedItem.id}_${uuidv4()}`,
+              : `${selectedItem.id}_${uuid.v4()}`,
         },
       ];
       const newCard = handleDataSeriesChange(selectedItems, cardConfig, null, null);

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { Edit16, Subtract16 } from '@carbon/icons-react';
 import { isEmpty, omit } from 'lodash-es';
-import uuid from 'uuid';
+import uuidv4 from 'uuid/v4';
 import hash from 'object-hash';
 
 import { settings } from '../../../../../constants/Settings';
@@ -201,7 +201,7 @@ const TableCardFormContent = ({
           dataSourceId:
             itemWithMetaData?.destination === 'groupBy'
               ? selectedItem.id
-              : `${selectedItem.id}_${uuid.v4()}`,
+              : `${selectedItem.id}_${uuidv4()}`,
         },
       ];
       const newCard = handleDataSeriesChange(selectedItems, cardConfig, null, null);

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ThresholdsFormItem.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ThresholdsFormItem.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Add16, TrashCan32 } from '@carbon/icons-react';
 import { omit, isEmpty } from 'lodash-es';
-import uuidv4 from 'uuid/v4';
+import * as uuid from 'uuid';
 import { red60 } from '@carbon/colors';
 import { TextInput } from 'carbon-components-react';
 
@@ -120,7 +120,7 @@ const ThresholdsFormItem = ({
 
   // initialize thresholds with a unique id
   const [thresholds, setThresholds] = useState(
-    thresholdsProp.map((threshold) => ({ ...threshold, id: uuidv4() }))
+    thresholdsProp.map((threshold) => ({ ...threshold, id: uuid.v4() }))
   );
 
   return (
@@ -284,7 +284,7 @@ const ThresholdsFormItem = ({
           setThresholds([
             ...thresholds,
             {
-              id: uuidv4(),
+              id: uuid.v4(),
               ...newThreshold,
             },
           ]);

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ThresholdsFormItem.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ThresholdsFormItem.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Add16, TrashCan32 } from '@carbon/icons-react';
 import { omit, isEmpty } from 'lodash-es';
-import uuid from 'uuid';
+import uuidv4 from 'uuid/v4';
 import { red60 } from '@carbon/colors';
 import { TextInput } from 'carbon-components-react';
 
@@ -120,7 +120,7 @@ const ThresholdsFormItem = ({
 
   // initialize thresholds with a unique id
   const [thresholds, setThresholds] = useState(
-    thresholdsProp.map((threshold) => ({ ...threshold, id: uuid.v4() }))
+    thresholdsProp.map((threshold) => ({ ...threshold, id: uuidv4() }))
   );
 
   return (
@@ -284,7 +284,7 @@ const ThresholdsFormItem = ({
           setThresholds([
             ...thresholds,
             {
-              id: uuid.v4(),
+              id: uuidv4(),
               ...newThreshold,
             },
           ]);

--- a/packages/react/src/components/DashboardEditor/editorUtils.jsx
+++ b/packages/react/src/components/DashboardEditor/editorUtils.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import uuidv4 from 'uuid/v4';
+import * as uuid from 'uuid';
 import { isNil, uniqBy, isEmpty } from 'lodash-es';
 import {
   purple70,
@@ -94,7 +94,7 @@ export const DataItemsPropTypes = PropTypes.arrayOf(
  */
 export const getDuplicateCard = (cardConfig) => ({
   ...cardConfig,
-  id: uuidv4(),
+  id: uuid.v4(),
 });
 
 /**
@@ -114,7 +114,7 @@ export const getDefaultCard = (type, i18n) => {
   };
 
   const baseCardProps = {
-    id: uuidv4(),
+    id: uuid.v4(),
     title: i18n.defaultCardTitle,
     size: defaultSizeForType[type] ?? CARD_SIZES.MEDIUM,
     ...(type.includes(CARD_TYPES.BAR) ? { type: CARD_TYPES.BAR } : { type }),

--- a/packages/react/src/components/DashboardEditor/editorUtils.jsx
+++ b/packages/react/src/components/DashboardEditor/editorUtils.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import uuid from 'uuid';
+import uuidv4 from 'uuid/v4';
 import { isNil, uniqBy, isEmpty } from 'lodash-es';
 import {
   purple70,
@@ -94,7 +94,7 @@ export const DataItemsPropTypes = PropTypes.arrayOf(
  */
 export const getDuplicateCard = (cardConfig) => ({
   ...cardConfig,
-  id: uuid.v4(),
+  id: uuidv4(),
 });
 
 /**
@@ -114,7 +114,7 @@ export const getDefaultCard = (type, i18n) => {
   };
 
   const baseCardProps = {
-    id: uuid.v4(),
+    id: uuidv4(),
     title: i18n.defaultCardTitle,
     size: defaultSizeForType[type] ?? CARD_SIZES.MEDIUM,
     ...(type.includes(CARD_TYPES.BAR) ? { type: CARD_TYPES.BAR } : { type }),

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
@@ -16,7 +16,7 @@ import {
 } from 'carbon-components-react';
 import { Calendar16 } from '@carbon/icons-react';
 import classnames from 'classnames';
-import uuid from 'uuid';
+import uuidv4 from 'uuid/v4';
 
 import TimePickerSpinner from '../TimePickerSpinner/TimePickerSpinner';
 import { settings } from '../../constants/Settings';
@@ -290,7 +290,7 @@ const DateTimePicker = ({
   i18n,
   light,
   locale,
-  id = uuid.v4(),
+  id = uuidv4(),
   ...others
 }) => {
   const strings = {

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
@@ -16,7 +16,7 @@ import {
 } from 'carbon-components-react';
 import { Calendar16 } from '@carbon/icons-react';
 import classnames from 'classnames';
-import uuidv4 from 'uuid/v4';
+import * as uuid from 'uuid';
 
 import TimePickerSpinner from '../TimePickerSpinner/TimePickerSpinner';
 import { settings } from '../../constants/Settings';
@@ -290,7 +290,7 @@ const DateTimePicker = ({
   i18n,
   light,
   locale,
-  id = uuidv4(),
+  id = uuid.v4(),
   ...others
 }) => {
   const strings = {

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
@@ -15,7 +15,7 @@ import {
 } from 'carbon-components-react';
 import { Calendar16 } from '@carbon/icons-react';
 import classnames from 'classnames';
-import uuid from 'uuid';
+import uuidv4 from 'uuid/v4';
 import warning from 'warning';
 
 import TimePickerSpinner from '../TimePickerSpinner/TimePickerSpinner';
@@ -249,7 +249,7 @@ const DateTimePicker = ({
   i18n,
   light,
   locale,
-  id = uuid.v4(),
+  id = uuidv4(),
   hasIconOnly,
   ...others
 }) => {

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
@@ -15,7 +15,7 @@ import {
 } from 'carbon-components-react';
 import { Calendar16 } from '@carbon/icons-react';
 import classnames from 'classnames';
-import uuidv4 from 'uuid/v4';
+import * as uuid from 'uuid';
 import warning from 'warning';
 
 import TimePickerSpinner from '../TimePickerSpinner/TimePickerSpinner';
@@ -249,7 +249,7 @@ const DateTimePicker = ({
   i18n,
   light,
   locale,
-  id = uuidv4(),
+  id = uuid.v4(),
   hasIconOnly,
   ...others
 }) => {

--- a/packages/react/src/components/Table/TableColumnCustomization.story.jsx
+++ b/packages/react/src/components/Table/TableColumnCustomization.story.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Column20 } from '@carbon/icons-react';
 import { action } from '@storybook/addon-actions';
 import { boolean, object, select } from '@storybook/addon-knobs';
-import uuid from 'uuid';
+import uuidv4 from 'uuid/v4';
 
 import { DragAndDrop } from '../../utils/DragAndDropUtils';
 import Button from '../Button';
@@ -202,7 +202,7 @@ export const Playground = () => {
           action('onLoadMore')(id);
         }}
         onReset={() => {
-          setModalKey(uuid.v4());
+          setModalKey(uuidv4());
           action('onReset');
         }}
         onSave={(updatedOrdering, updatedColumns) => {

--- a/packages/react/src/components/Table/TableColumnCustomization.story.jsx
+++ b/packages/react/src/components/Table/TableColumnCustomization.story.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Column20 } from '@carbon/icons-react';
 import { action } from '@storybook/addon-actions';
 import { boolean, object, select } from '@storybook/addon-knobs';
-import uuidv4 from 'uuid/v4';
+import * as uuid from 'uuid';
 
 import { DragAndDrop } from '../../utils/DragAndDropUtils';
 import Button from '../Button';
@@ -202,7 +202,7 @@ export const Playground = () => {
           action('onLoadMore')(id);
         }}
         onReset={() => {
-          setModalKey(uuidv4());
+          setModalKey(uuid.v4());
           action('onReset');
         }}
         onSave={(updatedOrdering, updatedColumns) => {

--- a/packages/react/src/hooks/useUniqueId.jsx
+++ b/packages/react/src/hooks/useUniqueId.jsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react';
-import uuid from 'uuid';
+import uuidv4 from 'uuid/v4';
 
-const getUniqueId = () => uuid.v4();
+const getUniqueId = () => uuidv4();
 
 export function useUniqueId() {
   const idRef = useRef(null);

--- a/packages/react/src/hooks/useUniqueId.jsx
+++ b/packages/react/src/hooks/useUniqueId.jsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react';
-import uuidv4 from 'uuid/v4';
+import * as uuid from 'uuid';
 
-const getUniqueId = () => uuidv4();
+const getUniqueId = () => uuid.v4();
 
 export function useUniqueId() {
   const idRef = useRef(null);


### PR DESCRIPTION
Closes #3258 

**Summary**

- ~updates all uuid imports to use `import uuidv4 from 'uuid/v4';`~
- updates all uuid imports to use `import * as uuid from 'uuid';`

**Change List (commits, features, bugs, etc)**

- ~updates all uuid imports to use `import uuidv4 from 'uuid/v4';`~
- updates all uuid imports to use `import * as uuid from 'uuid';`

**Acceptance Test (how to verify the PR)**

- tests pass

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests pass

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
