### PR TITLE
feat(ai-flyout-menu): track open/close state

### DIFF
--- a/packages/angular/src/flyout-menu/flyout-menu.component.ts
+++ b/packages/angular/src/flyout-menu/flyout-menu.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, ViewEncapsulation } from '@angular/core';
 import { IconService } from 'carbon-components-angular';
 import { Filter16 } from '@carbon/icons';
 
@@ -29,6 +29,7 @@ import { Filter16 } from '@carbon/icons';
     </ng-template>
     <div
       [aiFlyoutMenu]="templateRef"
+      (flyoutStateChange)="flyoutOpenChangeHandler($event)"
       [offset]="offset"
       [flip]="flip"
       trigger="click"
@@ -73,11 +74,23 @@ export class FlyoutMenu implements OnInit {
 
   @Input() placement: 'bottom' | 'top' | 'left' | 'right' = 'bottom';
 
+  @Output() flyoutOpenChange = new EventEmitter;
+
   private _offset;
+  private isOpen;
+
+  public getFlyoutState() {
+    return this.isOpen;
+  }
 
   constructor(protected iconService: IconService) {}
 
   ngOnInit() {
     this.iconService.register(Filter16);
+  }
+
+  flyoutOpenChangeHandler(flyoutState) {
+    this.isOpen = flyoutState;
+    this.flyoutOpenChange.emit(flyoutState);
   }
 }

--- a/packages/angular/src/flyout-menu/flyout-menu.directive.ts
+++ b/packages/angular/src/flyout-menu/flyout-menu.directive.ts
@@ -5,6 +5,8 @@ import {
   ElementRef,
   ViewContainerRef,
   HostBinding,
+  Output,
+  EventEmitter,
 } from '@angular/core';
 import { EventService } from 'carbon-components-angular/utils';
 import { TooltipDirective, DialogService } from 'carbon-components-angular';
@@ -27,6 +29,10 @@ export class FlyoutMenuDirective extends TooltipDirective {
    * Controls wether the overflow menu is flipped
    */
   @Input() flip = false;
+  /**
+   * Emit the open/close state of the menu
+   */
+  @Output() flyoutStateChange = new EventEmitter;
   @HostBinding('class.iot--flyout-menu') menuClass = true;
   /**
    * bx--tooltip__trigger is inherited from TooltipDirective and it enables focus indication
@@ -57,6 +63,9 @@ export class FlyoutMenuDirective extends TooltipDirective {
   ) {
     super(elementRef, viewContainerRef, dialogService, eventService);
     dialogService.setContext({ component: FlyoutMenuPane });
+    this.isOpenChange.subscribe( isOpen => {
+      this.flyoutStateChange.emit(isOpen);
+    })
   }
 
   updateConfig() {

--- a/packages/angular/src/flyout-menu/flyout-menu.stories.ts
+++ b/packages/angular/src/flyout-menu/flyout-menu.stories.ts
@@ -19,7 +19,7 @@ storiesOf('Components/Filter menu', module)
   .add('Basic', () => ({
     template: `
       <div style="position: absolute; left: 50%; top: 50%;">
-        <ai-flyout-menu [flip]="flip" [placement]="placement">
+        <ai-flyout-menu #flyoutElem (flyoutOpenChange)="handleOpenChange($event, flyoutElem)" [flip]="flip" [placement]="placement">
           <div class="title">
             Filter
             <a ibmLink (click)="clearFilterClicked($event)" class="clear-flyout" href="#">Clear</a>
@@ -36,5 +36,9 @@ storiesOf('Components/Filter menu', module)
     props: {
       flip: boolean('flip', false),
       placement: select('Placement', ['bottom', 'top', 'left', 'right'], 'bottom'),
+      handleOpenChange: (state, flyoutElem) => {
+        console.log(`Flyout is ${ state ? 'Open' : 'Closed' }`);
+        console.log('Flyout is: ', flyoutElem.getFlyoutState());
+      }
     },
   }));


### PR DESCRIPTION
Closes #3334 

**Summary**

- Provide a way to track the filter menu's open/close state by emitting events from underlying elements.

**Change List (commits, features, bugs, etc)**

- Added `flyoutOpenChange` event to track the filter's active state.
- You can also get the filter's current state by calling `getFlyoutState` public method on the component.

**Acceptance Test (how to verify the PR)**

- Clicking on the filter trigger should output the filter's state in the console

**Regression Test (how to make sure this PR doesn't break old functionality)**

- The changes shouldn't really break anything. Let me know if it does, though.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
