### PR TITLE
Card title resize

### DIFF
--- a/packages/react/src/components/BarChartCard/__snapshots__/BarChartCard.story.storyshot
+++ b/packages/react/src/components/BarChartCard/__snapshots__/BarChartCard.story.storyshot
@@ -34,6 +34,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/B
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Particles and temperature in cities
           </div>
@@ -136,6 +137,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/B
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Particles by city
           </div>
@@ -238,6 +240,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/B
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Particles over 4 days
           </div>
@@ -389,6 +392,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/B
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Temperature over time
           </div>
@@ -491,6 +495,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/B
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Particles and temperature in cities
           </div>
@@ -593,6 +598,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/B
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Particles / emissions over 4 days
           </div>
@@ -744,6 +750,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/B
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Particles by city over time
           </div>

--- a/packages/react/src/components/Card/Card.jsx
+++ b/packages/react/src/components/Card/Card.jsx
@@ -386,8 +386,8 @@ const Card = (props) => {
   // Ensure the title and subtitle have a tooltip only if their text is truncated
   const titleRef = useRef();
   const subTitleRef = useRef();
-  const hasTitleTooltip = useHasTextOverflow(titleRef);
-  const hasSubTitleTooltip = useHasTextOverflow(subTitleRef);
+  const hasTitleTooltip = useHasTextOverflow(titleRef, title);
+  const hasSubTitleTooltip = useHasTextOverflow(subTitleRef, subtitle);
   const visibilityRef = useRef(null);
   const [isVisible] = useVisibilityObserver(visibilityRef, {
     unobserveAfterVisible: true,
@@ -473,6 +473,7 @@ const Card = (props) => {
             ) : (
               <div
                 ref={titleRef}
+                data-testid={`${testId}-title-notip`}
                 className={classnames(`${iotPrefix}--card--title--text`, {
                   [`${iotPrefix}--card--title--text--wrapped`]: hasTitleWrap && !subtitle,
                 })}

--- a/packages/react/src/components/Card/Card.test.e2e.jsx
+++ b/packages/react/src/components/Card/Card.test.e2e.jsx
@@ -37,4 +37,36 @@ describe('Card', () => {
     cy.scrollTo('bottom', { duration: 1000 });
     cy.findAllByText(/renderprop/).should('have.length', 8);
   });
+
+  it('should render tooltip if the text is too long', () => {
+    cy.viewport(1680, 900);
+    const aLongTitle =
+      'A very very long title which will almost certainly overflow and require a tooltip and we must test these things, you know.';
+    mount(
+      <Card
+        style={{ width: '400px', height: '360px' }}
+        id="myCard"
+        title={aLongTitle}
+        size={CARD_SIZES.MEDIUM}
+      />
+    );
+
+    cy.findByRole('button', { name: aLongTitle }).should('exist');
+  });
+
+  it('should not render tooltip if the text is not too long', () => {
+    cy.viewport(1680, 900);
+    const aShortTitle = 'A short title';
+    mount(
+      <Card
+        style={{ width: '600px', height: '360px' }}
+        id="myCard"
+        title={aShortTitle}
+        size={CARD_SIZES.MEDIUM}
+        breakpoint="lg"
+      />
+    );
+
+    cy.findByRole('button', { name: aShortTitle }).should('not.exist');
+  });
 });

--- a/packages/react/src/components/Card/Card.test.jsx
+++ b/packages/react/src/components/Card/Card.test.jsx
@@ -417,6 +417,31 @@ describe('Card', () => {
       expect(tooltipButton).toHaveAttribute('aria-expanded', 'true');
     });
 
+    it('should remove the tooltip if the title changes to a shorter string', async () => {
+      const aLongTitle =
+        'A very very long title which will almost certainly overflow and require a tooltip and we must test these things, you know.';
+
+      const aShortTitle = 'A Title';
+      const { rerender } = render(<Card {...cardProps} title={aLongTitle} />);
+      const tooltipButton = screen.getByRole('button', {
+        name: aLongTitle,
+      });
+      expect(tooltipButton).toBeVisible();
+      expect(tooltipButton).toHaveClass(`${iotPrefix}--card--title--text__overflow`);
+      Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+        writable: true,
+        configurable: true,
+        value: 500,
+      });
+      Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+        writable: true,
+        configurable: true,
+        value: 500,
+      });
+      rerender(<Card {...cardProps} title={aShortTitle} subtitle="This is subtitle" />);
+      expect(screen.getByTestId('Card-title-notip')).toBeVisible();
+    });
+
     it('should put the subtitle in a tooltip if it overflows', () => {
       const aLongSubTitle =
         'A very very long subtitle which will almost certainly overflow and require a tooltip and we must test these things, you know.';

--- a/packages/react/src/components/Card/__snapshots__/Card.story.storyshot
+++ b/packages/react/src/components/Card/__snapshots__/Card.story.storyshot
@@ -38,6 +38,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Card title
           </div>
@@ -497,6 +498,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Card Title
           </div>
@@ -557,6 +559,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Card Title
           </div>
@@ -671,6 +674,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Card Title
           </div>
@@ -785,6 +789,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Card Title
           </div>
@@ -899,6 +904,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Card Title
           </div>
@@ -1013,6 +1019,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Card Title
           </div>
@@ -1127,6 +1134,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Card Title
           </div>
@@ -1241,6 +1249,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Card Title
           </div>
@@ -1355,6 +1364,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Card Title
           </div>
@@ -1473,6 +1483,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Card Title
           </div>
@@ -1580,6 +1591,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Card with date picker
           </div>
@@ -1724,6 +1736,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Card Title
           </div>
@@ -1878,6 +1891,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Card Title that should be truncated and presented in a tooltip while the cards also has an external tooltip.
           </div>
@@ -2070,6 +2084,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Card Title
           </div>
@@ -2138,6 +2153,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Card with render prop
           </div>

--- a/packages/react/src/components/ComboChartCard/__snapshots__/ComboChartCard.story.storyshot
+++ b/packages/react/src/components/ComboChartCard/__snapshots__/ComboChartCard.story.storyshot
@@ -40,6 +40,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
           >
             <div
               className="iot--card--title--text"
+              data-testid="Card-title-notip"
             >
               Health history
             </div>
@@ -1963,6 +1964,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Health history
           </div>
@@ -2114,6 +2116,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             ComboChartCard Empty
           </div>
@@ -2306,6 +2309,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             ComboChartCard Loading
           </div>

--- a/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -94,6 +94,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Facility Metrics with a very long title that should be truncated and have a tooltip for the full text 
                   </div>
@@ -305,6 +306,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Bar chart
                   </div>
@@ -403,6 +405,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Humidity
                   </div>
@@ -510,6 +513,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Show tooltip when the card title has ellipsis 
                   </div>
@@ -660,6 +664,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Utilization
                   </div>
@@ -769,6 +774,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Alert Count
                   </div>
@@ -906,6 +912,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Comfort Level
                   </div>
@@ -1030,6 +1037,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Foot Traffic
                   </div>
@@ -1165,6 +1173,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Health
                   </div>
@@ -1323,6 +1332,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Health
                   </div>
@@ -1452,6 +1462,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Temperature with a very long title that should be truncated and have a tooltip for the full text 
                   </div>
@@ -2419,6 +2430,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Environment
                   </div>
@@ -2567,6 +2579,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Floor Map
                   </div>
@@ -3029,6 +3042,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Facility Metrics with a very long title that should be truncated and have a tooltip for the full text 
                   </div>
@@ -3240,6 +3254,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Bar chart
                   </div>
@@ -3338,6 +3353,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Humidity
                   </div>
@@ -3445,6 +3461,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Show tooltip when the card title has ellipsis 
                   </div>
@@ -3595,6 +3612,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Utilization
                   </div>
@@ -3704,6 +3722,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Alert Count
                   </div>
@@ -3841,6 +3860,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Comfort Level
                   </div>
@@ -3965,6 +3985,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Foot Traffic
                   </div>
@@ -4100,6 +4121,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Health
                   </div>
@@ -4258,6 +4280,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Health
                   </div>
@@ -4387,6 +4410,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Temperature with a very long title that should be truncated and have a tooltip for the full text 
                   </div>
@@ -5354,6 +5378,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Environment
                   </div>
@@ -5502,6 +5527,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Floor Map
                   </div>
@@ -5999,6 +6025,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Facility Metrics with a very long title that should be truncated and have a tooltip for the full text 
                   </div>
@@ -6210,6 +6237,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Bar chart
                   </div>
@@ -6308,6 +6336,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Humidity
                   </div>
@@ -6415,6 +6444,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Show tooltip when the card title has ellipsis 
                   </div>
@@ -6565,6 +6595,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Utilization
                   </div>
@@ -6674,6 +6705,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Alert Count
                   </div>
@@ -6811,6 +6843,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Comfort Level
                   </div>
@@ -6935,6 +6968,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Foot Traffic
                   </div>
@@ -7070,6 +7104,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Health
                   </div>
@@ -7228,6 +7263,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Health
                   </div>
@@ -7357,6 +7393,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Temperature with a very long title that should be truncated and have a tooltip for the full text 
                   </div>
@@ -8324,6 +8361,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Environment
                   </div>
@@ -8472,6 +8510,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Floor Map
                   </div>
@@ -8934,6 +8973,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
               >
                 <div
                   className="iot--card--title--text"
+                  data-testid="Card-title-notip"
                 >
                   Expanded card
                 </div>
@@ -9114,6 +9154,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Expanded card
                   </div>
@@ -9381,6 +9422,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
               >
                 <div
                   className="iot--card--title--text"
+                  data-testid="Card-title-notip"
                 >
                   Expanded card
                 </div>
@@ -11263,6 +11305,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Facility Metrics with a very long title that should be truncated and have a tooltip for the full text 
                   </div>
@@ -11474,6 +11517,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Bar chart
                   </div>
@@ -11572,6 +11616,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Humidity
                   </div>
@@ -11679,6 +11724,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Show tooltip when the card title has ellipsis 
                   </div>
@@ -11829,6 +11875,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Utilization
                   </div>
@@ -11938,6 +11985,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Alert Count
                   </div>
@@ -12075,6 +12123,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Comfort Level
                   </div>
@@ -12199,6 +12248,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Foot Traffic
                   </div>
@@ -12334,6 +12384,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Health
                   </div>
@@ -12492,6 +12543,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Health
                   </div>
@@ -12621,6 +12673,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Temperature with a very long title that should be truncated and have a tooltip for the full text 
                   </div>
@@ -13588,6 +13641,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Environment
                   </div>
@@ -13736,6 +13790,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Floor Map
                   </div>
@@ -14198,6 +14253,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
               >
                 <div
                   className="iot--card--title--text"
+                  data-testid="Card-title-notip"
                 >
                   No options card
                 </div>
@@ -14341,6 +14397,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: 13 
                     </div>
@@ -14442,6 +14499,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: 1352 steps
                     </div>
@@ -14545,6 +14603,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: 103.2 ËšF
                     </div>
@@ -14648,6 +14707,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: 107324.3 kJ
                     </div>
@@ -14751,6 +14811,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: 1709384.1 people
                     </div>
@@ -14854,6 +14915,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: false 
                     </div>
@@ -14962,6 +15024,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: true 
                     </div>
@@ -15148,6 +15211,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: 13 
                     </div>
@@ -15249,6 +15313,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: 1352 steps
                     </div>
@@ -15352,6 +15417,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: 103.2 ËšF
                     </div>
@@ -15455,6 +15521,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: 107324.3 kJ
                     </div>
@@ -15558,6 +15625,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: 1709384.1 people
                     </div>
@@ -15661,6 +15729,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: false 
                     </div>
@@ -15769,6 +15838,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: true 
                     </div>
@@ -15955,6 +16025,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Temperature
                     </div>
@@ -16058,6 +16129,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Temperature
                     </div>
@@ -16163,6 +16235,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Temperature
                     </div>
@@ -16294,6 +16367,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Temperature
                     </div>
@@ -16500,6 +16574,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Temperature
                     </div>
@@ -16603,6 +16678,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Temperature
                     </div>
@@ -16708,6 +16784,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Temperature
                     </div>
@@ -16839,6 +16916,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Temperature
                     </div>
@@ -17045,6 +17123,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -17165,6 +17244,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -17290,6 +17370,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -17418,6 +17499,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -17611,6 +17693,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -17731,6 +17814,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -17856,6 +17940,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -17984,6 +18069,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -18177,6 +18263,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -18280,6 +18367,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -18383,6 +18471,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -18486,6 +18575,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -18589,6 +18679,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -18765,6 +18856,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -18868,6 +18960,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -18971,6 +19064,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -19074,6 +19168,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -19177,6 +19272,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -19353,6 +19449,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: 13 
                     </div>
@@ -19454,6 +19551,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: 1352 steps
                     </div>
@@ -19557,6 +19655,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: 103.2 ËšF
                     </div>
@@ -19660,6 +19759,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: 107324.3 kJ
                     </div>
@@ -19763,6 +19863,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: 1709384.1 people
                     </div>
@@ -19866,6 +19967,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: false 
                     </div>
@@ -19979,6 +20081,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: true 
                     </div>
@@ -20092,6 +20195,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Temperature
                     </div>
@@ -20195,6 +20299,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Temperature
                     </div>
@@ -20300,6 +20405,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Temperature
                     </div>
@@ -20431,6 +20537,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Temperature
                     </div>
@@ -20564,6 +20671,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -20684,6 +20792,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -20809,6 +20918,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -20937,6 +21047,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -21057,6 +21168,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -21160,6 +21272,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -21263,6 +21376,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -21366,6 +21480,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -21469,6 +21584,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -21645,6 +21761,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: 13 
                     </div>
@@ -21746,6 +21863,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: 1352 steps
                     </div>
@@ -21849,6 +21967,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: 103.2 ËšF
                     </div>
@@ -21952,6 +22071,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: 107324.3 kJ
                     </div>
@@ -22055,6 +22175,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: 1709384.1 people
                     </div>
@@ -22158,6 +22279,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: false 
                     </div>
@@ -22271,6 +22393,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       value: true 
                     </div>
@@ -22384,6 +22507,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Temperature
                     </div>
@@ -22487,6 +22611,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Temperature
                     </div>
@@ -22592,6 +22717,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Temperature
                     </div>
@@ -22723,6 +22849,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Temperature
                     </div>
@@ -22856,6 +22983,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -22976,6 +23104,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -23101,6 +23230,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -23229,6 +23359,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -23349,6 +23480,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -23452,6 +23584,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -23555,6 +23688,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -23658,6 +23792,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -23761,6 +23896,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -23937,6 +24073,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       values: 89.2%, 76 mb
                     </div>
@@ -24093,6 +24230,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       values: 88.3ËšF, Elevated
                     </div>
@@ -24247,6 +24385,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       values: 88.3ËšF, Elevated
                     </div>
@@ -24476,6 +24615,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       values: 89.2%, 76 mb
                     </div>
@@ -24632,6 +24772,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       values: 88.3ËšF, Elevated
                     </div>
@@ -24786,6 +24927,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       values: 88.3ËšF, Elevated
                     </div>
@@ -25015,6 +25157,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       values: 89.2%, 76 mb
                     </div>
@@ -25227,6 +25370,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       values: 88.3ËšF, Elevated
                     </div>
@@ -25409,6 +25553,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       values: 88.3ËšF, Elevated
                     </div>
@@ -25693,6 +25838,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       values: 89.2%, 76 mb
                     </div>
@@ -25905,6 +26051,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       values: 88.3ËšF, Elevated
                     </div>
@@ -26087,6 +26234,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       values: 88.3ËšF, Elevated
                     </div>
@@ -26371,6 +26519,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -26566,6 +26715,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -26837,6 +26987,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -27032,6 +27183,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -27303,6 +27455,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -27566,6 +27719,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -27767,6 +27921,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -28105,6 +28260,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Humidity
                     </div>
@@ -28368,6 +28524,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -28569,6 +28726,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Danger Level
                     </div>
@@ -28936,6 +29094,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Facility Metrics with a very long title that should be truncated and have a tooltip for the full text 
                   </div>
@@ -29147,6 +29306,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Bar chart
                   </div>
@@ -29245,6 +29405,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Humidity
                   </div>
@@ -29352,6 +29513,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Show tooltip when the card title has ellipsis 
                   </div>
@@ -29502,6 +29664,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Utilization
                   </div>
@@ -29611,6 +29774,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Alert Count
                   </div>
@@ -29748,6 +29912,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Comfort Level
                   </div>
@@ -29872,6 +30037,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Foot Traffic
                   </div>
@@ -30007,6 +30173,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Health
                   </div>
@@ -30165,6 +30332,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Health
                   </div>
@@ -30294,6 +30462,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Temperature with a very long title that should be truncated and have a tooltip for the full text 
                   </div>
@@ -31261,6 +31430,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Environment
                   </div>
@@ -31409,6 +31579,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                 >
                   <div
                     className="iot--card--title--text"
+                    data-testid="Card-title-notip"
                   >
                     Floor Map
                   </div>
@@ -33372,6 +33543,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Tutorials
                     </div>
@@ -33577,6 +33749,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
                   >
                     <div
                       className="iot--card--title--text"
+                      data-testid="Card-title-notip"
                     >
                       Announcements
                     </div>

--- a/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
@@ -66,6 +66,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 Small
               </div>
@@ -132,6 +133,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 Small Wide
               </div>
@@ -198,6 +200,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 Medium Thin
               </div>
@@ -264,6 +267,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 Medium
               </div>
@@ -330,6 +334,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 Medium Wide
               </div>
@@ -396,6 +401,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 Large Thin
               </div>
@@ -462,6 +468,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 Large
               </div>
@@ -528,6 +535,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 Large Wide
               </div>
@@ -633,6 +641,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 Card - SMALL
               </div>
@@ -713,6 +722,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 ValueCard - SMALLWIDE
               </div>
@@ -866,6 +876,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 GaugeCard - MEDIUMTHIN
               </div>
@@ -1035,6 +1046,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 PieChartCard - MEDIUM
               </div>
@@ -1115,6 +1127,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="map-card-title-notip"
               >
                 MapCard - LARGEWIDE
               </div>
@@ -3347,6 +3360,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 ImageCard - LARGE
               </div>
@@ -3608,6 +3622,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 TimeSeriesCard - LARGETHIN
               </div>
@@ -3677,6 +3692,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 ListCard - LARGETHIN
               </div>
@@ -3936,6 +3952,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 BarChartCard - LARGEWIDE
               </div>
@@ -4044,6 +4061,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 Facility Metrics
               </div>
@@ -4111,6 +4129,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 Humidity
               </div>
@@ -4178,6 +4197,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 Utilization
               </div>
@@ -4299,6 +4319,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
               >
                 <div
                   className="iot--card--title--text"
+                  data-testid="Card-title-notip"
                 >
                   Facility Metrics
                 </div>
@@ -4366,6 +4387,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
               >
                 <div
                   className="iot--card--title--text"
+                  data-testid="Card-title-notip"
                 >
                   Humidity
                 </div>
@@ -4433,6 +4455,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
               >
                 <div
                   className="iot--card--title--text"
+                  data-testid="Card-title-notip"
                 >
                   Utilization
                 </div>
@@ -4539,6 +4562,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 Facility Metrics
               </div>
@@ -4606,6 +4630,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 Humidity
               </div>
@@ -4673,6 +4698,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 Utilization
               </div>
@@ -4776,6 +4802,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
             >
               <div
                 className="iot--card--title--text"
+                data-testid="Card-title-notip"
               >
                 Card - SMALL
               </div>

--- a/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -1665,6 +1665,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       >
                         <div
                           className="iot--card--title--text"
+                          data-testid="Card-title-notip"
                         >
                           Custom rendered card
                         </div>
@@ -1799,6 +1800,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       >
                         <div
                           className="iot--card--title--text"
+                          data-testid="Card-title-notip"
                         >
                           Value card
                         </div>
@@ -1979,6 +1981,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       >
                         <div
                           className="iot--card--title--text"
+                          data-testid="Card-title-notip"
                         >
                           Timeseries
                         </div>
@@ -2099,6 +2102,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       >
                         <div
                           className="iot--card--title--text"
+                          data-testid="Card-title-notip"
                         >
                           Bar
                         </div>
@@ -9713,6 +9717,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     >
                       <div
                         className="iot--card--title--text"
+                        data-testid="Card-title-notip"
                       >
                         Custom rendered card
                       </div>
@@ -9850,6 +9855,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     >
                       <div
                         className="iot--card--title--text"
+                        data-testid="Card-title-notip"
                       >
                         my custom title: Default rendered card
                       </div>
@@ -18535,6 +18541,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     >
                       <div
                         className="iot--card--title--text"
+                        data-testid="Card-title-notip"
                       >
                         Untitled
                       </div>
@@ -20940,6 +20947,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     >
                       <div
                         className="iot--card--title--text"
+                        data-testid="Card-title-notip"
                       >
                         Custom rendered card
                       </div>
@@ -21066,6 +21074,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     >
                       <div
                         className="iot--card--title--text"
+                        data-testid="Card-title-notip"
                       >
                         Default rendered card
                       </div>
@@ -21297,6 +21306,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     >
                       <div
                         className="iot--card--title--text"
+                        data-testid="Card-title-notip"
                       >
                         Timeseries
                       </div>
@@ -21417,6 +21427,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     >
                       <div
                         className="iot--card--title--text"
+                        data-testid="Card-title-notip"
                       >
                         Bar
                       </div>
@@ -21538,6 +21549,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     >
                       <div
                         className="iot--card--title--text"
+                        data-testid="Card-title-notip"
                       >
                         Custom rendered card
                       </div>

--- a/packages/react/src/components/GaugeCard/__snapshots__/GaugeCard.story.storyshot
+++ b/packages/react/src/components/GaugeCard/__snapshots__/GaugeCard.story.storyshot
@@ -34,6 +34,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/G
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Health
           </div>
@@ -196,6 +197,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/G
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Health
           </div>
@@ -399,6 +401,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/G
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Health
           </div>
@@ -557,6 +560,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/G
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Health
           </div>

--- a/packages/react/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
+++ b/packages/react/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
@@ -35,6 +35,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/I
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Image
           </div>
@@ -344,6 +345,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/I
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Image
           </div>
@@ -740,6 +742,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/I
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Image
           </div>
@@ -846,6 +849,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/I
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Image
           </div>
@@ -952,6 +956,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/I
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Image
           </div>
@@ -1190,6 +1195,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/I
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Image
           </div>
@@ -1357,6 +1363,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/I
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Image
           </div>
@@ -1524,6 +1531,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/I
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Image
           </div>

--- a/packages/react/src/components/ListCard/__snapshots__/ListCard.story.storyshot
+++ b/packages/react/src/components/ListCard/__snapshots__/ListCard.story.storyshot
@@ -35,6 +35,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/L
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Simple List with Icon
           </div>
@@ -288,6 +289,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/L
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Simple List with Icon
           </div>
@@ -353,6 +355,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/L
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             List with extra content
           </div>
@@ -535,6 +538,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/L
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             List with extra long content
           </div>

--- a/packages/react/src/components/PieChartCard/__snapshots__/PieChartCard.story.storyshot
+++ b/packages/react/src/components/PieChartCard/__snapshots__/PieChartCard.story.storyshot
@@ -40,6 +40,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
           >
             <div
               className="iot--card--title--text"
+              data-testid="basicCardStoryTest-title-notip"
             >
               Animations turned on and FlyoutMenu added to table
             </div>
@@ -590,6 +591,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
         >
           <div
             className="iot--card--title--text"
+            data-testid="basicCardStoryTest-title-notip"
           >
             Schools
           </div>
@@ -692,6 +694,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
         >
           <div
             className="iot--card--title--text"
+            data-testid="basicCardStoryTest-title-notip"
           >
             Schools
           </div>
@@ -794,6 +797,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
         >
           <div
             className="iot--card--title--text"
+            data-testid="basicCardStoryTest-title-notip"
           >
             Schools
           </div>
@@ -896,6 +900,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
         >
           <div
             className="iot--card--title--text"
+            data-testid="basicCardStoryTest-title-notip"
           >
             Schools
           </div>
@@ -998,6 +1003,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
         >
           <div
             className="iot--card--title--text"
+            data-testid="basicCardStoryTest-title-notip"
           >
             Schools
           </div>
@@ -1103,6 +1109,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
         >
           <div
             className="iot--card--title--text"
+            data-testid="basicCardStoryTest-title-notip"
           >
             Schools
           </div>

--- a/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -34,6 +34,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Temperature
           </div>
@@ -185,6 +186,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Temperature
           </div>
@@ -336,6 +338,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Temperature
           </div>
@@ -451,6 +454,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Temperature
           </div>
@@ -602,6 +606,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Temperature
           </div>
@@ -753,6 +758,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Temperature
           </div>
@@ -824,6 +830,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           >
             <div
               className="iot--card--title--text"
+              data-testid="Card-title-notip"
             >
               Temperature
             </div>
@@ -2844,6 +2851,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Temperature, Humidity, eCount, and Pressure
           </div>
@@ -2995,6 +3003,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Temperature
           </div>
@@ -3146,6 +3155,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Temperature with variables
           </div>
@@ -3297,6 +3307,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Pressure
           </div>

--- a/packages/react/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/packages/react/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -34,6 +34,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Health score
           </div>
@@ -193,6 +194,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Facility Conditions per device
           </div>
@@ -373,6 +375,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Facility Conditions
           </div>
@@ -736,6 +739,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Status
           </div>
@@ -1038,6 +1042,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Really really really long card title?
           </div>
@@ -1218,6 +1223,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Tagpath
           </div>
@@ -1327,6 +1333,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Facility Conditions
           </div>
@@ -1812,6 +1819,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Facility Conditions
           </div>
@@ -2128,6 +2136,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Status
           </div>
@@ -2262,6 +2271,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Alert Count
           </div>
@@ -2399,6 +2409,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/V
         >
           <div
             className="iot--card--title--text"
+            data-testid="Card-title-notip"
           >
             Foot Traffic - working
           </div>

--- a/packages/react/src/hooks/useHasTextOverflow.jsx
+++ b/packages/react/src/hooks/useHasTextOverflow.jsx
@@ -1,15 +1,23 @@
 import { useEffect, useState } from 'react';
 
-const useHasTextOverflow = (elementRef) => {
+const useHasTextOverflow = (elementRef, text = '') => {
   const [isOverflowed, setIsOverflowed] = useState(false);
 
   useEffect(() => {
     const overFlowing =
       elementRef.current &&
-      (elementRef.current.scrollHeight > elementRef.current.clientHeight ||
-        elementRef.current.scrollWidth > elementRef.current.clientWidth);
+      (elementRef?.current?.scrollHeight > elementRef?.current?.clientHeight ||
+        elementRef?.current?.scrollWidth > elementRef?.current?.clientWidth);
     setIsOverflowed(overFlowing);
-  }, [elementRef]);
+    /* disabling to not put the ref in dep array */
+    /* eslint-disable react-hooks/exhaustive-deps */
+  }, [
+    elementRef?.current?.clientHeight,
+    elementRef?.current?.clientWidth,
+    elementRef?.current?.scrollHeight,
+    elementRef?.current?.scrollWidth,
+    text,
+  ]);
 
   return isOverflowed;
 };


### PR DESCRIPTION
Closes #3266

**Summary**

This PR fixes a bug in the logic for `useHasTextOverflow` hook and updates the card to handle the changes from this fix.

**Change List (commits, features, bugs, etc)**

- Updated the `useHasTextOverflow.jsx` to make more dynamic
- Updated `Card.jsx` to handle changes need for text overlfow
- Wrote some jest unit test to test if it would change via prop update
- Wrote cypress test since our jest test manually update the values for `clientWidth` and `scrollWidth` to ensure it behaves well in actual browser. 

**Acceptance Test (how to verify the PR)**

- Go to 
[this story](https://deploy-preview-1824--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-card--with-ellipsed-title-tooltip-external-tooltip)
- click on subtitle and see that there is a tooltip
- click on isExpanded knob
- Check that tooltip is off for subtitle
then:
- Click on title and see tooltip
- Update the title in knobs to something short
- click on title and see tooltip has gone away


**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
