### PR TITLE
fix(table): show correct number of columns in tableskeleton

### DIFF
--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -1034,6 +1034,7 @@ const Table = (props) => {
                 columns={visibleColumns}
                 {...pick(options, 'hasRowSelection', 'hasRowActions')}
                 hasRowExpansion={!!options.hasRowExpansion}
+                hasRowNesting={!!options.hasRowNesting}
                 rowCount={view.table.loadingState.rowCount}
                 columnCount={view.table.loadingState.columnCount}
                 // TODO: remove 'id' in v3.

--- a/packages/react/src/components/Table/TableSkeletonWithHeaders/TableSkeletonWithHeader.test.jsx
+++ b/packages/react/src/components/Table/TableSkeletonWithHeaders/TableSkeletonWithHeader.test.jsx
@@ -1,7 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
+import { settings } from '../../../constants/Settings';
+
 import TableSkeletonWithHeaders from './TableSkeletonWithHeaders';
+
+const { iotPrefix } = settings;
 
 describe('TableSkeletonWithHeaders', () => {
   it('should be selectable with testID or testId', () => {
@@ -22,6 +26,69 @@ describe('TableSkeletonWithHeaders', () => {
     });
     expect(screen.getByTestId('table_skeleton-expander-column')).toBeDefined();
     expect(screen.getByTestId('table_skeleton-skeletonRow-0-expander-column')).toBeDefined();
+  });
+
+  it('should show column for rowExpansion when present', () => {
+    const { container } = render(
+      <TableSkeletonWithHeaders
+        testId="table_skeleton"
+        rowCount={2}
+        columnCount={5}
+        hasRowExpansion
+      />,
+      {
+        container: document.body.appendChild(document.createElement('table')),
+      }
+    );
+    expect(
+      container.querySelectorAll(`.${iotPrefix}--table-skeleton-with-headers--table-row--head td`)
+    ).toHaveLength(6);
+    expect(
+      container.querySelectorAll(`.${iotPrefix}--table-skeleton-with-headers--table-row td`)
+    ).toHaveLength(12);
+  });
+
+  it('should show column for rowNesting when present', () => {
+    const { container } = render(
+      <TableSkeletonWithHeaders
+        testId="table_skeleton"
+        rowCount={2}
+        columnCount={5}
+        hasRowNesting
+      />,
+      {
+        container: document.body.appendChild(document.createElement('table')),
+      }
+    );
+    expect(
+      container.querySelectorAll(`.${iotPrefix}--table-skeleton-with-headers--table-row--head td`)
+    ).toHaveLength(6);
+    expect(
+      container.querySelectorAll(`.${iotPrefix}--table-skeleton-with-headers--table-row td`)
+    ).toHaveLength(12);
+  });
+
+  it('should show all "additional" columns when present', () => {
+    const { container } = render(
+      <TableSkeletonWithHeaders
+        testId="table_skeleton"
+        columnCount={5}
+        rowCount={2}
+        hasRowNesting
+        hasRowActions
+        hasRowSelection="multi"
+        showExpanderColumn
+      />,
+      {
+        container: document.body.appendChild(document.createElement('table')),
+      }
+    );
+    expect(
+      container.querySelectorAll(`.${iotPrefix}--table-skeleton-with-headers--table-row--head td`)
+    ).toHaveLength(9);
+    expect(
+      container.querySelectorAll(`.${iotPrefix}--table-skeleton-with-headers--table-row td`)
+    ).toHaveLength(18);
   });
 
   it('should render the same number of rows given except for 0', () => {

--- a/packages/react/src/components/Table/TableSkeletonWithHeaders/TableSkeletonWithHeaders.jsx
+++ b/packages/react/src/components/Table/TableSkeletonWithHeaders/TableSkeletonWithHeaders.jsx
@@ -11,6 +11,7 @@ const { iotPrefix } = settings;
 const propTypes = {
   hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
   hasRowExpansion: PropTypes.bool,
+  hasRowNesting: PropTypes.bool,
   hasRowActions: PropTypes.bool,
   rowCount: PropTypes.number,
   /* used to show X number of loading skeletons when columns are unknown */
@@ -31,6 +32,7 @@ const defaultProps = {
   hasRowSelection: false,
   hasRowExpansion: false,
   hasRowActions: false,
+  hasRowNesting: false,
   rowCount: 10,
   columnCount: 5,
   columns: [],
@@ -43,6 +45,7 @@ const TableSkeletonWithHeaders = ({
   hasRowSelection,
   hasRowExpansion,
   hasRowActions,
+  hasRowNesting,
   columns,
   rowCount,
   columnCount,
@@ -62,7 +65,7 @@ const TableSkeletonWithHeaders = ({
         })}
       >
         {hasRowSelection === 'multi' ? <TableCell /> : null}
-        {hasRowExpansion ? <TableCell /> : null}
+        {hasRowExpansion || hasRowNesting ? <TableCell /> : null}
         {loadingColumns.map((column) => (
           <TableCell key={`skeletonCol-${column.id}`}>
             <SkeletonText />
@@ -79,7 +82,7 @@ const TableSkeletonWithHeaders = ({
           className={`${iotPrefix}--table-skeleton-with-headers--table-row`}
         >
           {hasRowSelection === 'multi' ? <TableCell /> : null}
-          {hasRowExpansion ? <TableCell /> : null}
+          {hasRowExpansion || hasRowNesting ? <TableCell /> : null}
           {loadingColumns.map((v, colIndex) => (
             <TableCell key={`emptycell-${colIndex}`}>
               {rowIndex === 0 && !columns.length ? <SkeletonText /> : null}

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -3968,6 +3968,7 @@ Map {
       "columns": Array [],
       "hasRowActions": false,
       "hasRowExpansion": false,
+      "hasRowNesting": false,
       "hasRowSelection": false,
       "rowCount": 10,
       "showExpanderColumn": false,
@@ -3997,6 +3998,9 @@ Map {
         "type": "bool",
       },
       "hasRowExpansion": Object {
+        "type": "bool",
+      },
+      "hasRowNesting": Object {
         "type": "bool",
       },
       "hasRowSelection": Object {


### PR DESCRIPTION
Closes #3323

**Summary**
Fixes the number of columns shown for TableSkeletonWithHeader when `rowNesting` is used

**Change List (commits, features, bugs, etc)**

- Add fix to TableSkeletonWithHeader and Table
- Added unit tests

**Acceptance Test (how to verify the PR)**

1. Go to https://deploy-preview-3326--carbon-addons-iot-react.netlify.app?path=/story/1-watson-iot-table--playground
2. Click on Tab "Nesting & expansion" and activate knob "Demo nested rows (options.hasRowNesting)"
3. Click on tab "States" and activate knob "Show table loading state (view.table.loadingState.isLoading)"
4. Make sure the number of columns is correct

**Regression Test (how to make sure this PR doesn't break old functionality)**
1.  TableSkeletonWithHeader works as expected

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
