### PR TITLE
fix(HotspotEditorDatasourceTab) edit existing image hotspot bug

### DIFF
--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/HotspotEditorDataSourceTab.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/HotspotEditorDataSourceTab.jsx
@@ -158,7 +158,7 @@ const HotspotEditorDataSourceTab = ({
   const handleEditButton = useCallback(
     async (dataItem) => {
       const dataItemWithMetaData = dataItems?.find(
-        ({ dataItemId }) => dataItemId === dataItem.dataItemId
+        ({ dataItemId }) => dataItemId === dataItem.dataSourceId
       );
       // Call back function for on click of edit button
       if (onEditDataItem) {


### PR DESCRIPTION
Closes #3479 

**Summary**

- Fix for edit dataItem on existing Image card with aggregated hotspots. 

**Change List (commits, features, bugs, etc)**

- HotspotEditorDatasourceTab 
- Changed dataItemId to dataSourceId

**Acceptance Test (how to verify the PR)**

- Go to 'Monitor' (MonitorDev3 tenant)
-Click on 'Devices' tab, select 'Compressor' device type
-Click on 'Herle Compresser Hourly', click on the settings icon within tab and select 'Edit dashboard'
-Scroll down to 'Robot image' card, select it, click 'Edit image'
-Within modal, select 'Hotspots', select a hotspot and click on 'Data source'
-Make sure a data item is added and click the pencil icon / edit button.
- Edit dataItem Modal opens


**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests
- Confirm card editor still works for image card 
- 

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
