### PR TITLE
style(simplepagination): fixed misaligned pagination footer

### DIFF
--- a/packages/react/src/components/List/_list.scss
+++ b/packages/react/src/components/List/_list.scss
@@ -38,6 +38,7 @@
 
         .#{$iot-prefix}-simple-pagination-page-label {
           flex-grow: 2;
+          text-align: right;
         }
       }
     }

--- a/packages/react/src/components/SimplePagination/_simple-pagination.scss
+++ b/packages/react/src/components/SimplePagination/_simple-pagination.scss
@@ -19,6 +19,7 @@
   padding-left: $spacing-05;
   font-size: 0.875rem;
   align-self: center;
+  white-space: nowrap;
 }
 
 .#{$iot-prefix}-addons-simple-pagination-button {


### PR DESCRIPTION
Closes #
- Related to https://github.ibm.com/wiotp/Maximo-Asset-Monitor/issues/3653 section 2

**Summary**

- footer of simple pagination is misaligned https://media.github.ibm.com/user/627/files/2caa0700-7eba-11ec-8f90-73ddb205f4b7

**Change List (commits, features, bugs, etc)**

- style(simplepagination): fixed misaligned pagination footer

**Acceptance Test (how to verify the PR)**

- Page Items should come in one line with Page No. on right side

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
