### PR TITLE
feat(SuiteHeader): Including an optional workspaceId parameter to the uiresources fetch helper and hook

### DIFF
--- a/packages/react/src/components/SuiteHeader/SuiteHeader.mdx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.mdx
@@ -37,12 +37,15 @@ const SuiteHeaderWithDataFetchingExample = () => {
     idleTimeoutData: null,
   });
   useEffect(() => {
-    fetch('http://localhost:3001/internal/uiresources?id=masthead&lang=en&surveyId=test', {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    })
+    fetch(
+      'http://localhost:3001/internal/uiresources?id=masthead&lang=en&surveyId=test&workspaceId=workspace1',
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    )
       .then((res) => res.json())
       .then((resJson) => {
         if (resJson.error || resJson.exception) {
@@ -88,6 +91,7 @@ const SuiteHeaderWithDataFetchingUtilExample = () => {
       baseApiUrl: 'http://localhost:3001/internal',
       lang: 'en',
       surveyId: 'test',
+      workspaceId: 'workspace1',
     }).then(setData);
   }, []);
 
@@ -117,6 +121,7 @@ const SuiteHeaderWithDataFetchingHookExample = () => {
     baseApiUrl: 'http://localhost:3001/internal',
     lang: 'en',
     surveyId: 'test',
+    workspaceId: 'workspace1',
   });
 
   return (

--- a/packages/react/src/components/SuiteHeader/hooks/useUiResources.js
+++ b/packages/react/src/components/SuiteHeader/hooks/useUiResources.js
@@ -7,6 +7,7 @@ const useUiResources = ({
   baseApiUrl,
   lang = 'en',
   surveyId = null,
+  workspaceId = null,
   fetchApi = defaultFetchApi,
   isTest = false,
 }) => {
@@ -29,6 +30,7 @@ const useUiResources = ({
         baseApiUrl,
         lang,
         surveyId,
+        workspaceId,
         fetchApi,
         isTest,
       });
@@ -38,7 +40,7 @@ const useUiResources = ({
     } finally {
       setIsLoading(false);
     }
-  }, [baseApiUrl, lang, surveyId, isTest, setIsLoading]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [baseApiUrl, lang, surveyId, workspaceId, isTest, setIsLoading]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     // load actual data

--- a/packages/react/src/components/SuiteHeader/util/uiresources.js
+++ b/packages/react/src/components/SuiteHeader/util/uiresources.js
@@ -24,6 +24,7 @@ const getUiResourcesData = async ({
   baseApiUrl,
   lang = 'en',
   surveyId = null,
+  workspaceId = null,
   fetchApi = defaultFetchApi,
   isTest = false,
 }) => {
@@ -38,7 +39,8 @@ const getUiResourcesData = async ({
 
   const langParam = `&lang=${lang}`;
   const surveyIdParam = surveyId ? `&surveyId=${surveyId}` : '';
-  return api('GET', `/uiresources?id=masthead${langParam}${surveyIdParam}`);
+  const workspaceIdParam = workspaceId ? `&workspaceId=${workspaceId}` : '';
+  return api('GET', `/uiresources?id=masthead${langParam}${surveyIdParam}${workspaceIdParam}`);
 };
 
 export default getUiResourcesData;


### PR DESCRIPTION
**Summary**

- Since the `GET /uiresources` API has changed to add support an optional `workspaceId` query parameter, the `uiresources` fetch helper function and the `useUiResources` hook need to forward the new `workspaceId` query parameter to the API call.

**Change List (commits, features, bugs, etc)**

- Including an optional `workspaceId` query parameter in the `uiresources` fetch helper and in the `useUiResources` hook.

**Acceptance Test (how to verify the PR)**

- Nothing was changed in any component so there is nothing to test in the storybook for this PR

**Regression Test (how to make sure this PR doesn't break old functionality)**

- The files changed in this PR are excluded from unit test list and coverage calculation.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
