### PR TITLE
refactor(wizard-footer): remove styled components

### DIFF
--- a/packages/react/src/components/Table/TableDetailWizard/__snapshots__/TableDetailWizard.story.storyshot
+++ b/packages/react/src/components/Table/TableDetailWizard/__snapshots__/TableDetailWizard.story.storyshot
@@ -348,7 +348,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
         className="bx--modal-footer"
       >
         <div
-          className="WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+          className="iot--wizard-footer__buttons"
           data-testid="wizard-footer"
         >
           <button
@@ -734,7 +734,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
         className="bx--modal-footer"
       >
         <div
-          className="WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+          className="iot--wizard-footer__buttons"
           data-testid="wizard-footer"
         >
           <button
@@ -1195,7 +1195,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
         className="bx--modal-footer"
       >
         <div
-          className="WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+          className="iot--wizard-footer__buttons"
           data-testid="wizard-footer"
         >
           <button

--- a/packages/react/src/components/WizardInline/WizardFooter/WizardFooter.jsx
+++ b/packages/react/src/components/WizardInline/WizardFooter/WizardFooter.jsx
@@ -1,13 +1,11 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import classnames from 'classnames';
 
 import Button from '../../Button/Button';
+import { settings } from '../../../constants/Settings';
 
-const StyledFooterButtons = styled.div`
-  display: flex;
-  margin: auto 0 auto auto;
-`;
+const { iotPrefix } = settings;
 
 const propTypes = {
   onNext: PropTypes.func.isRequired,
@@ -56,7 +54,10 @@ const WizardFooter = ({
     {footerLeftContent && (
       <div className="WizardInline-custom-footer-content">{footerLeftContent}</div>
     )}
-    <StyledFooterButtons data-testid={testId} className={className}>
+    <div
+      data-testid={testId}
+      className={classnames(className, `${iotPrefix}--wizard-footer__buttons`)}
+    >
       {!hasPrev ? (
         <Button
           onClick={onCancel}
@@ -97,7 +98,7 @@ const WizardFooter = ({
           {submitLabel}
         </Button>
       )}
-    </StyledFooterButtons>
+    </div>
   </Fragment>
 );
 

--- a/packages/react/src/components/WizardInline/__snapshots__/WizardInline.story.storyshot
+++ b/packages/react/src/components/WizardInline/__snapshots__/WizardInline.story.storyshot
@@ -393,7 +393,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
             </p>
           </div>
           <div
-            className="WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+            className="iot--wizard-footer__buttons"
             data-testid="wizard-inline-footer"
           >
             <button
@@ -798,7 +798,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
           data-id="WizardInlineFooter"
         >
           <div
-            className="WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+            className="iot--wizard-footer__buttons"
             data-testid="wizard-inline-footer"
           >
             <button
@@ -1202,7 +1202,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
             </p>
           </div>
           <div
-            className="WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+            className="iot--wizard-footer__buttons"
             data-testid="wizard-inline-footer"
           >
             <button
@@ -1624,7 +1624,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
           data-id="WizardInlineFooter"
         >
           <div
-            className="WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+            className="iot--wizard-footer__buttons"
             data-testid="wizard-inline-footer"
           >
             <button
@@ -2029,7 +2029,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
           data-id="WizardInlineFooter"
         >
           <div
-            className="WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+            className="iot--wizard-footer__buttons"
             data-testid="wizard-inline-footer"
           >
             <button
@@ -2510,7 +2510,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ð
           data-id="WizardInlineFooter"
         >
           <div
-            className="WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+            className="iot--wizard-footer__buttons"
             data-testid="wizard-inline-footer"
           >
             <button

--- a/packages/react/src/components/WizardInline/_wizard-inline.scss
+++ b/packages/react/src/components/WizardInline/_wizard-inline.scss
@@ -18,3 +18,8 @@
     padding-left: $spacing-05;
   }
 }
+
+.#{$iot-prefix}--wizard-footer__buttons {
+  display: flex;
+  margin: auto 0 auto auto;
+}

--- a/packages/react/src/components/WizardModal/__snapshots__/WizardModal.story.storyshot
+++ b/packages/react/src/components/WizardModal/__snapshots__/WizardModal.story.storyshot
@@ -255,7 +255,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/W
         className="bx--modal-footer iot--composed-modal-footer bx--btn-set"
       >
         <div
-          className="iot--wizard-modal__footer WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+          className="iot--wizard-modal__footer iot--wizard-footer__buttons"
           data-testid="wizard-modal-footer"
         >
           <button
@@ -566,7 +566,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/W
           </p>
         </div>
         <div
-          className="iot--wizard-modal__footer WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+          className="iot--wizard-modal__footer iot--wizard-footer__buttons"
           data-testid="wizard-modal-footer"
         >
           <button
@@ -860,7 +860,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/W
         className="bx--modal-footer iot--composed-modal-footer bx--btn-set"
       >
         <div
-          className="iot--wizard-modal__footer WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+          className="iot--wizard-modal__footer iot--wizard-footer__buttons"
           data-testid="wizard-modal-footer"
         >
           <button


### PR DESCRIPTION
Closes #3317 

**Summary**

- removes styled components from WizardFooter

**Change List (commits, features, bugs, etc)**

- replaces one styled component div with a div and scss class

**Acceptance Test (how to verify the PR)**

- WizardInline story footers match those of next

**Regression Test (how to make sure this PR doesn't break old functionality)**

- WizardInline story footers match those of next

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
