### PR TITLE
chore(ci): add concurrency option to CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build
-
+# test comment
 on: [push, pull_request]
 
 concurrency:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: Build
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: '`yarn build`'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build
-# test comment
+
 on: [push, pull_request]
 
 concurrency:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,10 +1,14 @@
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   push:
-    branches: [ next, beta, master ]
+    branches: [next, beta, master]
   pull_request:
-    branches: [ next, beta, master ]
+    branches: [next, beta, master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze:
@@ -12,14 +16,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: javascript
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: javascript
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,6 +2,10 @@ name: Format
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   format:
     name: '`yarn format:check`'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,10 @@ name: Lint
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: '`yarn lint`'

--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -2,6 +2,10 @@ name: Test-app
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-pal:
     name: Build PAL

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: Test
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   react-jest-test:
     name: React Jest test


### PR DESCRIPTION
**Summary**

- Hi there! 👋 This PR adds a setting to the CI workflows to cancel existing jobs for a given PR when a new commit is added. This option helps to reduce the number of runners used across repos as the org is limited to only 20 runners.

**Change List (commits, features, bugs, etc)**

- I updated CI status check workflows in `.github/workflows` to use the `concurrency` option from: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
  - I didn't modify the `codesandbox`, `release`, or `update-v3` workflows

**Acceptance Test (how to verify the PR)**

- Go through the commit history of this PR, it should show that jobs for earlier commits have been "skipped" or "cancelled". This will show that the concurrency syntax is working as-intended
- We are currently using this config over on the Design System monorepo to reduce the number of runners being used by actions.
  - https://github.com/carbon-design-system/carbon/pull/10880

**Regression Test (how to make sure this PR doesn't break old functionality)**

- n/a

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
