### PR TITLE
fix(table): update table pagination to include an initialWidth

### DIFF
--- a/packages/react/src/components/Table/Pagination.jsx
+++ b/packages/react/src/components/Table/Pagination.jsx
@@ -21,7 +21,7 @@ const SizedPagination = ({
   size,
   ...rest
 }) => {
-  const [{ width }, paginationRef] = useSizeObserver();
+  const [{ width }, paginationRef] = useSizeObserver({ initialWidth: 500 });
   return (
     <>
       {/** empty div to fill the width of the pagination area so we don't have to wrap the pagination


### PR DESCRIPTION
Closes #

**Summary**

- simple addition of a initialWidth on the table pagination 
In graphite one of the table tests has it wrapped in a stretch flex container that doesn't resize correctly to trigger the ResizeHandler and cause the pagination text to show as it does in our stories. This is a simple addition of the initialWidth to force it to show it on initial render.

**Change List (commits, features, bugs, etc)**

- add initialWidth to Table pagination size hook

**Acceptance Test (how to verify the PR)**

- check the playground story
- turn on pagination
- resize the window to ensure the pagination text still disappears when less than 500 
- resize to ensure it re-appears when greater than 500
- check the statefultable with pre-filled search story
- confirm text is hidden when less than 500px

**Regression Test (how to make sure this PR doesn't break old functionality)**

- see above

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
