### PR TITLE
Side nav issue

### DIFF
--- a/packages/react/src/components/SideNav/SideNav.jsx
+++ b/packages/react/src/components/SideNav/SideNav.jsx
@@ -200,20 +200,7 @@ const SideNav = ({
         ? handleSpecificKeyDown(['Escape'], (evt) => evt.stopPropagation())
         : undefined;
       const content = searchValue ? markText(childLink.content, searchValue) : childLink.content;
-      // istanbul ignore else
-      if (link.metaData?.onClick) {
-        return (
-          <SideNavLink
-            onKeyDown={onKeyDown}
-            key={`menu-link-${link.childContent.indexOf(childLink)}-child`}
-            isActive={childLink.isActive}
-            data-testid={`${testId}-menu-item-${index}`}
-            {...childLink.metaData}
-          >
-            {content}
-          </SideNavLink>
-        );
-      }
+
       return (
         <SideNavMenuItem
           onKeyDown={onKeyDown}

--- a/packages/react/src/components/SideNav/SideNav.jsx
+++ b/packages/react/src/components/SideNav/SideNav.jsx
@@ -66,7 +66,7 @@ export const SideNavPropTypes = {
   links: PropTypes.arrayOf(
     PropTypes.shape({
       /** is current link active */
-      current: PropTypes.bool,
+      isActive: PropTypes.bool,
       /** bot show/hide link */
       isEnabled: PropTypes.bool,
       /** pins the link to the top if hasSearch is true */
@@ -105,6 +105,8 @@ export const SideNavPropTypes = {
             PropTypes.bool,
             PropTypes.func,
           ]).isRequired,
+          /** is current link active */
+          isActive: PropTypes.bool,
         })
       ),
     })
@@ -198,7 +200,20 @@ const SideNav = ({
         ? handleSpecificKeyDown(['Escape'], (evt) => evt.stopPropagation())
         : undefined;
       const content = searchValue ? markText(childLink.content, searchValue) : childLink.content;
-
+      // istanbul ignore else
+      if (link.metaData?.onClick) {
+        return (
+          <SideNavLink
+            onKeyDown={onKeyDown}
+            key={`menu-link-${link.childContent.indexOf(childLink)}-child`}
+            isActive={childLink.isActive}
+            data-testid={`${testId}-menu-item-${index}`}
+            {...childLink.metaData}
+          >
+            {content}
+          </SideNavLink>
+        );
+      }
       return (
         <SideNavMenuItem
           onKeyDown={onKeyDown}

--- a/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
+++ b/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
@@ -296,7 +296,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             className="bx--side-nav__menu"
           >
             <li
-              className="bx--side-nav__menu-item"
+              className="bx--side-nav__item"
             >
               <button
                 className="bx--side-nav__link"

--- a/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
+++ b/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
@@ -296,7 +296,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             className="bx--side-nav__menu"
           >
             <li
-              className="bx--side-nav__item"
+              className="bx--side-nav__menu-item"
             >
               <button
                 className="bx--side-nav__link"

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { UserAvatar20, Settings20, Help20 } from '@carbon/icons-react';
 import { ButtonSkeleton } from 'carbon-components-react';
 import classnames from 'classnames';
+import { HeaderContainer } from 'carbon-components-react/es/components/UIShell';
 
 import SideNav, { SideNavPropTypes } from '../SideNav/SideNav';
 import { ToastNotification } from '../Notification';
@@ -157,13 +158,6 @@ const SuiteHeader = ({
     }
   }, [surveyData]);
 
-  // State for expandable sidenav
-  const [isSideNavExpandedState, setIsSideNavExpandedState] = useState(false);
-
-  const handleSideNavButtonClick = useCallback(() => {
-    setIsSideNavExpandedState((prevIsSideNavExpanded) => !prevIsSideNavExpanded);
-  }, [setIsSideNavExpandedState]);
-
   const navigatorRoute = routes?.navigator || 'javascript:void(0)';
   const adminRoute = routes?.admin || 'javascript:void(0)';
 
@@ -278,215 +272,229 @@ const SuiteHeader = ({
           </span>
         </>
       )}
-      <Header
-        testId={testId}
-        className={classnames(`${settings.iotPrefix}--suite-header`, className)}
-        url={navigatorRoute}
-        hasSideNav={hasSideNav || sideNavProps !== null}
-        onClickSideNavExpand={(evt) => {
-          onSideNavToggled(evt);
-          handleSideNavButtonClick(evt);
-        }}
-        headerPanel={{
-          // eslint-disable-next-line react/prop-types
-          content: React.forwardRef(({ isExpanded }, ref) => (
-            <SuiteHeaderAppSwitcher
-              ref={ref}
-              applications={applications}
-              customApplications={customApplications}
-              allApplicationsLink={routes?.navigator}
-              noAccessLink={routes?.gettingStarted || 'javascript:void(0)'}
-              onRouteChange={onRouteChange}
-              i18n={{
-                myApplications: mergedI18N.switcherMyApplications,
-                allApplicationsLink: mergedI18N.switcherNavigatorLink,
-                requestAccess: mergedI18N.switcherRequestAccess,
-                learnMoreLink: mergedI18N.switcherLearnMoreLink,
+      <HeaderContainer
+        render={({ isSideNavExpanded, onClickSideNavExpand }) => (
+          <>
+            <Header
+              testId={testId}
+              className={classnames(`${settings.iotPrefix}--suite-header`, className)}
+              url={navigatorRoute}
+              hasSideNav={hasSideNav || sideNavProps !== null}
+              onClickSideNavExpand={(evt) => {
+                onSideNavToggled(evt);
+                onClickSideNavExpand(evt);
               }}
-              testId={`${testId}-app-switcher`}
-              isExpanded={isExpanded}
-            />
-          )),
-        }}
-        appName={suiteName}
-        subtitle={
-          extraContent ? (
-            <div>
-              {appName}
-              <span className={`${settings.iotPrefix}--suite-header-subtitle`}>{extraContent}</span>
-            </div>
-          ) : (
-            appName
-          )
-        }
-        actionItems={[
-          ...customActionItems,
-          {
-            id: 'admin',
-            label: mergedI18N.administrationIcon,
-            className: [
-              'admin-icon',
-              !routes?.admin ? 'admin-icon__hidden' : null,
-              isAdminView ? 'admin-icon__selected' : null,
-            ]
-              .filter((i) => i)
-              .join(' '),
-            btnContent: (
-              <span id="suite-header-action-item-admin">
-                <Settings20
-                  fill="white"
-                  data-testid="admin-icon"
-                  description={mergedI18N.settingsIcon}
-                />
-              </span>
-            ),
-            onClick: async (e) => {
-              e.preventDefault();
-              let href = adminRoute;
-              let routeType = SUITE_HEADER_ROUTE_TYPES.ADMIN;
-              if (isAdminView) {
-                href = navigatorRoute;
-                routeType = SUITE_HEADER_ROUTE_TYPES.NAVIGATOR;
+              headerPanel={{
+                // eslint-disable-next-line react/prop-types
+                content: React.forwardRef(({ isExpanded }, ref) => (
+                  <SuiteHeaderAppSwitcher
+                    ref={ref}
+                    applications={applications}
+                    customApplications={customApplications}
+                    allApplicationsLink={routes?.navigator}
+                    noAccessLink={routes?.gettingStarted || 'javascript:void(0)'}
+                    onRouteChange={onRouteChange}
+                    i18n={{
+                      myApplications: mergedI18N.switcherMyApplications,
+                      allApplicationsLink: mergedI18N.switcherNavigatorLink,
+                      requestAccess: mergedI18N.switcherRequestAccess,
+                      learnMoreLink: mergedI18N.switcherLearnMoreLink,
+                    }}
+                    testId={`${testId}-app-switcher`}
+                    isExpanded={isExpanded}
+                  />
+                )),
+              }}
+              appName={suiteName}
+              subtitle={
+                extraContent ? (
+                  <div>
+                    {appName}
+                    <span className={`${settings.iotPrefix}--suite-header-subtitle`}>
+                      {extraContent}
+                    </span>
+                  </div>
+                ) : (
+                  appName
+                )
               }
-              handleOnClick(routeType, href)(e);
-            },
-            href: isAdminView ? navigatorRoute : adminRoute,
-          },
-          {
-            id: 'help',
-            label: mergedI18N.help,
-            onClick: () => {},
-            btnContent: (
-              <span id="suite-header-action-item-help">
-                <Help20 fill="white" description={mergedI18N.help} />
-              </span>
-            ),
-            childContent: routes
-              ? [
-                  ...mergedCustomHelpLinks,
-                  ...[
-                    'whatsNew',
-                    'gettingStarted',
-                    'documentation',
-                    'requestEnhancement',
-                    'support',
-                  ].map((item) => ({
-                    metaData: {
-                      element: 'a',
-                      'data-testid': `suite-header-help--${item}`,
-                      href: routes[item],
-                      rel: 'noopener noreferrer',
-                      title: mergedI18N[item],
-                      onClick: handleOnClick(
-                        SUITE_HEADER_ROUTE_TYPES.DOCUMENTATION,
-                        routes[item],
-                        true
+              actionItems={[
+                ...customActionItems,
+                {
+                  id: 'admin',
+                  label: mergedI18N.administrationIcon,
+                  className: [
+                    'admin-icon',
+                    !routes?.admin ? 'admin-icon__hidden' : null,
+                    isAdminView ? 'admin-icon__selected' : null,
+                  ]
+                    .filter((i) => i)
+                    .join(' '),
+                  btnContent: (
+                    <span id="suite-header-action-item-admin">
+                      <Settings20
+                        fill="white"
+                        data-testid="admin-icon"
+                        description={mergedI18N.settingsIcon}
+                      />
+                    </span>
+                  ),
+                  onClick: async (e) => {
+                    e.preventDefault();
+                    let href = adminRoute;
+                    let routeType = SUITE_HEADER_ROUTE_TYPES.ADMIN;
+                    if (isAdminView) {
+                      href = navigatorRoute;
+                      routeType = SUITE_HEADER_ROUTE_TYPES.NAVIGATOR;
+                    }
+                    handleOnClick(routeType, href)(e);
+                  },
+                  href: isAdminView ? navigatorRoute : adminRoute,
+                },
+                {
+                  id: 'help',
+                  label: mergedI18N.help,
+                  onClick: () => {},
+                  btnContent: (
+                    <span id="suite-header-action-item-help">
+                      <Help20 fill="white" description={mergedI18N.help} />
+                    </span>
+                  ),
+                  childContent: routes
+                    ? [
+                        ...mergedCustomHelpLinks,
+                        ...[
+                          'whatsNew',
+                          'gettingStarted',
+                          'documentation',
+                          'requestEnhancement',
+                          'support',
+                        ].map((item) => ({
+                          metaData: {
+                            element: 'a',
+                            'data-testid': `suite-header-help--${item}`,
+                            href: routes[item],
+                            rel: 'noopener noreferrer',
+                            title: mergedI18N[item],
+                            onClick: handleOnClick(
+                              SUITE_HEADER_ROUTE_TYPES.DOCUMENTATION,
+                              routes[item],
+                              true
+                            ),
+                          },
+                          content: (
+                            <span id={`suite-header-help-menu-${item}`}>{mergedI18N[item]}</span>
+                          ),
+                        })),
+                        {
+                          metaData: {
+                            element: 'a',
+                            'data-testid': 'suite-header-help--about',
+                            href: routes.about,
+                            rel: 'noopener noreferrer',
+                            title: mergedI18N.about,
+                            onClick: handleOnClick(SUITE_HEADER_ROUTE_TYPES.ABOUT, routes.about),
+                          },
+                          content: (
+                            <span id="suite-header-help-menu-about">{mergedI18N.about}</span>
+                          ),
+                        },
+                      ]
+                    : [
+                        {
+                          metaData: {
+                            element: 'div',
+                          },
+                          content: (
+                            <div
+                              className={`${settings.iotPrefix}--suite-header-help--loading`}
+                              data-testid="suite-header-help--loading"
+                            >
+                              <SkeletonText paragraph lineCount={6} />
+                            </div>
+                          ),
+                        },
+                      ],
+                },
+                {
+                  id: 'user',
+                  label: 'user',
+                  btnContent: (
+                    <span id="suite-header-action-item-profile">
+                      <UserAvatar20
+                        data-testid="user-icon"
+                        fill="white"
+                        description={mergedI18N.userIcon}
+                      />
+                    </span>
+                  ),
+                  childContent: [
+                    {
+                      metaData: {
+                        element: 'div',
+                      },
+                      content: (
+                        <span id="suite-header-profile-menu-profile" style={{ width: '100%' }}>
+                          <SuiteHeaderProfile
+                            displayName={userDisplayName}
+                            username={username}
+                            profileLink={routes?.profile}
+                            onProfileClick={handleOnClick(
+                              SUITE_HEADER_ROUTE_TYPES.PROFILE,
+                              routes?.profile
+                            )}
+                            i18n={{
+                              profileTitle: mergedI18N.profileTitle,
+                              profileButton: mergedI18N.profileManageButton,
+                            }}
+                            testId={`${testId}-profile`}
+                          />
+                        </span>
                       ),
                     },
-                    content: <span id={`suite-header-help-menu-${item}`}>{mergedI18N[item]}</span>,
-                  })),
-                  {
-                    metaData: {
-                      element: 'a',
-                      'data-testid': 'suite-header-help--about',
-                      href: routes.about,
-                      rel: 'noopener noreferrer',
-                      title: mergedI18N.about,
-                      onClick: handleOnClick(SUITE_HEADER_ROUTE_TYPES.ABOUT, routes.about),
-                    },
-                    content: <span id="suite-header-help-menu-about">{mergedI18N.about}</span>,
-                  },
-                ]
-              : [
-                  {
-                    metaData: {
-                      element: 'div',
-                    },
-                    content: (
-                      <div
-                        className={`${settings.iotPrefix}--suite-header-help--loading`}
-                        data-testid="suite-header-help--loading"
-                      >
-                        <SkeletonText paragraph lineCount={6} />
-                      </div>
-                    ),
-                  },
-                ],
-          },
-          {
-            id: 'user',
-            label: 'user',
-            btnContent: (
-              <span id="suite-header-action-item-profile">
-                <UserAvatar20
-                  data-testid="user-icon"
-                  fill="white"
-                  description={mergedI18N.userIcon}
-                />
-              </span>
-            ),
-            childContent: [
-              {
-                metaData: {
-                  element: 'div',
+                    ...customProfileLinks,
+                    username
+                      ? {
+                          metaData: {
+                            className: `${settings.iotPrefix}--suite-header--logout`,
+                            element: 'a',
+                            'data-testid': 'suite-header-profile--logout',
+                            href: 'javascript:void(0)',
+                            title: mergedI18N.logout,
+                            onClick: () => setShowLogoutModal(true),
+                          },
+                          content: (
+                            <span id="suite-header-profile-menu-logout">{mergedI18N.logout}</span>
+                          ),
+                        }
+                      : {
+                          metaData: {
+                            element: 'div',
+                          },
+                          content: (
+                            <div
+                              className={`${settings.iotPrefix}--suite-header--logout--loading`}
+                              data-testid="suite-header--logout--loading"
+                            >
+                              <ButtonSkeleton />
+                            </div>
+                          ),
+                        },
+                  ],
                 },
-                content: (
-                  <span id="suite-header-profile-menu-profile" style={{ width: '100%' }}>
-                    <SuiteHeaderProfile
-                      displayName={userDisplayName}
-                      username={username}
-                      profileLink={routes?.profile}
-                      onProfileClick={handleOnClick(
-                        SUITE_HEADER_ROUTE_TYPES.PROFILE,
-                        routes?.profile
-                      )}
-                      i18n={{
-                        profileTitle: mergedI18N.profileTitle,
-                        profileButton: mergedI18N.profileManageButton,
-                      }}
-                      testId={`${testId}-profile`}
-                    />
-                  </span>
-                ),
-              },
-              ...customProfileLinks,
-              username
-                ? {
-                    metaData: {
-                      className: `${settings.iotPrefix}--suite-header--logout`,
-                      element: 'a',
-                      'data-testid': 'suite-header-profile--logout',
-                      href: 'javascript:void(0)',
-                      title: mergedI18N.logout,
-                      onClick: () => setShowLogoutModal(true),
-                    },
-                    content: <span id="suite-header-profile-menu-logout">{mergedI18N.logout}</span>,
-                  }
-                : {
-                    metaData: {
-                      element: 'div',
-                    },
-                    content: (
-                      <div
-                        className={`${settings.iotPrefix}--suite-header--logout--loading`}
-                        data-testid="suite-header--logout--loading"
-                      >
-                        <ButtonSkeleton />
-                      </div>
-                    ),
-                  },
-            ],
-          },
-        ].filter((i) => i)}
-        {...otherHeaderProps}
+              ].filter((i) => i)}
+              {...otherHeaderProps}
+            />
+            {sideNavProps ? (
+              <SideNav
+                {...sideNavProps}
+                isSideNavExpanded={isSideNavExpanded}
+                testId={`${testId}-side-nav`}
+              />
+            ) : null}
+          </>
+        )}
       />
-      {sideNavProps ? (
-        <SideNav
-          {...sideNavProps}
-          isSideNavExpanded={isSideNavExpandedState}
-          testId={`${testId}-side-nav`}
-        />
-      ) : null}
     </>
   );
 };

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.story.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.story.jsx
@@ -1,12 +1,10 @@
 /* eslint-disable no-script-url */
 /* eslint-disable no-alert */
 
-import React from 'react';
+import React, { createElement, useEffect, useState } from 'react';
 import { text, object, boolean, select } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
-import { ScreenOff16, Switcher24 } from '@carbon/icons-react';
-import Chip from '@carbon/icons-react/es/chip/24';
-import Dashboard from '@carbon/icons-react/es/dashboard/24';
+import { ScreenOff16, Switcher24, Home24 } from '@carbon/icons-react';
 import Group from '@carbon/icons-react/es/group/24';
 import NotificationOn from '@carbon/icons-react/es/notification/24';
 import Bee from '@carbon/icons-react/es/bee/24';
@@ -21,89 +19,6 @@ import SuiteHeaderI18N from './i18n';
 import SuiteHeaderREADME from './SuiteHeader.mdx';
 
 const { prefix } = settings;
-
-const sideNavLinks = [
-  {
-    icon: Switcher24,
-    isEnabled: true,
-    metaData: {
-      tabIndex: 0,
-      label: 'Boards',
-      element: ({ children, ...rest }) => <div {...rest}>{children}</div>,
-      // isActive: true,
-    },
-    linkContent: 'Boards',
-    childContent: [
-      {
-        metaData: {
-          label: 'Yet another link',
-          title: 'Yet another link',
-          element: 'button',
-        },
-        content: 'Yet another link',
-      },
-    ],
-  },
-  {
-    isEnabled: true,
-    icon: Chip,
-    metaData: {
-      label: 'Devices',
-      href: 'https://google.com',
-      element: 'a',
-      target: '_blank',
-    },
-    linkContent: 'Devices',
-  },
-  {
-    isEnabled: true,
-    icon: Dashboard,
-    metaData: {
-      label: 'Dashboards',
-      href: 'https://google.com',
-      element: 'a',
-      target: '_blank',
-    },
-    linkContent: 'Dashboards',
-    childContent: [
-      {
-        metaData: {
-          label: 'Link 1',
-          title: 'Link 1',
-          element: 'button',
-        },
-        content: 'Link 1',
-      },
-      {
-        metaData: {
-          label: 'Link 2',
-          title: 'Link 2',
-        },
-        content: 'Link 2',
-      },
-    ],
-  },
-  {
-    isEnabled: true,
-    icon: Group,
-    metaData: {
-      label: 'Members',
-      element: 'button',
-    },
-    linkContent: 'Members',
-    childContent: [
-      {
-        metaData: {
-          label: 'Yet another link',
-          title: 'Yet another link',
-          element: 'button',
-        },
-        content: 'Link 3',
-        isActive: true,
-      },
-    ],
-  },
-];
 
 const customActionItems = [
   {
@@ -437,43 +352,143 @@ export const HeaderWithExtraContent = () => {
 
 HeaderWithExtraContent.storyName = 'Header with extra content';
 
-export const HeaderWithSideNav = () => (
-  <SuiteHeader
-    suiteName="Application Suite"
-    appName="Application Name"
-    userDisplayName="Admin User"
-    username="adminuser"
-    routes={{
-      profile: 'https://www.ibm.com',
-      navigator: 'https://www.ibm.com',
-      admin: 'https://www.ibm.com',
-      logout: 'https://www.ibm.com',
-      whatsNew: 'https://www.ibm.com',
-      gettingStarted: 'https://www.ibm.com',
-      documentation: 'https://www.ibm.com',
-      requestEnhancement: 'https://www.ibm.com',
-      support: 'https://www.ibm.com',
-      about: 'https://www.ibm.com',
-    }}
-    applications={[
-      {
-        id: 'monitor',
-        name: 'Monitor',
-        href: 'https://www.ibm.com',
-      },
-      {
-        id: 'health',
-        name: 'Health',
-        href: 'https://www.ibm.com',
-        isExternal: true,
-      },
-    ]}
-    sideNavProps={{
-      links: sideNavLinks,
-    }}
-  />
-);
+export const HeaderWithSideNav = () => {
+  const [linksState, setLinksState] = useState([]);
+  const onSideNavMenuItemClick = (linkLabel) => {
+    setLinksState((currentLinks) =>
+      currentLinks.map((group) => {
+        if (group.childContent) {
+          return {
+            ...group,
+            childContent: group.childContent.map((child) => ({
+              ...child,
+              isActive: linkLabel === child.metaData.label,
+            })),
+          };
+        }
 
+        return { ...group, isActive: linkLabel === group.metaData.label };
+      })
+    );
+  };
+
+  useEffect(() => {
+    setLinksState([
+      {
+        icon: Home24,
+        isEnabled: true,
+        isPinned: true,
+        metaData: {
+          onClick: () => onSideNavMenuItemClick('Home'),
+          tabIndex: 0,
+          label: 'Home',
+        },
+        linkContent: 'Home',
+      },
+      {
+        isEnabled: true,
+        icon: Switcher24,
+        metaData: {
+          label: 'Dashboards',
+          element: 'button',
+        },
+        linkContent: 'Dashboards',
+        childContent: [
+          {
+            metaData: {
+              label: 'Link 1',
+              title: 'Link 1',
+              onClick: () => onSideNavMenuItemClick('Link 1'),
+              element: 'button',
+            },
+            content: 'Link 1',
+          },
+          {
+            metaData: {
+              label: 'Link 2',
+              title: 'Link 2',
+              onClick: () => onSideNavMenuItemClick('Link 2'),
+            },
+            content: 'Link 2',
+          },
+        ],
+      },
+      {
+        isEnabled: true,
+        icon: Group,
+        metaData: {
+          label: 'Members',
+          element: 'button',
+        },
+        linkContent: 'Members',
+        childContent: [
+          {
+            metaData: {
+              label: 'Link 3',
+              title: 'Link 3',
+              onClick: () => onSideNavMenuItemClick('Link 3'),
+              element: 'button',
+            },
+            content: 'Link 3',
+            isActive: true,
+          },
+          {
+            metaData: {
+              label: 'Link 4',
+              title: 'Link 4',
+              onClick: () => onSideNavMenuItemClick('Link 4'),
+              element: 'button',
+            },
+            content: 'Link 4',
+            isActive: false,
+          },
+        ],
+      },
+    ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <>
+      <SuiteHeader
+        suiteName="Application Suite"
+        appName="Application Name"
+        userDisplayName="Admin User"
+        username="adminuser"
+        routes={{
+          profile: 'https://www.ibm.com',
+          navigator: 'https://www.ibm.com',
+          admin: 'https://www.ibm.com',
+          logout: 'https://www.ibm.com',
+          whatsNew: 'https://www.ibm.com',
+          gettingStarted: 'https://www.ibm.com',
+          documentation: 'https://www.ibm.com',
+          requestEnhancement: 'https://www.ibm.com',
+          support: 'https://www.ibm.com',
+          about: 'https://www.ibm.com',
+        }}
+        applications={[
+          {
+            id: 'monitor',
+            name: 'Monitor',
+            href: 'https://www.ibm.com',
+          },
+          {
+            id: 'health',
+            name: 'Health',
+            href: 'https://www.ibm.com',
+            isExternal: true,
+          },
+        ]}
+        sideNavProps={{
+          links: linksState,
+        }}
+      />
+    </>
+  );
+};
+
+HeaderWithSideNav.decorators = [createElement];
 HeaderWithSideNav.storyName = 'Header with side nav';
 
 export const HeaderWithCustomSideNav = () => (

--- a/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
@@ -3954,88 +3954,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
       className="bx--side-nav__items"
     >
       <li
-        className="bx--side-nav__item bx--side-nav__item--icon iot--side-nav__item--depth-0"
-        onKeyDown={[Function]}
-      >
-        <button
-          aria-expanded={false}
-          className="bx--side-nav__submenu"
-          onClick={[Function]}
-          type="button"
-        >
-          <div
-            className="bx--side-nav__icon"
-          >
-            <svg
-              aria-hidden={true}
-              fill="currentColor"
-              focusable="false"
-              height={24}
-              preserveAspectRatio="xMidYMid meet"
-              viewBox="0 0 32 32"
-              width={24}
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M14 4H18V8H14zM4 4H8V8H4zM24 4H28V8H24zM14 14H18V18H14zM4 14H8V18H4zM24 14H28V18H24zM14 24H18V28H14zM4 24H8V28H4zM24 24H28V28H24z"
-              />
-            </svg>
-          </div>
-          <span
-            className="bx--side-nav__submenu-title"
-          >
-            Boards
-          </span>
-          <div
-            className="bx--side-nav__icon bx--side-nav__icon--small bx--side-nav__submenu-chevron"
-          >
-            <svg
-              aria-hidden={true}
-              fill="currentColor"
-              focusable="false"
-              height={20}
-              preserveAspectRatio="xMidYMid meet"
-              viewBox="0 0 32 32"
-              width={20}
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M16 22L6 12 7.4 10.6 16 19.2 24.6 10.6 26 12z"
-              />
-            </svg>
-          </div>
-        </button>
-        <ul
-          className="bx--side-nav__menu"
-        >
-          <li
-            className="bx--side-nav__menu-item"
-          >
-            <button
-              className="bx--side-nav__link"
-              data-testid="suite-header-side-nav-menu-item-0"
-              label="Yet another link"
-              title="Yet another link"
-            >
-              <span
-                className="bx--side-nav__link-text"
-              >
-                Yet another link
-              </span>
-            </button>
-          </li>
-        </ul>
-      </li>
-      <li
         className="bx--side-nav__item"
       >
         <a
-          aria-label="Devices"
+          aria-label="Home"
           className="bx--side-nav__link"
-          data-testid="suite-header-side-nav-link-1"
-          href="https://google.com"
-          label="Devices"
-          target="_blank"
+          data-testid="suite-header-side-nav-link-0"
+          label="Home"
+          onClick={[Function]}
+          tabIndex={0}
         >
           <div
             className="bx--side-nav__icon bx--side-nav__icon--small"
@@ -4051,17 +3978,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M11,11V21H21V11Zm8,8H13V13h6Z"
-              />
-              <path
-                d="M30,13V11H26V8a2,2,0,0,0-2-2H21V2H19V6H13V2H11V6H8A2,2,0,0,0,6,8v3H2v2H6v6H2v2H6v3a2,2,0,0,0,2,2h3v4h2V26h6v4h2V26h3a2,2,0,0,0,2-2V21h4V19H26V13ZM24,24H8V8H24Z"
+                d="M16.6123,2.2138a1.01,1.01,0,0,0-1.2427,0L1,13.4194l1.2427,1.5717L4,13.6209V26a2.0041,2.0041,0,0,0,2,2H26a2.0037,2.0037,0,0,0,2-2V13.63L29.7573,15,31,13.4282ZM18,26H14V18h4Zm2,0V18a2.0023,2.0023,0,0,0-2-2H14a2.002,2.002,0,0,0-2,2v8H6V12.0615l10-7.79,10,7.8005V26Z"
               />
             </svg>
           </div>
           <span
             className="bx--side-nav__link-text"
           >
-            Devices
+            Home
           </span>
         </a>
       </li>
@@ -4089,10 +4013,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M24 21H26V26H24zM20 16H22V26H20zM11 26a5.0059 5.0059 0 01-5-5H8a3 3 0 103-3V16a5 5 0 010 10z"
-              />
-              <path
-                d="M28,2H4A2.002,2.002,0,0,0,2,4V28a2.0023,2.0023,0,0,0,2,2H28a2.0027,2.0027,0,0,0,2-2V4A2.0023,2.0023,0,0,0,28,2Zm0,9H14V4H28ZM12,4v7H4V4ZM4,28V13H28.0007l.0013,15Z"
+                d="M14 4H18V8H14zM4 4H8V8H4zM24 4H28V8H24zM14 14H18V18H14zM4 14H8V18H4zM24 14H28V18H24zM14 24H18V28H14zM4 24H8V28H4zM24 24H28V28H24z"
               />
             </svg>
           </div>
@@ -4128,8 +4049,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           >
             <button
               className="bx--side-nav__link"
-              data-testid="suite-header-side-nav-menu-item-2"
+              data-testid="suite-header-side-nav-menu-item-1"
               label="Link 1"
+              onClick={[Function]}
               title="Link 1"
             >
               <span
@@ -4144,8 +4066,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           >
             <a
               className="bx--side-nav__link"
-              data-testid="suite-header-side-nav-menu-item-2"
+              data-testid="suite-header-side-nav-menu-item-1"
               label="Link 2"
+              onClick={[Function]}
               title="Link 2"
             >
               <span
@@ -4217,14 +4140,32 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           >
             <button
               className="bx--side-nav__link bx--side-nav__link--current"
-              data-testid="suite-header-side-nav-menu-item-3"
-              label="Yet another link"
-              title="Yet another link"
+              data-testid="suite-header-side-nav-menu-item-2"
+              label="Link 3"
+              onClick={[Function]}
+              title="Link 3"
             >
               <span
                 className="bx--side-nav__link-text"
               >
                 Link 3
+              </span>
+            </button>
+          </li>
+          <li
+            className="bx--side-nav__menu-item"
+          >
+            <button
+              className="bx--side-nav__link"
+              data-testid="suite-header-side-nav-menu-item-2"
+              label="Link 4"
+              onClick={[Function]}
+              title="Link 4"
+            >
+              <span
+                className="bx--side-nav__link-text"
+              >
+                Link 4
               </span>
             </button>
           </li>

--- a/packages/react/src/components/Table/TableSaveViewModal/__snapshots__/TableSaveViewModal.story.storyshot
+++ b/packages/react/src/components/Table/TableSaveViewModal/__snapshots__/TableSaveViewModal.story.storyshot
@@ -333,7 +333,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               onAnimationEnd={[Function]}
             >
               <button
-                aria-controls="accordion-item-1373"
+                aria-controls="accordion-item-1379"
                 aria-expanded={false}
                 className="bx--accordion__heading"
                 onClick={[Function]}
@@ -364,7 +364,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               </button>
               <div
                 className="bx--accordion__content"
-                id="accordion-item-1373"
+                id="accordion-item-1379"
               >
                 <p>
                   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -376,7 +376,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               onAnimationEnd={[Function]}
             >
               <button
-                aria-controls="accordion-item-1374"
+                aria-controls="accordion-item-1380"
                 aria-expanded={false}
                 className="bx--accordion__heading"
                 onClick={[Function]}
@@ -407,7 +407,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               </button>
               <div
                 className="bx--accordion__content"
-                id="accordion-item-1374"
+                id="accordion-item-1380"
               >
                 <p>
                   Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/packages/react/src/components/TileGallery/__snapshots__/TileGallery.story.storyshot
+++ b/packages/react/src/components/TileGallery/__snapshots__/TileGallery.story.storyshot
@@ -201,7 +201,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   onAnimationEnd={[Function]}
                 >
                   <button
-                    aria-controls="accordion-item-1490"
+                    aria-controls="accordion-item-1496"
                     aria-expanded={true}
                     className="bx--accordion__heading"
                     onClick={[Function]}
@@ -232,7 +232,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   </button>
                   <div
                     className="bx--accordion__content"
-                    id="accordion-item-1490"
+                    id="accordion-item-1496"
                   >
                     <div
                       className="tile-gallery--section--items"
@@ -624,7 +624,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   onAnimationEnd={[Function]}
                 >
                   <button
-                    aria-controls="accordion-item-1491"
+                    aria-controls="accordion-item-1497"
                     aria-expanded={true}
                     className="bx--accordion__heading"
                     onClick={[Function]}
@@ -655,7 +655,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   </button>
                   <div
                     className="bx--accordion__content"
-                    id="accordion-item-1491"
+                    id="accordion-item-1497"
                   >
                     <div
                       className="tile-gallery--section--items"
@@ -1494,7 +1494,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   onAnimationEnd={[Function]}
                 >
                   <button
-                    aria-controls="accordion-item-1497"
+                    aria-controls="accordion-item-1503"
                     aria-expanded={true}
                     className="bx--accordion__heading"
                     onClick={[Function]}
@@ -1525,7 +1525,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   </button>
                   <div
                     className="bx--accordion__content"
-                    id="accordion-item-1497"
+                    id="accordion-item-1503"
                   >
                     <div
                       className="tile-gallery--section--items"
@@ -1694,7 +1694,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
             onAnimationEnd={[Function]}
           >
             <button
-              aria-controls="accordion-item-1494"
+              aria-controls="accordion-item-1500"
               aria-expanded={true}
               className="bx--accordion__heading"
               onClick={[Function]}
@@ -1725,7 +1725,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
             </button>
             <div
               className="bx--accordion__content"
-              id="accordion-item-1494"
+              id="accordion-item-1500"
             >
               <div
                 className="tile-gallery--section--items"
@@ -2142,7 +2142,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
             onAnimationEnd={[Function]}
           >
             <button
-              aria-controls="accordion-item-1495"
+              aria-controls="accordion-item-1501"
               aria-expanded={true}
               className="bx--accordion__heading"
               onClick={[Function]}
@@ -2173,7 +2173,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
             </button>
             <div
               className="bx--accordion__content"
-              id="accordion-item-1495"
+              id="accordion-item-1501"
             >
               <div
                 className="tile-gallery--section--items"
@@ -2429,7 +2429,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               onAnimationEnd={[Function]}
             >
               <button
-                aria-controls="accordion-item-1492"
+                aria-controls="accordion-item-1498"
                 aria-expanded={true}
                 className="bx--accordion__heading"
                 onClick={[Function]}
@@ -2460,7 +2460,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </button>
               <div
                 className="bx--accordion__content"
-                id="accordion-item-1492"
+                id="accordion-item-1498"
               >
                 <div
                   className="tile-gallery--section--items"
@@ -2877,7 +2877,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               onAnimationEnd={[Function]}
             >
               <button
-                aria-controls="accordion-item-1493"
+                aria-controls="accordion-item-1499"
                 aria-expanded={true}
                 className="bx--accordion__heading"
                 onClick={[Function]}
@@ -2908,7 +2908,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </button>
               <div
                 className="bx--accordion__content"
-                id="accordion-item-1493"
+                id="accordion-item-1499"
               >
                 <div
                   className="tile-gallery--section--items"

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -10805,6 +10805,9 @@ Map {
                             "isRequired": true,
                             "type": "oneOfType",
                           },
+                          "isActive": Object {
+                            "type": "bool",
+                          },
                           "metaData": Object {
                             "args": Array [
                               Object {
@@ -10832,9 +10835,6 @@ Map {
                   ],
                   "type": "arrayOf",
                 },
-                "current": Object {
-                  "type": "bool",
-                },
                 "icon": Object {
                   "args": Array [
                     Array [
@@ -10848,6 +10848,9 @@ Map {
                   ],
                   "isRequired": true,
                   "type": "oneOfType",
+                },
+                "isActive": Object {
+                  "type": "bool",
                 },
                 "isEnabled": Object {
                   "type": "bool",
@@ -11500,6 +11503,9 @@ Map {
                                   "isRequired": true,
                                   "type": "oneOfType",
                                 },
+                                "isActive": Object {
+                                  "type": "bool",
+                                },
                                 "metaData": Object {
                                   "args": Array [
                                     Object {
@@ -11527,9 +11533,6 @@ Map {
                         ],
                         "type": "arrayOf",
                       },
-                      "current": Object {
-                        "type": "bool",
-                      },
                       "icon": Object {
                         "args": Array [
                           Array [
@@ -11543,6 +11546,9 @@ Map {
                         ],
                         "isRequired": true,
                         "type": "oneOfType",
+                      },
+                      "isActive": Object {
+                        "type": "bool",
                       },
                       "isEnabled": Object {
                         "type": "bool",


### PR DESCRIPTION
Closes #3433

**Summary**

Side nav props were not updating the sidenav for SuiteHeader. 

**Change List (commits, features, bugs, etc)**

- wrapped `Header` and `SideNav` component with Carbon's `HeaderContainer` component. Replaced the state management for SideNav open state with the ones provided by HeaderContainer component in `SuiteHeader.jsx`
- made the 'Header with side nav' story stateful to demonstrate the sidenav `isActive` state change in `SuiteHeader.story.jsx`
- updated the prop type, `current` which was not being used to `isActive` in `SideNav.jsx`

**Acceptance Test (how to verify the PR)**

- Go to 'Header with side nav' story and confirm that `isActive` state is updating appropriately. 

**Regression Test (how to make sure this PR doesn't break old functionality)**

- All of stories should still work the same and all test should still pass. 

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
