### PR TITLE
feat(readonlyvalue): Read only value updates

### DIFF
--- a/packages/react/src/components/ReadOnlyValue/ReadOnlyValue.jsx
+++ b/packages/react/src/components/ReadOnlyValue/ReadOnlyValue.jsx
@@ -9,7 +9,7 @@ const { iotPrefix } = settings;
 const propTypes = {
   type: PropTypes.oneOf(['stacked', 'inline', 'inline_small']),
   label: PropTypes.string,
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   testId: PropTypes.string,
 };
 
@@ -28,16 +28,21 @@ const ReadOnlyValue = ({ type, label, value, className, testId }) => {
         [`${iotPrefix}--read-only-value__inline_small`]: type === 'inline_small',
       })}
     >
+      {/* eslint-disable-next-line jsx-a11y/label-has-for */}
       <label data-testid={`${testId}--label`} htmlFor={`readonly-${label}`}>
         {label}
-        <textarea
-          data-testid={`${testId}--value`}
-          type="text"
-          id={`readonly-${label}`}
-          name={value}
-          value={value}
-          readOnly
-        />
+        {typeof value === 'string' ? (
+          <textarea
+            data-testid={`${testId}--value`}
+            type="text"
+            id={`readonly-${label}`}
+            name={value}
+            value={value}
+            readOnly
+          />
+        ) : (
+          <div id={`readonly-${label}`}>{value}</div>
+        )}
       </label>
     </div>
   );

--- a/packages/react/src/components/ReadOnlyValue/ReadOnlyValue.mdx
+++ b/packages/react/src/components/ReadOnlyValue/ReadOnlyValue.mdx
@@ -24,7 +24,7 @@ import { ReadOnlyValue } from 'carbon-addons-iot-react';
 | Name      | Type                                                        | Default   | Description                                     |
 | :-------- | :---------------------------------------------------------- | :-------- | :---------------------------------------------- | ----------------------------------- |
 | label     | string                                                      | ''        | read only label text                            |
-| value     | string                                                      | node      | ''                                              | read only value text or custom node |
+| value     | string, node                                                | string    | ''                                              | read only value text or custom node |
 | type      | enum: <br/>'stacked'<br/>'inline'<br/> 'inline_small' <br/> | stacked   | Type of how should be the read only be rendered |
 | testId    | string                                                      | 'testId'  | Test id for selecting the element               |
 | className | string                                                      | undefined | Custom class for component                      |

--- a/packages/react/src/components/ReadOnlyValue/ReadOnlyValue.mdx
+++ b/packages/react/src/components/ReadOnlyValue/ReadOnlyValue.mdx
@@ -22,9 +22,9 @@ import { ReadOnlyValue } from 'carbon-addons-iot-react';
 ## Props
 
 | Name      | Type                                                        | Default   | Description                                     |
-| :-------- | :---------------------------------------------------------- | :-------- | :---------------------------------------------- |
+| :-------- | :---------------------------------------------------------- | :-------- | :---------------------------------------------- | ----------------------------------- |
 | label     | string                                                      | ''        | read only label text                            |
-| value     | string                                                      | ''        | read only value text                            |
+| value     | string                                                      | node      | ''                                              | read only value text or custom node |
 | type      | enum: <br/>'stacked'<br/>'inline'<br/> 'inline_small' <br/> | stacked   | Type of how should be the read only be rendered |
 | testId    | string                                                      | 'testId'  | Test id for selecting the element               |
 | className | string                                                      | undefined | Custom class for component                      |

--- a/packages/react/src/components/ReadOnlyValue/ReadOnlyValue.story.jsx
+++ b/packages/react/src/components/ReadOnlyValue/ReadOnlyValue.story.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { text } from '@storybook/addon-knobs';
+import { Link, UnorderedList, ListItem } from 'carbon-components-react';
 
 import ReadOnlyValueREADME from './ReadOnlyValue.mdx';
 import ReadOnlyValue from './ReadOnlyValue';
