### PR TITLE
fix width of drag preview on large rows

### DIFF
--- a/packages/react/src/components/List/ListItem/_list-item.scss
+++ b/packages/react/src/components/List/ListItem/_list-item.scss
@@ -31,6 +31,14 @@
     flex-direction: column;
     position: absolute;
     align-items: stretch;
+
+    &.#{$iot-prefix}--list-item__large {
+      margin-left: -($spacing-05);
+
+      [dir='rtl'] & {
+        margin-right: -($spacing-05);
+      }
+    }
   }
 
   &--drop-target-above {

--- a/packages/react/src/components/List/ListItem/_list-item.scss
+++ b/packages/react/src/components/List/ListItem/_list-item.scss
@@ -48,8 +48,9 @@
 
     &__over {
       border-top: solid 2px $focus;
+      position: absolute;
       width: calc(100% + #{$spacing-07});
-      margin-top: -($spacing-05);
+      top: 0;
     }
   }
 

--- a/packages/react/src/components/List/ListItem/_list-item.scss
+++ b/packages/react/src/components/List/ListItem/_list-item.scss
@@ -48,14 +48,8 @@
 
     &__over {
       border-top: solid 2px $focus;
-    }
-
-    &.#{$iot-prefix}--list-item__large {
-      margin-left: -($spacing-05);
-
-      [dir='rtl'] & {
-        margin-right: -($spacing-05);
-      }
+      width: calc(100% + #{$spacing-07});
+      margin-top: -($spacing-05);
     }
   }
 

--- a/packages/react/src/components/List/ListItem/_list-item.scss
+++ b/packages/react/src/components/List/ListItem/_list-item.scss
@@ -49,6 +49,14 @@
     &__over {
       border-top: solid 2px $focus;
     }
+
+    &.#{$iot-prefix}--list-item__large {
+      margin-left: -($spacing-05);
+
+      [dir='rtl'] & {
+        margin-right: -($spacing-05);
+      }
+    }
   }
 
   &--drop-target-nested {


### PR DESCRIPTION
#3147

Closes #

**Summary**

- The drag preview was not covering full width for large rows. This is now fixed and accounted for with RTL.

**Change List (commits, features, bugs, etc)**

- `_list-item.scss` added sub styles for `--drop-targets`

**Acceptance Test (how to verify the PR)**

- Verify on watson-iot-hierarchylist--with-nested-reorder story that the drag preview borders on large rows are correct

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Ensure regular rows dragging looks fine as well as other list actions

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
