### PR TITLE
fix(tabletoolbar): add prop to disable advanced filter button

### DIFF
--- a/packages/react/src/components/Table/StatefulTable.test.jsx
+++ b/packages/react/src/components/Table/StatefulTable.test.jsx
@@ -659,6 +659,55 @@ describe('stateful table with real reducer', () => {
       expect(container.querySelectorAll('tbody > tr')).toHaveLength(10);
       expect(screen.getByText('1–10 of 11 items')).toBeVisible();
     });
+    it('toolbar icon is disabled when isDisabled prop set to true', () => {
+      render(
+        <StatefulTable
+          id="advanced-filters-disabled-icon"
+          {...initialState}
+          options={{
+            ...initialState.options,
+            hasFilter: false,
+            hasAdvancedFilter: true,
+          }}
+          view={{
+            ...initialState.view,
+            toolbar: {
+              ...initialState.view.toolbar,
+              isDisabled: true,
+              advancedFilterFlyoutOpen: false,
+            },
+            selectedAdvancedFilterIds: ['my-filter'],
+            advancedFilters: [
+              {
+                filterId: 'my-filter',
+                filterTitleText: 'My Filter',
+                filterRules: {
+                  id: '14p5ho3pcu',
+                  groupLogic: 'ALL',
+                  rules: [
+                    {
+                      id: 'rsiru4rjba',
+                      columnId: 'date',
+                      operand: 'CONTAINS',
+                      value: '19',
+                    },
+                    {
+                      id: '34bvyub9jq',
+                      columnId: 'boolean',
+                      operand: 'EQ',
+                      value: 'true',
+                    },
+                  ],
+                },
+              },
+            ],
+          }}
+        />
+      );
+      const advancedFilterToolbarIcon = screen.getByTestId('advanced-filter-flyout-button');
+      expect(advancedFilterToolbarIcon).toBeVisible();
+      expect(advancedFilterToolbarIcon).toBeDisabled();
+    });
   });
   it('properly changes state of child and parent row selections', () => {
     const onRowSelectedMock = jest.fn();

--- a/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -522,6 +522,7 @@ const TableToolbar = ({
                 advancedFilterFlyoutOpen,
                 ordering,
                 hasFastFilter: hasAdvancedFilter === 'onKeyPress',
+                isDisabled,
               }}
               i18n={{
                 ...pick(

--- a/packages/react/src/components/Table/TableToolbar/TableToolbarAdvancedFilterFlyout.jsx
+++ b/packages/react/src/components/Table/TableToolbar/TableToolbarAdvancedFilterFlyout.jsx
@@ -256,6 +256,7 @@ const TableToolbarAdvancedFilterFlyout = ({
       testId="advanced-filter-flyout"
       iconDescription="advanced-filter-flyout-icon"
       direction={FlyoutMenuDirection.BottomEnd}
+      disabled={isDisabled}
       renderIcon={Filter20}
       light
       isOpen={advancedFilterFlyoutOpen}


### PR DESCRIPTION
Closes #

**Summary**

- Add prop in `TableToolbar` to disable advanced filter icon button

**Change List (commits, features, bugs, etc)**

- Passing prop from `TableToolbar` to `TableToolbarAdvancedFilterFlyout` to disable icon button
- Add unit test

**Acceptance Test (how to verify the PR)**

- Go to [this story](https://deploy-preview-3541--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table--playground)
- Click on tab `Toolbar` and enable `view.toolbar.isDisabled` in order to disable toolbar actions.
- Click on tab `Sort & filter` and enable `options.hasAdvancedFilter` to see filter icon button.
- Verify that filter icon button is disabled.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
