### PR TITLE
fix(table): add onapplytoolbaraction to statefultable

### DIFF
--- a/packages/react/src/components/Table/StatefulTable.jsx
+++ b/packages/react/src/components/Table/StatefulTable.jsx
@@ -141,6 +141,7 @@ const StatefulTable = ({ data: initialData, expandedData, ...other }) => {
     onCancelAdvancedFilter,
     onCreateAdvancedFilter,
     onToggleAggregations,
+    onApplyToolbarAction,
   } = toolbar || {};
   const {
     onChangeSort,
@@ -226,6 +227,9 @@ const StatefulTable = ({ data: initialData, expandedData, ...other }) => {
       onToggleAggregations: () => {
         dispatch(tableToggleAggregations());
         callbackParent(onToggleAggregations);
+      },
+      onApplyToolbarAction: (action) => {
+        callbackParent(onApplyToolbarAction, action);
       },
       onDownloadCSV,
     },

--- a/packages/react/src/components/Table/StatefulTable.test.jsx
+++ b/packages/react/src/components/Table/StatefulTable.test.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { merge, pick } from 'lodash-es';
 import { screen, render, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Screen16, ViewOff16 } from '@carbon/icons-react';
 
 import { settings } from '../../constants/Settings';
 
@@ -902,5 +903,92 @@ describe('stateful table with real reducer', () => {
     expect(container.querySelectorAll('tr')).toHaveLength(101);
     expect(screen.getByTitle('String')).toBeVisible();
     expect(screen.getByTitle('Date')).toBeVisible();
+  });
+
+  describe('toolbarActions in toolbar', () => {
+    beforeEach(() => {
+      jest
+        .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+        .mockImplementation(() => ({ width: 100, height: 100 }));
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('should add items to the toolbarActions overflow menu', async () => {
+      const onApplyToolbarAction = jest.fn();
+      const toolbarActions = [
+        {
+          id: 'in-toolbar',
+          labelText: 'Do something',
+          renderIcon: Screen16,
+        },
+        {
+          id: 'edit',
+          labelText: 'Edit something',
+          disabled: true,
+          isOverflow: true,
+        },
+        {
+          id: 'hide',
+          labelText: 'Hide something',
+          renderIcon: ViewOff16,
+          hasDivider: true,
+          isOverflow: true,
+        },
+        {
+          id: 'delete',
+          labelText: 'Delete something',
+          isDelete: true,
+          isOverflow: true,
+        },
+        {
+          id: 'hidden',
+          labelText: 'Hidden option',
+          hidden: true,
+          isOverflow: true,
+        },
+      ];
+
+      render(
+        <StatefulTable
+          columns={tableColumns}
+          data={[tableData[0]]}
+          actions={merge(mockActions, { toolbar: { onApplyToolbarAction } })}
+          view={{
+            toolbar: {
+              toolbarActions,
+            },
+          }}
+        />
+      );
+
+      expect(screen.getByRole('button', { name: 'Do something' })).toBeVisible();
+      userEvent.click(screen.getByRole('button', { name: 'Do something' }));
+      expect(onApplyToolbarAction).toHaveBeenCalledWith({
+        id: 'in-toolbar',
+        labelText: 'Do something',
+        renderIcon: expect.anything(),
+      });
+
+      userEvent.click(screen.getByRole('button', { name: 'open and close list of options' }));
+      expect(screen.getByRole('menuitem', { name: 'Edit something' })).toBeVisible();
+      expect(screen.getByRole('menuitem', { name: 'Edit something' })).toBeDisabled();
+      expect(screen.getByRole('menuitem', { name: /Hide something/ })).toBeVisible();
+      expect(screen.queryByRole('menuitem', { name: 'Hidden option' })).toBeNull();
+      expect(screen.getByRole('menuitem', { name: /Delete something/ })).toBeVisible();
+      expect(screen.getByRole('menuitem', { name: /Delete something/ }).parentNode).toHaveClass(
+        `${prefix}--overflow-menu-options__option--danger`
+      );
+      userEvent.click(screen.getByRole('menuitem', { name: /Hide something/ }));
+      expect(onApplyToolbarAction).toHaveBeenCalledWith({
+        id: 'hide',
+        labelText: 'Hide something',
+        renderIcon: expect.anything(),
+        hasDivider: true,
+        isOverflow: true,
+      });
+    });
   });
 });


### PR DESCRIPTION
Closes #3354

**Summary**

Adds onApplyToolbarAction callback for the StatefulTable

**Change List (commits, features, bugs, etc)**

- add callback
- add unit test

**Acceptance Test (how to verify the PR)**
1. Go to https://deploy-preview-3355--carbon-addons-iot-react.netlify.app?path=/story/1-watson-iot-table--playground
2. Click on the Title & Toolbar tab
3. Enable knob view.toolbar.toolbarActions
4. Select an action in the toolbar overflow menu
5. Make sure the onApplyToolbarAction is triggered in the Actions tab.

**Regression Test (how to make sure this PR doesn't break old functionality)**



<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
