### PR TITLE
fix(BarChartCard): add conditions for timestamp formatter

### DIFF
--- a/packages/react/src/components/BarChartCard/BarChartCard.jsx
+++ b/packages/react/src/components/BarChartCard/BarChartCard.jsx
@@ -292,7 +292,7 @@ const BarChartCard = ({
             timeDataSourceId,
           mapsTo: axes.bottomAxesMapsTo,
           ...(domainRange && layout === BAR_CHART_LAYOUTS.VERTICAL ? { domain: domainRange } : {}),
-          ...(layout === BAR_CHART_LAYOUTS.HORIZONTAL && !isNil(decimalPrecision)
+          ...(layout === BAR_CHART_LAYOUTS.HORIZONTAL
             ? {
                 ticks: {
                   formatter: (axisValue) =>

--- a/packages/react/src/components/BarChartCard/BarChartCard.jsx
+++ b/packages/react/src/components/BarChartCard/BarChartCard.jsx
@@ -292,19 +292,21 @@ const BarChartCard = ({
             timeDataSourceId,
           mapsTo: axes.bottomAxesMapsTo,
           ...(domainRange && layout === BAR_CHART_LAYOUTS.VERTICAL ? { domain: domainRange } : {}),
-          ...(layout === BAR_CHART_LAYOUTS.HORIZONTAL
+          ...(layout === BAR_CHART_LAYOUTS.HORIZONTAL && !isNil(decimalPrecision)
             ? {
                 ticks: {
                   formatter: (axisValue) =>
                     chartValueFormatter(axisValue, size, null, locale, decimalPrecision),
                 },
               }
-            : {
+            : scaleType === 'time' && axes.bottomAxesMapsTo === 'date'
+            ? {
                 ticks: {
                   number: maxTicksPerSize,
                   formatter: formatTick,
                 },
-              }),
+              }
+            : {}),
         },
         left: {
           title: `${yLabel || ''} ${


### PR DESCRIPTION
Closes #3457 

**Summary**

- only use timestamp formatter when `scaleType` is `time` and `bottomAxesMapsTo` is `date`

**Change List (commits, features, bugs, etc)**

- added checks for `scaleType` and `bottomAxesMapsTo`

**Acceptance Test (how to verify the PR)**

- Go BarChartCard story and change `content.layout` to `Horizontal`. Check the x-axis show value correctly 
- 
![image](https://user-images.githubusercontent.com/24279794/175968726-c046aaa8-fcab-4d3c-80a0-ae00166d8b50.png)
![image](https://user-images.githubusercontent.com/24279794/175968812-932901fd-cc30-4633-b1ca-3e4b90e0ab3c.png)


<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
