### PR TITLE
Removed  default prop triggering our deprecation warning

### DIFF
--- a/packages/react/src/components/Table/TableHead/TableHead.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.jsx
@@ -167,7 +167,6 @@ const defaultProps = {
     ...defaultI18NPropTypes,
   },
   hasFastFilter: true,
-  testID: '',
   testId: '',
   showExpanderColumn: false,
   size: undefined,


### PR DESCRIPTION
Closes #3421 

**Summary**

- Users were getting deprecation warnings from our default for testID

**Change List (commits, features, bugs, etc)**

- removed `testID` from default props on TableHead.js

**Acceptance Test (how to verify the PR)**

- can load a table in development and see that there are no testID deprecation warnings


