### PR TITLE
feat(table): radio button on single select row

### DIFF
--- a/packages/react/src/components/DataTable/_data-table.scss
+++ b/packages/react/src/components/DataTable/_data-table.scss
@@ -82,7 +82,8 @@ html[dir='rtl'] {
 
   // override padding on checkbox cells, so that it aligns with cell content in tables with xl size prop
   &.#{$prefix}--data-table--xl {
-    .#{$prefix}--checkbox-table-cell {
+    .#{$prefix}--checkbox-table-cell,
+    .#{$prefix}--radiobutton-table-cell {
       padding-top: $spacing-05;
     }
   }
@@ -90,7 +91,8 @@ html[dir='rtl'] {
   &.#{$prefix}--data-table--xs,
   &.#{$prefix}--data-table--sm,
   &.#{$prefix}--data-table--md {
-    .#{$prefix}--checkbox-table-cell {
+    .#{$prefix}--checkbox-table-cell,
+    .#{$prefix}--radiobutton-table-cell {
       padding-top: $spacing-01;
       padding-bottom: $spacing-01;
     }
@@ -104,6 +106,16 @@ html[dir='rtl'] {
     /* Added to undo carbon component. this needs to be removed when we redo this table */
     &::after {
       background-color: transparent !important;
+    }
+  }
+
+  .#{$prefix}--radiobutton-table-cell {
+    padding-bottom: $spacing-03;
+    padding-top: $spacing-03;
+    width: 2.5rem;
+
+    .#{$prefix}--radio-button__appearance {
+      margin-right: 0;
     }
   }
 }

--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -991,7 +991,7 @@ const Table = (props) => {
                   'hasRowNesting',
                   'hasSingleRowEdit',
                   'hasRowSelection',
-                  'showRadioButton',
+                  'showRadioButtonSingleSelect',
                   'useAutoTableLayoutForResize',
                   'hasMultiSort',
                   'preserveColumnWidths'
@@ -1094,7 +1094,7 @@ const Table = (props) => {
                   'shouldExpandOnRowClick',
                   'shouldLazyRender',
                   'preserveCellWhiteSpace',
-                  'showRadioButton'
+                  'showRadioButtonSingleSelect'
                 )}
                 hasRowExpansion={!!options.hasRowExpansion}
                 wrapCellText={options.wrapCellText}

--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -991,7 +991,7 @@ const Table = (props) => {
                   'hasRowNesting',
                   'hasSingleRowEdit',
                   'hasRowSelection',
-                  'showRadioButtonSingleSelect',
+                  'useRadioButtonSingleSelect',
                   'useAutoTableLayoutForResize',
                   'hasMultiSort',
                   'preserveColumnWidths'
@@ -1094,7 +1094,7 @@ const Table = (props) => {
                   'shouldExpandOnRowClick',
                   'shouldLazyRender',
                   'preserveCellWhiteSpace',
-                  'showRadioButtonSingleSelect'
+                  'useRadioButtonSingleSelect'
                 )}
                 hasRowExpansion={!!options.hasRowExpansion}
                 wrapCellText={options.wrapCellText}

--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -1092,7 +1092,8 @@ const Table = (props) => {
                   'hasRowNesting',
                   'shouldExpandOnRowClick',
                   'shouldLazyRender',
-                  'preserveCellWhiteSpace'
+                  'preserveCellWhiteSpace',
+                  'showRadioButton'
                 )}
                 hasRowExpansion={!!options.hasRowExpansion}
                 wrapCellText={options.wrapCellText}

