### PR TITLE
3421 proptype warning

### DIFF
--- a/packages/react/src/components/Dashboard/Dashboard.test.jsx
+++ b/packages/react/src/components/Dashboard/Dashboard.test.jsx
@@ -148,12 +148,6 @@ let wrapper = mount(
   />
 );
 describe('Dashboard', () => {
-  it('should show an error for testID', () => {
-    expect(console.error).toHaveBeenCalledWith(
-      `Warning: The 'testID' prop has been deprecated. Please use 'testId' instead.`
-    );
-    console.error.mockReset();
-  });
   it('should be selectable with testId', () => {
     render(
       <Dashboard

--- a/packages/react/src/components/PieChartCard/PieChartCard.test.jsx
+++ b/packages/react/src/components/PieChartCard/PieChartCard.test.jsx
@@ -107,6 +107,9 @@ describe('PieChartCard', () => {
     rerender(<PieChartCard {...props} isExpanded testID="PIE_CHART_CARD" />);
     expect(screen.getByTestId('PIE_CHART_CARD')).toBeDefined();
     expect(screen.getByTestId('PIE_CHART_CARD-table')).toBeDefined();
+    expect(console.error).toHaveBeenCalledWith(
+      `Warning: The 'testID' prop has been deprecated. Please use 'testId' instead.`
+    );
   });
 
   it('shows loading skeleton for isLoading even for empty data  ', async () => {

--- a/packages/react/src/components/PieChartCard/PieChartCard.test.jsx
+++ b/packages/react/src/components/PieChartCard/PieChartCard.test.jsx
@@ -107,9 +107,6 @@ describe('PieChartCard', () => {
     rerender(<PieChartCard {...props} isExpanded testID="PIE_CHART_CARD" />);
     expect(screen.getByTestId('PIE_CHART_CARD')).toBeDefined();
     expect(screen.getByTestId('PIE_CHART_CARD-table')).toBeDefined();
-    expect(console.error).toHaveBeenCalledWith(
-      `Warning: The 'testID' prop has been deprecated. Please use 'testId' instead.`
-    );
   });
 
   it('shows loading skeleton for isLoading even for empty data  ', async () => {

--- a/packages/react/src/components/RuleBuilder/RuleBuilder.test.jsx
+++ b/packages/react/src/components/RuleBuilder/RuleBuilder.test.jsx
@@ -74,10 +74,7 @@ describe('The RuleBuilder', () => {
         ]}
       />
     );
-    expect(console.error).toHaveBeenCalledWith(
-      `Warning: The 'testID' prop has been deprecated. Please use 'testId' instead.`
-    );
-    console.error.mockReset();
+
     expect(screen.getByTestId('rule_builder')).toBeDefined();
     expect(screen.getByTestId('rule_builder-tabs')).toBeDefined();
     expect(screen.getByTestId('rule_builder-editor')).toBeDefined();

--- a/packages/react/src/components/Table/StatefulTable.test.jsx
+++ b/packages/react/src/components/Table/StatefulTable.test.jsx
@@ -35,10 +35,7 @@ describe('stateful table with real reducer', () => {
   it('should clear filters', async () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
     render(<StatefulTable {...initialState} actions={mockActions} />);
-    expect(console.error).toHaveBeenCalledWith(
-      `Warning: The 'testID' prop has been deprecated. Please use 'testId' instead.`
-    );
-    console.error.mockReset();
+
     const whiteboardFilter = await screen.findByDisplayValue('whiteboard');
     expect(whiteboardFilter).toBeInTheDocument();
     expect(screen.getByDisplayValue('option-B')).toBeInTheDocument();

--- a/packages/react/src/components/Table/StatefulTableMockReducers.test.jsx
+++ b/packages/react/src/components/Table/StatefulTableMockReducers.test.jsx
@@ -30,10 +30,7 @@ describe('StatefulTable tests with Mock reducer', () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
     const statefulTable = mount(<StatefulTable {...initialState} actions={mockActions} />);
-    expect(console.error).toHaveBeenCalledWith(
-      `Warning: The 'testID' prop has been deprecated. Please use 'testId' instead.`
-    );
-    console.error.mockReset();
+
     expect(statefulTable.find(Table)).toHaveLength(1);
   });
   it('check renders nested table passthrough props', () => {

--- a/packages/react/src/components/Table/Table.test.jsx
+++ b/packages/react/src/components/Table/Table.test.jsx
@@ -137,10 +137,7 @@ describe('Table', () => {
         testId="__table__"
       />
     );
-    expect(console.error).toHaveBeenCalledWith(
-      `Warning: The 'testID' prop has been deprecated. Please use 'testId' instead.`
-    );
-    console.error.mockReset();
+
     expect(screen.getByTestId('__table__')).toBeDefined();
     expect(screen.getByTestId('__table__-table-container')).toBeDefined();
     expect(screen.getByTestId('__table__-table-toolbar')).toBeDefined();

--- a/packages/react/src/components/Table/TableFoot/TableFoot.test.jsx
+++ b/packages/react/src/components/Table/TableFoot/TableFoot.test.jsx
@@ -162,9 +162,7 @@ describe('TableFoot', () => {
         }}
       />
     );
-    expect(console.error).toHaveBeenCalledWith(
-      `Warning: The 'testID' prop has been deprecated. Please use 'testId' instead.`
-    );
+
     console.error.mockReset();
     const newFirstAggregationCell = screen.getByTestId(
       `${tableTestId}-${tableFootTestId}-aggregation-${modifiedColumns[0].id}`

--- a/packages/react/src/components/Table/TableHead/TableHead.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.jsx
@@ -168,7 +168,6 @@ const defaultProps = {
     ...defaultI18NPropTypes,
   },
   hasFastFilter: true,
-  testID: '',
   testId: '',
   showExpanderColumn: false,
   size: undefined,

--- a/packages/react/src/constants/CardPropTypes.js
+++ b/packages/react/src/constants/CardPropTypes.js
@@ -416,7 +416,6 @@ export const PieCardPropTypes = {
     pieChart: OverridePropTypes,
     table: OverridePropTypes,
   }),
-  testID: PropTypes.string,
   /**
    * array of data objects from the backend for instance [{group: 'Group A', value: 50}, {group: 'Group B', value: 50}, ...]
    * The group property can be called anything since it can be mapped via the groupDataSourceId but there must at least

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -16534,9 +16534,7 @@ Map {
       "tabIndex": Object {
         "type": "number",
       },
-      "testID": Object {
-        "type": "string",
-      },
+      "testID": [Function],
       "testId": Object {
         "type": "string",
       },

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -2251,7 +2251,6 @@ Map {
       "selectAllText": "Select all",
       "showExpanderColumn": false,
       "size": undefined,
-      "testID": "",
       "testId": "",
     },
     "propTypes": Object {


### PR DESCRIPTION
Closes #3421

**Summary**

Default prop in `TableHead.jsx` is triggering our proptype warning we have for `testID` prop that is deprecated. 

**Change List (commits, features, bugs, etc)**

- Remove default prop for `testID` from `TableHead.jsx`;
- Remove assertions expecting that proptype warning in our test when not specifically passing in a `testID` prop.
- Updated the `PieChartCard` proptypes since it listed `testID` but did not have warning as part of proptype definition. Get's all of CardPropTypes which does have the prop and warning. 


**Acceptance Test (how to verify the PR)**

- make sure all test pass. 


**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