@@ -49,6 +50,36 @@ export const MultipleValuesStacked = () => (
 
 MultipleValuesStacked.storyName = 'multiple values - stacked';
 
+export const BasicStackedWithCustomValue = () => (
+  <div style={{ width: '100%', heigh: 'calc(100vh - 100px)' }}>
+    <ReadOnlyValue label="Label" value={<div>custom div component</div>} type="stacked" />
+    <ReadOnlyValue
+      label="Label"
+      value={
+        <div>
+          custom div component <Link href="www.ibm.com">Link</Link>
+        </div>
+      }
+      type="stacked"
+    />
+    <ReadOnlyValue
+      label="Label"
+      value={
+        <div>
+          custom div component
+          <UnorderedList>
+            <ListItem>Unordered List level 1</ListItem>
+            <ListItem>Unordered List level 1</ListItem>
+            <ListItem>Unordered List level 1</ListItem>
+          </UnorderedList>
+        </div>
+      }
+      type="stacked"
+    />
+  </div>
+);
+
+BasicStackedWithCustomValue.storyName = 'basic stacked with custom value';
 export const BasicInline = () => (
   <div style={{ width: '100%', height: 'calc(100vh - 100px)' }}>
     <ReadOnlyValue label="Label" value="input value" type="inline" />

--- a/packages/react/src/components/ReadOnlyValue/__snapshots__/ReadOnlyValue.story.storyshot
+++ b/packages/react/src/components/ReadOnlyValue/__snapshots__/ReadOnlyValue.story.storyshot
@@ -70,6 +70,102 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/R
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ReadOnlyValue basic stacked with custom value 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "heigh": "calc(100vh - 100px)",
+        "width": "100%",
+      }
+    }
+  >
+    <div
+      className="iot--read-only-value"
+      data-testid="read-only-value"
+    >
+      <label
+        data-testid="read-only-value--label"
+        htmlFor="readonly-Label"
+      >
+        Label
+        <div
+          id="readonly-Label"
+        >
+          <div>
+            custom div component
+          </div>
+        </div>
+      </label>
+    </div>
+    <div
+      className="iot--read-only-value"
+      data-testid="read-only-value"
+    >
+      <label
+        data-testid="read-only-value--label"
+        htmlFor="readonly-Label"
+      >
+        Label
+        <div
+          id="readonly-Label"
+        >
+          <div>
+            custom div component 
+            <a
+              className="bx--link"
+              href="www.ibm.com"
+              rel={null}
+            >
+              Link
+            </a>
+          </div>
+        </div>
+      </label>
+    </div>
+    <div
+      className="iot--read-only-value"
+      data-testid="read-only-value"
+    >
+      <label
+        data-testid="read-only-value--label"
+        htmlFor="readonly-Label"
+      >
+        Label
+        <div
+          id="readonly-Label"
+        >
+          <div>
+            custom div component
+            <ul
+              className="bx--list--unordered"
+            >
+              <li
+                className="bx--list__item"
+              >
+                Unordered List level 1
+              </li>
+              <li
+                className="bx--list__item"
+              >
+                Unordered List level 1
+              </li>
+              <li
+                className="bx--list__item"
+              >
+                Unordered List level 1
+              </li>
+            </ul>
+          </div>
+        </div>
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/ReadOnlyValue multiple values - inline 1`] = `
 <div
   className="storybook-container"

--- a/packages/react/src/components/ReadOnlyValue/_read-only-value.scss
+++ b/packages/react/src/components/ReadOnlyValue/_read-only-value.scss
@@ -2,7 +2,8 @@
   display: block;
   margin-bottom: $spacing-06;
   label,
-  textarea {
+  textarea,
+  div {
     display: block;
     &:focus-visible {
       outline: unset;
@@ -12,7 +13,8 @@
     display: inline-block;
     @include type-style('label-01');
     color: $text-02;
-    > textarea {
+    > textarea,
+    div {
       @include type-style('body-short-01');
       margin-top: $spacing-02;
       color: $text-01;
@@ -32,7 +34,8 @@
       gap: $spacing-06;
       color: $text-02;
       align-items: baseline;
-      > textarea {
+      > textarea,
+      div {
         @include type-style('body-short-01');
         color: $text-01;
       }
@@ -41,7 +44,8 @@
   &__inline_small {
     > label {
       @include type-style('label-01');
-      > textarea {
+      > textarea,
+      div {
         @include type-style('label-01');
       }
     }

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -12756,7 +12756,17 @@ Map {
         "type": "oneOf",
       },
       "value": Object {
-        "type": "string",
+        "args": Array [
+          Array [
+            Object {
+              "type": "string",
+            },
+            Object {
+              "type": "node",
+            },
+          ],
+        ],
+        "type": "oneOfType",
       },
     },
   },


### PR DESCRIPTION
**Summary**

- Support to send a node in prop value of ReadOnlyValue  component

**Change List (commits, features, bugs, etc)**

- Prop support to render a node

**Acceptance Test (how to verify the PR)**

- Check that the value prop supports a node to be rendered and 

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Nothing changed in the already supported cases

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
