### PR TITLE
docs(table): remove react wrapper for table stories

### DIFF
--- a/packages/react/src/components/Table/Table.main.story.jsx
+++ b/packages/react/src/components/Table/Table.main.story.jsx
@@ -1,4 +1,4 @@
-import React, { useState, createElement } from 'react';
+import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { object, select, boolean } from '@storybook/addon-knobs';
 import { merge, uniqueId } from 'lodash-es';
@@ -8,6 +8,7 @@ import Button from '../Button';
 import EmptyState from '../EmptyState';
 import { DragAndDrop } from '../../utils/DragAndDropUtils';
 import RuleBuilder from '../RuleBuilder/RuleBuilder';
+import useStoryState from '../../internal/storyState';
 
 import TableREADME from './mdx/Table.mdx';
 import SortingREADME from './mdx/Sorting.mdx';
@@ -65,8 +66,8 @@ export default {
  */
 export const Playground = () => {
   // STATES
-  const [showRowEditBar, setShowRowEditBar] = useState(false);
-  const [rowActionsState, setRowActionsState] = useState(getRowActionStates());
+  const [showRowEditBar, setShowRowEditBar] = useStoryState(false);
+  const [rowActionsState, setRowActionsState] = useStoryState(getRowActionStates());
 
   // KNOBS
   // The order of appearance is defined function getTableKnobs.
@@ -216,13 +217,24 @@ export const Playground = () => {
   );
 
   // INITIAL DATA STATE
-  const [data, setData] = useState(
+  const [data, setData] = useStoryState(
     [...(demoEmptyState || demoCustomEmptyState ? [] : getTableData())]
       .slice(0, numerOfRows)
       .map((row, index) => (hasRowActions ? addRowAction(row, hasSingleRowEdit, index) : row))
       .map((row, index) => (hasRowNesting ? addChildRows(row, index) : row))
       .map((row) => (!selectionCheckboxEnabled ? { ...row, isSelectable: false } : row))
-      .map((row) => (demoHasLoadMore ? { ...row, hasLoadMore: true } : row))
+      .map((row) => (demoHasLoadMore ? { ...row, hasLoadMore: true } : row)),
+    // Reset initial state and trigger a story re-render when any
+    // of the following values change
+    [
+      demoEmptyState,
+      demoCustomEmptyState,
+      hasRowActions,
+      hasSingleRowEdit,
+      hasRowNesting,
+      selectionCheckboxEnabled,
+      demoHasLoadMore,
+    ]
   );
 
   const onRowLoadMore = (parentId) => {
@@ -275,95 +287,94 @@ export const Playground = () => {
   const errorState = demoCustomErrorState ? customErrorState : undefined;
   const error = demoCustomErrorState ? 'Error!' : undefined;
 
-  const knobRegeneratedKey = `table${demoInitialColumnSizes}${JSON.stringify(aggregationsColumns)}`;
+  // For demo and test purposes we generate an new key for the table when
+  // some knobs change that normally wouldn't trigger a rerender in the StatefulTable.
+  const knobRegeneratedKey = `table${demoInitialColumnSizes}${JSON.stringify(aggregationsColumns)}
+  ${aggregationLabel}${demoCustomEmptyState}${loadingRowCount}${loadingColumnCount}${maxPages}
+  ${isItemPerPageHidden}${paginationSize}${demoToolbarActions}${toolbarIsDisabled}`;
 
   return (
-    <MyTable
-      key={knobRegeneratedKey}
-      id="table"
-      style={style}
-      secondaryTitle={secondaryTitle}
-      useZebraStyles={useZebraStyles}
-      tooltip={tableTooltip}
-      columns={columns}
-      columnGroups={columnGroups}
-      data={data}
-      expandedData={expandedData}
-      actions={myTableActions}
-      size={size}
-      options={{
-        hasAggregations,
-        hasColumnSelection,
-        hasColumnSelectionConfig,
-        hasFilter: hasFilter && !hasAdvancedFilter,
-        hasAdvancedFilter,
-        hasMultiSort,
-        hasPagination,
-        hasResize,
-        hasRowExpansion,
-        hasRowNesting,
-        hasRowSelection,
-        shouldExpandOnRowClick,
-        hasFastSearch,
-        hasSearch,
-        preserveColumnWidths,
-        useAutoTableLayoutForResize,
-        wrapCellText,
-        preserveCellWhiteSpace,
-        hasRowActions,
-        shouldLazyRender,
-        hasRowEdit,
-        hasSingleRowEdit,
-      }}
-      view={{
-        advancedFilters,
-        aggregations: {
-          label: aggregationLabel,
-          columns: aggregationsColumns,
-        },
-        toolbar: {
-          activeBar,
-          isDisabled: toolbarIsDisabled,
-          customToolbarContent,
-          toolbarActions,
-          rowEditBarButtons,
-          batchActions,
-        },
-        table: {
-          emptyState,
-          errorState,
-          expandedIds,
-          selectedIds,
-          rowActions: rowActionsState,
-          singleRowEditButtons,
-          loadingState: {
-            isLoading: tableIsLoading,
-            rowCount: loadingRowCount,
-            columnCount: loadingColumnCount,
+    <DragAndDrop>
+      <MyTable
+        key={knobRegeneratedKey}
+        id="table"
+        style={style}
+        secondaryTitle={secondaryTitle}
+        useZebraStyles={useZebraStyles}
+        tooltip={tableTooltip}
+        columns={columns}
+        columnGroups={columnGroups}
+        data={data}
+        expandedData={expandedData}
+        actions={myTableActions}
+        size={size}
+        options={{
+          hasAggregations,
+          hasColumnSelection,
+          hasColumnSelectionConfig,
+          hasFilter: hasFilter && !hasAdvancedFilter,
+          hasAdvancedFilter,
+          hasMultiSort,
+          hasPagination,
+          hasResize,
+          hasRowExpansion,
+          hasRowNesting,
+          hasRowSelection,
+          shouldExpandOnRowClick,
+          hasFastSearch,
+          hasSearch,
+          preserveColumnWidths,
+          useAutoTableLayoutForResize,
+          wrapCellText,
+          preserveCellWhiteSpace,
+          hasRowActions,
+          shouldLazyRender,
+          hasRowEdit,
+          hasSingleRowEdit,
+        }}
+        view={{
+          advancedFilters,
+          aggregations: {
+            label: aggregationLabel,
+            columns: aggregationsColumns,
           },
-          ordering,
-        },
-        pagination: {
-          pageSizes,
-          maxPages,
-          isItemPerPageHidden,
-          size: paginationSize,
-        },
-      }}
-      i18n={getI18nKnobs()}
-      error={error}
-      locale={locale}
-    />
+          toolbar: {
+            activeBar,
+            isDisabled: toolbarIsDisabled,
+            customToolbarContent,
+            toolbarActions,
+            rowEditBarButtons,
+            batchActions,
+          },
+          table: {
+            emptyState,
+            errorState,
+            expandedIds,
+            selectedIds,
+            rowActions: rowActionsState,
+            singleRowEditButtons,
+            loadingState: {
+              isLoading: tableIsLoading,
+              rowCount: loadingRowCount,
+              columnCount: loadingColumnCount,
+            },
+            ordering,
+          },
+          pagination: {
+            pageSizes,
+            maxPages,
+            isItemPerPageHidden,
+            size: paginationSize,
+          },
+        }}
+        i18n={getI18nKnobs()}
+        error={error}
+        locale={locale}
+      />
+    </DragAndDrop>
   );
 };
 Playground.storyName = 'Playground';
-Playground.decorators = [
-  (Story) => (
-    <DragAndDrop>
-      <Story />
-    </DragAndDrop>
-  ),
-];
 
 export const WithSorting = () => {
   const { selectedTableType, demoSingleSort, hasMultiSort } = getTableKnobs({
@@ -390,30 +401,25 @@ export const WithSorting = () => {
   });
 
   return (
-    <MyTable
-      actions={getTableActions()}
-      columns={columns}
-      data={data}
-      options={{
-        hasMultiSort,
-      }}
-      view={{
-        table: {
-          sort,
-        },
-      }}
-    />
+    <DragAndDrop>
+      <MyTable
+        actions={getTableActions()}
+        columns={columns}
+        data={data}
+        options={{
+          hasMultiSort,
+        }}
+        view={{
+          table: {
+            sort,
+          },
+        }}
+      />
+    </DragAndDrop>
   );
 };
 
 WithSorting.storyName = 'With sorting';
-WithSorting.decorators = [
-  (Story) => (
-    <DragAndDrop>
-      <Story />
-    </DragAndDrop>
-  ),
-];
 WithSorting.parameters = {
   component: Table,
   docs: {
@@ -463,7 +469,6 @@ export const WithRowExpansion = () => {
 };
 
 WithRowExpansion.storyName = 'With row expansion';
-WithRowExpansion.decorators = [createElement];
 WithRowExpansion.parameters = {
   component: Table,
   docs: {
@@ -486,13 +491,13 @@ export const WithRowNesting = () => {
     ],
     enableKnob: () => true,
   });
-  const initiallyExpandedIds = object('Expanded ids (view.table.expandedIds)', ['row-1']);
 
+  const initiallyExpandedIds = object('Expanded ids (view.table.expandedIds)', ['row-1']);
+  const demoDeepNesting = !hasRowNesting.hasSingleNestedHierarchy;
   const MyTable = selectedTableType === 'StatefulTable' ? StatefulTable : Table;
   const initialData = getTableData()
     .slice(0, 10)
     .map((row, index) => {
-      const demoDeepNesting = !hasRowNesting.hasSingleNestedHierarchy;
       return addChildRows(row, index, demoDeepNesting);
     })
     .map((row) => ({
@@ -502,9 +507,9 @@ export const WithRowNesting = () => {
   const columns = getTableColumns();
   const actions = getTableActions();
 
-  const [loadingMoreIds, setLoadingMoreIds] = useState([]);
-  const [data, setData] = useState(initialData);
-  const [expandedIds, setExpandedIds] = useState(initiallyExpandedIds);
+  const [loadingMoreIds, setLoadingMoreIds] = useStoryState([]);
+  const [data, setData] = useStoryState(initialData, [demoHasLoadMore, demoDeepNesting]);
+  const [expandedIds, setExpandedIds] = useStoryState(initiallyExpandedIds, initiallyExpandedIds);
 
   const onRowLoadMore = (parentId) => {
     action('onRowLoadMore')(parentId);
@@ -523,9 +528,8 @@ export const WithRowNesting = () => {
 
   const onRowExpanded = (rowId, expanded) => {
     action('onRowExpanded')(rowId, expanded);
-    setExpandedIds((currentlyExpanded) =>
-      expanded ? [...currentlyExpanded, rowId] : currentlyExpanded.filter((id) => id !== rowId)
-    );
+    const temp = expanded ? [...expandedIds, rowId] : expandedIds.filter((id) => id !== rowId);
+    setExpandedIds(temp);
   };
   return (
     <MyTable
@@ -554,7 +558,6 @@ export const WithRowNesting = () => {
 };
 
 WithRowNesting.storyName = 'With row nesting';
-WithRowNesting.decorators = [createElement];
 WithRowNesting.parameters = {
   component: Table,
   docs: {
@@ -602,8 +605,8 @@ export const WithFiltering = () => {
   }
 
   // Advanced filter settings
-  const [showBuilder, setShowBuilder] = useState(false);
-  const [advancedFilters, setAdvancedFilters] = useState(
+  const [showBuilder, setShowBuilder] = useStoryState(false);
+  const [advancedFilters, setAdvancedFilters] = useStoryState(
     hasAdvancedFilter ? getAdvancedFilters() : undefined
   );
   const selectedAdvancedFilterIds = hasAdvancedFilter
@@ -619,10 +622,12 @@ export const WithFiltering = () => {
     <StoryNotice experimental componentName="StatefulTable with advancedFilters" />
   ) : null;
 
+  const knobRegeneratedKey = `${JSON.stringify(activeFilters)}`;
   return (
     <>
       {storyNotice}
       <MyTable
+        key={knobRegeneratedKey}
         actions={actions}
         columns={columns}
         data={data}
@@ -671,7 +676,6 @@ export const WithFiltering = () => {
 };
 
 WithFiltering.storyName = 'With filtering';
-WithFiltering.decorators = [createElement];
 WithFiltering.parameters = {
   component: Table,
   docs: {
@@ -726,7 +730,6 @@ export const WithSelectionAndBatchActions = () => {
 };
 
 WithSelectionAndBatchActions.storyName = 'With selection and batch actions';
-WithSelectionAndBatchActions.decorators = [createElement];
 WithSelectionAndBatchActions.parameters = {
   component: Table,
   docs: {
@@ -787,7 +790,6 @@ export const WithInlineActions = () => {
   );
 };
 WithInlineActions.storyName = 'With inline actions';
-WithInlineActions.decorators = [createElement];
 WithInlineActions.parameters = {
   component: Table,
   docs: {

--- a/packages/react/src/components/Table/Table.story.helpers.jsx
+++ b/packages/react/src/components/Table/Table.story.helpers.jsx
@@ -1052,7 +1052,7 @@ export const getTableKnobs = ({ knobsToCreate, enableKnob, useGroups = false }) 
         )
       : null,
     batchActions: shouldCreate('batchActions')
-      ? object(
+      ? objectWithSubstitution(
           'Batch actions for selected rows (view.toolbar.batchActions)',
           getBatchActions(),
           SELECTIONS_ACTIONS_GROUP

--- a/packages/react/src/internal/storyState.js
+++ b/packages/react/src/internal/storyState.js
@@ -1,0 +1,80 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import addons from '@storybook/addons';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { FORCE_RE_RENDER, STORY_RENDERED, STORY_CHANGED } from '@storybook/core-events';
+import { isEqual } from 'lodash-es';
+
+let callOrder = 0;
+let states = [];
+let dependencies = [];
+
+addons.getChannel().addListener(STORY_CHANGED, () => {
+  // Clear the global state and reset the capll order when
+  // the user selects another story
+  callOrder = 0;
+  states = [];
+  dependencies = [];
+});
+
+addons.getChannel().addListener(STORY_RENDERED, () => {
+  // Reset on every render so that the index of the useStoryState
+  // doesn't keep increasing.
+  callOrder = 0;
+});
+
+/**
+ * useStoryState can be used as a substitute for React's useState when you for
+ * performance reasons don't want to wrap the story in a react element.
+ * For more advanced stories it is also possible to add dependencies to the state
+ * that when changed will force the state to use the value passed in (i.e. a new initial value)
+ * and trigger a force rerender of the story to show the modified changes.
+ *
+ * Example 1
+ * The dependencies can be a one or more knob values affecting the initial value like the Table's
+ * 'hasLoadMore' affects the 'data' prop.
+ *
+ * Example 2
+ * The dependencies can be the value of a knob representing the same table prop as the state does
+ * so that that they can be used together, i.e. when the knob is modified the state
+ * is also updatet with the same value.
+ * @param {any} initialValue The inital value of the state
+ * @param {any} currentDep The dependencies that when changed will force a reset to the
+ * initial value and re-render
+ * @returns
+ */
+export default function useStoryState(initialValue, currentDep) {
+  // The call order is the "id" used to link a stored state with the actual
+  // call of the useStoryState function. The 'callOrder' const has to be reassigned
+  // so that the update function can use the index matching this closure.
+  const index = callOrder;
+
+  // Set the value to the initialValue if this is the first render, if not
+  // the value stays unchanged
+  const isInitialRender = states[index] === undefined;
+  const value = isInitialRender ? initialValue : states[index];
+  states[index] = value;
+
+  // If the dependencies has changed the state is "reset" to use the
+  // new initial value and force a rerender of the story just like
+  // a normal update would, thus the resetted value is picked up during
+  // next render
+  const previousDep = dependencies[index];
+  const dependenciesHasChanged = !isEqual(previousDep, currentDep);
+  if (dependenciesHasChanged) {
+    states[index] = initialValue;
+    dependencies[index] = currentDep;
+    if (!isInitialRender) {
+      addons.getChannel().emit(FORCE_RE_RENDER);
+    }
+  }
+
+  callOrder += 1;
+
+  // The update function returned together with the value
+  const update = (newValue) => {
+    states[index] = typeof newValue === 'function' ? newValue(states[index]) : newValue;
+    addons.getChannel().emit(FORCE_RE_RENDER);
+  };
+
+  return [value, update];
+}

--- a/packages/react/src/internal/storyState.js
+++ b/packages/react/src/internal/storyState.js
@@ -36,7 +36,7 @@ addons.getChannel().addListener(STORY_RENDERED, () => {
  * Example 2
  * The dependencies can be the value of a knob representing the same table prop as the state does
  * so that that they can be used together, i.e. when the knob is modified the state
- * is also updatet with the same value.
+ * is also updated with the same value.
  * @param {any} initialValue The inital value of the state
  * @param {any} currentDep The dependencies that when changed will force a reset to the
  * initial value and re-render
@@ -56,7 +56,7 @@ export default function useStoryState(initialValue, currentDep) {
 
   // If the dependencies has changed the state is "reset" to use the
   // new initial value and force a rerender of the story just like
-  // a normal update would, thus the resetted value is picked up during
+  // a normal update would, thus the reset value is picked up during
   // next render
   const previousDep = dependencies[index];
   const dependenciesHasChanged = !isEqual(previousDep, currentDep);

--- a/packages/react/src/internal/storyState.js
+++ b/packages/react/src/internal/storyState.js
@@ -9,7 +9,7 @@ let states = [];
 let dependencies = [];
 
 addons.getChannel().addListener(STORY_CHANGED, () => {
-  // Clear the global state and reset the capll order when
+  // Clear the global state and reset the call order when
   // the user selects another story
   callOrder = 0;
   states = [];


### PR DESCRIPTION
Closes #3304

**Summary**
Our stories using the StatefulTable had become slow due to the fact that the whole story was re-generated each time a knob was changed. This happened when the story was wrapped in a React element using the story `decorator`, which we did for each story that needed DragAndDrop or needed a react state.


**Change List (commits, features, bugs, etc)**
- The Tables are no longer re-generated from scratch when a knob changes. Some knobs still explicitly re-renders the table for demo purposes, e.g. when view related knobs change for the StatefulTable we need to use `key` to get the change picked up.
- Removed DnD wrapper from the decorator and added the `<DragAndDrop>` element in the story itself.
- Created a non-react dependent version of React's `useState` called `useStoryState`. For simplicity of use I built it with the same API as react. In order to support our more advanced stories where different knobs also affects the state I added the option of providing a dependency array that when changed will "reset" the state to the current initial value.

**Acceptance Test (how to verify the PR)**
Not re-generating the story when knob changes has exposed yet more bugs in the table. I have filed issues for the once I have found in my testing but there might be more.

1. Go to https://deploy-preview-3324--carbon-addons-iot-react.netlify.app?path=/story/1-watson-iot-table--playground
2. Click on the Title & Toolbar tab
3. Edit the knob `secondaryTitle` and make sure the table doesn't reload in a noticeable manner
4. Test with more knobs (remember that some knobs explicitly re-renders the table using the key)
5. Test the other "new" table stories to make sure there is no slow re-generation that makes the table flicker when knob changes

**Regression Test (how to make sure this PR doesn't break old functionality)**
https://deploy-preview-3324--carbon-addons-iot-react.netlify.app?path=/story/1-watson-iot-table--playground

All "new" table stories works as expected, no crashes when knobs are changed. Note, not all knobs in the stories are applied when changed when the type of table is StatefulTable (since the state of the knob has moved into the table after the initial render).

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
