### PR TITLE
fix(statefultable): include rowedit buttons in tableregister

### DIFF
--- a/packages/react/src/components/Table/tableReducer.js
+++ b/packages/react/src/components/Table/tableReducer.js
@@ -564,6 +564,7 @@ export const tableReducer = (state = {}, action) => {
             activeBar: {
               $set: activeBar,
             },
+            rowEditBarButtons: { $set: get(view, 'toolbar.rowEditBarButtons') },
           },
           table: {
             ordering: { $set: ordering },
@@ -600,6 +601,7 @@ export const tableReducer = (state = {}, action) => {
             loadingMoreIds: {
               $set: loadingMoreIds,
             },
+            singleRowEditButtons: { $set: get(view, 'table.singleRowEditButtons') },
           },
         },
       });

--- a/packages/react/src/components/Table/tableReducer.test.jsx
+++ b/packages/react/src/components/Table/tableReducer.test.jsx
@@ -720,6 +720,25 @@ describe('table reducer', () => {
       expect(turnOffRowEditActiveBar.view.table.rowActions).toHaveLength(0);
       expect(turnOffRowEditActiveBar.view.table.rowActions).toEqual([]);
       expect(turnOffRowEditActiveBar.view.toolbar.activeBar).toBeUndefined();
+
+      // It updates element used for row editing
+      const initialRowEditState = merge({}, initialState, {
+        view: {
+          toolbar: { rowEditBarButtons: <div>initial</div> },
+          table: { singleRowEditButtons: <div>initial</div> },
+        },
+      });
+      const modifiedRowEditState = tableReducer(
+        initialRowEditState,
+        tableRegister({
+          view: {
+            toolbar: { rowEditBarButtons: <div>updated</div> },
+            table: { singleRowEditButtons: <div>updated</div> },
+          },
+        })
+      );
+      expect(modifiedRowEditState.view.toolbar.rowEditBarButtons).toEqual(<div>updated</div>);
+      expect(modifiedRowEditState.view.table.singleRowEditButtons).toEqual(<div>updated</div>);
     });
   });
 });


### PR DESCRIPTION
Closes #3404

**Summary**

- includes updates to view.toolbar.rowEditBarButtons and view.table.singleRowEditButtons when the TABLE_REGISTER action is called

**Change List (commits, features, bugs, etc)**

- updated action
- added unit test

**Acceptance Test (how to verify the PR)**
1. Go to the PR for the table state stories which contains the same commit but also provides the UI to verify it
https://deploy-preview-3397--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table--with-data-editing
2. Change to StatefulTable
3. Edit row 2
4. change number to '5'
5. Verify that the save button is now enabled
6. Repeat for multi edit button

**Regression Test (how to make sure this PR doesn't break old functionality)**
- na

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
