### PR TITLE
feat(commoncardeditformfield): hide time range on empty values

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormContent.test.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormContent.test.jsx
@@ -34,6 +34,7 @@ const cardConfig = {
 
 const mockOnChange = jest.fn();
 const mockGetValidTimeRanges = jest.fn(() => ['last2Hours']);
+const mockGetValidTimeRangesWithEmptyArray = jest.fn(() => []);
 
 afterEach(() => {
   jest.clearAllMocks();
@@ -65,6 +66,17 @@ describe('CardEditFormContent', () => {
       );
       const timeRangeSelector = screen.getAllByLabelText('Time range');
       expect(timeRangeSelector[0].innerHTML).toEqual(expect.stringContaining('last2Hours'));
+    });
+    it('Should hide the timerange selector', () => {
+      render(
+        <CardEditFormContent
+          cardConfig={{ ...cardConfig }}
+          onChange={mockOnChange}
+          getValidTimeRanges={mockGetValidTimeRangesWithEmptyArray}
+        />
+      );
+      const timeRangeSelector = screen.queryByLabelText('Time range');
+      expect(timeRangeSelector).not.toBeInTheDocument();
     });
   });
   describe('handleTranslationCallback', () => {

--- a/packages/react/src/components/CardEditor/CardEditForm/CommonCardEditFormFields.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CommonCardEditFormFields.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { isEmpty } from 'lodash-es';
 
 import {
   CARD_SIZES,
@@ -207,34 +208,36 @@ const CommonCardEditFormFields = ({
           titleText={mergedI18n.size}
         />
       </div>
-      <div className={`${baseClassName}--input`}>
-        <Dropdown
-          key={`card_${id}`}
-          id={`${id}_time_range`}
-          label={mergedI18n.selectATimeRange}
-          title={mergedI18n.selectATimeRange}
-          direction="bottom"
-          itemToString={(item) => item.text}
-          items={validTimeRangeOptions}
-          selectedItem={validTimeRangeOptions.find(
-            // This is a hacky workaround for a carbon issue
-            (validTimeRangeOption) => validTimeRangeOption.id === cardConfig.timeRange
-          )}
-          light
-          translateWithId={translateWithId}
-          onChange={({ selectedItem }) => {
-            const timeRangeInterval = selectedItem.id;
-            const { range } = timeRangeToJSON[timeRangeInterval];
-            setSelectedTimeRange(timeRangeInterval);
-            onChange({
-              ...cardConfig,
-              timeRange: timeRangeInterval,
-              dataSource: { ...cardConfig.dataSource, range },
-            });
-          }}
-          titleText={mergedI18n.timeRange}
-        />
-      </div>
+      {isEmpty(validTimeRangeOptions) ? null : (
+        <div className={`${baseClassName}--input`}>
+          <Dropdown
+            key={`card_${id}`}
+            id={`${id}_time_range`}
+            label={mergedI18n.selectATimeRange}
+            title={mergedI18n.selectATimeRange}
+            direction="bottom"
+            itemToString={(item) => item.text}
+            items={validTimeRangeOptions}
+            selectedItem={validTimeRangeOptions.find(
+              // This is a hacky workaround for a carbon issue
+              (validTimeRangeOption) => validTimeRangeOption.id === cardConfig.timeRange
+            )}
+            light
+            translateWithId={translateWithId}
+            onChange={({ selectedItem }) => {
+              const timeRangeInterval = selectedItem.id;
+              const { range } = timeRangeToJSON[timeRangeInterval];
+              setSelectedTimeRange(timeRangeInterval);
+              onChange({
+                ...cardConfig,
+                timeRange: timeRangeInterval,
+                dataSource: { ...cardConfig.dataSource, range },
+              });
+            }}
+            titleText={mergedI18n.timeRange}
+          />
+        </div>
+      )}
     </>
   );
 };


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-addons-iot-react/issues/3519

Related to https://github.ibm.com/wiotp/Maximo-Asset-Monitor/issues/4474.

**Summary**

- hide time range selector

**Change List (commits, features, bugs, etc)**

- feat(CommonCardEditFormFields): hide time range selector if there is no value. 

**Acceptance Test (how to verify the PR)**

- time range selector should be hidden if we don't send or send an empty array

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Dashboard should work without any issues. 

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
