### PR TITLE
fix(CardEditor) the display options match json

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditor.jsx
+++ b/packages/react/src/components/CardEditor/CardEditor.jsx
@@ -158,6 +158,8 @@ const defaultProps = {
     openJSONButton: 'Open JSON editor',
     searchPlaceHolderText: 'Enter a search',
     editDataItems: 'Edit data items',
+    fit: 'Contain',
+    stretch: 'Fill',
   },
   getValidDimensions: null,
   getValidDataItems: null,


### PR DESCRIPTION
Closes #3269

**Summary**
Fix Inconsitancy between JSON values and UI display options

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

Display options values should be Contain and Fill 

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
