### PR TITLE
3352 side nav implement search functionality of links

### DIFF
--- a/packages/react/src/components/SideNav/FilterableSideNavMenu.jsx
+++ b/packages/react/src/components/SideNav/FilterableSideNavMenu.jsx
@@ -1,0 +1,51 @@
+import PropTypes from 'prop-types';
+import React, { useCallback } from 'react';
+import { SideNavMenu } from 'carbon-components-react/es/components/UIShell';
+import classnames from 'classnames';
+
+import { settings } from '../../constants/Settings';
+
+const { iotPrefix } = settings;
+
+const propTypes = {
+  children: PropTypes.node.isRequired,
+  isFiltering: PropTypes.bool.isRequired,
+  className: PropTypes.string,
+};
+
+const defaultProps = {
+  className: '',
+};
+
+const FilterableSideNavMenu = ({ children, isFiltering, testId, className, ...myProps }) => {
+  // Unfortunately there is other way to set tabindex
+  // without modifying the Carbon SideNavMenu source code.
+  // TODO: create carbon issue for that
+  const callbackRef = useCallback(
+    (menuElement) => {
+      if (menuElement !== null && isFiltering) {
+        menuElement.setAttribute('tabIndex', -1);
+      }
+    },
+    [isFiltering]
+  );
+
+  const sideNavMenu = (
+    <SideNavMenu
+      data-testid={testId}
+      ref={callbackRef}
+      defaultExpanded={isFiltering}
+      className={classnames(className, {
+        [`${iotPrefix}--side-nav__item--is-filtering`]: isFiltering,
+      })}
+      {...myProps}
+    >
+      {children}
+    </SideNavMenu>
+  );
+  return sideNavMenu;
+};
+
+FilterableSideNavMenu.propTypes = propTypes;
+FilterableSideNavMenu.defautProps = defaultProps;
+export default FilterableSideNavMenu;

--- a/packages/react/src/components/SideNav/SideNav.jsx
+++ b/packages/react/src/components/SideNav/SideNav.jsx
@@ -7,19 +7,60 @@ import {
   // SideNavSwitcher,
 } from 'carbon-components-react/es/components/UIShell';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState } from 'react';
 import classnames from 'classnames';
 
 import { settings } from '../../constants/Settings';
 import { CarbonIconPropType } from '../../constants/SharedPropTypes';
+import { Search } from '../Search';
+import { handleSpecificKeyDown } from '../../utils/componentUtilityFunctions';
 
 import { SideNavMetaDataPropType } from './sideNavPropTypes';
+import FilterableSideNavMenu from './FilterableSideNavMenu';
 
 const { iotPrefix, prefix } = settings;
