### PR TITLE
fix(table): adjust padding on empty state

### DIFF
--- a/packages/react/src/components/EmptyState/_emptystate.scss
+++ b/packages/react/src/components/EmptyState/_emptystate.scss
@@ -7,7 +7,7 @@
   flex-flow: column;
   justify-content: center;
   height: 100%;
-  padding: $spacing-09;
+  padding: $spacing-09 $spacing-09 $spacing-09 $spacing-11;
   &--icon {
     margin-bottom: $spacing-05;
     height: 80px;

--- a/packages/react/src/components/Table/_table.scss
+++ b/packages/react/src/components/Table/_table.scss
@@ -82,11 +82,7 @@ html[dir='rtl'] {
     // stylelint-disable-next-line declaration-property-unit-blacklist
     padding: Max(calc(48 * var(--is-large-card)), 0px);
     svg {
-      margin: $spacing-05;
-    }
-
-    & > * {
-      margin: $spacing-03;
+      margin: $spacing-05 $spacing-05 $spacing-05 0;
     }
   }
 


### PR DESCRIPTION
Closes #3236 

**Summary**

Removed the left margin on the svg image and added padding to the left side to align the empty-state on the grid

**Change List (commits, features, bugs, etc)**

- removed margin on left edge of image
- added more padding

**Acceptance Test (how to verify the PR)**

- matches grid in original issue

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
