### PR TITLE
fix: minor style update in PageTitleBar storybook

### DIFF
--- a/packages/react/src/components/PageTitleBar/PageTitleBar.story.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.story.jsx
@@ -11,9 +11,12 @@ import { getTiles } from '../TileCatalogNew/TileCatalogNew.story';
 import Button from '../Button';
 import StatefulTable from '../Table/StatefulTable';
 import { initialState } from '../Table/Table.story';
+import { settings } from '../../constants/Settings';
 
 import PageTitleBar from './PageTitleBar';
 import PageTitleBarREADME from './PageTitleBar.mdx';
+
+const { prefix } = settings;
 
 export const commonPageTitleBarProps = {
   title: 'Page title',
@@ -131,6 +134,18 @@ WithTooltipDescriptionWithNode.storyName = 'with tooltip description with node';
 
 export const WithStatusDescriptionAndCrumbs = () => (
   <div style={{ height: '150vh' }}>
+    <style>
+      {`
+      .${prefix}--tooltip__content .${prefix}--inline-loading__text {
+        color: white
+      }
+
+      .${prefix}--tooltip__content .${prefix}--inline-loading__checkmark-container path + path {
+        fill: white;
+        opacity: 1
+      }
+    `}
+    </style>
     <PageTitleBar
       title={text('title', 'ZH002')}
       description={<InlineLoading status="finished" description="Running" />}

--- a/packages/react/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
+++ b/packages/react/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
@@ -7277,6 +7277,18 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
         }
       }
     >
+      <style>
+        
+      .bx--tooltip__content .bx--inline-loading__text {
+        color: white
+      }
+
+      .bx--tooltip__content .bx--inline-loading__checkmark-container path + path {
+        fill: white;
+        opacity: 1
+      }
+    
+      </style>
       <div
         className="page-title-bar"
         data-testid="page-title-bar"


### PR DESCRIPTION
Closes #3346 

**Summary**

- simple style fix within the story when the inline loader is inside the tooltip

**Change List (commits, features, bugs, etc)**

- adds style block to the story to fix the colors of the InlineLoader text when it's collapsed in the tooltip

**Acceptance Test (how to verify the PR)**

- go to the with status description and breadcrumbs story
- turn on collapse description knob
- open tooltip
- confirm text is white and readable

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
