### PR TITLE
[CardEditor]: remove children from json stringify

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditor.jsx
+++ b/packages/react/src/components/CardEditor/CardEditor.jsx
@@ -257,7 +257,7 @@ export const hideCardPropertiesForEditor = (card) => {
       : columns // TABLE CARD
       ? { ...card, content: { ...card.content, columns } }
       : card,
-    ['content.src', 'content.imgState', 'i18n', 'validateUploadedImage']
+    ['content.src', 'content.imgState', 'i18n', 'validateUploadedImage', 'children']
   );
 };
 


### PR DESCRIPTION
Closes #3484 

**Summary**

When opening up the JSON editor in the `DashboardEditor` component we were passing react children to the `JSON.stringify` function which was making it error. This fix excludes those children from the cardConfig object we pass to this function. 

**Change List (commits, features, bugs, etc)**

- add "children" to the omit list in `CardEditor.jsx`

**Acceptance Test (how to verify the PR)**

1. Go to dashboard [story](
https://deploy-preview-1824--carbon-addons-iot-react.netlify.app/?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-dashboardeditor--with-initial-value)
2. Click on image in the right sidebar gallery
3. Go to new card and upload an image
4. Click on open JSON editor on the right sidebar
5. See JSON editor open up with no errors thrown




