### PR TITLE
[Table]: loop in overflow menu state update

### DIFF
--- a/packages/react/src/components/Table/Table.main.story.jsx
+++ b/packages/react/src/components/Table/Table.main.story.jsx
@@ -934,6 +934,16 @@ export const WithInlineActions = () => {
       getHiddenRowAction(),
       getHiddenOverflowRowAction(),
     ]),
+    null,
+    null,
+    null,
+    null,
+    null,
+    objectWithSubstitution('Row actions for row-9 (data[9].rowActions)', [
+      getOverflowEditRowAction(),
+      getOverflowAddRowAction(),
+      getOverflowDeleteRowAction(),
+    ]),
   ];
 
   const rowActionsState = object(

--- a/packages/react/src/components/Table/__snapshots__/Table.main.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/Table.main.story.storyshot
@@ -33278,7 +33278,53 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
                     className="iot--row-actions-container__background"
                     data-testid="row-action-container-background"
                     onClick={[Function]}
-                  />
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="More actions"
+                      className="iot--row-actions-cell--overflow-menu bx--overflow-menu bx--overflow-menu--md"
+                      data-testid="table-28-row-9-row-actions-cell-overflow"
+                      id="table-28-row-9-row-actions-cell-overflow"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      type="button"
+                    >
+                      <svg
+                        aria-label="More actions"
+                        className="bx--overflow-menu__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          More actions
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
                 </div>
               </td>
             </tr>

--- a/packages/react/src/hooks/usePopoverPositioning.jsx
+++ b/packages/react/src/hooks/usePopoverPositioning.jsx
@@ -206,7 +206,7 @@ export const usePopoverPositioning = ({
             tooltipElement.setAttribute('data-floating-menu-direction', 'left');
           } else if (isOverflowMenu) {
             setAdjustedFlipped(true);
-            setAdjustedDirection('bottom');
+            setAdjustedDirection((prevDirection) => (prevDirection === 'top' ? 'top' : 'bottom'));
             tooltipElement.setAttribute('data-floating-menu-direction', 'bottom');
           } else {
             setAdjustedDirection('left');
@@ -239,7 +239,7 @@ export const usePopoverPositioning = ({
             tooltipElement.setAttribute('data-floating-menu-direction', 'right');
           } else if (isOverflowMenu) {
             setAdjustedFlipped(false);
-            setAdjustedDirection('bottom');
+            setAdjustedDirection((prevDirection) => (prevDirection === 'top' ? 'top' : 'bottom'));
             tooltipElement.setAttribute('data-floating-menu-direction', 'bottom');
           } else {
             setAdjustedDirection('right');


### PR DESCRIPTION
Closes #3359 

**Summary**

- Fix loop in React state update for OverflowMenu when at bottom of the browser.

**Change List (commits, features, bugs, etc)**

- Update Storybook to reproduce issue
- Check for previous state before updating overflow direction.

**Acceptance Test (how to verify the PR)**

- Go to [this story](https://deploy-preview-3539--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table--with-inline-actions)
- Resize window vertically so that scrollbar appears.
- Scroll to the bottom of the table.
- Hover on the last row and click on "kebab" menu icon.
- Verify that overflow menu has appeared above the "kebab" menu icon.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
