### PR TITLE
fix(suiteheader): Making sure that IdleLogoutConfirmationModal also appends the the originHref to the logout routes when used standalone

### DIFF
--- a/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.jsx
+++ b/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.jsx
@@ -82,6 +82,29 @@ const IdleLogoutConfirmationModal = ({
     []
   );
 
+  // Append originHref query parameter to the logout routes
+  let logoutRoute = routes?.logout;
+  try {
+    const url = new URL(routes.logout);
+    if (window.location.href) {
+      url.searchParams.append('originHref', window.location.href);
+      logoutRoute = url.href;
+    }
+  } catch (e) {
+    logoutRoute = routes?.logout;
+  }
+
+  let logoutInactivityRoute = routes?.logoutInactivity;
+  try {
+    const url = new URL(routes.logoutInactivity);
+    if (window.location.href) {
+      url.searchParams.append('originHref', window.location.href);
+      logoutInactivityRoute = url.href;
+    }
+  } catch (e) {
+    logoutInactivityRoute = routes?.logoutInactivity;
+  }
+
   // This state is just to force the recreation of the IdleTimer object in the useEffect below
   const [restartIdleTimer, setRestartIdleTimer] = useState(false);
   // Countdown state. If countdown is greater than zero, logout confirmation dialog is going to be displayed
@@ -102,16 +125,16 @@ const IdleLogoutConfirmationModal = ({
         onIdleTimeout: async () => {
           const result = await onRouteChange(
             SUITE_HEADER_ROUTE_TYPES.LOGOUT,
-            routes.logoutInactivity
+            logoutInactivityRoute
           );
           if (result) {
-            window.location.href = routes.logoutInactivity;
+            window.location.href = logoutInactivityRoute;
           }
         },
         onCookieCleared: async () => {
-          const result = await onRouteChange(SUITE_HEADER_ROUTE_TYPES.LOGOUT, routes.logout);
+          const result = await onRouteChange(SUITE_HEADER_ROUTE_TYPES.LOGOUT, logoutRoute);
           if (result) {
-            window.location.href = routes.logout;
+            window.location.href = logoutRoute;
           }
         },
         onRestart: () => {
@@ -124,7 +147,15 @@ const IdleLogoutConfirmationModal = ({
         timer.cleanUp();
       };
     }
-  }, [restartIdleTimer, idleTimeoutData, routes, onRouteChange, onStayLoggedIn]);
+  }, [
+    restartIdleTimer,
+    idleTimeoutData,
+    routes,
+    logoutInactivityRoute,
+    logoutRoute,
+    onRouteChange,
+    onStayLoggedIn,
+  ]);
 
   return (
     <Modal
@@ -140,9 +171,9 @@ const IdleLogoutConfirmationModal = ({
       onSecondarySubmit={async () => {
         // Disable the "Stay Logged in" button after the "Log out" button is clicked
         setStayLoggedInButtonDisabled(true);
-        const result = await onRouteChange(SUITE_HEADER_ROUTE_TYPES.LOGOUT, routes?.logout);
+        const result = await onRouteChange(SUITE_HEADER_ROUTE_TYPES.LOGOUT, logoutRoute);
         if (result) {
-          window.location.href = routes?.logout;
+          window.location.href = logoutRoute;
         }
       }}
       onRequestSubmit={() => {

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
@@ -189,17 +189,17 @@ const SuiteHeader = ({
 
   const navigatorRoute = currentWorkspace?.href || routes?.navigator || 'javascript:void(0)';
   const adminRoute = routes?.admin || 'javascript:void(0)';
-  // Append originHref query parameter to the logout routes
-  const logoutRoute = window.location.href
-    ? `${routes?.logout}${routes?.logout?.includes('?') ? '&' : '?'}originHref=${encodeURIComponent(
-        window.location.href
-      )}`
-    : routes?.logout;
-  const logoutInactivityRoute = window.location.href
-    ? `${routes?.logoutInactivity}${
-        routes?.logoutInactivity?.includes('?') ? '&' : '?'
-      }originHref=${encodeURIComponent(window.location.href)}`
-    : routes?.logoutInactivity;
+  // Append originHref query parameter to the logout route
+  let logoutRoute = routes?.logout;
+  try {
+    const url = new URL(routes.logout);
+    if (window.location.href) {
+      url.searchParams.append('originHref', window.location.href);
+      logoutRoute = url.href;
+    }
+  } catch (e) {
+    logoutRoute = routes?.logout;
+  }
 
   // If there are custom help links, include an extra child content entry for the separator
   const mergedCustomHelpLinks =
@@ -278,7 +278,7 @@ const SuiteHeader = ({
       {idleTimeoutData ? (
         <IdleLogoutConfirmationModal
           idleTimeoutData={idleTimeoutData}
-          routes={{ ...routes, logout: logoutRoute, logoutInactivity: logoutInactivityRoute }}
+          routes={routes}
           onRouteChange={onRouteChange}
           onStayLoggedIn={onStayLoggedIn}
           i18n={i18n}

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
@@ -54,6 +54,13 @@ const idleTimeoutDataProp = {
 };
 
 describe('SuiteHeader', () => {
+  const originHref = 'https://ibm.com';
+  const expectedLogoutRoute = `${commonProps.routes.logout}?originHref=${encodeURIComponent(
+    originHref
+  )}`;
+  const expectedLogoutInactivityRoute = `${
+    commonProps.routes.logoutInactivity
+  }?originHref=${encodeURIComponent(originHref)}`;
   let originalWindowLocation;
   let originalWindowDocumentCookie;
   beforeEach(() => {
@@ -61,7 +68,7 @@ describe('SuiteHeader', () => {
     originalWindowLocation = { ...window.location };
     originalWindowDocumentCookie = window.document.cookie;
     delete window.location;
-    window.location = { href: '' };
+    window.location = { href: originHref };
     window.open = jest.fn();
   });
 
@@ -152,12 +159,18 @@ describe('SuiteHeader', () => {
   it('clicks logout link', async () => {
     render(<SuiteHeader {...commonProps} />);
     await userEvent.click(screen.getAllByRole('button', { name: 'Log out' })[0]);
+    expect(window.location.href).toBe(expectedLogoutRoute);
+  });
+  it('clicks logout link (no originHref)', async () => {
+    window.location = { href: '' };
+    render(<SuiteHeader {...commonProps} />);
+    await userEvent.click(screen.getAllByRole('button', { name: 'Log out' })[0]);
     expect(window.location.href).toBe(commonProps.routes.logout);
   });
   it('clicks logout link (but no redirect)', async () => {
     render(<SuiteHeader {...commonProps} onRouteChange={async () => false} />);
     await userEvent.click(screen.getAllByRole('button', { name: 'Log out' })[0]);
-    expect(window.location.href).not.toBe(commonProps.routes.logout);
+    expect(window.location.href).not.toBe(expectedLogoutRoute);
   });
   it('admin link from admin view takes you to navigator route', async () => {
     render(<SuiteHeader {...commonProps} isAdminView />);
@@ -370,6 +383,23 @@ describe('SuiteHeader', () => {
       SuiteHeaderI18N.en.sessionTimeoutModalLogoutButton
     );
     await userEvent.click(modalLogoutButton);
+    expect(window.location.href).toBe(expectedLogoutRoute);
+  });
+  it('user clicks Log Out on the idle logout confirmation dialog (no originHref)', async () => {
+    window.location = { href: '' };
+    render(<SuiteHeader {...commonProps} idleTimeoutData={idleTimeoutDataProp} />);
+    // Simulate a timestamp cookie that is in the past
+    Object.defineProperty(window.document, 'cookie', {
+      writable: true,
+      value: `${idleTimeoutDataProp.cookieName}=${Date.now() - 1000}`,
+    });
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    const modalLogoutButton = within(screen.getByTestId('idle-logout-confirmation')).getByText(
+      SuiteHeaderI18N.en.sessionTimeoutModalLogoutButton
+    );
+    await userEvent.click(modalLogoutButton);
     expect(window.location.href).toBe(commonProps.routes.logout);
   });
   it('user clicks Log Out on the idle logout confirmation dialog (but no redirect)', async () => {
@@ -392,9 +422,24 @@ describe('SuiteHeader', () => {
       SuiteHeaderI18N.en.sessionTimeoutModalLogoutButton
     );
     await userEvent.click(modalLogoutButton);
-    expect(window.location.href).not.toBe(commonProps.routes.logout);
+    expect(window.location.href).not.toBe(expectedLogoutRoute);
   });
   it('idle user waits for the logout confirmation dialog countdown to finish', async () => {
+    render(<SuiteHeader {...commonProps} idleTimeoutData={idleTimeoutDataProp} />);
+    // Simulate a timestamp cookie that is in the past
+    Object.defineProperty(window.document, 'cookie', {
+      writable: true,
+      value: `${idleTimeoutDataProp.cookieName}=${Date.now() - 1000}`,
+    });
+    // Go to the future by a little more than idleTimeoutDataProp.countdown seconds
+    MockDate.set(Date.now() + (idleTimeoutDataProp.countdown + 1) * 1000);
+    await act(async () => {
+      await jest.runOnlyPendingTimers();
+    });
+    await waitFor(() => expect(window.location.href).toBe(expectedLogoutInactivityRoute));
+  });
+  it('idle user waits for the logout confirmation dialog countdown to finish (no originHref)', async () => {
+    window.location = { href: '' };
     render(<SuiteHeader {...commonProps} idleTimeoutData={idleTimeoutDataProp} />);
     // Simulate a timestamp cookie that is in the past
     Object.defineProperty(window.document, 'cookie', {
@@ -426,7 +471,7 @@ describe('SuiteHeader', () => {
     await act(async () => {
       await jest.runOnlyPendingTimers();
     });
-    await waitFor(() => expect(window.location.href).not.toBe(commonProps.routes.logoutInactivity));
+    await waitFor(() => expect(window.location.href).not.toBe(expectedLogoutInactivityRoute));
   });
   it('renders Walkme', async () => {
     render(<SuiteHeader {...commonProps} walkmePath="/some/test/path" walkmeLang="en" />);


### PR DESCRIPTION
**Summary**

- Making sure that `IdleLogoutConfirmationModal` also appends the the originHref to the logout routes when used standalone

**Change List (commits, features, bugs, etc)**

- Appending the `originHref` to the logout routes using `new URL()` instead of doing it manually.
- Making sure that `IdleLogoutConfirmationModal` also appends the the `originHref` to the logout routes when used standalone.
- Improving unit tests to validate the existence of the `originHref` query parameters in the logout routes.

**Acceptance Test (how to verify the PR)**

- Check that the standalone IdleLogoutConfirmationModal also appends the `originHref` in logout and inactivity logout routes.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- All existing tests are passing.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
