### PR TITLE
[StatefulTable]: fix filter handler on close button click

### DIFF
--- a/packages/react/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
+++ b/packages/react/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
@@ -977,6 +977,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                                   className="bx--list-box__selection"
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
+                                  onMouseDown={[Function]}
                                   role="button"
                                   tabIndex="0"
                                   title="Clear filter"
@@ -3179,6 +3180,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                                   className="bx--list-box__selection"
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
+                                  onMouseDown={[Function]}
                                   role="button"
                                   tabIndex="0"
                                   title="Clear filter"

--- a/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
+++ b/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
@@ -1542,6 +1542,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                             className="bx--list-box__selection"
                             onClick={[Function]}
                             onKeyDown={[Function]}
+                            onMouseDown={[Function]}
                             role="button"
                             tabIndex="0"
                             title="Clear filter"

--- a/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
+++ b/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
@@ -410,6 +410,7 @@ class FilterHeaderRow extends Component {
                       [`${iotPrefix}--clear-filters-button--disabled`]: isDisabled,
                     })}
                     tabIndex={isDisabled ? '-1' : '0'}
+                    onMouseDown={(event) => event.preventDefault()}
                     onClick={(event) => {
                       if (!isDisabled) {
                         this.handleClearFilter(event, column);

--- a/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.test.e2e.jsx
+++ b/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.test.e2e.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { mount } from '@cypress/react';
+
+import FilterHeaderRow from './FilterHeaderRow';
+
+const myProps = {
+  hasFastFilter: false,
+  onApplyFilter: () => null,
+  ordering: [{ columnId: 'col1' }],
+  columns: [{ id: 'col1', name: 'Column 1', tooltip: 'this is a tooltip' }],
+  showExpanderColumn: true,
+};
+
+describe('FilterHeaderRow', () => {
+  beforeEach(() => {
+    cy.viewport(1680, 900);
+  });
+
+  it('should call handler only once if close button is clicked', () => {
+    cy.spy(myProps, 'onApplyFilter');
+    mount(<FilterHeaderRow {...myProps} />);
+    cy.findByPlaceholderText('Type and hit enter to apply').type('mytext');
+    cy.findByRole('button')
+      .click()
+      .then(() => {
+        expect(myProps.onApplyFilter).to.be.calledOnce;
+      });
+  });
+});

--- a/packages/react/src/components/Table/__snapshots__/Table.main.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/Table.main.story.storyshot
@@ -28942,6 +28942,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                       className="bx--list-box__selection"
                       onClick={[Function]}
                       onKeyDown={[Function]}
+                      onMouseDown={[Function]}
                       role="button"
                       tabIndex="0"
                       title="Clear filter"

--- a/packages/react/src/components/Table/__snapshots__/TableUserViewManagement.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/TableUserViewManagement.story.storyshot
@@ -1461,6 +1461,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                         className="bx--list-box__selection"
                         onClick={[Function]}
                         onKeyDown={[Function]}
+                        onMouseDown={[Function]}
                         role="button"
                         tabIndex="0"
                         title="Clear filter"


### PR DESCRIPTION
Closes #3460 

**Summary**

- Fix calling filter handler if close button clicked

**Change List (commits, features, bugs, etc)**

- Prevent default behaviour for `onMouseDown` event
- Add e2e test
- Update storyshots

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
