### PR TITLE
fix(suiteheader): Appending originHref to the logout and logoutInactivity routes

### DIFF
--- a/packages/react/src/components/SuiteHeader/MultiWorkspaceSuiteHeader.story.jsx
+++ b/packages/react/src/components/SuiteHeader/MultiWorkspaceSuiteHeader.story.jsx
@@ -28,6 +28,7 @@ const routes = {
   navigator: 'https://www.ibm.com',
   admin: 'https://www.ibm.com',
   logout: 'https://www.ibm.com',
+  logoutInactivity: 'https://www.ibm.com',
   whatsNew: 'https://www.ibm.com',
   gettingStarted: 'https://www.ibm.com',
   documentation: 'https://www.ibm.com',

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
@@ -189,6 +189,17 @@ const SuiteHeader = ({
 
   const navigatorRoute = currentWorkspace?.href || routes?.navigator || 'javascript:void(0)';
   const adminRoute = routes?.admin || 'javascript:void(0)';
+  // Append originHref query parameter to the logout routes
+  const logoutRoute = window.location.href
+    ? `${routes?.logout}${routes?.logout?.includes('?') ? '&' : '?'}originHref=${encodeURIComponent(
+        window.location.href
+      )}`
+    : routes?.logout;
+  const logoutInactivityRoute = window.location.href
+    ? `${routes?.logoutInactivity}${
+        routes?.logoutInactivity?.includes('?') ? '&' : '?'
+      }originHref=${encodeURIComponent(window.location.href)}`
+    : routes?.logoutInactivity;
 
   // If there are custom help links, include an extra child content entry for the separator
   const mergedCustomHelpLinks =
@@ -267,7 +278,7 @@ const SuiteHeader = ({
       {idleTimeoutData ? (
         <IdleLogoutConfirmationModal
           idleTimeoutData={idleTimeoutData}
-          routes={routes}
+          routes={{ ...routes, logout: logoutRoute, logoutInactivity: logoutInactivityRoute }}
           onRouteChange={onRouteChange}
           onStayLoggedIn={onStayLoggedIn}
           i18n={i18n}
@@ -276,7 +287,7 @@ const SuiteHeader = ({
       <SuiteHeaderLogoutModal
         isOpen={showLogoutModal}
         onClose={() => setShowLogoutModal(false)}
-        onLogout={handleOnClick(SUITE_HEADER_ROUTE_TYPES.LOGOUT, routes?.logout)}
+        onLogout={handleOnClick(SUITE_HEADER_ROUTE_TYPES.LOGOUT, logoutRoute)}
         i18n={{
           heading: mergedI18N.profileLogoutModalHeading,
           primaryButton: mergedI18N.profileLogoutModalPrimaryButton,

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.story.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.story.jsx
@@ -28,6 +28,7 @@ const routes = {
   navigator: 'https://www.ibm.com',
   admin: 'https://www.ibm.com',
   logout: 'https://www.ibm.com',
+  logoutInactivity: 'https://www.ibm.com',
   whatsNew: 'https://www.ibm.com',
   gettingStarted: 'https://www.ibm.com',
   documentation: 'https://www.ibm.com',


### PR DESCRIPTION
Closes #

**Summary**

- Appending originHref to the logout and logoutInactivity routes so that it is possible for the logout route handler page to extract an origin URL in order to allow for redirection to that page when user reattempts to log in.

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- No noticeable effect in stories
- Check that page redirections by regular logout and idle user logout now include the `originHref` query parameter with the url of the current page.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- All tests are passing.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
