### PR TITLE
feat(tableviewdropdown): add prop isHidingStandardActions

### DIFF
--- a/packages/react/src/components/Table/TableViewDropdown/TableViewDropdown.jsx
+++ b/packages/react/src/components/Table/TableViewDropdown/TableViewDropdown.jsx
@@ -49,6 +49,8 @@ const propTypes = {
   }),
   style: PropTypes.objectOf(PropTypes.string),
   testID: PropTypes.string,
+  /** When true hides all action items and only allows the selection of views  */
+  isHidingStandardActions: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -69,6 +71,7 @@ const defaultProps = {
   overrides: undefined,
   style: undefined,
   testID: 'TableViewDropdown',
+  isHidingStandardActions: false,
 };
 
 const TableViewDropdown = ({
@@ -81,6 +84,7 @@ const TableViewDropdown = ({
   overrides,
   style,
   testID,
+  isHidingStandardActions,
 }) => {
   const viewAllItem = {
     id: 'view-all',
@@ -103,7 +107,7 @@ const TableViewDropdown = ({
       customAction: onManageViews,
       icon: Settings16,
     };
-    // Save changes button show only appear if the view has been edited and the current view is not 'View all'
+    // Save changes item should only appear if the view has been edited and the current view is not 'View all'
     // 'View all' is equivalent to a "default view", which would not be able to get re-saved. The user should supply
     // their own default views that can be changed if they would like that functionality
     const dialogItems =
@@ -111,9 +115,11 @@ const TableViewDropdown = ({
         ? [saveAsNewItem, saveItem, manageViewsItem]
         : [saveAsNewItem, manageViewsItem];
 
-    // move the action / dialog items to the top so that they are always easily accessible in the case that there are
-    // many views. The user would need to scroll all the way to the bottom to find the actions
-    return [...dialogItems, viewAllItem, ...views];
+    return isHidingStandardActions
+      ? views
+      : // move the action / dialog items to the top so that they are always accessible
+        // without scrolling in the case that there are many views.
+        [...dialogItems, viewAllItem, ...views];
   }, [
     i18n.saveAsNewView,
     i18n.saveChanges,
@@ -125,6 +131,7 @@ const TableViewDropdown = ({
     selectedViewId,
     viewAllItem,
     views,
+    isHidingStandardActions,
   ]);
 
   const mySelectedItem = allItems.find((item) => item.id === selectedViewId) || viewAllItem;

--- a/packages/react/src/components/Table/TableViewDropdown/TableViewDropdown.story.jsx
+++ b/packages/react/src/components/Table/TableViewDropdown/TableViewDropdown.story.jsx
@@ -1,6 +1,6 @@
 import React, { useState, createElement } from 'react';
 import { action } from '@storybook/addon-actions';
-import { boolean, select, object } from '@storybook/addon-knobs';
+import { boolean, select, object, text } from '@storybook/addon-knobs';
 
 import TableViewDropdownREADME from './TableViewDropdown.mdx';
 import TableViewDropdown from './TableViewDropdown';
@@ -45,8 +45,9 @@ export const Playground = () => {
 
   return (
     <TableViewDropdown
-      selectedViewId={select('Selected view (selectedViewId)', ['view-1', 'view-2'], 'view-3')}
+      selectedViewId={text('Selected view (selectedViewId)', 'view-1')}
       selectedViewEdited={boolean('selectedViewEdited', true)}
+      isHidingStandardActions={boolean('isHidingStandardActions', false)}
       views={viewsAndActions}
       actions={{
         onSaveAsNewView: action('onSaveAsNewView'),

--- a/packages/react/src/components/Table/TableViewDropdown/TableViewDropdownContent.mdx
+++ b/packages/react/src/components/Table/TableViewDropdown/TableViewDropdownContent.mdx
@@ -1,7 +1,10 @@
 The TableViewDropdown allows the user to select an existing view and to open
 the related modals for creating new views and modifying existing ones. The component
 expects a list of views specified by the application but will also add the following items
-to the list: `save-new-view`, `save-changes` and `manage-views`.
+to the list: `save-new-view`, `save-changes` and `manage-views`. If you don't want these items
+you can set `isHidingStandardActions` to true and by doing so create a dropdown that can only
+be used to select existing views.
+
 The `save-changes` item will only appear if the view has been edited and the current view
 is not 'View all'. The 'View all' is equivalent to a "default view", which would not
 be able to get re-saved.
@@ -72,29 +75,30 @@ export const CodeExmple = () => {
 
 #### TableViewDropdown props
 
-| Name                 | Type                           | Default             | Description                                                                   |
-| :------------------- | :----------------------------- | :------------------ | :---------------------------------------------------------------------------- |
-| selectedViewEdited   | bool                           | false               | Set to true if the user has modified filters etc since the view was loaded    |
-| selectedViewId       | string                         | undefined           | The id of the view that is currently selected                                 |
-| disabled             | bool                           | false               |                                                                               |
-| views                | arrayOf(TableViewItemPropType) | []                  | An array of items representing the user generated views                       |
-| views[].id           | string                         |                     | Required item id                                                              |
-| views[].text         | string                         |                     | Required item label text                                                      |
-| views[].customAction | string                         |                     | Callback that will be called instead of the onChangeView                      |
-| views[].icon         | elementType                    |                     | Icon used by the item if any                                                  |
-| i18n                 | obj                            |                     | Object holding all i18n strings                                               |
-| i18n.view            | string                         | 'View'              |                                                                               |
-| i18n.edited          | string                         | 'Edited'            |                                                                               |
-| i18n.viewAll         | string                         | 'View All'          |                                                                               |
-| i18n.saveAsNewView   | string                         | 'Save as new view'  |                                                                               |
-| i18n.saveChanges     | string                         | 'Save changes'      |                                                                               |
-| i18n.manageViews     | string                         | 'Manage views'      |                                                                               |
-| i18n.ariaLabel       | string                         | 'Select view'       |                                                                               |
-| i18n.tableViewMenu   | string                         | 'Table view menu'   |                                                                               |
-| onSaveAsNewView      | function                       |                     | Callback for when the user selected save new View                             |
-| onSaveChanges        | function                       |                     | Callback for when the user selected save View                                 |
-| onManageViews        | function                       |                     | Callback for when the user selected Manage views                              |
-| onChangeView         | function                       |                     | Callback for when the current view is changed by the user                     |
-| style                | objectOf                       |                     |                                                                               |
-| testID               | string                         | 'TableViewDropdown' |                                                                               |
-| overrides            | obj                            | undefined           | Used to override the internal components and props for advanced customisation |
+| Name                    | Type                           | Default             | Description                                                                   |
+| :---------------------- | :----------------------------- | :------------------ | :---------------------------------------------------------------------------- |
+| selectedViewEdited      | bool                           | false               | Set to true if the user has modified filters etc since the view was loaded    |
+| selectedViewId          | string                         | undefined           | The id of the view that is currently selected                                 |
+| disabled                | bool                           | false               |                                                                               |
+| views                   | arrayOf(TableViewItemPropType) | []                  | An array of items representing the user generated views                       |
+| views[].id              | string                         |                     | Required item id                                                              |
+| views[].text            | string                         |                     | Required item label text                                                      |
+| views[].customAction    | string                         |                     | Callback that will be called instead of the onChangeView                      |
+| views[].icon            | elementType                    |                     | Icon used by the item if any                                                  |
+| i18n                    | obj                            |                     | Object holding all i18n strings                                               |
+| i18n.view               | string                         | 'View'              |                                                                               |
+| i18n.edited             | string                         | 'Edited'            |                                                                               |
+| i18n.viewAll            | string                         | 'View All'          |                                                                               |
+| i18n.saveAsNewView      | string                         | 'Save as new view'  |                                                                               |
+| i18n.saveChanges        | string                         | 'Save changes'      |                                                                               |
+| i18n.manageViews        | string                         | 'Manage views'      |                                                                               |
+| i18n.ariaLabel          | string                         | 'Select view'       |                                                                               |
+| i18n.tableViewMenu      | string                         | 'Table view menu'   |                                                                               |
+| onSaveAsNewView         | function                       |                     | Callback for when the user selected save new View                             |
+| onSaveChanges           | function                       |                     | Callback for when the user selected save View                                 |
+| onManageViews           | function                       |                     | Callback for when the user selected Manage views                              |
+| onChangeView            | function                       |                     | Callback for when the current view is changed by the user                     |
+| style                   | objectOf                       |                     |                                                                               |
+| testID                  | string                         | 'TableViewDropdown' |                                                                               |
+| overrides               | obj                            | undefined           | Used to override the internal components and props for advanced customisation |
+| isHidingStandardActions | bool                           | false               | When true hides all standard action items                                     |

--- a/packages/react/src/components/Table/TableViewDropdown/__snapshots__/TableViewDropdown.story.storyshot
+++ b/packages/react/src/components/Table/TableViewDropdown/__snapshots__/TableViewDropdown.story.storyshot
@@ -48,11 +48,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               isSelected={true}
               item={
                 Object {
-                  "id": "view-3",
-                  "text": "My saved 3",
+                  "id": "view-1",
+                  "text": "My saved 1",
                 }
               }
-              testID="TableViewDropdownItem-view-3"
+              testID="TableViewDropdownItem-view-1"
             />
           }
           type="button"
@@ -62,8 +62,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           >
             <div
               className="iot--view-dropdown__item"
-              data-testid="TableViewDropdownItem-view-3"
-              title="My saved 3 - Edited"
+              data-testid="TableViewDropdownItem-view-1"
+              title="My saved 1 - Edited"
             >
               <span
                 className="iot--view-dropdown__button-prefix"
@@ -90,7 +90,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                 </span>
               </span>
               <span>
-                My saved 3
+                My saved 1
                 <span
                   className="iot--view-dropdown__edited-text"
                 >

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -9305,6 +9305,7 @@ Map {
         "view": "View",
         "viewAll": "View All",
       },
+      "isHidingStandardActions": false,
       "overrides": undefined,
       "selectedViewEdited": false,
       "selectedViewId": undefined,
@@ -9366,6 +9367,9 @@ Map {
           },
         ],
         "type": "shape",
+      },
+      "isHidingStandardActions": Object {
+        "type": "bool",
       },
       "overrides": Object {
         "args": Array [


### PR DESCRIPTION
Closes #3298

**Summary**
Adds prop `isHidingStandardActions`  to the TableViewDropdown so that it can be turned in to a 
component only allowing selecting existing views.

**Change List (commits, features, bugs, etc)**
- Updated story with knob
- Wrote test
- Updated TableViewDropdown
- Updated mdx

**Acceptance Test (how to verify the PR)**

1.  Go to story https://deploy-preview-3301--carbon-addons-iot-react.netlify.app?path=/story/1-watson-iot-table-user-view-management-tableviewdropdown--playground
2. Make sure the standard actions (`Save as new view`, `Save changes` and `Manage views`) are showing in the dropdown
3. Enable knob "isHidingStandardActions"
4. Make sure the standard actions are no longer showing


**Regression Test (how to make sure this PR doesn't break old functionality)**

- Verify that the other stories are unaffected

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
