### PR TITLE
feat(card): adding tooltip to the card extra actions

### DIFF
--- a/packages/react/src/components/Card/Card.story.jsx
+++ b/packages/react/src/components/Card/Card.story.jsx
@@ -137,10 +137,13 @@ export const WithEllipsedTitleTooltipExternalTooltip = () => {
   const singleExtraAction = {
     id: 'extrasingleaction',
     icon: Add16,
+    iconDescription: 'Add',
     callback: action('extra single action icon clicked.'),
   };
   const multiExtraAction = {
     id: 'extramultiaction',
+    icon: Tree16,
+    iconDescription: 'Settings',
     children: [
       {
         id: 'firstItem',

--- a/packages/react/src/components/Card/Card.test.jsx
+++ b/packages/react/src/components/Card/Card.test.jsx
@@ -618,16 +618,19 @@ describe('Card', () => {
     const singleExtraAction = {
       id: 'extrasingleaction',
       icon: Add16,
+      iconDescription: 'Add',
       callback: mockExtraSingle,
     };
     const singleExtraDisabledAction = {
       id: 'extrasingleaction',
       icon: Add16,
+      iconDescription: 'Add',
       disabled: true,
       callback: mockExtraSingle,
     };
     const multiExtraAction = {
       id: 'extramultiaction',
+      iconDescription: 'Settings',
       children: [
         {
           id: 'firstItem',
@@ -665,7 +668,7 @@ describe('Card', () => {
         }}
       />
     );
-    fireEvent.click(screen.getAllByTitle('Action Label')[0]);
+    fireEvent.click(screen.getAllByTitle('Add')[0]);
     expect(mockExtraSingle).toHaveBeenCalled();
     jest.resetAllMocks();
 
@@ -680,7 +683,7 @@ describe('Card', () => {
         }}
       />
     );
-    expect(screen.getAllByTitle('Action Label')[0]).toBeDisabled();
+    expect(screen.getAllByTitle('Add')[0]).toBeDisabled();
     expect(mockExtraSingle).not.toHaveBeenCalled();
     jest.resetAllMocks();
 
@@ -697,7 +700,7 @@ describe('Card', () => {
         }}
       />
     );
-    fireEvent.click(screen.getAllByTitle('Action Label')[0]);
+    fireEvent.click(screen.getAllByTitle('Add')[0]);
     expect(mockExtraSingle).toHaveBeenCalled();
     jest.resetAllMocks();
 
@@ -712,25 +715,25 @@ describe('Card', () => {
         }}
       />
     );
-    fireEvent.click(screen.getAllByTitle('Open and close list of options')[0]);
+    fireEvent.click(screen.getAllByTitle('Settings')[0]);
     const firstItem = await screen.findByText('Item1');
     fireEvent.click(firstItem);
     expect(mockExtraMultiple).toHaveBeenCalled();
 
     // Reopen menu
-    fireEvent.click(screen.getAllByTitle('Open and close list of options')[0]);
+    fireEvent.click(screen.getAllByTitle('Settings')[0]);
     mockExtraMultiple.mockClear();
     const secondItem = await screen.findByText('Item2');
     fireEvent.click(secondItem);
     expect(mockExtraMultiple).toHaveBeenCalled();
 
     // Reopen menu to verify disabled item
-    fireEvent.click(screen.getAllByTitle('Open and close list of options')[0]);
+    fireEvent.click(screen.getAllByTitle('Settings')[0]);
     const thirdItem = await screen.findByText('Item3');
     expect(thirdItem.closest('button')).toBeDisabled();
 
     // Reopen menu to verify hidden item
-    fireEvent.click(screen.getAllByTitle('Open and close list of options')[0]);
+    fireEvent.click(screen.getAllByTitle('Settings')[0]);
     expect(screen.queryByText('Item4')).not.toBeInTheDocument();
   });
 

--- a/packages/react/src/components/Card/Card.test.jsx
+++ b/packages/react/src/components/Card/Card.test.jsx
@@ -658,7 +658,23 @@ describe('Card', () => {
     };
 
     // Test single icon button action
+
+    // when there is no icon description use the global Action Label
     const { rerender } = render(
+      <Card
+        {...cardProps}
+        size={CARD_SIZES.LARGE}
+        extraActions={{ ...singleExtraAction, iconDescription: null }}
+        availableActions={{
+          extra: true,
+        }}
+      />
+    );
+    fireEvent.click(screen.getAllByTitle('Action Label')[0]);
+    expect(mockExtraSingle).toHaveBeenCalled();
+    jest.resetAllMocks();
+
+    render(
       <Card
         {...cardProps}
         size={CARD_SIZES.LARGE}
@@ -716,7 +732,7 @@ describe('Card', () => {
       />
     );
     fireEvent.click(screen.getAllByTitle('Settings')[0]);
-    const firstItem = await screen.findByText('Item1');
+    let firstItem = await screen.findByText('Item1');
     fireEvent.click(firstItem);
     expect(mockExtraMultiple).toHaveBeenCalled();
 
@@ -735,6 +751,24 @@ describe('Card', () => {
     // Reopen menu to verify hidden item
     fireEvent.click(screen.getAllByTitle('Settings')[0]);
     expect(screen.queryByText('Item4')).not.toBeInTheDocument();
+    jest.resetAllMocks();
+
+    // when there is no icon description use the global Action Label
+    rerender(
+      <Card
+        {...cardProps}
+        size={CARD_SIZES.LARGE}
+        extraActions={{ ...multiExtraAction, icon: Tree16, iconDescription: null }}
+        availableActions={{
+          extra: true,
+        }}
+      />
+    );
+    fireEvent.click(screen.getAllByTitle('Action Label')[0]);
+
+    firstItem = await screen.findByText('Item1');
+    fireEvent.click(firstItem);
+    expect(mockExtraMultiple).toHaveBeenCalled();
   });
 
   it('should not have padding when padding="none"', () => {

--- a/packages/react/src/components/Card/Card.test.jsx
+++ b/packages/react/src/components/Card/Card.test.jsx
@@ -764,7 +764,7 @@ describe('Card', () => {
         }}
       />
     );
-    fireEvent.click(screen.getAllByTitle('Action Label')[0]);
+    fireEvent.click(screen.getAllByTitle('Open and close list of options')[0]);
 
     firstItem = await screen.findByText('Item1');
     fireEvent.click(firstItem);

--- a/packages/react/src/components/Card/CardToolbar.jsx
+++ b/packages/react/src/components/Card/CardToolbar.jsx
@@ -175,8 +175,8 @@ const CardToolbar = ({
       extraActions.children && extraActions.children.length ? (
         <OverflowMenu
           flipped={overflowMenuPosition}
-          title={extraActions.iconDescription || mergedI18n.extraActionLabel}
-          iconDescription={extraActions.iconDescription || mergedI18n.extraActionLabel}
+          title={extraActions.iconDescription || mergedI18n.overflowMenuDescription}
+          iconDescription={extraActions.iconDescription || mergedI18n.overflowMenuDescription}
           {...(extraActions.icon ? { renderIcon: extraActions.icon } : {})}
         >
           {extraActions.children.map((child, i) =>

--- a/packages/react/src/components/Card/CardToolbar.jsx
+++ b/packages/react/src/components/Card/CardToolbar.jsx
@@ -175,8 +175,9 @@ const CardToolbar = ({
       extraActions.children && extraActions.children.length ? (
         <OverflowMenu
           flipped={overflowMenuPosition}
-          title={mergedI18n.overflowMenuDescription}
-          iconDescription={mergedI18n.overflowMenuDescription}
+          title={extraActions.iconDescription || mergedI18n.extraActionLabel}
+          iconDescription={extraActions.iconDescription || mergedI18n.extraActionLabel}
+          {...(extraActions.icon ? { renderIcon: extraActions.icon } : {})}
         >
           {extraActions.children.map((child, i) =>
             !child.hidden ? (
@@ -192,9 +193,8 @@ const CardToolbar = ({
         </OverflowMenu>
       ) : extraActions.icon ? (
         <ToolbarSVGWrapper
-          title={mergedI18n.extraActionLabel}
+          title={extraActions.iconDescription || mergedI18n.extraActionLabel}
           onClick={() => (extraActions.callback ? extraActions.callback(extraActions) : null)}
-          iconDescription={mergedI18n.extraActionLabel}
           renderIcon={extraActions.icon}
           testId={`${testId}-extra-single-action`}
           disabled={extraActions.disabled}

--- a/packages/react/src/components/Card/__snapshots__/Card.story.storyshot
+++ b/packages/react/src/components/Card/__snapshots__/Card.story.storyshot
@@ -5564,18 +5564,16 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             tabIndex={0}
-            title="Action Label"
+            title="Add"
             type="button"
           >
             <svg
-              aria-hidden="true"
-              aria-label="Action Label"
+              aria-hidden={true}
               className="bx--btn__icon"
               fill="currentColor"
               focusable="false"
               height={16}
               preserveAspectRatio="xMidYMid meet"
-              role="img"
               viewBox="0 0 32 32"
               width={16}
               xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-addons-iot-react/issues/3526

**Summary**

- adding tooltip to the card extra actions

**Change List (commits, features, bugs, etc)**

- feat(card): adding tooltip to the card extra actions

**Acceptance Test (how to verify the PR)**

- tooltips can be passed from the props

**Regression Test (how to make sure this PR doesn't break old functionality)**

- card should work with out any issues

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
