### PR TITLE
fix(DataSeriesFormItemModal): larger form modal

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
@@ -665,7 +665,7 @@ const DataSeriesFormItemModal = ({
                   ? mergedI18n.dataItemEditorValueCardTitle
                   : mergedI18n.dataItemEditorDataSeriesTitle,
             }}
-            size="xs"
+            size="md"
             isLarge={isLarge}
             footer={{
               primaryButtonLabel: mergedI18n.primaryButtonLabelText,

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.test.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.test.jsx
@@ -967,7 +967,7 @@ describe('DataSeriesFormItemModal', () => {
     expect(modalTitle).toBeInTheDocument();
   });
 
-  it('Renders the DataSeriesEditorTable as size xs by default', () => {
+  it('Renders the DataSeriesEditorTable as size md by default', () => {
     render(
       <DataSeriesFormItemModal
         {...commonProps}
@@ -978,10 +978,10 @@ describe('DataSeriesFormItemModal', () => {
       />
     );
 
-    const xsContainer = screen
+    const mdContainer = screen
       .getByText('Customize data series')
-      .closest(`.${prefix}--modal-container--xs`);
-    expect(xsContainer).toBeInTheDocument();
+      .closest(`.${prefix}--modal-container--md`);
+    expect(mdContainer).toBeInTheDocument();
 
     const largeContainer = screen
       .queryByText('Customize data series')

--- a/packages/react/src/components/CardEditor/CardEditForm/_card-edit-form.scss
+++ b/packages/react/src/components/CardEditor/CardEditForm/_card-edit-form.scss
@@ -174,7 +174,7 @@
       width: 50%;
     }
     &--item-end {
-      width: 50%;
+      width: 100%;
 
       .#{$prefix}--number input[type='number'] {
         padding-right: 0;
@@ -191,7 +191,6 @@
     &--item-dropdown {
       margin-right: $spacing-05;
       max-width: 6rem;
-      min-width: 15%;
 
       [dir='rtl'] & {
         margin-right: 0;

--- a/packages/react/src/components/CardEditor/CardEditForm/_card-edit-form.scss
+++ b/packages/react/src/components/CardEditor/CardEditForm/_card-edit-form.scss
@@ -174,7 +174,7 @@
       width: 50%;
     }
     &--item-end {
-      width: 100%;
+      width: 50%;
 
       .#{$prefix}--number input[type='number'] {
         padding-right: 0;
@@ -191,6 +191,7 @@
     &--item-dropdown {
       margin-right: $spacing-05;
       max-width: 6rem;
+      min-width: 15%;
 
       [dir='rtl'] & {
         margin-right: 0;


### PR DESCRIPTION
Closes #3468

**Summary**

- Increased modal size from xs -> md
- Modified test case for the md modal size

**Acceptance Test (how to verify the PR)**

 - Go to any dashboard -> Edit dashboard: eg. https://dashboard-dev.connectedproducts.internetofthings.ibmcloud.com/monitor/Compresser/editSummary/227605/2
 - Add a 'Data Table' card
- Select a 'Data item'
- Edit newly added data item
- In the 'Customize data series' modal, click 'Add threshold'
- Enter a value in the number input
- Modal size is larger (md), with no overlap in the number input between the value and +- symbols

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
