### PR TITLE
fix(DataSeriesFormItemModal):downsample methods for timeseries card

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
@@ -589,7 +589,8 @@ const DataSeriesFormItemModal = ({
         )}
         {editDataItem?.type !== 'DIMENSION' &&
           editDataItem?.type !== 'TIMESTAMP' &&
-          editDataItem?.hasStreamingMetricEnabled && (
+          editDataItem?.hasStreamingMetricEnabled &&
+          type === CARD_TYPES.TIMESERIES && ( // Downsample methods are only alowed on Timeseries card.
             <div className={`${baseClassName}--input-group`}>
               {!initialDownSample || !isSummaryDashboard ? ( // selector should only be use-able in an instance dash or if there is no initial aggregation
                 <div className={`${baseClassName}--input-group--item-half`}>

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.test.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.test.jsx
@@ -1325,49 +1325,14 @@ describe('DataSeriesFormItemModal', () => {
     expect(screen.queryByLabelText('DownSample Method')).not.toBeInTheDocument();
     expect(screen.getByText('Aggregation method')).toBeVisible();
   });
-  it('Version is V2 for timebased stacked bar should show Downsample method and hide grain and aggregation methods', () => {
-    const stackedTimeBasedBar = {
-      title: 'Untitled',
-      size: 'MEDIUM',
-      type: 'BAR',
-      content: {
-        type: 'STACKED',
-        layout: 'VERTICAL',
-        series: [
-          {
-            dataItemId: 'torque',
-            dataSourceId: 'torque_565ba583-dc00-4ee2-a480-5ed7d3e47ab1',
-            label: 'Torque',
-            downSampleMethod: 'mean',
-            color: '#6929c4',
-          },
-        ],
-        timeDataSourceId: 'timestamp',
-      },
-      dataSource: {},
-    };
-    const downSampleBarChartDataItem = {
-      label: 'Temperature Max',
-      dataSourceId: 'torque_565ba583-dc00-4ee2-a480-5ed7d3e47ab1',
-      color: 'red',
-      hasStreamingMetricEnabled: true,
-      downSampleMethods: [
-        { id: 'none', text: 'None' },
-        { id: 'last', text: 'Last' },
-        { id: 'mean', text: 'Mean' },
-        { id: 'max', text: 'Max' },
-        { id: 'min', text: 'Min' },
-      ],
-      downSampleMethod: 'max',
-    };
-
+  it('Version is V2 for timeseries card should show Downsample method and hide grain and aggregation methods', () => {
     render(
       <DataSeriesFormItemModal
         {...commonProps}
         showEditor
         isSummaryDashboard
-        cardConfig={stackedTimeBasedBar}
-        editDataItem={downSampleBarChartDataItem}
+        cardConfig={timeSeriesCardConfig}
+        editDataItem={editTimeseriesDataItemDownSample}
       />
     );
     expect(screen.queryByLabelText('Aggregation Method')).not.toBeInTheDocument();


### PR DESCRIPTION
Closes #3471 

**Summary**
Fix for downsample method dropdown. Downsample methods dropdown should only show on Timeseries card.

**Change List (commits, features, bugs, etc)**

- DataSeriesFormItemModal
- DataSeriesFormItemModal.test


**Acceptance Test (how to verify the PR)**

- Go to 'Monitor'
-Click on 'any V2 data item'
-Edit dashboard 'Add any card other then a Timeseries card'
-Add a Data item
-Edit the Data Item
-If card is not a Timeseries card downsample method dropdown should not show.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests 
- Go to Storybook
- CardEditor
- Select V2 pressure
- Confirm can see Downsample methods dropdown when you edit dataItem
- Now Select 'for Timeseries ' edit data item an confirm you can see Aggregation method dropdown

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
