### PR TITLE
fix: sidenav state example with pinned fix open/close on hover

### DIFF
--- a/packages/react/src/components/SideNav/SideNav.jsx
+++ b/packages/react/src/components/SideNav/SideNav.jsx
@@ -342,7 +342,7 @@ const SideNav = ({
     >
       {
         // We use an array for the children since CarbonSideNav can't handle null or
-        // undfined being passed as a child so if hasSearch is false we don't pass anthing.
+        // undefined being passed as a child so if hasSearch is false we don't pass anything.
         [...search, ...staticSideNavContent, dynamicSideNavContent]
       }
     </CarbonSideNav>
@@ -357,5 +357,6 @@ SideNavItems.displayName = 'SideNavItems';
 SideNavLink.displayName = 'SideNavLink';
 SideNavMenu.displayName = 'SideNavMenu';
 SideNavMenuItem.displayName = 'SideNavMenuItem';
+FilterableSideNavMenu.displayName = 'SideNavMenu';
 
 export default SideNav;

--- a/packages/react/src/components/SideNav/SideNav.story.jsx
+++ b/packages/react/src/components/SideNav/SideNav.story.jsx
@@ -352,23 +352,46 @@ SideNavComponent.parameters = {
 };
 
 export const SideNavComponentWithState = () => {
+  const demoPinnedLink = boolean('Demo pinned link', true);
+  const pinnedLinks = demoPinnedLink
+    ? [
+        {
+          icon: Home24,
+          isEnabled: true,
+          isPinned: true,
+          metaData: {
+            onClick: action('menu click'),
+            tabIndex: 0,
+            label: 'Home',
+          },
+          linkContent: 'Home',
+          isActive: false,
+        },
+      ]
+    : [];
+
   const [linksState, setLinksState] = useState([]);
   const onSideNavMenuItemClick = (linkLabel) => {
     setLinksState((currentLinks) =>
       currentLinks.map((group) => {
-        return {
-          ...group,
-          childContent: group.childContent.map((child) => ({
-            ...child,
-            isActive: linkLabel === child.metaData.label,
-          })),
-        };
+        if (group.childContent) {
+          return {
+            ...group,
+            childContent: group.childContent.map((child) => ({
+              ...child,
+              isActive: linkLabel === child.metaData.label,
+            })),
+          };
+        }
+
+        return group;
       })
     );
   };
 
   useEffect(() => {
     setLinksState([
+      ...pinnedLinks,
       {
         isEnabled: true,
         icon: Dashboard24,
@@ -429,6 +452,7 @@ export const SideNavComponentWithState = () => {
         ],
       },
     ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
+++ b/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
@@ -5914,6 +5914,42 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
         className="bx--side-nav__items"
       >
         <li
+          className="bx--side-nav__item"
+        >
+          <a
+            aria-label="Home"
+            className="bx--side-nav__link"
+            data-testid="side-nav-link-0"
+            label="Home"
+            onClick={[Function]}
+            tabIndex={0}
+          >
+            <div
+              className="bx--side-nav__icon bx--side-nav__icon--small"
+            >
+              <svg
+                aria-hidden={true}
+                fill="currentColor"
+                focusable="false"
+                height={24}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={24}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.6123,2.2138a1.01,1.01,0,0,0-1.2427,0L1,13.4194l1.2427,1.5717L4,13.6209V26a2.0041,2.0041,0,0,0,2,2H26a2.0037,2.0037,0,0,0,2-2V13.63L29.7573,15,31,13.4282ZM18,26H14V18h4Zm2,0V18a2.0023,2.0023,0,0,0-2-2H14a2.002,2.002,0,0,0-2,2v8H6V12.0615l10-7.79,10,7.8005V26Z"
+                />
+              </svg>
+            </div>
+            <span
+              className="bx--side-nav__link-text"
+            >
+              Home
+            </span>
+          </a>
+        </li>
+        <li
           className="bx--side-nav__item bx--side-nav__item--icon iot--side-nav__item--depth-0"
           onKeyDown={[Function]}
         >
@@ -5976,7 +6012,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             >
               <button
                 className="bx--side-nav__link"
-                data-testid="side-nav-menu-item-0"
+                data-testid="side-nav-menu-item-1"
                 label="Link 1"
                 onClick={[Function]}
                 title="Link 1"
@@ -5993,7 +6029,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             >
               <a
                 className="bx--side-nav__link"
-                data-testid="side-nav-menu-item-0"
+                data-testid="side-nav-menu-item-1"
                 label="Link 2"
                 onClick={[Function]}
                 title="Link 2"
@@ -6067,7 +6103,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             >
               <button
                 className="bx--side-nav__link bx--side-nav__link--current"
-                data-testid="side-nav-menu-item-1"
+                data-testid="side-nav-menu-item-2"
                 label="Link 3"
                 onClick={[Function]}
                 title="Link 3"
@@ -6084,7 +6120,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             >
               <button
                 className="bx--side-nav__link"
-                data-testid="side-nav-menu-item-1"
+                data-testid="side-nav-menu-item-2"
                 label="Link 4"
                 onClick={[Function]}
                 title="Link 4"

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.story.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.story.jsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import { text, object, boolean, select } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 import { ScreenOff16, Switcher24 } from '@carbon/icons-react';
 import Chip from '@carbon/icons-react/es/chip/24';
 import Dashboard from '@carbon/icons-react/es/dashboard/24';
@@ -116,6 +117,7 @@ const customActionItems = [
         <NotificationOn id="notification-button" fill="white" description="Icon" />
       </span>
     ),
+    onClick: action('bell clicked'),
   },
   {
     label: 'bee',


### PR DESCRIPTION
Closes #

**Summary**

- added example of state management in the sidenav with a pinned link

**Change List (commits, features, bugs, etc)**

- fixed expand/collapse of sidenav items when closed

**Acceptance Test (how to verify the PR)**

- go to [sidenav component with state management](https://deploy-preview-3412--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-ui-shell-sidenav--side-nav-component-with-state)
- open sidenav
- open members
- click link 4
- open sidenav
- open members
- confirm link four is active with blue bar
- hover off sidenav
- confirm sidenav closes and members section collapses when closed with blue bar now beside the icon

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
