### PR TITLE
fix(table): empty state message with word break

### DIFF
--- a/packages/react/src/components/EmptyState/_emptystate.scss
+++ b/packages/react/src/components/EmptyState/_emptystate.scss
@@ -23,6 +23,7 @@
     @include type-style('productive-heading-03');
     color: $text-01;
     margin-bottom: $spacing-03;
+    word-break: break-word;
   }
 
   &--text {

--- a/packages/react/src/components/Table/Table.story.helpers.jsx
+++ b/packages/react/src/components/Table/Table.story.helpers.jsx
@@ -1470,7 +1470,11 @@ export const getI18nKnobs = (useGroup = true) => {
     ),
     simpleFiltersTabLabel: text('i18n.simpleFiltersTabLabel', 'Simple filters', I18N_GROUP),
     advancedFiltersTabLabel: text('i18n.advancedFiltersTabLabel', 'Advanced filters', I18N_GROUP),
-    emptyMessage: text('i18n.emptyMessage', 'There is no data', I18N_GROUP),
+    emptyMessage: text(
+      'i18n.emptyMessage',
+      'Empty state message. There is no more data. Test word break with extra strings. ',
+      I18N_GROUP
+    ),
     emptyMessageWithFilters: text(
       'i18n.emptyMessageWithFilters',
       'No results match the current filters',


### PR DESCRIPTION
Closes #3415 

**Summary**

-  add`word-break: break-word` for `emptyMessage`

**Change List (commits, features, bugs, etc)**

- fixed in `_emptystate.scss`

**Acceptance Test (how to verify the PR)**

before:
![image](https://user-images.githubusercontent.com/24279794/165631043-58735c6a-86e2-4a16-99cf-0cca203af385.png)

after:
![image](https://user-images.githubusercontent.com/24279794/165631106-3847ea1a-0417-4d3b-a314-7e75795e98bd.png)


<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
