### PR TITLE
feat(progress-bar): add inline variant

### DIFF
--- a/packages/react/src/components/ProgressBar/ProgressBar.jsx
+++ b/packages/react/src/components/ProgressBar/ProgressBar.jsx
@@ -23,6 +23,8 @@ const propTypes = {
   helperText: PropTypes.string,
   /* if true, hide the label  */
   hideLabel: PropTypes.bool,
+  /** When true, show the inline variant without an icon or label */
+  inline: PropTypes.bool,
   /* the number used to fill the bar */
   value: PropTypes.number.isRequired,
   /* the unit shown beside the value label text */
@@ -64,6 +66,7 @@ const defaultProps = {
   className: undefined,
   helperText: '',
   hideLabel: false,
+  inline: false,
   light: false,
   thresholds: [],
   max: 100,
@@ -82,6 +85,7 @@ const ProgressBar = ({
   helperText,
   hideLabel,
   i18n,
+  inline,
   label,
   light,
   max,
@@ -99,6 +103,63 @@ const ProgressBar = ({
   const fillColor = hasColorObject ? matchingThreshold.color.fill : matchingFillColor;
   const strokeColor = hasColorObject ? matchingThreshold.color.stroke : undefined;
 
+  /**
+   * When the progress bar is not using the inline variant, render the label and icon
+   * above the progress bar.
+   *
+   * @returns JSX Element
+   */
+  const renderProgressBarLabel = () => (
+    <div
+      className={classnames(`${iotPrefix}--progress-bar__label--right`, {
+        [`${prefix}--visually-hidden`]: hideLabel,
+      })}
+    >
+      {Icon ? (
+        <span className={`${iotPrefix}--progress-bar__icon`} data-testid="progress-bar-icon">
+          {renderIconByName && typeof Icon === 'string' ? (
+            renderIconByName(Icon, {
+              fill: fillColor,
+              stroke: strokeColor,
+              'aria-label': mergedI18n.iconLabel,
+            })
+          ) : (
+            <Icon fill={fillColor} stroke={strokeColor} aria-label={mergedI18n.iconLabel} />
+          )}
+        </span>
+      ) : null}
+      <span
+        className={classnames(`${iotPrefix}--progress-bar__value-label`, {
+          // allow styling the value label differently when above max
+          [`${iotPrefix}--progress-bar__value-label--over`]: value > max,
+        })}
+      >{`${value}${valueUnit}`}</span>
+    </div>
+  );
+
+  const renderProgressBarWithInlineWrapper = () => (
+    <div
+      className={classnames({
+        [`${iotPrefix}--progress-bar-wrapper--inline`]: inline,
+      })}
+    >
+      <CarbonProgressBar
+        label={label}
+        helperText={!inline ? helperText : undefined}
+        hideLabel={hideLabel || inline}
+        value={value}
+        max={max}
+      />
+      <span
+        className={classnames(`${iotPrefix}--progress-bar__value-label`, {
+          // allow styling the value label differently when above max
+          [`${iotPrefix}--progress-bar__value-label--over`]: value > max,
+          [`${iotPrefix}--progress-bar__value-label--inline`]: inline,
+        })}
+      >{`${value}${valueUnit}`}</span>
+    </div>
+  );
+
   return (
     <div
       className={classnames(
@@ -114,38 +175,20 @@ const ProgressBar = ({
         '--progress-bar-stroke-color': strokeColor,
       }}
     >
-      <div
-        className={classnames(`${iotPrefix}--progress-bar__label--right`, {
-          [`${prefix}--visually-hidden`]: hideLabel,
-        })}
-      >
-        {Icon ? (
-          <span className={`${iotPrefix}--progress-bar__icon`} data-testid="progress-bar-icon">
-            {renderIconByName && typeof Icon === 'string' ? (
-              renderIconByName(Icon, {
-                fill: fillColor,
-                stroke: strokeColor,
-                'aria-label': mergedI18n.iconLabel,
-              })
-            ) : (
-              <Icon fill={fillColor} stroke={strokeColor} aria-label={mergedI18n.iconLabel} />
-            )}
-          </span>
-        ) : null}
-        <span
-          className={classnames(`${iotPrefix}--progress-bar__value-label`, {
-            // allow styling the value label differently when above max
-            [`${iotPrefix}--progress-bar__value-label--over`]: value > max,
-          })}
-        >{`${value}${valueUnit}`}</span>
-      </div>
-      <CarbonProgressBar
-        label={label}
-        helperText={helperText}
-        hideLabel={hideLabel}
-        value={value}
-        max={max}
-      />
+      {inline ? (
+        renderProgressBarWithInlineWrapper()
+      ) : (
+        <>
+          {renderProgressBarLabel()}
+          <CarbonProgressBar
+            label={label}
+            helperText={!inline ? helperText : undefined}
+            hideLabel={hideLabel || inline}
+            value={value}
+            max={max}
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/packages/react/src/components/ProgressBar/ProgressBar.jsx
+++ b/packages/react/src/components/ProgressBar/ProgressBar.jsx
@@ -102,23 +102,23 @@ const ProgressBar = ({
   const matchingFillColor = matchingThreshold?.color ?? DEFAULT_PROGRESS_BAR_COLOR;
   const fillColor = hasColorObject ? matchingThreshold.color.fill : matchingFillColor;
   const strokeColor = hasColorObject ? matchingThreshold.color.stroke : undefined;
-  const valueAndUnit = Number.isInteger(value) ? `${value}${valueUnit}` : '';
+  const valueAndUnitString = Number.isInteger(value) ? `${value}${valueUnit}` : '';
 
   /**
    * helper to render the value and unit
    *
    * @returns JSXElement
    */
-  const renderValueAndUnit = () => (
+  const valueAndUnit = (
     <span
       className={classnames(`${iotPrefix}--progress-bar__value-label`, {
         // allow styling the value label differently when above max
         [`${iotPrefix}--progress-bar__value-label--over`]: value > max,
         [`${iotPrefix}--progress-bar__value-label--inline`]: inline,
       })}
-      title={valueAndUnit}
+      title={valueAndUnitString}
     >
-      {valueAndUnit}
+      {valueAndUnitString}
     </span>
   );
 
@@ -128,7 +128,7 @@ const ProgressBar = ({
    *
    * @returns JSX Element
    */
-  const renderProgressBarLabel = () => (
+  const progressBarLabel = (
     <div
       className={classnames(`${iotPrefix}--progress-bar__label--right`, {
         [`${prefix}--visually-hidden`]: hideLabel,
@@ -147,7 +147,7 @@ const ProgressBar = ({
           )}
         </span>
       ) : null}
-      {renderValueAndUnit()}
+      {valueAndUnit}
     </div>
   );
 
@@ -156,10 +156,10 @@ const ProgressBar = ({
    *
    * @returns JSXElement
    */
-  const renderProgressBarWithInlineWrapper = () => (
+  const progressBarWithInlineWrapper = (
     <div className={`${iotPrefix}--progress-bar-wrapper--inline`}>
       <CarbonProgressBar label={label} helperText={undefined} hideLabel value={value} max={max} />
-      {renderValueAndUnit()}
+      {valueAndUnit}
     </div>
   );
 
@@ -180,10 +180,10 @@ const ProgressBar = ({
       }}
     >
       {inline ? (
-        renderProgressBarWithInlineWrapper()
+        progressBarWithInlineWrapper
       ) : (
         <>
-          {renderProgressBarLabel()}
+          {progressBarLabel}
           <CarbonProgressBar
             label={label}
             helperText={helperText}

--- a/packages/react/src/components/ProgressBar/ProgressBar.jsx
+++ b/packages/react/src/components/ProgressBar/ProgressBar.jsx
@@ -104,6 +104,21 @@ const ProgressBar = ({
   const strokeColor = hasColorObject ? matchingThreshold.color.stroke : undefined;
 
   /**
+   * helper to render the value and unit
+   *
+   * @returns JSXElement
+   */
+  const renderValueAndUnit = () => (
+    <span
+      className={classnames(`${iotPrefix}--progress-bar__value-label`, {
+        // allow styling the value label differently when above max
+        [`${iotPrefix}--progress-bar__value-label--over`]: value > max,
+        [`${iotPrefix}--progress-bar__value-label--inline`]: inline,
+      })}
+    >{`${value}${valueUnit}`}</span>
+  );
+
+  /**
    * When the progress bar is not using the inline variant, render the label and icon
    * above the progress bar.
    *
@@ -128,15 +143,15 @@ const ProgressBar = ({
           )}
         </span>
       ) : null}
-      <span
-        className={classnames(`${iotPrefix}--progress-bar__value-label`, {
-          // allow styling the value label differently when above max
-          [`${iotPrefix}--progress-bar__value-label--over`]: value > max,
-        })}
-      >{`${value}${valueUnit}`}</span>
+      {renderValueAndUnit()}
     </div>
   );
 
+  /**
+   * helper method to render the progress bar with a div wrapper for the inline variant
+   *
+   * @returns JSXElement
+   */
   const renderProgressBarWithInlineWrapper = () => (
     <div
       className={classnames({
@@ -150,13 +165,7 @@ const ProgressBar = ({
         value={value}
         max={max}
       />
-      <span
-        className={classnames(`${iotPrefix}--progress-bar__value-label`, {
-          // allow styling the value label differently when above max
-          [`${iotPrefix}--progress-bar__value-label--over`]: value > max,
-          [`${iotPrefix}--progress-bar__value-label--inline`]: inline,
-        })}
-      >{`${value}${valueUnit}`}</span>
+      {renderValueAndUnit()}
     </div>
   );
 

--- a/packages/react/src/components/ProgressBar/ProgressBar.jsx
+++ b/packages/react/src/components/ProgressBar/ProgressBar.jsx
@@ -102,6 +102,7 @@ const ProgressBar = ({
   const matchingFillColor = matchingThreshold?.color ?? DEFAULT_PROGRESS_BAR_COLOR;
   const fillColor = hasColorObject ? matchingThreshold.color.fill : matchingFillColor;
   const strokeColor = hasColorObject ? matchingThreshold.color.stroke : undefined;
+  const valueAndUnit = Number.isInteger(value) ? `${value}${valueUnit}` : '';
 
   /**
    * helper to render the value and unit
@@ -115,7 +116,10 @@ const ProgressBar = ({
         [`${iotPrefix}--progress-bar__value-label--over`]: value > max,
         [`${iotPrefix}--progress-bar__value-label--inline`]: inline,
       })}
-    >{`${value}${valueUnit}`}</span>
+      title={valueAndUnit}
+    >
+      {valueAndUnit}
+    </span>
   );
 
   /**
@@ -153,18 +157,8 @@ const ProgressBar = ({
    * @returns JSXElement
    */
   const renderProgressBarWithInlineWrapper = () => (
-    <div
-      className={classnames({
-        [`${iotPrefix}--progress-bar-wrapper--inline`]: inline,
-      })}
-    >
-      <CarbonProgressBar
-        label={label}
-        helperText={!inline ? helperText : undefined}
-        hideLabel={hideLabel || inline}
-        value={value}
-        max={max}
-      />
+    <div className={`${iotPrefix}--progress-bar-wrapper--inline`}>
+      <CarbonProgressBar label={label} helperText={undefined} hideLabel value={value} max={max} />
       {renderValueAndUnit()}
     </div>
   );
@@ -191,8 +185,8 @@ const ProgressBar = ({
           {renderProgressBarLabel()}
           <CarbonProgressBar
             label={label}
-            helperText={!inline ? helperText : undefined}
-            hideLabel={hideLabel || inline}
+            helperText={helperText}
+            hideLabel={hideLabel}
             value={value}
             max={max}
           />

--- a/packages/react/src/components/ProgressBar/ProgressBar.jsx
+++ b/packages/react/src/components/ProgressBar/ProgressBar.jsx
@@ -169,6 +169,7 @@ const ProgressBar = ({
         `${iotPrefix}--progress-bar-container`,
         {
           [`${iotPrefix}--progress-bar-container--light`]: light,
+          [`${iotPrefix}--progress-bar-container--with-icon`]: Icon,
         },
         className
       )}

--- a/packages/react/src/components/ProgressBar/ProgressBar.mdx
+++ b/packages/react/src/components/ProgressBar/ProgressBar.mdx
@@ -78,6 +78,7 @@ Thresholds can be given to change the color of the bar (and icon) at various val
 | label \*                | string                              |                     | The label show above the bar                                                                                                |
 | helperText              | string                              | ''                  | The text shown below the bar                                                                                                |
 | hideLabel               | bool                                | false               | If true, hide the label                                                                                                     |
+| inline                  | bool                                | false               | When true, the progress bar will render inline without a label or icons and with the value to the right of the progress bar |
 | value \*                | number                              |                     | The number used to fill the bar                                                                                             |
 | valueUnit               | string                              | '%'                 | The unit shown beside the value label text                                                                                  |
 | max                     | number                              | 100                 | the maximum value this bar supports, values higher trigger the `over` class to style the value label text differently       |
@@ -91,6 +92,8 @@ Thresholds can be given to change the color of the bar (and icon) at various val
 | renderIconByName        | function                            |                     | Required if the threshold icons or renderIcon is using a string                                                             |
 | i18n                    | shape                               |                     |                                                                                                                             |
 | i18n.iconLabel          | string                              | 'Progress bar icon' | aria-label used on the icon                                                                                                 |
+
+- Denotes required props
 
 ## External Links
 

--- a/packages/react/src/components/ProgressBar/ProgressBar.mdx
+++ b/packages/react/src/components/ProgressBar/ProgressBar.mdx
@@ -93,7 +93,7 @@ Thresholds can be given to change the color of the bar (and icon) at various val
 | i18n                    | shape                               |                     |                                                                                                                             |
 | i18n.iconLabel          | string                              | 'Progress bar icon' | aria-label used on the icon                                                                                                 |
 
-- Denotes required props
+\*) Denotes required props
 
 ## External Links
 

--- a/packages/react/src/components/ProgressBar/ProgressBar.story.jsx
+++ b/packages/react/src/components/ProgressBar/ProgressBar.story.jsx
@@ -21,6 +21,7 @@ const props = ({ light } = {}) => ({
   label: text('Label text (label)', 'Progress bar label'),
   helperText: text('Helper text (helperText)', 'Optional helper text'),
   hideLabel: boolean('Hide the label (hideLabel)', false),
+  inline: boolean('Show the inline variant without label or icons (inline)', false),
   value: number('Current value (value)', 75),
   valueUnit: text('The unit displayed with the text value above the bar (valueUnit)', '%'),
   max: number('Maximum value (max)', 100),
@@ -36,7 +37,7 @@ const ProgressBarContainer = ({ maxWidth = 300, children, light = false }) => (
 export const Default = () => {
   return (
     <ProgressBarContainer>
-      <ProgressBar {...props()} label="Mon, Oct 5" valueUnit="%" />
+      <ProgressBar {...props()} />
     </ProgressBarContainer>
   );
 };
@@ -46,7 +47,7 @@ Default.storyName = 'default';
 export const WithLight = () => {
   return (
     <ProgressBarContainer light>
-      <ProgressBar {...props({ light: true })} label="Mon, Oct 5" valueUnit="%" />
+      <ProgressBar {...props({ light: true })} />
     </ProgressBarContainer>
   );
 };
@@ -56,7 +57,7 @@ WithLight.storyName = 'with light';
 export const WithIcon = () => {
   return (
     <ProgressBarContainer>
-      <ProgressBar {...props()} label="Mon, Oct 5" valueUnit="%" renderIcon={WarningFilled16} />
+      <ProgressBar {...props()} renderIcon={WarningFilled16} />
     </ProgressBarContainer>
   );
 };

--- a/packages/react/src/components/ProgressBar/ProgressBar.test.jsx
+++ b/packages/react/src/components/ProgressBar/ProgressBar.test.jsx
@@ -15,6 +15,20 @@ describe('ProgressBar', () => {
     expect(screen.getByLabelText('A progress label')).toBeVisible();
   });
 
+  it('should render without labels and icons when inline:true', () => {
+    render(
+      <ProgressBar
+        label="A progress label"
+        value={40}
+        inline
+        renderIcon={() => <WarningFilled16 aria-label="warning filled 16" />}
+      />
+    );
+    expect(screen.getByText('A progress label')).toHaveClass(`${prefix}--visually-hidden`);
+    expect(screen.queryByLabelText('warning filled 16')).not.toBeInTheDocument();
+    expect(screen.getByText('40%')).toBeVisible();
+  });
+
   it('should render with the given className', () => {
     const { container } = render(
       <ProgressBar label="A progress label" value={40} className="a-test-class" />

--- a/packages/react/src/components/ProgressBar/__snapshots__/ProgressBar.story.storyshot
+++ b/packages/react/src/components/ProgressBar/__snapshots__/ProgressBar.story.storyshot
@@ -39,7 +39,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
           className="bx--progress-bar__label"
           id="progress-bar-675"
         >
-          Mon, Oct 5
+          Progress bar label
         </span>
         <div
           aria-describedby="progress-bar-helper-676"
@@ -135,7 +135,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
           className="bx--progress-bar__label"
           id="progress-bar-679"
         >
-          Mon, Oct 5
+          Progress bar label
         </span>
         <div
           aria-describedby="progress-bar-helper-680"
@@ -206,7 +206,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
           className="bx--progress-bar__label"
           id="progress-bar-677"
         >
-          Mon, Oct 5
+          Progress bar label
         </span>
         <div
           aria-describedby="progress-bar-helper-678"

--- a/packages/react/src/components/ProgressBar/__snapshots__/ProgressBar.story.storyshot
+++ b/packages/react/src/components/ProgressBar/__snapshots__/ProgressBar.story.storyshot
@@ -28,6 +28,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
       >
         <span
           className="iot--progress-bar__value-label"
+          title="75%"
         >
           75%
         </span>
@@ -124,6 +125,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
         </span>
         <span
           className="iot--progress-bar__value-label"
+          title="75%"
         >
           75%
         </span>
@@ -195,6 +197,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
       >
         <span
           className="iot--progress-bar__value-label"
+          title="75%"
         >
           75%
         </span>
@@ -287,6 +290,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
         </span>
         <span
           className="iot--progress-bar__value-label"
+          title="75%"
         >
           75%
         </span>
@@ -358,6 +362,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
       >
         <span
           className="iot--progress-bar__value-label"
+          title="75%"
         >
           75%
         </span>

--- a/packages/react/src/components/ProgressBar/__snapshots__/ProgressBar.story.storyshot
+++ b/packages/react/src/components/ProgressBar/__snapshots__/ProgressBar.story.storyshot
@@ -86,7 +86,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
     }
   >
     <div
-      className="iot--progress-bar-container"
+      className="iot--progress-bar-container iot--progress-bar-container--with-icon"
       data-testid="progress-bar-container"
       style={
         Object {
@@ -255,7 +255,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
     }
   >
     <div
-      className="iot--progress-bar-container"
+      className="iot--progress-bar-container iot--progress-bar-container--with-icon"
       data-testid="progress-bar-container"
       style={
         Object {

--- a/packages/react/src/components/ProgressBar/_progress-bar.scss
+++ b/packages/react/src/components/ProgressBar/_progress-bar.scss
@@ -7,9 +7,15 @@
   .#{$prefix}--progress-bar__label {
     @include carbon--type-style('productive-heading-01');
     color: $text-01;
-    margin-right: calc(#{$spacing-10} + #{$spacing-05});
+    margin-right: calc(#{$spacing-10} + #{$spacing-03});
     text-overflow: ellipsis;
     overflow: hidden;
+  }
+}
+
+.#{$iot-prefix}--progress-bar-container--with-icon {
+  .#{$prefix}--progress-bar__label {
+    margin-right: calc(#{$spacing-11} + #{$spacing-03});
   }
 }
 
@@ -37,7 +43,7 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  max-width: calc(#{$spacing-09} + #{$spacing-03});
+  max-width: $spacing-10;
 }
 
 // reposition the inline label to be even with the progress bar

--- a/packages/react/src/components/ProgressBar/_progress-bar.scss
+++ b/packages/react/src/components/ProgressBar/_progress-bar.scss
@@ -33,6 +33,12 @@
   color: $text-01;
 }
 
+// reposition the inline label to be even with the progress bar
+.#{$iot-prefix}--progress-bar__value-label--inline {
+  position: relative;
+  top: -($spacing-02);
+}
+
 .#{$iot-prefix}--progress-bar__value-label--over {
   color: var(--progress-bar-fill-color);
 }
@@ -53,4 +59,10 @@
     // make the bar fill from the right when in RTL
     transform-origin: 100% 50%;
   }
+}
+
+.#{$iot-prefix}--progress-bar-wrapper--inline {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  column-gap: $spacing-03;
 }

--- a/packages/react/src/components/ProgressBar/_progress-bar.scss
+++ b/packages/react/src/components/ProgressBar/_progress-bar.scss
@@ -3,11 +3,14 @@
 
 .#{$iot-prefix}--progress-bar-container {
   position: relative;
-}
 
-.#{$prefix}--progress-bar__label {
-  @include carbon--type-style('productive-heading-01');
-  color: $text-01;
+  .#{$prefix}--progress-bar__label {
+    @include carbon--type-style('productive-heading-01');
+    color: $text-01;
+    margin-right: calc(#{$spacing-10} + #{$spacing-05});
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
 }
 
 .#{$iot-prefix}--progress-bar__label--right {
@@ -31,6 +34,10 @@
 .#{$iot-prefix}--progress-bar__value-label {
   @include carbon--type-style('body-short-01');
   color: $text-01;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  max-width: calc(#{$spacing-09} + #{$spacing-03});
 }
 
 // reposition the inline label to be even with the progress bar
@@ -65,4 +72,8 @@
   display: grid;
   grid-template-columns: 1fr auto;
   column-gap: $spacing-03;
+
+  .#{$prefix}--progress-bar__label {
+    margin-right: 0;
+  }
 }

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -29770,6 +29770,7 @@ Map {
       "i18n": Object {
         "iconLabel": "Progress bar icon",
       },
+      "inline": false,
       "light": false,
       "max": 100,
       "renderIcon": undefined,
@@ -29796,6 +29797,9 @@ Map {
           },
         ],
         "type": "shape",
+      },
+      "inline": Object {
+        "type": "bool",
       },
       "label": Object {
         "isRequired": true,


### PR DESCRIPTION
Closes #3339 

**Summary**

- adds `inline` prop to ProgressBar to hide label/icon/helperText and show the value and unit inlined with the bar

**Change List (commits, features, bugs, etc)**

- add `inline` prop
- update docs
- add test
- update snapshots
- cleanup code

**Acceptance Test (how to verify the PR)**

- go to the [ProgressBar story](https://deploy-preview-3347--carbon-addons-iot-react.netlify.app?path=/story/1-watson-iot-progressbar--default)
- turn on the inline prop
- confirm label and helperText disappear and value is inlined beside the bar with 8px of space in between
- repeat with icons/thresholds
- check RTL

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
