### PR TITLE
fix(breadcrumb): text-overflow: ellipsis not working

### DIFF
--- a/packages/react/src/components/Breadcrumb/_breadcrumb.scss
+++ b/packages/react/src/components/Breadcrumb/_breadcrumb.scss
@@ -15,6 +15,7 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+      display: block;
     }
   }
 }


### PR DESCRIPTION
Closes #3499 

**Summary**

- use `display:block` for links when `hasOverflow` is enabled

**Change List (commits, features, bugs, etc)**


**Acceptance Test (how to verify the PR)**

Before: first and last BreadCrumbItem are overflow:hidden but not showing ellipsis

![image](https://user-images.githubusercontent.com/24279794/190168227-c6660e63-7266-4f58-b7c1-63d1ff1d2c31.png)


After: put display:block for link element
![image](https://user-images.githubusercontent.com/24279794/190168465-5b9d43d1-012c-4d6d-a4dd-b5739f2722e8.png)


**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