+
+const markText = (allText, substringToMark) => {
+  const regex = new RegExp(`(.*)(${substringToMark})(.*)`, 'i');
+  const regexResult = regex.exec(allText);
+
+  if (regexResult !== null) {
+    const [textInFront, markedText, textBehind] = regexResult.slice(1, 4);
+    return (
+      <>
+        <span>{textInFront}</span>
+        <mark>{markedText}</mark>
+        <span>{textBehind}</span>
+      </>
+    );
+  }
+
+  return allText;
+};
+
+const filterLinks = (items, searchValue) => {
+  const filteredItems = [];
+  items.forEach((link) => {
+    const isLeaf = !link.childContent;
+    const content = link.linkContent || link.content;
+
+    if (isLeaf && content.toLowerCase().includes(searchValue)) {
+      filteredItems.push(link);
+    } else if (!isLeaf) {
+      const matchingChildren = filterLinks(link.childContent, searchValue);
+      if (matchingChildren.length) {
+        filteredItems.push({ ...link, childContent: matchingChildren });
+      }
+    }
+  });
+  return filteredItems;
+};
 
 export const SideNavPropTypes = {
   /** Specify whether the side navigation is expanded or collapsed */
   defaultExpanded: PropTypes.bool,
+  /** Enables search functionality for the links */
+  hasSearch: PropTypes.bool,
   /** array of link item objects */
   links: PropTypes.arrayOf(
     PropTypes.shape({
@@ -71,6 +112,10 @@ export const SideNavPropTypes = {
     openText: PropTypes.string,
     sideNavLabelText: PropTypes.string,
     submenuLabel: PropTypes.string,
+    emptySearchText: PropTypes.string,
+    searchCloseButtonLabelText: PropTypes.string,
+    searchPlaceholder: PropTypes.string,
+    searchLabelText: PropTypes.string,
   }),
 
   testId: PropTypes.string,
@@ -78,12 +123,17 @@ export const SideNavPropTypes = {
 
 const defaultProps = {
   defaultExpanded: false,
+  hasSearch: false,
   isSideNavExpanded: false,
   i18n: {
     closeText: 'Close',
     openText: 'Open',
     sideNavLabelText: 'Side navigation',
     submenuLabel: 'dropdown',
+    emptySearchText: 'No matches found',
+    searchCloseButtonLabelText: 'Clear search input',
+    searchPlaceholder: 'Find navigation item...',
+    searchLabelText: 'Find navigation item',
   },
   testId: 'side-nav',
 };
@@ -111,7 +161,15 @@ const isAnyChildActive = (link) => {
 /**
  * Side Navigation. part of UI shell
  */
-const SideNav = ({ links, defaultExpanded, isSideNavExpanded, i18n, testId, ...props }) => {
+const SideNav = ({
+  links,
+  defaultExpanded,
+  hasSearch,
+  isSideNavExpanded,
+  i18n,
+  testId,
+  ...props
+}) => {
   /**
    * Recursive function for rendering all the nested children nav items
    *
@@ -120,7 +178,8 @@ const SideNav = ({ links, defaultExpanded, isSideNavExpanded, i18n, testId, ...p
    * @param {Number} level The number of levels deep this link is
    * @returns ReactElement
    */
-  const renderLinkMenu = (link, index, level = 0) => {
+  const renderLinkMenu = (link, index, level = 0, searchValue) => {
+    const isFiltering = searchValue !== undefined;
     let parentActive = false;
     const children = link.childContent.map((childLink, childIndex) => {
       if (isAnyChildActive(childLink)) {
@@ -128,63 +187,112 @@ const SideNav = ({ links, defaultExpanded, isSideNavExpanded, i18n, testId, ...p
       }
 
       if (childLink.hasOwnProperty('childContent')) {
-        return renderLinkMenu(childLink, childIndex, level + 1);
+        return renderLinkMenu(childLink, childIndex, level + 1, searchValue);
       }
+
+      const preventSideNavMenuFromClosingOnBublingEsc = isFiltering;
+      const onKeyDown = preventSideNavMenuFromClosingOnBublingEsc
+        ? handleSpecificKeyDown(['Escape'], (evt) => evt.stopPropagation())
+        : undefined;
+      const content = searchValue ? markText(childLink.content, searchValue) : childLink.content;
 
       return (
         <SideNavMenuItem
+          onKeyDown={onKeyDown}
           key={`menu-link-${link.childContent.indexOf(childLink)}-child`}
           isActive={childLink.isActive}
           data-testid={`${testId}-menu-item-${index}`}
           {...childLink.metaData}
         >
-          {childLink.content}
+          {content}
         </SideNavMenuItem>
       );
     });
-
     return (
-      <SideNavMenu
+      <FilterableSideNavMenu
+        isFiltering={isFiltering}
         isActive={parentActive}
         renderIcon={link.icon}
         aria-label={i18n.submenuLabel}
-        key={`menu-link-${links.indexOf(link)}-dropdown`}
+        key={`menu-link-${link.linkContent.replace(/\s/g, '')}-dropdown`}
         title={link.linkContent}
-        data-testid={`${testId}-menu-${index}`}
+        testId={`${testId}-menu-${index}`}
         className={`${iotPrefix}--side-nav__item--depth-${level}`}
       >
         {children}
-      </SideNavMenu>
+      </FilterableSideNavMenu>
     );
   };
 
-  const nav = links
-    .map((link, index) => {
-      const enabled = link.isEnabled ? link.isEnabled : false;
-      if (!enabled) {
-        return null;
-      }
+  const renderLinks = (linkConfigurations, searchValue) =>
+    linkConfigurations
+      .map((link, index) => {
+        if (!link.isEnabled) {
+          return null;
+        }
 
-      if (link.hasOwnProperty('childContent')) {
-        return renderLinkMenu(link, index, 0);
-      }
+        if (link.hasOwnProperty('childContent')) {
+          return renderLinkMenu(link, index, 0, searchValue);
+        }
 
-      return (
-        <SideNavLink
-          key={`menu-link-${link.metaData.label.replace(/\s/g, '')}-global`}
-          aria-label={link.metaData.label}
-          onClick={link.metaData.onClick}
-          href={link.metaData.href}
-          renderIcon={link.icon}
-          isActive={link.isActive}
-          data-testid={`${testId}-link-${index}`}
-          {...link.metaData}
-        >
-          {link.linkContent}
-        </SideNavLink>
-      );
-    })
-    .filter((i) => i);
+        const isFiltering = searchValue !== undefined;
+        const content = searchValue ? markText(link.linkContent, searchValue) : link.linkContent;
+
+        return (
+          <SideNavLink
+            key={`menu-link-${link.metaData.label.replace(/\s/g, '')}-global`}
+            aria-label={link.metaData.label}
+            onClick={link.metaData.onClick}
+            href={link.metaData.href}
+            renderIcon={link.icon}
+            isActive={link.isActive}
+            data-testid={`${testId}-link-${index}`}
+            className={classnames({
+              [`${iotPrefix}--side-nav__item--is-filtering`]: isFiltering,
+            })}
+            {...link.metaData}
+          >
+            {content}
+          </SideNavLink>
+        );
+      })
+      .filter((i) => i);
+
+  const [navItems, setNavItems] = useState(renderLinks(links));
+  const [isFiltering, setIsFiltering] = useState(false);
+
+  const handleSearchChange = (event) => {
+    const isSearching = 'value' in event.target && event.target?.value !== '';
+    const newSearchValue = isSearching ? event.target.value.toLowerCase() : undefined;
+    setIsFiltering(isSearching);
+    const linksToRender = isSearching ? filterLinks(links, newSearchValue) : links;
+    setNavItems(renderLinks(linksToRender, newSearchValue));
+  };
+
+  const search = hasSearch
+    ? [
+        <Search
+          key="sidenav-search"
+          id="sidenav-search"
+          data-testid={`${testId}-search`}
+          closeButtonLabelText={i18n.searchCloseButtonLabelText}
+          placeholder={i18n.searchPlaceholder}
+          labelText={i18n.searchLabelText}
+          onChange={handleSearchChange}
+          size="lg"
+        />,
+      ]
+    : [];
+
+  const constSideNavContent =
+    isFiltering && navItems.length === 0 ? (
+      <div key="empty-search" className={`${iotPrefix}--side-nav__empty-search-msg`}>
+        {i18n.emptySearchText}
+      </div>
+    ) : (
+      // The key needed to pick up the change of `defaultExpanded` in the SideNavMenuItems
+      <SideNavItems key={`${isFiltering}`}>{navItems}</SideNavItems>
+    );
 
   // TODO: Will be added back in when footer is added for rails.
   // see: https://github.com/carbon-design-system/carbon/blob/main/packages/react/src/components/UIShell/SideNav.js#L143
@@ -207,7 +315,11 @@ const SideNav = ({ links, defaultExpanded, isSideNavExpanded, i18n, testId, ...p
       isRail
       {...props} // spreading here as base component does not pass to DOM element.
     >
-      <SideNavItems>{nav}</SideNavItems>
+      {
+        // We use an array for the children since CarbonSideNav can't handle null or
+        // undfined being passed as a child so if hasSearch is false we don't pass anthing.
+        [...search, constSideNavContent]
+      }
     </CarbonSideNav>
   );
 };

--- a/packages/react/src/components/SideNav/SideNav.jsx
+++ b/packages/react/src/components/SideNav/SideNav.jsx
@@ -250,7 +250,7 @@ const SideNav = ({
             renderIcon={link.icon}
             isActive={link.isActive}
             data-testid={`${testId}-link-${index}`}
-            className={classnames({
+            className={classnames(link.metaData.className, {
               [`${iotPrefix}--side-nav__item--is-filtering`]: isFiltering,
             })}
             {...link.metaData}

--- a/packages/react/src/components/SideNav/SideNav.story.jsx
+++ b/packages/react/src/components/SideNav/SideNav.story.jsx
@@ -1,6 +1,13 @@
 import React, { useState, createElement, useEffect } from 'react';
 import { action } from '@storybook/addon-actions';
-import { Switcher24, Chip24, Dashboard24, Group24, ParentChild24 } from '@carbon/icons-react';
+import {
+  Switcher24,
+  Chip24,
+  Dashboard24,
+  Group24,
+  ParentChild24,
+  Home24,
+} from '@carbon/icons-react';
 import { HeaderContainer } from 'carbon-components-react/es/components/UIShell';
 import { boolean } from '@storybook/addon-knobs';
 
@@ -29,7 +36,6 @@ const links = (isActive = false) => [
       tabIndex: 0,
       label: 'Boards',
       element: RouterComponent,
-      // isActive: true,
     },
     linkContent: 'Boards',
     childContent: [
@@ -143,8 +149,30 @@ export default {
 export const SideNavComponent = () => {
   const showDeepNesting = boolean('show deep nesting example', false);
   const enableSearch = boolean('Enable searching (hasSearch)', true);
+  const demoPinnedLink = boolean('Demo pinned link during search', true);
+  const pinnedLinks = demoPinnedLink
+    ? [
+        {
+          icon: Home24,
+          isEnabled: true,
+          isPinned: true,
+          metaData: {
+            onClick: action('menu click'),
+            tabIndex: 0,
+            label: 'Home',
+            element: RouterComponent,
+          },
+          linkContent: 'Home',
+          isActive: true,
+        },
+      ]
+    : [];
+
+  const shallowLinks = [...links(!demoPinnedLink), ...pinnedLinks];
+
   const deepLinks = [
     ...links(),
+    ...pinnedLinks,
     {
       isEnabled: true,
       icon: ParentChild24,
@@ -197,7 +225,7 @@ export const SideNavComponent = () => {
                     element: 'button',
                   },
                   content: 'Grandchild Button',
-                  isActive: true,
+                  isActive: !demoPinnedLink,
                 },
                 {
                   metaData: {
@@ -245,7 +273,7 @@ export const SideNavComponent = () => {
               onClickSideNavExpand={onClickSideNavExpand}
             />
             <SideNav
-              links={showDeepNesting ? deepLinks : links(true)}
+              links={showDeepNesting ? deepLinks : shallowLinks}
               isSideNavExpanded={isSideNavExpanded}
               hasSearch={enableSearch}
             />

--- a/packages/react/src/components/SideNav/SideNav.story.jsx
+++ b/packages/react/src/components/SideNav/SideNav.story.jsx
@@ -142,6 +142,7 @@ export default {
 
 export const SideNavComponent = () => {
   const showDeepNesting = boolean('show deep nesting example', false);
+  const enableSearch = boolean('Enable searching (hasSearch)', true);
   const deepLinks = [
     ...links(),
     {
@@ -200,12 +201,12 @@ export const SideNavComponent = () => {
                 },
                 {
                   metaData: {
-                    label: 'Grandchild Link',
-                    title: 'Grandchild Link',
+                    label: 'Grandchild Link with long label',
+                    title: 'Grandchild Link with long label',
                     href: 'https://www.ibm.com',
                     element: 'a',
                   },
-                  content: 'Grandchild Link',
+                  content: 'Grandchild Link with long label',
                 },
               ],
             },
@@ -246,6 +247,7 @@ export const SideNavComponent = () => {
             <SideNav
               links={showDeepNesting ? deepLinks : links(true)}
               isSideNavExpanded={isSideNavExpanded}
+              hasSearch={enableSearch}
             />
             <div className={`${iotPrefix}--main-content`}>
               <PageTitleBar title="Title" description="Description" />
@@ -411,7 +413,7 @@ export const SideNavComponentWithState = () => {
               isSideNavExpanded={isSideNavExpanded}
               onClickSideNavExpand={onClickSideNavExpand}
             />
-            <SideNav links={linksState} isSideNavExpanded={isSideNavExpanded} />
+            <SideNav hasSearch={false} links={linksState} isSideNavExpanded={isSideNavExpanded} />
             <div className={`${iotPrefix}--main-content`}>
               <PageTitleBar title="Title" description="Description" />
             </div>

--- a/packages/react/src/components/SideNav/SideNav.test.jsx
+++ b/packages/react/src/components/SideNav/SideNav.test.jsx
@@ -249,10 +249,10 @@ describe('SideNav', () => {
     // the mark tag.
     screen.getByTextContent = (text) => {
       return screen.getByText((content, node) => {
-        const childrenMathcing = Array.from(node?.children || []).some(
+        const childrenMatching = Array.from(node?.children || []).some(
           (child) => child.textContent === text
         );
-        return node.textContent === text && !childrenMathcing;
+        return node.textContent === text && !childrenMatching;
       });
     };
   });

--- a/packages/react/src/components/SideNav/SideNav.test.jsx
+++ b/packages/react/src/components/SideNav/SideNav.test.jsx
@@ -149,7 +149,117 @@ describe('SideNav', () => {
     },
   ];
 
+  const getDeeplyNestedlinks = (onClick) => [
+    {
+      isEnabled: true,
+      icon: ParentChild24,
+      metaData: {
+        label: 'Nested Levels',
+        element: 'button',
+      },
+      linkContent: 'Nested Levels',
+      childContent: [
+        {
+          metaData: {
+            label: 'Co-Parent Link',
+            title: 'Co-Parent Link',
+            element: 'a',
+            href: 'https://www.ibm.com',
+          },
+          content: 'Co-Parent Link',
+        },
+        {
+          metaData: {
+            label: 'Parent',
+            title: 'Parent',
+            element: 'button',
+          },
+          content: 'Parent',
+          linkContent: 'Parent',
+          childContent: [
+            {
+              metaData: {
+                label: 'Sibling 1 Link',
+                title: 'Sibling 1 Link',
+                element: 'a',
+                href: 'https://www.ibm.com',
+              },
+              content: 'Sibling 1 Link',
+            },
+            {
+              isEnabled: true,
+              metaData: {
+                label: 'Child',
+                element: 'button',
+              },
+              linkContent: 'Child',
+              childContent: [
+                {
+                  metaData: {
+                    label: 'Grandchild Button',
+                    title: 'Grandchild Button',
+                    onClick,
+                    element: 'button',
+                  },
+                  content: 'Grandchild Button',
+                  isActive: true,
+                },
+                {
+                  metaData: {
+                    label: 'Grandchild Link',
+                    title: 'Grandchild Link',
+                    href: 'https://www.ibm.com',
+                    element: 'a',
+                  },
+                  content: 'Grandchild Link',
+                },
+              ],
+            },
+            {
+              metaData: {
+                label: 'Sibling 2 Button',
+                title: 'Sibling 2 Button',
+                element: 'button',
+                onClick,
+              },
+              content: 'Sibling 2 Button',
+            },
+          ],
+        },
+        {
+          metaData: {
+            label: 'Co-Parent Button',
+            title: 'Co-Parent Button',
+            element: 'button',
+            onClick,
+          },
+          content: 'Co-Parent Button',
+        },
+      ],
+    },
+  ];
+
   let mockProps;
+
+  const { i18n } = SideNav.defaultProps;
+
+  beforeAll(() => {
+    // This is needed to find texts that have been split up in
+    // multiple DOM nodes, like when search result item texts are using
+    // the mark tag.
+    screen.getByTextContent = (text) => {
+      return screen.getByText((content, node) => {
+        const childrenMathcing = Array.from(node?.children || []).some(
+          (child) => child.textContent === text
+        );
+        return node.textContent === text && !childrenMathcing;
+      });
+    };
+  });
+
+  afterAll(() => {
+    delete screen.getByTextContent;
+  });
 
   beforeEach(() => {
     mockProps = {
@@ -221,100 +331,7 @@ describe('SideNav', () => {
 
   it('should render nested levels of children', () => {
     const onClick = jest.fn();
-    render(
-      <SideNav
-        {...mockProps}
-        links={[
-          {
-            isEnabled: true,
-            icon: ParentChild24,
-            metaData: {
-              label: 'Nested Levels',
-              element: 'button',
-            },
-            linkContent: 'Nested Levels',
-            childContent: [
-              {
-                metaData: {
-                  label: 'Co-Parent Link',
-                  title: 'Co-Parent Link',
-                  element: 'a',
-                  href: 'https://www.ibm.com',
-                },
-                content: 'Co-Parent Link',
-              },
-              {
-                metaData: {
-                  label: 'Parent',
-                  title: 'Parent',
-                  element: 'button',
-                },
-                content: 'Parent',
-                linkContent: 'Parent',
-                childContent: [
-                  {
-                    metaData: {
-                      label: 'Sibling 1 Link',
-                      title: 'Sibling 1 Link',
-                      element: 'a',
-                      href: 'https://www.ibm.com',
-                    },
-                    content: 'Sibling 1 Link',
-                  },
-                  {
-                    isEnabled: true,
-                    metaData: {
-                      label: 'Child',
-                      element: 'button',
-                    },
-                    linkContent: 'Child',
-                    childContent: [
-                      {
-                        metaData: {
-                          label: 'Grandchild Button',
-                          title: 'Grandchild Button',
-                          onClick,
-                          element: 'button',
-                        },
-                        content: 'Grandchild Button',
-                        isActive: true,
-                      },
-                      {
-                        metaData: {
-                          label: 'Grandchild Link',
-                          title: 'Grandchild Link',
-                          href: 'https://www.ibm.com',
-                          element: 'a',
-                        },
-                        content: 'Grandchild Link',
-                      },
-                    ],
-                  },
-                  {
-                    metaData: {
-                      label: 'Sibling 2 Button',
-                      title: 'Sibling 2 Button',
-                      element: 'button',
-                      onClick,
-                    },
-                    content: 'Sibling 2 Button',
-                  },
-                ],
-              },
-              {
-                metaData: {
-                  label: 'Co-Parent Button',
-                  title: 'Co-Parent Button',
-                  element: 'button',
-                  onClick,
-                },
-                content: 'Co-Parent Button',
-              },
-            ],
-          },
-        ]}
-      />
-    );
+    render(<SideNav {...mockProps} links={getDeeplyNestedlinks(onClick)} />);
 
     const expectToBeVisible = (text) => {
       expect(screen.getByText(text)).toBeVisible();
@@ -363,5 +380,100 @@ describe('SideNav', () => {
     expectToBeVisible('Grandchild Link');
     clickText('Grandchild Button');
     expect(onClick).toHaveBeenCalledTimes(3);
+  });
+
+  it('should render search field when hasSearch is true', () => {
+    const { rerender } = render(<SideNav {...mockProps} hasSearch />);
+    expect(screen.getByTestId('side-nav-search')).toBeVisible();
+
+    rerender(<SideNav {...mockProps} />);
+    expect(screen.queryByTestId('side-nav-search')).toBeNull();
+  });
+
+  it('filters to show matched child leaf nodes and their parents when user types in the search field', () => {
+    render(<SideNav {...mockProps} hasSearch />);
+    expect(screen.getByLabelText('Boards')).toBeVisible();
+    expect(screen.getByLabelText('Devices')).toBeVisible();
+    expect(screen.getByText('Members')).toBeVisible();
+    expect(screen.getByText('Members sub menu')).toBeVisible();
+
+    userEvent.type(screen.getByTestId('side-nav-search'), 'ers sub');
+    expect(screen.queryByLabelText('Boards')).toBeNull();
+    expect(screen.queryByLabelText('Devices')).toBeNull();
+    // This is the parent of matched "Members sub menu"
+    expect(screen.getByText('Members')).toBeVisible();
+    expect(screen.getByText('Members')).toHaveClass('bx--side-nav__submenu-title');
+    // The original item text is split in multiple tags so we
+    // have to use a textContent search
+    expect(screen.getByTextContent('Members sub menu')).toBeVisible();
+  });
+
+  it('filters to show matched leaf nodes at top level when user types in the search field', () => {
+    render(<SideNav {...mockProps} hasSearch />);
+    expect(screen.getByLabelText('Boards')).toBeVisible();
+    expect(screen.getByLabelText('Devices')).toBeVisible();
+    expect(screen.getByText('Members')).toBeVisible();
+    expect(screen.getByText('Members sub menu')).toBeVisible();
+
+    userEvent.type(screen.getByTestId('side-nav-search'), 'Boa');
+    expect(screen.getByTextContent('Boards')).toBeVisible();
+    expect(screen.queryByLabelText('Devices')).toBeNull();
+    expect(screen.queryByText('Members')).toBeNull();
+    expect(screen.queryByText('Members sub menu')).toBeNull();
+  });
+
+  it('filters on deeply nested leaf nodes when user types in the search field', () => {
+    render(<SideNav {...mockProps} hasSearch links={getDeeplyNestedlinks(jest.fn())} />);
+    expect(screen.getByText('Grandchild Button')).toBeVisible();
+    expect(screen.getByText('Grandchild Link')).toBeVisible();
+
+    userEvent.type(screen.getByTestId('side-nav-search'), 'Grandchild Butt');
+    expect(screen.getByTextContent('Grandchild Button')).toBeVisible();
+    expect(screen.queryByText('Grandchild Link')).toBeNull();
+  });
+
+  it('filters using case insensitive search', () => {
+    render(<SideNav {...mockProps} hasSearch />);
+    expect(screen.getByLabelText('Boards')).toBeVisible();
+    expect(screen.getByLabelText('Devices')).toBeVisible();
+
+    userEvent.type(screen.getByTestId('side-nav-search'), 'boards');
+    expect(screen.getByLabelText('Boards')).toBeVisible();
+    expect(screen.queryByLabelText('Devices')).toBeNull();
+  });
+
+  it('marks searched string in the filtered result', () => {
+    const { container } = render(<SideNav {...mockProps} hasSearch />);
+
+    expect(screen.getByLabelText('Boards')).toBeVisible();
+    expect(screen.getByLabelText('Devices')).toBeVisible();
+
+    userEvent.type(screen.getByTestId('side-nav-search'), 'oard');
+
+    expect(container.querySelector('mark').innerHTML).toEqual('oard');
+    expect(screen.getByLabelText('Boards')).toBeVisible();
+    expect(screen.queryByLabelText('Devices')).toBeNull();
+  });
+
+  it('shows "No matches found" message and no links when search result is empty', () => {
+    render(<SideNav {...mockProps} hasSearch />);
+    expect(screen.getByLabelText('Boards')).toBeVisible();
+    expect(screen.getByLabelText('Devices')).toBeVisible();
+    expect(screen.getByText('Members')).toBeVisible();
+
+    userEvent.type(screen.getByTestId('side-nav-search'), 'xxx');
+    expect(screen.getByText(i18n.emptySearchText)).toBeVisible();
+    expect(screen.queryByLabelText('Boards')).toBeNull();
+    expect(screen.queryByLabelText('Devices')).toBeNull();
+    expect(screen.queryByText('Members')).toBeNull();
+  });
+
+  it('removes parents from tab order in the search result', () => {
+    render(<SideNav {...mockProps} hasSearch />);
+    expect(screen.getByText('Members').closest('button')).not.toHaveAttribute('tabindex', '-1');
+
+    userEvent.type(screen.getByTestId('side-nav-search'), 'ers sub');
+    // This is the parent of matched "Members sub menu"
+    expect(screen.getByText('Members').closest('button')).toHaveAttribute('tabindex', '-1');
   });
 });

--- a/packages/react/src/components/SideNav/SideNav.test.jsx
+++ b/packages/react/src/components/SideNav/SideNav.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Switcher24, Chip24, Group24, ParentChild24 } from '@carbon/icons-react';
+import { Switcher24, Chip24, Group24, ParentChild24, Home24 } from '@carbon/icons-react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -475,5 +475,108 @@ describe('SideNav', () => {
     userEvent.type(screen.getByTestId('side-nav-search'), 'ers sub');
     // This is the parent of matched "Members sub menu"
     expect(screen.getByText('Members').closest('button')).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('it always renders pinned links in a separate list when hasSearch is true', () => {
+    const homeClicked = jest.fn();
+    const myLinks = [
+      ...links,
+      {
+        icon: Home24,
+        isEnabled: true,
+        isPinned: true,
+        metaData: {
+          onClick: homeClicked,
+          tabIndex: 0,
+          label: 'Home',
+          element: 'button',
+        },
+        linkContent: 'Home',
+        isActive: true,
+      },
+      {
+        icon: Home24,
+        isEnabled: true,
+        isPinned: true,
+        metaData: {
+          onClick: homeClicked,
+          tabIndex: 0,
+          label: 'Another pinned',
+          element: 'a',
+        },
+        linkContent: 'Another pinned',
+        isActive: true,
+      },
+    ];
+    render(<SideNav links={myLinks} hasSearch />);
+    expect(screen.getByLabelText('Home')).toBeVisible();
+    expect(screen.getByLabelText('Home').closest('ul')).toHaveClass(
+      `${iotPrefix}--side-nav__pinned-items`
+    );
+    expect(screen.getByLabelText('Another pinned')).toBeVisible();
+    expect(screen.getByLabelText('Another pinned').closest('ul')).toHaveClass(
+      `${iotPrefix}--side-nav__pinned-items`
+    );
+    expect(screen.getByLabelText('Boards')).toBeVisible();
+    expect(screen.getByLabelText('Boards').closest('ul')).not.toHaveClass(
+      `${iotPrefix}--side-nav__pinned-items`
+    );
+
+    userEvent.type(screen.getByTestId('side-nav-search'), 'xxxx');
+    expect(screen.getByLabelText('Home')).toBeVisible();
+    expect(screen.getByLabelText('Home').closest('ul')).toHaveClass(
+      `${iotPrefix}--side-nav__pinned-items`
+    );
+    expect(screen.getByLabelText('Another pinned')).toBeVisible();
+    expect(screen.getByLabelText('Another pinned').closest('ul')).toHaveClass(
+      `${iotPrefix}--side-nav__pinned-items`
+    );
+    expect(screen.queryByLabelText('Boards')).toBeNull();
+  });
+
+  it('it does not render pinned links in a separate list when hasSearch is false', () => {
+    const homeClicked = jest.fn();
+    const myLinks = [
+      ...links,
+      {
+        icon: Home24,
+        isEnabled: true,
+        isPinned: true,
+        metaData: {
+          onClick: homeClicked,
+          tabIndex: 0,
+          label: 'Home',
+          element: 'button',
+        },
+        linkContent: 'Home',
+        isActive: true,
+      },
+      {
+        icon: Home24,
+        isEnabled: true,
+        isPinned: true,
+        metaData: {
+          onClick: homeClicked,
+          tabIndex: 0,
+          label: 'Another pinned',
+          element: 'a',
+        },
+        linkContent: 'Another pinned',
+        isActive: true,
+      },
+    ];
+    render(<SideNav links={myLinks} />);
+    expect(screen.getByLabelText('Home')).toBeVisible();
+    expect(screen.getByLabelText('Home').closest('ul')).not.toHaveClass(
+      `${iotPrefix}--side-nav__pinned-items`
+    );
+    expect(screen.getByLabelText('Another pinned')).toBeVisible();
+    expect(screen.getByLabelText('Another pinned').closest('ul')).not.toHaveClass(
+      `${iotPrefix}--side-nav__pinned-items`
+    );
+    expect(screen.getByLabelText('Boards')).toBeVisible();
+    expect(screen.getByLabelText('Boards').closest('ul')).not.toHaveClass(
+      `${iotPrefix}--side-nav__pinned-items`
+    );
   });
 });

--- a/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
+++ b/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
@@ -198,6 +198,46 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
         </button>
       </div>
       <ul
+        className="bx--side-nav__items iot--side-nav__pinned-items"
+      >
+        <li
+          className="bx--side-nav__item"
+        >
+          <div
+            aria-label="Home"
+            className="bx--side-nav__link bx--side-nav__link--current"
+            data-testid="side-nav-link-0"
+            label="Home"
+            onClick={[Function]}
+            tabIndex={0}
+          >
+            <div
+              className="bx--side-nav__icon bx--side-nav__icon--small"
+            >
+              <svg
+                aria-hidden={true}
+                fill="currentColor"
+                focusable="false"
+                height={24}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={24}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.6123,2.2138a1.01,1.01,0,0,0-1.2427,0L1,13.4194l1.2427,1.5717L4,13.6209V26a2.0041,2.0041,0,0,0,2,2H26a2.0037,2.0037,0,0,0,2-2V13.63L29.7573,15,31,13.4282ZM18,26H14V18h4Zm2,0V18a2.0023,2.0023,0,0,0-2-2H14a2.002,2.002,0,0,0-2,2v8H6V12.0615l10-7.79,10,7.8005V26Z"
+                />
+              </svg>
+            </div>
+            <span
+              className="bx--side-nav__link-text"
+            >
+              Home
+            </span>
+          </div>
+        </li>
+      </ul>
+      <ul
         className="bx--side-nav__items"
       >
         <li
@@ -409,7 +449,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
           </ul>
         </li>
         <li
-          className="bx--side-nav__item bx--side-nav__item--active bx--side-nav__item--icon iot--side-nav__item--depth-0"
+          className="bx--side-nav__item bx--side-nav__item--icon iot--side-nav__item--depth-0"
           onKeyDown={[Function]}
         >
           <button
@@ -467,7 +507,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
               className="bx--side-nav__menu-item"
             >
               <button
-                className="bx--side-nav__link bx--side-nav__link--current"
+                className="bx--side-nav__link"
                 data-testid="side-nav-menu-item-3"
                 label="Yet another link"
                 onClick={[Function]}

--- a/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
+++ b/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
@@ -133,6 +133,70 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/S
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
     >
+      <div
+        aria-labelledby="sidenav-search-search"
+        className="bx--search bx--search--lg"
+        role="search"
+      >
+        <div
+          className="bx--search-magnifier"
+        >
+          <svg
+            aria-hidden={true}
+            className="bx--search-magnifier-icon"
+            fill="currentColor"
+            focusable="false"
+            height={16}
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+            />
+          </svg>
+        </div>
+        <label
+          className="bx--label"
+          htmlFor="sidenav-search"
+          id="sidenav-search-search"
+        >
+          Find navigation item
+        </label>
+        <input
+          autoComplete="off"
+          className="bx--search-input"
+          data-testid="side-nav-search"
+          id="sidenav-search"
+          onChange={[Function]}
+          onKeyDown={[Function]}
+          placeholder="Find navigation item..."
+          role="searchbox"
+          type="text"
+        />
+        <button
+          aria-label="Clear search input"
+          className="bx--search-close bx--search-close--hidden"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden={true}
+            fill="currentColor"
+            focusable="false"
+            height={16}
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 32 32"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+            />
+          </svg>
+        </button>
+      </div>
       <ul
         className="bx--side-nav__items"
       >

--- a/packages/react/src/components/SideNav/_side-nav.scss
+++ b/packages/react/src/components/SideNav/_side-nav.scss
@@ -39,7 +39,7 @@ $hoverBgColor: #2c2c2c;
     border-bottom-color: transparent;
   }
   .#{$prefix}--search-magnifier-icon {
-    left: 1rem;
+    left: $spacing-05;
   }
   .#{$prefix}--search-magnifier-icon,
   .#{$prefix}--search-close svg {
@@ -65,8 +65,10 @@ $hoverBgColor: #2c2c2c;
 
   .#{$iot-prefix}--side-nav__pinned-items {
     flex: none;
-    margin-bottom: -($spacing-05);
     border-bottom: 1px solid $ui-04;
+    & + .#{$prefix}--side-nav__items {
+      padding-top: 0;
+    }
   }
 
   .#{$iot-prefix}--side-nav__item--is-filtering .#{$prefix}--side-nav__submenu {

--- a/packages/react/src/components/SideNav/_side-nav.scss
+++ b/packages/react/src/components/SideNav/_side-nav.scss
@@ -32,6 +32,7 @@ $hoverBgColor: #2c2c2c;
   .#{$prefix}--search {
     // Prevent the close button from overlaying the magnifier when side nav is collapsed
     min-width: $spacing-11;
+    margin-bottom: -($spacing-05);
   }
   .#{$prefix}--search-input,
   .#{$prefix}--search-close:hover {
@@ -60,6 +61,12 @@ $hoverBgColor: #2c2c2c;
     &::placeholder {
       color: $ui-03;
     }
+  }
+
+  .#{$iot-prefix}--side-nav__pinned-items {
+    flex: none;
+    margin-bottom: -($spacing-05);
+    border-bottom: 1px solid $ui-04;
   }
 
   .#{$iot-prefix}--side-nav__item--is-filtering .#{$prefix}--side-nav__submenu {
@@ -91,7 +98,7 @@ $hoverBgColor: #2c2c2c;
   }
 
   .#{$iot-prefix}--side-nav__empty-search-msg {
-    margin: $spacing-05 $spacing-09;
+    margin: $spacing-07 $spacing-09 $spacing-05 $spacing-09;
     color: $textColor;
     display: none;
     @include type-style('body-short-01');

--- a/packages/react/src/components/SideNav/_side-nav.scss
+++ b/packages/react/src/components/SideNav/_side-nav.scss
@@ -1,4 +1,7 @@
 @import './side-nav-carbon';
+@import '../../globals/typography';
+@import '../../globals/vars';
+@import '../../globals/spacing';
 
 /////////////////////////////////////////////
 // AI applications dark sidenav theme styles
@@ -21,8 +24,84 @@ $hoverBgColor: #2c2c2c;
     > .#{$prefix}--side-nav__link:hover
     > span,
   .#{$prefix}--side-nav__menu .#{$prefix}--side-nav__link--current > span,
-  .#{$prefix}--side-nav__link--current > span {
+  .#{$prefix}--side-nav__link--current > span,
+  .#{$prefix}--search-input {
     color: $textColor;
+  }
+
+  .#{$prefix}--search {
+    // Prevent the close button from overlaying the magnifier when side nav is collapsed
+    min-width: $spacing-11;
+  }
+  .#{$prefix}--search-input,
+  .#{$prefix}--search-close:hover {
+    border-bottom-color: transparent;
+  }
+  .#{$prefix}--search-magnifier-icon {
+    left: 1rem;
+  }
+  .#{$prefix}--search-magnifier-icon,
+  .#{$prefix}--search-close svg {
+    fill: $inverse-01;
+  }
+
+  .#{$prefix}--search-close {
+    &:hover,
+    &:active {
+      background-color: $hoverBgColor;
+    }
+    &::before {
+      background-color: transparent;
+    }
+  }
+
+  .#{$prefix}--search-input {
+    background-color: $ui-05;
+    &::placeholder {
+      color: $ui-03;
+    }
+  }
+
+  .#{$iot-prefix}--side-nav__item--is-filtering .#{$prefix}--side-nav__submenu {
+    pointer-events: none;
+    .#{$prefix}--side-nav__submenu-chevron {
+      display: none;
+    }
+  }
+
+  .#{$iot-prefix}--side-nav__item--is-filtering .#{$prefix}--side-nav__link-text {
+    display: inline-flex;
+    mark {
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: pre;
+      text-overflow: ellipsis;
+      flex-shrink: 1;
+      background: $ui-01;
+      color: $interactive-04;
+    }
+
+    span {
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: pre;
+      text-overflow: ellipsis;
+      flex-shrink: 2;
+    }
+  }
+
+  .#{$iot-prefix}--side-nav__empty-search-msg {
+    margin: $spacing-05 $spacing-09;
+    color: $textColor;
+    display: none;
+    @include type-style('body-short-01');
+  }
+
+  &.#{$iot-prefix}--side-nav--expanded,
+  &.#{$prefix}--side-nav--expanded {
+    .#{$iot-prefix}--side-nav__empty-search-msg {
+      display: block;
+    }
   }
 
   .#{$prefix}--side-nav__icon > svg {

--- a/packages/react/src/components/SideNav/_side-nav.scss
+++ b/packages/react/src/components/SideNav/_side-nav.scss
@@ -82,7 +82,6 @@ $hoverBgColor: #2c2c2c;
       text-overflow: ellipsis;
       overflow: hidden;
       white-space: pre;
-      text-overflow: ellipsis;
       flex-shrink: 1;
       background: $ui-01;
       color: $interactive-04;
@@ -92,7 +91,6 @@ $hoverBgColor: #2c2c2c;
       text-overflow: ellipsis;
       overflow: hidden;
       white-space: pre;
-      text-overflow: ellipsis;
       flex-shrink: 2;
     }
   }
@@ -155,6 +153,17 @@ html[dir='rtl'] {
   .#{$iot-prefix}--side-nav {
     left: unset;
     right: 0;
+
+    &.#{$prefix}--side-nav--rail {
+      &:not(.#{$prefix}--side-nav--expanded) {
+        .#{$prefix}--search-close {
+          display: none;
+        }
+      }
+    }
+    .#{$prefix}--search {
+      min-width: unset;
+    }
   }
 
   .#{$prefix}--side-nav__icon:not(.#{$prefix}--side-nav__submenu-chevron) {

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -10606,9 +10606,14 @@ Map {
   "SideNav" => Object {
     "defaultProps": Object {
       "defaultExpanded": false,
+      "hasSearch": false,
       "i18n": Object {
         "closeText": "Close",
+        "emptySearchText": "No matches found",
         "openText": "Open",
+        "searchCloseButtonLabelText": "Clear search input",
+        "searchLabelText": "Find navigation item",
+        "searchPlaceholder": "Find navigation item...",
         "sideNavLabelText": "Side navigation",
         "submenuLabel": "dropdown",
       },
@@ -10619,13 +10624,28 @@ Map {
       "defaultExpanded": Object {
         "type": "bool",
       },
+      "hasSearch": Object {
+        "type": "bool",
+      },
       "i18n": Object {
         "args": Array [
           Object {
             "closeText": Object {
               "type": "string",
             },
+            "emptySearchText": Object {
+              "type": "string",
+            },
             "openText": Object {
+              "type": "string",
+            },
+            "searchCloseButtonLabelText": Object {
+              "type": "string",
+            },
+            "searchLabelText": Object {
+              "type": "string",
+            },
+            "searchPlaceholder": Object {
               "type": "string",
             },
             "sideNavLabelText": Object {
@@ -11187,13 +11207,28 @@ Map {
             "defaultExpanded": Object {
               "type": "bool",
             },
+            "hasSearch": Object {
+              "type": "bool",
+            },
             "i18n": Object {
               "args": Array [
                 Object {
                   "closeText": Object {
                     "type": "string",
                   },
+                  "emptySearchText": Object {
+                    "type": "string",
+                  },
                   "openText": Object {
+                    "type": "string",
+                  },
+                  "searchCloseButtonLabelText": Object {
+                    "type": "string",
+                  },
+                  "searchLabelText": Object {
+                    "type": "string",
+                  },
+                  "searchPlaceholder": Object {
                     "type": "string",
                   },
                   "sideNavLabelText": Object {

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -10738,6 +10738,9 @@ Map {
                 "isEnabled": Object {
                   "type": "bool",
                 },
+                "isPinned": Object {
+                  "type": "bool",
+                },
                 "linkContent": Object {
                   "type": "string",
                 },
@@ -11319,6 +11322,9 @@ Map {
                         "type": "oneOfType",
                       },
                       "isEnabled": Object {
+                        "type": "bool",
+                      },
+                      "isPinned": Object {
                         "type": "bool",
                       },
                       "linkContent": Object {


### PR DESCRIPTION
Closes #3352

**Summary**
Adds search functionality and the possibility to pin links to the SideNav

**Change List (commits, features, bugs, etc)**
- Added search functionality behind prop `hasSearch`. Improves on existing nav search in Maximo by 
  - allowing keyboard navigation on search result
  - show all the parents of a matched leaf, not just the closest one
- Added unit testing for search
- Added possibility to pin items when prop `hasSearch` is true using link prop `isPinned`
- Added unit tests for pinned items
- Updated story with new knobs and data

**Acceptance Test (how to verify the PR)**
The functionality is based on the existing implementation in Maximo with a few differences as mentioned above

**Search**
1. Go to https://deploy-preview-3374--carbon-addons-iot-react.netlify.app?path=/story/1-watson-iot-sidenav--side-nav-component
2. Enable the knobs "show deep nesting example" and "Enable searching (hasSearch)". 
3. Uncheck knob "Demo pinned link during search".
4. Verify that search matches all leaf node links 
5. Verify that parents of matched links are shown but are not clickable or collapsable 
6. Verify that the string entered in the search input is highlighted in the search result (for the leafs)
7. Verify that text overflow is still properly handled
8. Verify that links are working as before (compare with next)
9. Make sure an empty result list with a msg is displayed when the search returns nothing

**Pinned links**
1. Uncheck knob "Enable searching (hasSearch)" 
2. Check knob "Demo pinned link during search"
3. Verify that a "home" link is shown in the list, but NOT pinned at the top
4. Check the knob "Enable searching (hasSearch)" 
5. Verify that a "home" link is now pinned at the top
6. Test different search scenarios to make sure the pinned home link stays visible without moving

**Regression Test (how to make sure this PR doesn't break old functionality)**
Verify that the stories are still working as before (compare with next) when the new knobs "Enable searching (hasSearch)" and "Demo pinned link during search" are unchecked.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