--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -991,6 +991,7 @@ const Table = (props) => {
                   'hasRowNesting',
                   'hasSingleRowEdit',
                   'hasRowSelection',
+                  'showRadioButton',
                   'useAutoTableLayoutForResize',
                   'hasMultiSort',
                   'preserveColumnWidths'

--- a/packages/react/src/components/Table/Table.main.story.jsx
+++ b/packages/react/src/components/Table/Table.main.story.jsx
@@ -154,7 +154,7 @@ export const Playground = () => {
     locale,
     batchActions,
     searchIsExpanded,
-    showRadioButtonSingleSelect,
+    useRadioButtonSingleSelect,
   } = getTableKnobs({
     getDefaultValue: (name) =>
       // For this story always disable the following knobs by default
@@ -178,7 +178,7 @@ export const Playground = () => {
         'demoCustomErrorState',
         'demoColumnOverflowMenuItems',
         'hasOnlyPageData',
-        'showRadioButtonSingleSelect',
+        'useRadioButtonSingleSelect',
       ].includes(name)
         ? false
         : // For this story always enable the following knobs by default
@@ -349,7 +349,7 @@ export const Playground = () => {
           shouldLazyRender,
           hasRowEdit,
           hasSingleRowEdit,
-          showRadioButtonSingleSelect,
+          useRadioButtonSingleSelect,
         }}
         view={{
           advancedFilters,
@@ -847,13 +847,13 @@ export const WithSelectionAndBatchActions = () => {
     selectedTableType,
     hasRowSelection,
     selectionCheckboxEnabled,
-    showRadioButtonSingleSelect,
+    useRadioButtonSingleSelect,
   } = getTableKnobs({
     knobsToCreate: [
       'selectedTableType',
       'hasRowSelection',
       'selectionCheckboxEnabled',
-      'showRadioButtonSingleSelect',
+      'useRadioButtonSingleSelect',
     ],
     getDefaultValue: () => true,
   });
@@ -887,7 +887,7 @@ export const WithSelectionAndBatchActions = () => {
       data={data}
       options={{
         hasRowSelection,
-        showRadioButtonSingleSelect,
+        useRadioButtonSingleSelect,
       }}
       view={{
         table: {

--- a/packages/react/src/components/Table/Table.main.story.jsx
+++ b/packages/react/src/components/Table/Table.main.story.jsx
@@ -154,7 +154,7 @@ export const Playground = () => {
     locale,
     batchActions,
     searchIsExpanded,
-    showRadioButton,
+    showRadioButtonSingleSelect,
   } = getTableKnobs({
     getDefaultValue: (name) =>
       // For this story always disable the following knobs by default
@@ -178,7 +178,7 @@ export const Playground = () => {
         'demoCustomErrorState',
         'demoColumnOverflowMenuItems',
         'hasOnlyPageData',
-        'showRadioButton',
+        'showRadioButtonSingleSelect',
       ].includes(name)
         ? false
         : // For this story always enable the following knobs by default
@@ -349,7 +349,7 @@ export const Playground = () => {
           shouldLazyRender,
           hasRowEdit,
           hasSingleRowEdit,
-          showRadioButton,
+          showRadioButtonSingleSelect,
         }}
         view={{
           advancedFilters,
@@ -847,13 +847,13 @@ export const WithSelectionAndBatchActions = () => {
     selectedTableType,
     hasRowSelection,
     selectionCheckboxEnabled,
-    showRadioButton,
+    showRadioButtonSingleSelect,
   } = getTableKnobs({
     knobsToCreate: [
       'selectedTableType',
       'hasRowSelection',
       'selectionCheckboxEnabled',
-      'showRadioButton',
+      'showRadioButtonSingleSelect',
     ],
     getDefaultValue: () => true,
   });
@@ -887,7 +887,7 @@ export const WithSelectionAndBatchActions = () => {
       data={data}
       options={{
         hasRowSelection,
-        showRadioButton,
+        showRadioButtonSingleSelect,
       }}
       view={{
         table: {

--- a/packages/react/src/components/Table/Table.main.story.jsx
+++ b/packages/react/src/components/Table/Table.main.story.jsx
@@ -154,6 +154,7 @@ export const Playground = () => {
     locale,
     batchActions,
     searchIsExpanded,
+    showRadioButton,
   } = getTableKnobs({
     getDefaultValue: (name) =>
       // For this story always disable the following knobs by default
@@ -177,6 +178,7 @@ export const Playground = () => {
         'demoCustomErrorState',
         'demoColumnOverflowMenuItems',
         'hasOnlyPageData',
+        'showRadioButton',
       ].includes(name)
         ? false
         : // For this story always enable the following knobs by default
@@ -347,6 +349,7 @@ export const Playground = () => {
           shouldLazyRender,
           hasRowEdit,
           hasSingleRowEdit,
+          showRadioButton,
         }}
         view={{
           advancedFilters,
@@ -840,8 +843,18 @@ WithFiltering.parameters = {
 };
 
 export const WithSelectionAndBatchActions = () => {
-  const { selectedTableType, hasRowSelection, selectionCheckboxEnabled } = getTableKnobs({
-    knobsToCreate: ['selectedTableType', 'hasRowSelection', 'selectionCheckboxEnabled'],
+  const {
+    selectedTableType,
+    hasRowSelection,
+    selectionCheckboxEnabled,
+    showRadioButton,
+  } = getTableKnobs({
+    knobsToCreate: [
+      'selectedTableType',
+      'hasRowSelection',
+      'selectionCheckboxEnabled',
+      'showRadioButton',
+    ],
     getDefaultValue: () => true,
   });
 
@@ -874,6 +887,7 @@ export const WithSelectionAndBatchActions = () => {
       data={data}
       options={{
         hasRowSelection,
+        showRadioButton,
       }}
       view={{
         table: {

--- a/packages/react/src/components/Table/Table.story.helpers.jsx
+++ b/packages/react/src/components/Table/Table.story.helpers.jsx
@@ -1226,10 +1226,10 @@ export const getTableKnobs = ({ knobsToCreate, getDefaultValue, useGroups = fals
           SELECTIONS_ACTIONS_GROUP
         )
       : null,
-    showRadioButton: shouldCreate('showRadioButton')
+    showRadioButtonSingleSelect: shouldCreate('showRadioButtonSingleSelect')
       ? boolean(
           'Show radio button for single select',
-          getDefaultValue('showRadioButton'),
+          getDefaultValue('showRadioButtonSingleSelect'),
           SELECTIONS_ACTIONS_GROUP
         )
       : null,

--- a/packages/react/src/components/Table/Table.story.helpers.jsx
+++ b/packages/react/src/components/Table/Table.story.helpers.jsx
@@ -1226,6 +1226,13 @@ export const getTableKnobs = ({ knobsToCreate, getDefaultValue, useGroups = fals
           SELECTIONS_ACTIONS_GROUP
         )
       : null,
+    showRadioButton: shouldCreate('showRadioButton')
+      ? boolean(
+          'Show radio button for single select',
+          getDefaultValue('showRadioButton'),
+          SELECTIONS_ACTIONS_GROUP
+        )
+      : null,
     selectedIds: shouldCreate('selectedIds')
       ? object(
           'Batch actions for selected rows (view.table.selectedIds)',

--- a/packages/react/src/components/Table/Table.story.helpers.jsx
+++ b/packages/react/src/components/Table/Table.story.helpers.jsx
@@ -1226,10 +1226,10 @@ export const getTableKnobs = ({ knobsToCreate, getDefaultValue, useGroups = fals
           SELECTIONS_ACTIONS_GROUP
         )
       : null,
-    showRadioButtonSingleSelect: shouldCreate('showRadioButtonSingleSelect')
+    useRadioButtonSingleSelect: shouldCreate('useRadioButtonSingleSelect')
       ? boolean(
           'Show radio button for single select',
-          getDefaultValue('showRadioButtonSingleSelect'),
+          getDefaultValue('useRadioButtonSingleSelect'),
           SELECTIONS_ACTIONS_GROUP
         )
       : null,

--- a/packages/react/src/components/Table/Table.story.helpers.jsx
+++ b/packages/react/src/components/Table/Table.story.helpers.jsx
@@ -1228,7 +1228,7 @@ export const getTableKnobs = ({ knobsToCreate, getDefaultValue, useGroups = fals
       : null,
     useRadioButtonSingleSelect: shouldCreate('useRadioButtonSingleSelect')
       ? boolean(
-          'Show radio button for single select',
+          'Use radio button for single select (options.useRadioButtonSingleSelect)',
           getDefaultValue('useRadioButtonSingleSelect'),
           SELECTIONS_ACTIONS_GROUP
         )

--- a/packages/react/src/components/Table/TableBody/TableBody.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBody.jsx
@@ -42,6 +42,7 @@ const propTypes = {
   /** since some columns might not be currently visible */
   totalColumns: PropTypes.number,
   hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
+  showRadioButton: PropTypes.bool,
   hasRowExpansion: PropTypes.bool,
   hasRowNesting: PropTypes.oneOfType([
     PropTypes.bool,
@@ -114,6 +115,7 @@ const defaultProps = {
   columns: [],
   totalColumns: 0,
   hasRowSelection: false,
+  showRadioButton: false,
   hasRowExpansion: false,
   hasRowNesting: false,
   hasRowActions: false,
@@ -155,6 +157,7 @@ const TableBody = ({
   rowActionsState,
   hasRowActions,
   hasRowSelection,
+  showRadioButton,
   hasRowExpansion,
   hasRowNesting,
   shouldExpandOnRowClick,
@@ -275,6 +278,7 @@ const TableBody = ({
           hasRowExpansion={hasRowExpansion}
           hasRowNesting={hasRowNesting}
           hasRowSelection={hasRowSelection}
+          showRadioButton={showRadioButton}
           indeterminateSelectionIds={getIndeterminateRowSelectionIds(rows, selectedIds)}
           inProgressText={inProgressText}
           langDir={langDir}

--- a/packages/react/src/components/Table/TableBody/TableBody.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBody.jsx
@@ -42,7 +42,7 @@ const propTypes = {
   /** since some columns might not be currently visible */
   totalColumns: PropTypes.number,
   hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
-  showRadioButton: PropTypes.bool,
+  showRadioButtonSingleSelect: PropTypes.bool,
   hasRowExpansion: PropTypes.bool,
   hasRowNesting: PropTypes.oneOfType([
     PropTypes.bool,
@@ -115,7 +115,7 @@ const defaultProps = {
   columns: [],
   totalColumns: 0,
   hasRowSelection: false,
-  showRadioButton: false,
+  showRadioButtonSingleSelect: false,
   hasRowExpansion: false,
   hasRowNesting: false,
   hasRowActions: false,
@@ -157,7 +157,7 @@ const TableBody = ({
   rowActionsState,
   hasRowActions,
   hasRowSelection,
-  showRadioButton,
+  showRadioButtonSingleSelect,
   hasRowExpansion,
   hasRowNesting,
   shouldExpandOnRowClick,
@@ -278,7 +278,7 @@ const TableBody = ({
           hasRowExpansion={hasRowExpansion}
           hasRowNesting={hasRowNesting}
           hasRowSelection={hasRowSelection}
-          showRadioButton={showRadioButton}
+          showRadioButtonSingleSelect={showRadioButtonSingleSelect}
           indeterminateSelectionIds={getIndeterminateRowSelectionIds(rows, selectedIds)}
           inProgressText={inProgressText}
           langDir={langDir}

--- a/packages/react/src/components/Table/TableBody/TableBody.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBody.jsx
@@ -42,7 +42,7 @@ const propTypes = {
   /** since some columns might not be currently visible */
   totalColumns: PropTypes.number,
   hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
-  showRadioButtonSingleSelect: PropTypes.bool,
+  useRadioButtonSingleSelect: PropTypes.bool,
   hasRowExpansion: PropTypes.bool,
   hasRowNesting: PropTypes.oneOfType([
     PropTypes.bool,
@@ -115,7 +115,7 @@ const defaultProps = {
   columns: [],
   totalColumns: 0,
   hasRowSelection: false,
-  showRadioButtonSingleSelect: false,
+  useRadioButtonSingleSelect: false,
   hasRowExpansion: false,
   hasRowNesting: false,
   hasRowActions: false,
@@ -157,7 +157,7 @@ const TableBody = ({
   rowActionsState,
   hasRowActions,
   hasRowSelection,
-  showRadioButtonSingleSelect,
+  useRadioButtonSingleSelect,
   hasRowExpansion,
   hasRowNesting,
   shouldExpandOnRowClick,
@@ -278,7 +278,7 @@ const TableBody = ({
           hasRowExpansion={hasRowExpansion}
           hasRowNesting={hasRowNesting}
           hasRowSelection={hasRowSelection}
-          showRadioButtonSingleSelect={showRadioButtonSingleSelect}
+          useRadioButtonSingleSelect={useRadioButtonSingleSelect}
           indeterminateSelectionIds={getIndeterminateRowSelectionIds(rows, selectedIds)}
           inProgressText={inProgressText}
           langDir={langDir}

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -1,6 +1,12 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { TableRow, TableExpandRow, TableCell, Checkbox } from 'carbon-components-react';
+import {
+  TableRow,
+  TableExpandRow,
+  TableCell,
+  Checkbox,
+  RadioButton,
+} from 'carbon-components-react';
 import classnames from 'classnames';
 
 import { settings } from '../../../../constants/Settings';
@@ -233,6 +239,31 @@ const TableBodyRow = ({
             indeterminate={isIndeterminate}
             checked={isSelected}
             disabled={isSelectable === false}
+          />
+        </span>
+      </TableCell>
+    ) : hasRowSelection === 'single' ? (
+      <TableCell
+        className={`${prefix}--checkbox-table-cell`}
+        key={`${id}-row-selection-cell`}
+        onChange={isSelectable !== false ? () => onRowSelected(id, !isSelected) : null}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <span
+          className={`${iotPrefix}--table__cell__offset`}
+          style={{ '--row-nesting-offset': `${nestingOffset}px` }}
+        >
+          <RadioButton
+            id={`select-row-${tableId}-${id}`}
+            // className={`${iotPrefix}--hierarchy-list-bulk-modal--radio`}
+            name={`select-row-${tableId}-${id}`}
+            // key={`radio-${item.content.value}`}
+            // value={item.content.value}
+            hideLabel
+            labelText={selectRowAria}
+            onChange={() => onRowSelected(id, !isSelected)}
+            tabIndex={0}
+            checked={isSelected}
           />
         </span>
       </TableCell>

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -65,8 +65,8 @@ const propTypes = {
     truncateCellText: PropTypes.bool.isRequired,
     /** use white-space: pre; css when true */
     preserveCellWhiteSpace: PropTypes.bool,
-    /** show raidon button on single selection */
-    showRadioButtonSingleSelect: PropTypes.bool,
+    /** use raidon button on single selection */
+    useRadioButtonSingleSelect: PropTypes.bool,
   }),
 
   /** The unique row id */
@@ -183,7 +183,7 @@ const TableBodyRow = ({
     wrapCellText,
     truncateCellText,
     preserveCellWhiteSpace,
-    showRadioButtonSingleSelect,
+    useRadioButtonSingleSelect,
   },
   tableActions: { onRowSelected, onRowExpanded, onRowClicked, onApplyRowAction, onClearRowError },
   isExpanded,
@@ -245,7 +245,7 @@ const TableBodyRow = ({
           />
         </span>
       </TableCell>
-    ) : hasRowSelection === 'single' && showRadioButtonSingleSelect ? (
+    ) : hasRowSelection === 'single' && useRadioButtonSingleSelect ? (
       <TableCell
         className={`${prefix}--radiobutton-table-cell`}
         key={`${id}-row-selection-cell`}
@@ -399,7 +399,7 @@ const TableBodyRow = ({
           <TableRow
             className={classnames(`${iotPrefix}--expanded-tablerow`, {
               [`${iotPrefix}--expanded-tablerow--singly-selected`]:
-                hasRowSelection === 'single' && isSelected && !showRadioButtonSingleSelect,
+                hasRowSelection === 'single' && isSelected && !useRadioButtonSingleSelect,
             })}
           >
             <TableCell colSpan={totalColumns}>{rowDetails}</TableCell>
@@ -416,7 +416,7 @@ const TableBodyRow = ({
             hasRowNesting && nestingChildCount === 0,
           [`${iotPrefix}--expandable-tablerow--indented`]: parseInt(nestingOffset, 10) > 0,
           [`${iotPrefix}--expandable-tablerow--singly-selected`]:
-            hasRowSelection === 'single' && isSelected && !showRadioButtonSingleSelect,
+            hasRowSelection === 'single' && isSelected && !useRadioButtonSingleSelect,
           [`${iotPrefix}--expandable-tablerow--last-child`]: isLastChild,
         })}
         data-row-nesting={hasRowNesting}
@@ -450,7 +450,7 @@ const TableBodyRow = ({
   ) : hasRowSelection === 'single' && isSelected ? (
     <TableRow
       className={classnames(`${iotPrefix}--table__row`, {
-        [`${iotPrefix}--table__row--singly-selected`]: isSelected && !showRadioButtonSingleSelect,
+        [`${iotPrefix}--table__row--singly-selected`]: isSelected && !useRadioButtonSingleSelect,
       })}
       key={id}
       onClick={() => {

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -66,7 +66,7 @@ const propTypes = {
     /** use white-space: pre; css when true */
     preserveCellWhiteSpace: PropTypes.bool,
     /** show raidon button on single selection */
-    showRadioButton: PropTypes.bool,
+    showRadioButtonSingleSelect: PropTypes.bool,
   }),
 
   /** The unique row id */
@@ -183,7 +183,7 @@ const TableBodyRow = ({
     wrapCellText,
     truncateCellText,
     preserveCellWhiteSpace,
-    showRadioButton,
+    showRadioButtonSingleSelect,
   },
   tableActions: { onRowSelected, onRowExpanded, onRowClicked, onApplyRowAction, onClearRowError },
   isExpanded,
@@ -245,7 +245,7 @@ const TableBodyRow = ({
           />
         </span>
       </TableCell>
-    ) : hasRowSelection === 'single' && showRadioButton ? (
+    ) : hasRowSelection === 'single' && showRadioButtonSingleSelect ? (
       <TableCell
         className={`${prefix}--radiobutton-table-cell`}
         key={`${id}-row-selection-cell`}
@@ -262,6 +262,7 @@ const TableBodyRow = ({
             hideLabel
             labelText={selectRowAria}
             checked={isSelected}
+            onClick={isSelectable !== false ? () => onRowSelected(id, !isSelected) : null}
             disabled={isSelectable === false}
           />
         </span>
@@ -398,7 +399,7 @@ const TableBodyRow = ({
           <TableRow
             className={classnames(`${iotPrefix}--expanded-tablerow`, {
               [`${iotPrefix}--expanded-tablerow--singly-selected`]:
-                hasRowSelection === 'single' && isSelected && !showRadioButton,
+                hasRowSelection === 'single' && isSelected && !showRadioButtonSingleSelect,
             })}
           >
             <TableCell colSpan={totalColumns}>{rowDetails}</TableCell>
@@ -415,7 +416,7 @@ const TableBodyRow = ({
             hasRowNesting && nestingChildCount === 0,
           [`${iotPrefix}--expandable-tablerow--indented`]: parseInt(nestingOffset, 10) > 0,
           [`${iotPrefix}--expandable-tablerow--singly-selected`]:
-            hasRowSelection === 'single' && isSelected && !showRadioButton,
+            hasRowSelection === 'single' && isSelected && !showRadioButtonSingleSelect,
           [`${iotPrefix}--expandable-tablerow--last-child`]: isLastChild,
         })}
         data-row-nesting={hasRowNesting}
@@ -449,13 +450,13 @@ const TableBodyRow = ({
   ) : hasRowSelection === 'single' && isSelected ? (
     <TableRow
       className={classnames(`${iotPrefix}--table__row`, {
-        [`${iotPrefix}--table__row--singly-selected`]: isSelected && !showRadioButton,
+        [`${iotPrefix}--table__row--singly-selected`]: isSelected && !showRadioButtonSingleSelect,
       })}
       key={id}
       onClick={() => {
         if (isSelectable !== false) {
           onRowClicked(id);
-          onRowSelected(id, true);
+          onRowSelected(id, !isSelected);
         }
       }}
     >

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -261,7 +261,6 @@ const TableBodyRow = ({
             name={`select-row-${tableId}-${id}`}
             hideLabel
             labelText={selectRowAria}
-            onChange={() => onRowSelected(id, !isSelected)}
             checked={isSelected}
             disabled={isSelectable === false}
           />

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -65,6 +65,8 @@ const propTypes = {
     truncateCellText: PropTypes.bool.isRequired,
     /** use white-space: pre; css when true */
     preserveCellWhiteSpace: PropTypes.bool,
+    /** show raidon button on single selection */
+    showRadioButton: PropTypes.bool,
   }),
 
   /** The unique row id */
@@ -181,6 +183,7 @@ const TableBodyRow = ({
     wrapCellText,
     truncateCellText,
     preserveCellWhiteSpace,
+    showRadioButton,
   },
   tableActions: { onRowSelected, onRowExpanded, onRowClicked, onApplyRowAction, onClearRowError },
   isExpanded,
@@ -242,9 +245,9 @@ const TableBodyRow = ({
           />
         </span>
       </TableCell>
-    ) : hasRowSelection === 'single' ? (
+    ) : hasRowSelection === 'single' && showRadioButton ? (
       <TableCell
-        className={`${prefix}--checkbox-table-cell`}
+        className={`${prefix}--radiobutton-table-cell`}
         key={`${id}-row-selection-cell`}
         onChange={isSelectable !== false ? () => onRowSelected(id, !isSelected) : null}
         onClick={(e) => e.stopPropagation()}
@@ -255,15 +258,12 @@ const TableBodyRow = ({
         >
           <RadioButton
             id={`select-row-${tableId}-${id}`}
-            // className={`${iotPrefix}--hierarchy-list-bulk-modal--radio`}
             name={`select-row-${tableId}-${id}`}
-            // key={`radio-${item.content.value}`}
-            // value={item.content.value}
             hideLabel
             labelText={selectRowAria}
             onChange={() => onRowSelected(id, !isSelected)}
-            tabIndex={0}
             checked={isSelected}
+            disabled={isSelectable === false}
           />
         </span>
       </TableCell>
@@ -399,7 +399,7 @@ const TableBodyRow = ({
           <TableRow
             className={classnames(`${iotPrefix}--expanded-tablerow`, {
               [`${iotPrefix}--expanded-tablerow--singly-selected`]:
-                hasRowSelection === 'single' && isSelected,
+                hasRowSelection === 'single' && isSelected && !showRadioButton,
             })}
           >
             <TableCell colSpan={totalColumns}>{rowDetails}</TableCell>
@@ -416,7 +416,7 @@ const TableBodyRow = ({
             hasRowNesting && nestingChildCount === 0,
           [`${iotPrefix}--expandable-tablerow--indented`]: parseInt(nestingOffset, 10) > 0,
           [`${iotPrefix}--expandable-tablerow--singly-selected`]:
-            hasRowSelection === 'single' && isSelected,
+            hasRowSelection === 'single' && isSelected && !showRadioButton,
           [`${iotPrefix}--expandable-tablerow--last-child`]: isLastChild,
         })}
         data-row-nesting={hasRowNesting}
@@ -450,7 +450,7 @@ const TableBodyRow = ({
   ) : hasRowSelection === 'single' && isSelected ? (
     <TableRow
       className={classnames(`${iotPrefix}--table__row`, {
-        [`${iotPrefix}--table__row--singly-selected`]: isSelected,
+        [`${iotPrefix}--table__row--singly-selected`]: isSelected && !showRadioButton,
       })}
       key={id}
       onClick={() => {

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.story.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.story.jsx
@@ -135,6 +135,22 @@ export const IsSelectable = () => (
 
 IsSelectable.storyName = 'is selectable';
 
+IsNotSelectable.storyName = 'is not selectable';
+
+export const SingleSelect = () => (
+  <TableBodyRow
+    {...tableBodyRowProps}
+    rowActions={[{ id: 'add', renderIcon: Add32, iconDescription: 'Add' }]}
+    options={{
+      ...tableBodyRowProps.options,
+      hasRowActions: true,
+      hasRowSelection: 'single',
+    }}
+  />
+);
+
+SingleSelect.storyName = 'single selected';
+
 export const RowActionsRunning = () => (
   <TableBodyRow
     {...tableBodyRowProps}

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.story.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.story.jsx
@@ -115,7 +115,7 @@ export const IsNotSelectable = () => (
       ...tableBodyRowProps.options,
       hasRowActions: true,
       hasRowSelection: select('Single/Multi select', ['single', 'multi'], 'multi'),
-      showRadioButtonSingleSelect: true,
+      useRadioButtonSingleSelect: true,
     }}
   />
 );
@@ -130,7 +130,7 @@ export const IsSelectable = () => (
       ...tableBodyRowProps.options,
       hasRowActions: true,
       hasRowSelection: select('Single/Multi select', ['single', 'multi'], 'multi'),
-      showRadioButtonSingleSelect: boolean('Show Radio button', false),
+      useRadioButtonSingleSelect: boolean('Use radio button', false),
     }}
   />
 );
@@ -147,7 +147,7 @@ export const SingleSelect = () => (
       ...tableBodyRowProps.options,
       hasRowActions: true,
       hasRowSelection: 'single',
-      showRadioButtonSingleSelect: boolean('show radio button', false),
+      useRadioButtonSingleSelect: boolean('Use radio button', false),
     }}
   />
 );

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.story.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.story.jsx
@@ -115,7 +115,7 @@ export const IsNotSelectable = () => (
       ...tableBodyRowProps.options,
       hasRowActions: true,
       hasRowSelection: select('Single/Multi select', ['single', 'multi'], 'multi'),
-      showRadioButton: true,
+      showRadioButtonSingleSelect: true,
     }}
   />
 );
@@ -130,7 +130,7 @@ export const IsSelectable = () => (
       ...tableBodyRowProps.options,
       hasRowActions: true,
       hasRowSelection: select('Single/Multi select', ['single', 'multi'], 'multi'),
-      showRadioButton: boolean('Show Radio button', false),
+      showRadioButtonSingleSelect: boolean('Show Radio button', false),
     }}
   />
 );
@@ -147,7 +147,7 @@ export const SingleSelect = () => (
       ...tableBodyRowProps.options,
       hasRowActions: true,
       hasRowSelection: 'single',
-      showRadioButton: boolean('show radio button', false),
+      showRadioButtonSingleSelect: boolean('show radio button', false),
     }}
   />
 );

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.story.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.story.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { actions } from '@storybook/addon-actions';
-import { boolean } from '@storybook/addon-knobs';
+import { boolean, select } from '@storybook/addon-knobs';
 import { Table, TableContainer, TableBody } from 'carbon-components-react';
 import { Add32, Edit16, Stop16, TrashCan16 } from '@carbon/icons-react';
 
@@ -114,7 +114,8 @@ export const IsNotSelectable = () => (
     options={{
       ...tableBodyRowProps.options,
       hasRowActions: true,
-      hasRowSelection: 'multi',
+      hasRowSelection: select('Single/Multi select', ['single', 'multi'], 'multi'),
+      showRadioButton: true,
     }}
   />
 );
@@ -128,7 +129,8 @@ export const IsSelectable = () => (
     options={{
       ...tableBodyRowProps.options,
       hasRowActions: true,
-      hasRowSelection: 'multi',
+      hasRowSelection: select('Single/Multi select', ['single', 'multi'], 'multi'),
+      showRadioButton: boolean('Show Radio button', false),
     }}
   />
 );
@@ -145,6 +147,7 @@ export const SingleSelect = () => (
       ...tableBodyRowProps.options,
       hasRowActions: true,
       hasRowSelection: 'single',
+      showRadioButton: boolean('show radio button', false),
     }}
   />
 );

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.test.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.test.jsx
@@ -312,7 +312,7 @@ describe('TableBodyRow', () => {
           hasRowSelection: 'single',
           wrapCellText: 'always',
           truncateCellText: true,
-          showRadioButton: true,
+          showRadioButtonSingleSelect: true,
         }}
         tableActions={mockActions}
         {...tableRowProps}
@@ -335,7 +335,7 @@ describe('TableBodyRow', () => {
           hasRowExpansion: true,
           wrapCellText: 'always',
           truncateCellText: true,
-          showRadioButton: true,
+          showRadioButtonSingleSelect: true,
         }}
         isExpanded
       />,
@@ -380,7 +380,7 @@ describe('TableBodyRow', () => {
           hasRowExpansion: true,
           wrapCellText: 'always',
           truncateCellText: true,
-          showRadioButton: true,
+          showRadioButtonSingleSelect: true,
         }}
         isExpanded
       />,
@@ -415,7 +415,7 @@ describe('TableBodyRow', () => {
     expect(mockActions.onRowSelected).not.toHaveBeenCalled();
     expect(mockActions.onRowClicked).not.toHaveBeenCalled();
     userEvent.click(screen.getByRole('cell', { name: 'value1' }));
-    expect(mockActions.onRowSelected).toHaveBeenCalledWith(tableRowProps.id, true);
+    expect(mockActions.onRowSelected).toHaveBeenCalledWith(tableRowProps.id, false);
     expect(mockActions.onRowClicked).toHaveBeenCalledWith(tableRowProps.id);
   });
 
@@ -428,7 +428,7 @@ describe('TableBodyRow', () => {
           hasRowSelection: 'single',
           wrapCellText: 'always',
           truncateCellText: true,
-          showRadioButton: true,
+          showRadioButtonSingleSelect: true,
         }}
         isSelectable
       />,
@@ -465,7 +465,7 @@ describe('TableBodyRow', () => {
     expect(mockActions.onRowSelected).not.toHaveBeenCalled();
   });
 
-  it('does not call onRowSelected when expanded rows with hasRowSelection:"single" and showRadioButton are clicked if isSelectable:"false"', () => {
+  it('does not call onRowSelected when expanded rows with hasRowSelection:"single" and showRadioButtonSingleSelect are clicked if isSelectable:"false"', () => {
     render(
       <TableBodyRow
         {...tableRowProps}
@@ -475,7 +475,7 @@ describe('TableBodyRow', () => {
           hasRowExpansion: true,
           wrapCellText: 'always',
           truncateCellText: true,
-          showRadioButton: true,
+          showRadioButtonSingleSelect: true,
         }}
         isSelectable={false}
       />,

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.test.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.test.jsx
@@ -20,6 +20,7 @@ const tableRowProps = {
   totalColumns: 1,
   id: 'tableRow',
   tableId: 'tableId',
+  selectRowAria: 'selectedRow',
   ordering: [{ columnId: 'col1', isHidden: false }],
   values: { col1: 'value1' },
   columns: [
@@ -301,6 +302,30 @@ describe('TableBodyRow', () => {
     userEvent.click(container.querySelector('tr'));
     expect(mockActions.onRowSelected).toHaveBeenCalledWith(tableRowProps.id, true);
     expect(mockActions.onRowClicked).toHaveBeenCalled();
+  });
+
+  it('hasRowSingleSelection with radio button', () => {
+    const { container } = render(
+      <TableBodyRow
+        options={{
+          hasRowSelection: 'single',
+          wrapCellText: 'always',
+          truncateCellText: true,
+          showRadioButton: true,
+        }}
+        tableActions={mockActions}
+        {...tableRowProps}
+      />,
+      {
+        container: document.body.appendChild(document.createElement('tbody')),
+      }
+    );
+    userEvent.click(container.querySelector('tr'));
+    expect(mockActions.onRowSelected).toHaveBeenCalledWith(tableRowProps.id, true);
+    expect(mockActions.onRowClicked).toHaveBeenCalled();
+    expect(screen.getByRole('radio', { name: tableRowProps.selectRowAria })).toHaveClass(
+      'bx--radio-button'
+    );
   });
 
   it('calls onRowSelected when expanded rows with hasRowSelection:"single" are clicked', () => {

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.test.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.test.jsx
@@ -312,7 +312,7 @@ describe('TableBodyRow', () => {
           hasRowSelection: 'single',
           wrapCellText: 'always',
           truncateCellText: true,
-          showRadioButtonSingleSelect: true,
+          useRadioButtonSingleSelect: true,
         }}
         tableActions={mockActions}
         {...tableRowProps}
@@ -335,7 +335,7 @@ describe('TableBodyRow', () => {
           hasRowExpansion: true,
           wrapCellText: 'always',
           truncateCellText: true,
-          showRadioButtonSingleSelect: true,
+          useRadioButtonSingleSelect: true,
         }}
         isExpanded
       />,
@@ -380,7 +380,7 @@ describe('TableBodyRow', () => {
           hasRowExpansion: true,
           wrapCellText: 'always',
           truncateCellText: true,
-          showRadioButtonSingleSelect: true,
+          useRadioButtonSingleSelect: true,
         }}
         isExpanded
       />,
@@ -428,7 +428,7 @@ describe('TableBodyRow', () => {
           hasRowSelection: 'single',
           wrapCellText: 'always',
           truncateCellText: true,
-          showRadioButtonSingleSelect: true,
+          useRadioButtonSingleSelect: true,
         }}
         isSelectable
       />,
@@ -465,7 +465,7 @@ describe('TableBodyRow', () => {
     expect(mockActions.onRowSelected).not.toHaveBeenCalled();
   });
 
-  it('does not call onRowSelected when expanded rows with hasRowSelection:"single" and showRadioButtonSingleSelect are clicked if isSelectable:"false"', () => {
+  it('does not call onRowSelected when expanded rows with hasRowSelection:"single" and useRadioButtonSingleSelect are clicked if isSelectable:"false"', () => {
     render(
       <TableBodyRow
         {...tableRowProps}
@@ -475,7 +475,7 @@ describe('TableBodyRow', () => {
           hasRowExpansion: true,
           wrapCellText: 'always',
           truncateCellText: true,
-          showRadioButtonSingleSelect: true,
+          useRadioButtonSingleSelect: true,
         }}
         isSelectable={false}
       />,

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.test.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.test.jsx
@@ -223,6 +223,7 @@ describe('TableBodyRow', () => {
     );
     expect(container).toBeDefined();
   });
+
   it('verify custom cell renderer', () => {
     const customRenderDataFunction = ({ value, columnId, rowId, row }) => (
       <div id={value}>
@@ -304,8 +305,8 @@ describe('TableBodyRow', () => {
     expect(mockActions.onRowClicked).toHaveBeenCalled();
   });
 
-  it('hasRowSingleSelection with radio button', () => {
-    const { container } = render(
+  it('shows radio button when rows hasRowSingleSelection', () => {
+    render(
       <TableBodyRow
         options={{
           hasRowSelection: 'single',
@@ -320,9 +321,28 @@ describe('TableBodyRow', () => {
         container: document.body.appendChild(document.createElement('tbody')),
       }
     );
-    userEvent.click(container.querySelector('tr'));
+    userEvent.click(screen.getByRole('radio', { name: tableRowProps.selectRowAria }));
     expect(mockActions.onRowSelected).toHaveBeenCalledWith(tableRowProps.id, true);
-    expect(mockActions.onRowClicked).toHaveBeenCalled();
+  });
+
+  it('shows radio button on row with expansion', () => {
+    render(
+      <TableBodyRow
+        {...tableRowProps}
+        tableActions={mockActions}
+        options={{
+          hasRowSelection: 'single',
+          hasRowExpansion: true,
+          wrapCellText: 'always',
+          truncateCellText: true,
+          showRadioButton: true,
+        }}
+        isExpanded
+      />,
+      {
+        container: document.body.appendChild(document.createElement('tbody')),
+      }
+    );
     expect(screen.getByRole('radio', { name: tableRowProps.selectRowAria })).toHaveClass(
       'bx--radio-button'
     );
@@ -350,6 +370,32 @@ describe('TableBodyRow', () => {
     expect(mockActions.onRowSelected).toHaveBeenCalledWith(tableRowProps.id, true);
   });
 
+  it('calls onRowSelected when expanded rows with hasRowSelection:"single" and radio button are clicked', () => {
+    render(
+      <TableBodyRow
+        {...tableRowProps}
+        tableActions={mockActions}
+        options={{
+          hasRowSelection: 'single',
+          hasRowExpansion: true,
+          wrapCellText: 'always',
+          truncateCellText: true,
+          showRadioButton: true,
+        }}
+        isExpanded
+      />,
+      {
+        container: document.body.appendChild(document.createElement('tbody')),
+      }
+    );
+    expect(mockActions.onRowSelected).not.toHaveBeenCalled();
+    userEvent.click(screen.getByRole('cell', { name: 'value1' }));
+    expect(mockActions.onRowSelected).toHaveBeenCalledWith(tableRowProps.id, true);
+    expect(screen.getByRole('radio', { name: tableRowProps.selectRowAria })).toHaveClass(
+      'bx--radio-button'
+    );
+  });
+
   it('calls onRowSelected & onRowClicked when selected rows with hasRowSelection:"single" are clicked', () => {
     render(
       <TableBodyRow
@@ -373,6 +419,30 @@ describe('TableBodyRow', () => {
     expect(mockActions.onRowClicked).toHaveBeenCalledWith(tableRowProps.id);
   });
 
+  it('calls onRowSelected & onRowClicked when selected rows with hasRowSelection:"single" and radio buttoon are clicked', () => {
+    render(
+      <TableBodyRow
+        {...tableRowProps}
+        tableActions={mockActions}
+        options={{
+          hasRowSelection: 'single',
+          wrapCellText: 'always',
+          truncateCellText: true,
+          showRadioButton: true,
+        }}
+        isSelectable
+      />,
+      {
+        container: document.body.appendChild(document.createElement('tbody')),
+      }
+    );
+    expect(mockActions.onRowSelected).not.toHaveBeenCalled();
+    expect(mockActions.onRowClicked).not.toHaveBeenCalled();
+    userEvent.click(screen.getByRole('cell', { name: 'value1' }));
+    expect(mockActions.onRowSelected).toHaveBeenCalledWith(tableRowProps.id, true);
+    expect(mockActions.onRowClicked).toHaveBeenCalledWith(tableRowProps.id);
+  });
+
   it('does not call onRowSelected when expanded rows with hasRowSelection:"single" are clicked if isSelectable:"false"', () => {
     render(
       <TableBodyRow
@@ -383,6 +453,29 @@ describe('TableBodyRow', () => {
           hasRowExpansion: true,
           wrapCellText: 'always',
           truncateCellText: true,
+        }}
+        isSelectable={false}
+      />,
+      {
+        container: document.body.appendChild(document.createElement('tbody')),
+      }
+    );
+
+    userEvent.click(screen.getByRole('cell', { name: 'value1' }));
+    expect(mockActions.onRowSelected).not.toHaveBeenCalled();
+  });
+
+  it('does not call onRowSelected when expanded rows with hasRowSelection:"single" and showRadioButton are clicked if isSelectable:"false"', () => {
+    render(
+      <TableBodyRow
+        {...tableRowProps}
+        tableActions={mockActions}
+        options={{
+          hasRowSelection: 'single',
+          hasRowExpansion: true,
+          wrapCellText: 'always',
+          truncateCellText: true,
+          showRadioButton: true,
         }}
         isSelectable={false}
       />,

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/__snapshots__/TableBodyRow.story.storyshot
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/__snapshots__/TableBodyRow.story.storyshot
@@ -942,3 +942,106 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
   </div>
 </div>
 `;
+
+exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/Table/TableBodyRow single selected 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    className="bx--data-table-container"
+  >
+    <div
+      className="bx--data-table-content"
+    >
+      <table
+        className="bx--data-table bx--data-table--no-border"
+      >
+        <tbody
+          aria-live="polite"
+        >
+          <tr
+            className="iot--table__row iot--table__row--selectable"
+            onClick={[Function]}
+          >
+            <td
+              align="start"
+              className="data-table-start"
+              data-column="string"
+              data-offset={0}
+              id="cell-tableId-rowId-string"
+              offset={0}
+            >
+              <span
+                className="iot--table__cell__offset"
+                style={
+                  Object {
+                    "--row-nesting-offset": "0px",
+                  }
+                }
+              >
+                <span
+                  className="iot--table__cell-text--no-wrap"
+                  title="My String"
+                >
+                  My String
+                </span>
+              </span>
+            </td>
+            <td
+              className="iot--row-actions-cell--table-cell"
+            >
+              <div
+                className="iot--row-actions-container"
+              >
+                <div
+                  className="iot--row-actions-container__background"
+                  data-testid="row-action-container-background"
+                  onClick={[Function]}
+                >
+                  <button
+                    aria-describedby={null}
+                    className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--left bx--tooltip--align-end"
+                    data-testid="tableId-rowId-row-actions-button-add"
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <div
+                      className="bx--assistive-text"
+                      onMouseEnter={[Function]}
+                    >
+                      Add
+                    </div>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Add"
+                      className="bx--btn__icon"
+                      fill="currentColor"
+                      focusable="false"
+                      height={32}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      viewBox="0 0 32 32"
+                      width={32}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/react/src/components/Table/TableBody/TableBodyRowRenderer.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRowRenderer.jsx
@@ -44,7 +44,7 @@ const propTypes = {
   totalColumns: PropTypes.number,
   hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
   /** show radio button on single selection */
-  showRadioButtonSingleSelect: PropTypes.bool,
+  useRadioButtonSingleSelect: PropTypes.bool,
   hasRowExpansion: PropTypes.bool,
   hasRowNesting: PropTypes.oneOfType([
     PropTypes.bool,
@@ -115,7 +115,7 @@ const defaultProps = {
   hasRowExpansion: false,
   hasRowNesting: false,
   hasRowSelection: false,
-  showRadioButtonSingleSelect: false,
+  useRadioButtonSingleSelect: false,
   indeterminateSelectionIds: [],
   inProgressText: 'In progress',
   langDir: 'ltr',
@@ -156,7 +156,7 @@ const TableBodyRowRenderer = (props) => {
     hasRowExpansion,
     hasRowNesting,
     hasRowSelection,
-    showRadioButtonSingleSelect,
+    useRadioButtonSingleSelect,
     indeterminateSelectionIds,
     inProgressText,
     langDir,
@@ -255,7 +255,7 @@ const TableBodyRowRenderer = (props) => {
         wrapCellText,
         truncateCellText,
         preserveCellWhiteSpace,
-        showRadioButtonSingleSelect,
+        useRadioButtonSingleSelect,
       }}
       nestingLevel={nestingLevel}
       nestingChildCount={row.children ? row.children.length : 0}

--- a/packages/react/src/components/Table/TableBody/TableBodyRowRenderer.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRowRenderer.jsx
@@ -44,7 +44,7 @@ const propTypes = {
   totalColumns: PropTypes.number,
   hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
   /** show radio button on single selection */
-  showRadioButton: PropTypes.bool,
+  showRadioButtonSingleSelect: PropTypes.bool,
   hasRowExpansion: PropTypes.bool,
   hasRowNesting: PropTypes.oneOfType([
     PropTypes.bool,
@@ -115,7 +115,7 @@ const defaultProps = {
   hasRowExpansion: false,
   hasRowNesting: false,
   hasRowSelection: false,
-  showRadioButton: false,
+  showRadioButtonSingleSelect: false,
   indeterminateSelectionIds: [],
   inProgressText: 'In progress',
   langDir: 'ltr',
@@ -156,7 +156,7 @@ const TableBodyRowRenderer = (props) => {
     hasRowExpansion,
     hasRowNesting,
     hasRowSelection,
-    showRadioButton,
+    showRadioButtonSingleSelect,
     indeterminateSelectionIds,
     inProgressText,
     langDir,
@@ -255,7 +255,7 @@ const TableBodyRowRenderer = (props) => {
         wrapCellText,
         truncateCellText,
         preserveCellWhiteSpace,
-        showRadioButton,
+        showRadioButtonSingleSelect,
       }}
       nestingLevel={nestingLevel}
       nestingChildCount={row.children ? row.children.length : 0}

--- a/packages/react/src/components/Table/TableBody/TableBodyRowRenderer.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRowRenderer.jsx
@@ -43,6 +43,8 @@ const propTypes = {
   /** since some columns might not be currently visible */
   totalColumns: PropTypes.number,
   hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
+  /** show radio button on single selection */
+  showRadioButton: PropTypes.bool,
   hasRowExpansion: PropTypes.bool,
   hasRowNesting: PropTypes.oneOfType([
     PropTypes.bool,
@@ -113,6 +115,7 @@ const defaultProps = {
   hasRowExpansion: false,
   hasRowNesting: false,
   hasRowSelection: false,
+  showRadioButton: false,
   indeterminateSelectionIds: [],
   inProgressText: 'In progress',
   langDir: 'ltr',
@@ -153,6 +156,7 @@ const TableBodyRowRenderer = (props) => {
     hasRowExpansion,
     hasRowNesting,
     hasRowSelection,
+    showRadioButton,
     indeterminateSelectionIds,
     inProgressText,
     langDir,
@@ -251,6 +255,7 @@ const TableBodyRowRenderer = (props) => {
         wrapCellText,
         truncateCellText,
         preserveCellWhiteSpace,
+        showRadioButton,
       }}
       nestingLevel={nestingLevel}
       nestingChildCount={row.children ? row.children.length : 0}

--- a/packages/react/src/components/Table/TableHead/TableHead.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.jsx
@@ -60,7 +60,7 @@ const propTypes = {
   options: PropTypes.shape({
     hasRowExpansion: PropTypes.bool,
     hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
-    showRadioButton: PropTypes.bool,
+    showRadioButtonSingleSelect: PropTypes.bool,
     hasRowActions: PropTypes.bool,
     hasResize: PropTypes.bool,
     hasSingleRowEdit: PropTypes.bool,
@@ -197,7 +197,7 @@ const TableHead = ({
     hasMultiSort,
     useAutoTableLayoutForResize,
     preserveColumnWidths,
-    showRadioButton,
+    showRadioButtonSingleSelect,
   },
   columns,
   columnGroups,
@@ -466,7 +466,7 @@ const TableHead = ({
               onChange={() => onSelectAll(!isSelectAllSelected)}
             />
           </TableHeader>
-        ) : hasRowSelection === 'single' && showRadioButton ? (
+        ) : hasRowSelection === 'single' && showRadioButtonSingleSelect ? (
           <TableHeader
             // TODO: remove deprecated 'testID' in v3
             testId={`${testID || testId}-row-selection-column`}

--- a/packages/react/src/components/Table/TableHead/TableHead.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.jsx
@@ -60,7 +60,7 @@ const propTypes = {
   options: PropTypes.shape({
     hasRowExpansion: PropTypes.bool,
     hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
-    showRadioButtonSingleSelect: PropTypes.bool,
+    useRadioButtonSingleSelect: PropTypes.bool,
     hasRowActions: PropTypes.bool,
     hasResize: PropTypes.bool,
     hasSingleRowEdit: PropTypes.bool,
@@ -197,7 +197,7 @@ const TableHead = ({
     hasMultiSort,
     useAutoTableLayoutForResize,
     preserveColumnWidths,
-    showRadioButtonSingleSelect,
+    useRadioButtonSingleSelect,
   },
   columns,
   columnGroups,
@@ -466,7 +466,7 @@ const TableHead = ({
               onChange={() => onSelectAll(!isSelectAllSelected)}
             />
           </TableHeader>
-        ) : hasRowSelection === 'single' && showRadioButtonSingleSelect ? (
+        ) : hasRowSelection === 'single' && useRadioButtonSingleSelect ? (
           <TableHeader
             // TODO: remove deprecated 'testID' in v3
             testId={`${testID || testId}-row-selection-column`}

--- a/packages/react/src/components/Table/TableHead/TableHead.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.jsx
@@ -60,6 +60,7 @@ const propTypes = {
   options: PropTypes.shape({
     hasRowExpansion: PropTypes.bool,
     hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
+    showRadioButton: PropTypes.bool,
     hasRowActions: PropTypes.bool,
     hasResize: PropTypes.bool,
     hasSingleRowEdit: PropTypes.bool,
@@ -196,6 +197,7 @@ const TableHead = ({
     hasMultiSort,
     useAutoTableLayoutForResize,
     preserveColumnWidths,
+    showRadioButton,
   },
   columns,
   columnGroups,
@@ -464,6 +466,15 @@ const TableHead = ({
               onChange={() => onSelectAll(!isSelectAllSelected)}
             />
           </TableHeader>
+        ) : hasRowSelection === 'single' && showRadioButton ? (
+          <TableHeader
+            // TODO: remove deprecated 'testID' in v3
+            testId={`${testID || testId}-row-selection-column`}
+            className={classnames(`${iotPrefix}--table-header-radiobutton`, {
+              [`${iotPrefix}--table-header-radiobutton-resize`]: hasResize,
+            })}
+            translateWithId={(...args) => tableTranslateWithId(...args)}
+          />
         ) : null}
         {ordering.map((item, columnIndex) => {
           const matchingColumnMeta = columns.find((column) => column.id === item.columnId);

--- a/packages/react/src/components/Table/TableHead/_table-head.scss
+++ b/packages/react/src/components/Table/TableHead/_table-head.scss
@@ -163,7 +163,18 @@
     }
   }
 
+  .#{$iot-prefix}--table-header-radiobutton {
+    vertical-align: middle;
+    .#{$prefix}--table-header-label {
+      overflow: visible;
+    }
+  }
+
   .#{$iot-prefix}--table-header-checkbox-resize {
+    width: 54px;
+  }
+
+  .#{$iot-prefix}--table-header-radiobutton-resize {
     width: 54px;
   }
 

--- a/packages/react/src/components/Table/TableSaveViewModal/__snapshots__/TableSaveViewModal.story.storyshot
+++ b/packages/react/src/components/Table/TableSaveViewModal/__snapshots__/TableSaveViewModal.story.storyshot
@@ -333,7 +333,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               onAnimationEnd={[Function]}
             >
               <button
-                aria-controls="accordion-item-1356"
+                aria-controls="accordion-item-1357"
                 aria-expanded={false}
                 className="bx--accordion__heading"
                 onClick={[Function]}
@@ -364,7 +364,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               </button>
               <div
                 className="bx--accordion__content"
-                id="accordion-item-1356"
+                id="accordion-item-1357"
               >
                 <p>
                   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -376,7 +376,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               onAnimationEnd={[Function]}
             >
               <button
-                aria-controls="accordion-item-1357"
+                aria-controls="accordion-item-1358"
                 aria-expanded={false}
                 className="bx--accordion__heading"
                 onClick={[Function]}
@@ -407,7 +407,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               </button>
               <div
                 className="bx--accordion__content"
-                id="accordion-item-1357"
+                id="accordion-item-1358"
               >
                 <p>
                   Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/packages/react/src/components/TileGallery/__snapshots__/TileGallery.story.storyshot
+++ b/packages/react/src/components/TileGallery/__snapshots__/TileGallery.story.storyshot
@@ -201,7 +201,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   onAnimationEnd={[Function]}
                 >
                   <button
-                    aria-controls="accordion-item-1468"
+                    aria-controls="accordion-item-1469"
                     aria-expanded={true}
                     className="bx--accordion__heading"
                     onClick={[Function]}
@@ -232,7 +232,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   </button>
                   <div
                     className="bx--accordion__content"
-                    id="accordion-item-1468"
+                    id="accordion-item-1469"
                   >
                     <div
                       className="tile-gallery--section--items"
@@ -624,7 +624,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   onAnimationEnd={[Function]}
                 >
                   <button
-                    aria-controls="accordion-item-1469"
+                    aria-controls="accordion-item-1470"
                     aria-expanded={true}
                     className="bx--accordion__heading"
                     onClick={[Function]}
@@ -655,7 +655,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   </button>
                   <div
                     className="bx--accordion__content"
-                    id="accordion-item-1469"
+                    id="accordion-item-1470"
                   >
                     <div
                       className="tile-gallery--section--items"
@@ -1494,7 +1494,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   onAnimationEnd={[Function]}
                 >
                   <button
-                    aria-controls="accordion-item-1475"
+                    aria-controls="accordion-item-1476"
                     aria-expanded={true}
                     className="bx--accordion__heading"
                     onClick={[Function]}
@@ -1525,7 +1525,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   </button>
                   <div
                     className="bx--accordion__content"
-                    id="accordion-item-1475"
+                    id="accordion-item-1476"
                   >
                     <div
                       className="tile-gallery--section--items"
@@ -1694,7 +1694,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
             onAnimationEnd={[Function]}
           >
             <button
-              aria-controls="accordion-item-1472"
+              aria-controls="accordion-item-1473"
               aria-expanded={true}
               className="bx--accordion__heading"
               onClick={[Function]}
@@ -1725,7 +1725,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
             </button>
             <div
               className="bx--accordion__content"
-              id="accordion-item-1472"
+              id="accordion-item-1473"
             >
               <div
                 className="tile-gallery--section--items"
@@ -2142,7 +2142,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
             onAnimationEnd={[Function]}
           >
             <button
-              aria-controls="accordion-item-1473"
+              aria-controls="accordion-item-1474"
               aria-expanded={true}
               className="bx--accordion__heading"
               onClick={[Function]}
@@ -2173,7 +2173,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
             </button>
             <div
               className="bx--accordion__content"
-              id="accordion-item-1473"
+              id="accordion-item-1474"
             >
               <div
                 className="tile-gallery--section--items"
@@ -2429,7 +2429,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               onAnimationEnd={[Function]}
             >
               <button
-                aria-controls="accordion-item-1470"
+                aria-controls="accordion-item-1471"
                 aria-expanded={true}
                 className="bx--accordion__heading"
                 onClick={[Function]}
@@ -2460,7 +2460,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </button>
               <div
                 className="bx--accordion__content"
-                id="accordion-item-1470"
+                id="accordion-item-1471"
               >
                 <div
                   className="tile-gallery--section--items"
@@ -2877,7 +2877,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               onAnimationEnd={[Function]}
             >
               <button
-                aria-controls="accordion-item-1471"
+                aria-controls="accordion-item-1472"
                 aria-expanded={true}
                 className="bx--accordion__heading"
                 onClick={[Function]}
@@ -2908,7 +2908,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </button>
               <div
                 className="bx--accordion__content"
-                id="accordion-item-1471"
+                id="accordion-item-1472"
               >
                 <div
                   className="tile-gallery--section--items"

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -2902,6 +2902,7 @@ Map {
       "shouldExpandOnRowClick": false,
       "shouldLazyRender": false,
       "showExpanderColumn": false,
+      "showRadioButton": false,
       "singleRowEditButtons": null,
       "size": undefined,
       "testId": "",
@@ -3390,6 +3391,9 @@ Map {
         "type": "bool",
       },
       "showExpanderColumn": Object {
+        "type": "bool",
+      },
+      "showRadioButton": Object {
         "type": "bool",
       },
       "singleRowEditButtons": Object {

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -2681,14 +2681,14 @@ Map {
             "preserveColumnWidths": Object {
               "type": "bool",
             },
-            "showRadioButtonSingleSelect": Object {
-              "type": "bool",
-            },
             "truncateCellText": Object {
               "isRequired": true,
               "type": "bool",
             },
             "useAutoTableLayoutForResize": Object {
+              "type": "bool",
+            },
+            "useRadioButtonSingleSelect": Object {
               "type": "bool",
             },
             "wrapCellText": Object {
@@ -2905,11 +2905,11 @@ Map {
       "shouldExpandOnRowClick": false,
       "shouldLazyRender": false,
       "showExpanderColumn": false,
-      "showRadioButtonSingleSelect": false,
       "singleRowEditButtons": null,
       "size": undefined,
       "testId": "",
       "totalColumns": 0,
+      "useRadioButtonSingleSelect": false,
     },
     "propTypes": Object {
       "actionFailedText": Object {
@@ -3396,9 +3396,6 @@ Map {
       "showExpanderColumn": Object {
         "type": "bool",
       },
-      "showRadioButtonSingleSelect": Object {
-        "type": "bool",
-      },
       "singleRowEditButtons": Object {
         "type": "element",
       },
@@ -3427,6 +3424,9 @@ Map {
       },
       "truncateCellText": Object {
         "isRequired": true,
+        "type": "bool",
+      },
+      "useRadioButtonSingleSelect": Object {
         "type": "bool",
       },
       "wrapCellText": Object {

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -2681,6 +2681,9 @@ Map {
             "preserveColumnWidths": Object {
               "type": "bool",
             },
+            "showRadioButton": Object {
+              "type": "bool",
+            },
             "truncateCellText": Object {
               "isRequired": true,
               "type": "bool",

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -2681,7 +2681,7 @@ Map {
             "preserveColumnWidths": Object {
               "type": "bool",
             },
-            "showRadioButton": Object {
+            "showRadioButtonSingleSelect": Object {
               "type": "bool",
             },
             "truncateCellText": Object {
@@ -2905,7 +2905,7 @@ Map {
       "shouldExpandOnRowClick": false,
       "shouldLazyRender": false,
       "showExpanderColumn": false,
-      "showRadioButton": false,
+      "showRadioButtonSingleSelect": false,
       "singleRowEditButtons": null,
       "size": undefined,
       "testId": "",
@@ -3396,7 +3396,7 @@ Map {
       "showExpanderColumn": Object {
         "type": "bool",
       },
-      "showRadioButton": Object {
+      "showRadioButtonSingleSelect": Object {
         "type": "bool",
       },
       "singleRowEditButtons": Object {


### PR DESCRIPTION
Closes #3394 

**Summary**

- single selection with radio button 
- there are 2 ways of single selection, it's either with a radio button or with a blue indicator.

**Change List (commits, features, bugs, etc)**

- add radio button when `hasRowSelection` is `single` and  option prop `showRadioButton` is `true`

**Acceptance Test (how to verify the PR)**

![image](https://user-images.githubusercontent.com/24279794/165622204-edbaa25e-3258-41ab-8aac-e63fc88bd231.png)

![image](https://user-images.githubusercontent.com/24279794/165622304-47628bed-25f8-4bf3-9707-e0dbc45c3200.png)


![image](https://user-images.githubusercontent.com/24279794/165622253-e57977f3-f7a3-445d-bd6d-93cca38d456d.png)

![image](https://user-images.githubusercontent.com/24279794/165623406-73746b7f-b0aa-4d0a-aac9-cc080f965c8a.png)

![image](https://user-images.githubusercontent.com/24279794/165623475-33df98ee-b7af-4f57-a991-f57333e486fc.png)


**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
