### PR TITLE
fix(tableCardFormContent): updating thresholds when dataItem is removed

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -251,6 +251,12 @@ const TableCardFormContent = ({
         (groupByItem) => groupByItem !== dataItem.dataSourceId
       );
 
+      const newCardConfig = cardConfig.content.hasOwnProperty('thresholds')
+        ? cardConfig.content.thresholds.filter(
+            (threshold) => dataItem.dataSourceId !== threshold.dataSourceId
+          )
+        : cardConfig;
+
       setSelectedDataItems(filteredColumns.map((item) => item.dataSourceId));
       setRemovedDataItems([...removedDataItems, dataItem]);
 
@@ -265,7 +271,7 @@ const TableCardFormContent = ({
       onChange({
         ...cardConfig,
         content: {
-          ...cardConfig.content,
+          ...newCardConfig.content,
           columns: filteredColumns,
         },
         ...updatedDataSource,


### PR DESCRIPTION
Closes #https://github.com/carbon-design-system/carbon-addons-iot-react/issues/3389#issue-1175479330

**Summary**

- Thresholds not updating when a data item is removed

**Change List (commits, features, bugs, etc)**

- Added code to remove thresholds for a data items when the data item is removed

**Acceptance Test (how to verify the PR)**

- tests in storybook generated by pr

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
