### PR TITLE
adjust size of loading spinner in row

### DIFF
--- a/packages/react/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
+++ b/packages/react/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
@@ -16,8 +16,8 @@
 
   /* the spinner was a little too big and causing the row to scroll so need to scale down a bit */
   .#{$prefix}--loading--small {
-    width: 1rem;
-    height: 1rem;
+    width: $spacing-05;
+    height: $spacing-05;
     margin-right: $spacing-03;
   }
 

--- a/packages/react/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
+++ b/packages/react/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
@@ -16,8 +16,8 @@
 
   /* the spinner was a little too big and causing the row to scroll so need to scale down a bit */
   .#{$prefix}--loading--small {
-    width: 1.875rem;
-    height: 1.875rem;
+    width: 1rem;
+    height: 1rem;
     margin-right: $spacing-03;
   }
 


### PR DESCRIPTION
#3188

Closes #3188 

**Summary**

- Adjust size of loading spinner in row
- Change width and height of loading small from 1.875 to 1 rem
- This matches the carbon size of the loading icon [here](https://react.carbondesignsystem.com/?path=/story/components-loading--default) 

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
