### PR TITLE
fix(table): advanced filter crash fix

### DIFF
--- a/packages/react/src/components/Table/TableToolbar/TableToolbarAdvancedFilterFlyout.jsx
+++ b/packages/react/src/components/Table/TableToolbar/TableToolbarAdvancedFilterFlyout.jsx
@@ -278,7 +278,7 @@ const TableToolbarAdvancedFilterFlyout = ({
           {ordering
             .filter((column) => {
               const fullColumn = columns.find((item) => column.columnId === item.id);
-              return !column.isHidden && fullColumn.isFilterable === true;
+              return !column.isHidden && fullColumn?.isFilterable === true;
             })
             .reduce((chunks, item, index) => {
               const newChunks = [...chunks];

--- a/packages/react/src/components/Table/TableToolbar/TableToolbarAdvancedFilterFlyout.test.jsx
+++ b/packages/react/src/components/Table/TableToolbar/TableToolbarAdvancedFilterFlyout.test.jsx
@@ -672,7 +672,7 @@ describe('TableToolbarAdvancedFilterFlyout', () => {
     );
   });
 
-  it('should not break on empty column arrry prop', () => {
+  it('should not break on empty column array prop', () => {
     const onApplyAdvancedFilter = jest.fn();
     const onCancelAdvancedFilter = jest.fn();
     render(

--- a/packages/react/src/components/Table/TableToolbar/TableToolbarAdvancedFilterFlyout.test.jsx
+++ b/packages/react/src/components/Table/TableToolbar/TableToolbarAdvancedFilterFlyout.test.jsx
@@ -671,4 +671,50 @@ describe('TableToolbarAdvancedFilterFlyout', () => {
       'true'
     );
   });
+
+  it('should not break on empty column arrry prop', () => {
+    const onApplyAdvancedFilter = jest.fn();
+    const onCancelAdvancedFilter = jest.fn();
+    render(
+      <TableToolbarAdvancedFilterFlyout
+        actions={{
+          onApplyAdvancedFilter,
+          onCancelAdvancedFilter,
+        }}
+        columns={[]}
+        i18n={null}
+        tableState={{
+          ordering: [
+            {
+              isHidden: false,
+              columnId: 'test-column',
+            },
+            {
+              isHidden: false,
+              columnId: 'string-column',
+            },
+          ],
+          filters: [
+            {
+              columnId: 'test-column',
+              value: 'test-column-value',
+            },
+            {
+              columnId: 'string-column',
+              value: [
+                {
+                  id: 'string-column-value',
+                  text: 'string-column-value',
+                },
+              ],
+            },
+          ],
+          advancedFilterFlyoutOpen: true,
+        }}
+        isDisabled
+      />
+    );
+
+    expect(screen.getByTestId('advanced-filter-flyout-container')).toBeVisible();
+  });
 });


### PR DESCRIPTION
Closes #3319

**Summary**
Small fix to prevent the TableToolbarAdvancedFilterFlyout.jsx from crashing if the columns prop array is empty

**Change List (commits, features, bugs, etc)**


**Acceptance Test (how to verify the PR)**

- Unit test is passing

(The bug is not easily testable without modifying the table main story like is being done for #3304)

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Advanced filters work as before

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
