### PR TITLE
fix(datetimepicker): disable apply button when absolute value is emtpy

### DIFF
--- a/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
@@ -623,7 +623,9 @@ const DateTimePicker = ({
   const disableAbsoluteApply =
     isCustomRange &&
     customRangeKind === PICKER_KINDS.ABSOLUTE &&
-    (absoluteStartTimeInvalid || absoluteEndTimeInvalid);
+    (absoluteStartTimeInvalid ||
+      absoluteEndTimeInvalid ||
+      (absoluteValue.startDate === '' && absoluteValue.endDate === ''));
 
   const disableApply = disableRelativeApply || disableAbsoluteApply;
 

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
@@ -764,6 +764,16 @@ describe('DateTimePicker', () => {
     expect(applyBytton).toBeDisabled();
   });
 
+  it('should disable apply button when switching from presets to relative then to absolute with empty startDate and endDate', () => {
+    render(<DateTimePicker {...dateTimePickerProps} id="picker-test" />);
+    jest.runAllTimers();
+
+    userEvent.click(screen.getByTestId('date-time-picker__field'));
+    userEvent.click(screen.getByText('Custom Range'));
+    userEvent.click(screen.getByText('Absolute'));
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+  });
+
   it('should enable apply button when absolute DatePicker input has start and end date in different dates', () => {
     const { i18n } = DateTimePicker.defaultProps;
 


### PR DESCRIPTION
Closes #3474 

**Summary**

- When switching from preset to relative and then absolute, the Apply button is enabled when no date is selected.

**Change List (commits, features, bugs, etc)**

- added a check for absolute value

**Acceptance Test (how to verify the PR)**

- Go to Default story
- Click on `Custom Range`
- Click on `Absolute`
- check `Apply` button is disabled

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
