### PR TITLE
fix(table): add extra header cell for single select using radio button

### DIFF
--- a/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
+++ b/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
@@ -71,6 +71,7 @@ class FilterHeaderRow extends Component {
       hasRowExpansion: PropTypes.bool,
       hasRowNesting: PropTypes.bool,
       hasRowActions: PropTypes.bool,
+      useRadioButtonSingleSelect: PropTypes.bool,
     }),
     /** filter can be hidden by the user but filters will still apply to the table */
     isVisible: PropTypes.bool,
@@ -246,7 +247,13 @@ class FilterHeaderRow extends Component {
       ordering,
       clearFilterText,
       filterText,
-      tableOptions: { hasRowSelection, hasRowExpansion, hasRowNesting, hasRowActions },
+      tableOptions: {
+        hasRowSelection,
+        hasRowExpansion,
+        hasRowNesting,
+        hasRowActions,
+        useRadioButtonSingleSelect,
+      },
       isVisible,
       lightweight,
       isDisabled,
@@ -263,7 +270,8 @@ class FilterHeaderRow extends Component {
           '--filter-header-dropdown-max-height': dropdownMaxHeight,
         }}
       >
-        {hasRowSelection === 'multi' ? (
+        {hasRowSelection === 'multi' ||
+        (hasRowSelection === 'single' && useRadioButtonSingleSelect) ? (
           <TableHeader className={`${iotPrefix}--filter-header-row--header`} ref={this.rowRef} />
         ) : null}
         {hasRowExpansion || hasRowNesting ? (


### PR DESCRIPTION
Closes #3498 

**Summary**

- added extra cell in FilterHeaderRow for single select when using radio button

**Change List (commits, features, bugs, etc)**

- fix(FilterHeaderRow): added extra conditions for single select when using radio button

**Acceptance Test (how to verify the PR)**

Filters should be aligned

![image](https://user-images.githubusercontent.com/24279794/180070955-0c3669c7-bd63-4589-8c27-89efb4099f77.png)


**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
