### PR TITLE
fix(table): empty search result should show EmptyTable

### DIFF
--- a/packages/react/src/components/Table/StatefulTable.jsx
+++ b/packages/react/src/components/Table/StatefulTable.jsx
@@ -122,7 +122,8 @@ const StatefulTable = ({ data: initialData, expandedData, ...other }) => {
   ]);
 
   const columns = hasUserViewManagement ? state.columns : initialColumns;
-  const initialDefaultSearch = view?.toolbar?.search?.defaultValue || '';
+  const defaultSearch = view?.toolbar?.search?.defaultValue || '';
+  const initialDefaultSearch = view?.toolbar?.initialDefaultSearch || '';
 
   const { onChangePage } = pagination || {};
   const {
@@ -350,9 +351,10 @@ const StatefulTable = ({ data: initialData, expandedData, ...other }) => {
           ...view?.toolbar,
           search: {
             ...view?.toolbar?.search,
-            defaultValue: initialDefaultSearch,
+            defaultValue: defaultSearch,
           },
           customToolbarContent,
+          initialDefaultSearch,
         },
         pagination: {
           ...view.pagination,

--- a/packages/react/src/components/Table/StatefulTable.jsx
+++ b/packages/react/src/components/Table/StatefulTable.jsx
@@ -122,7 +122,7 @@ const StatefulTable = ({ data: initialData, expandedData, ...other }) => {
   ]);
 
   const columns = hasUserViewManagement ? state.columns : initialColumns;
-  const initialDefaultSearch = state?.view?.toolbar?.initialDefaultSearch || '';
+  const initialDefaultSearch = view?.toolbar?.search?.defaultValue || '';
 
   const { onChangePage } = pagination || {};
   const {

--- a/packages/react/src/components/Table/StatefulTable.test.e2e.jsx
+++ b/packages/react/src/components/Table/StatefulTable.test.e2e.jsx
@@ -73,7 +73,11 @@ describe('StatefulTable', () => {
       />
     );
     cy.get('tr').should('have.length', 101);
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.findByRole('searchbox')
+      .as('searchboxAlias')
+      .wait(1000)
+      .get('@searchboxAlias')
       .type('Ia2eQMSi8i{enter}')
       .should(() => {
         expect(onApplySearch).to.have.been.callCount(1);
@@ -110,7 +114,11 @@ describe('StatefulTable', () => {
     );
     // 100 rows plus the header
     cy.get('tr').should('have.length', 101);
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.findByRole('searchbox')
+      .as('searchboxAlias')
+      .wait(1000)
+      .get('@searchboxAlias')
       .type('Ia2eQMSi8i')
       .should(() => {
         expect(onApplySearch).to.have.been.callCount(10);
@@ -147,7 +155,11 @@ describe('StatefulTable', () => {
     );
     // 100 rows plus the header
     cy.get('tr').should('have.length', 101);
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.findByRole('searchbox')
+      .as('searchboxAlias')
+      .wait(1000)
+      .get('@searchboxAlias')
       .type('Ia2eQMSi8i{enter}')
       .should(() => {
         expect(onApplySearch).to.have.been.callCount(1);
@@ -192,7 +204,12 @@ describe('StatefulTable', () => {
     // isn't open by default.
     cy.findByRole('search').should('not.have.class', `${prefix}--toolbar-search-container-active`);
 
-    cy.findByPlaceholderText('Search').type('testing{enter}');
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.findByRole('search')
+      .wait(1000)
+      .then(($el) => Cypress.dom.isAttached($el))
+      .findByRole('search')
+      .type('testing{enter}');
 
     // is open now that we have a search value.
     cy.findByRole('search').should('have.class', `${prefix}--toolbar-search-container-active`);
@@ -233,7 +250,11 @@ describe('StatefulTable', () => {
 
     cy.findByRole('search').should('have.class', `${prefix}--toolbar-search-container-active`);
 
-    cy.findByPlaceholderText('Search')
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.findByRole('search')
+      .wait(1000)
+      .then(($el) => Cypress.dom.isAttached($el))
+      .findByRole('search')
       .type('testing{enter}')
       .should(() => {
         expect(onApplySearch).to.have.been.called;

--- a/packages/react/src/components/Table/StatefulTable.test.e2e.jsx
+++ b/packages/react/src/components/Table/StatefulTable.test.e2e.jsx
@@ -73,11 +73,9 @@ describe('StatefulTable', () => {
       />
     );
     cy.get('tr').should('have.length', 101);
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
+
     cy.findByRole('searchbox')
-      .as('searchboxAlias')
-      .wait(1000)
-      .get('@searchboxAlias')
+      .focus()
       .type('Ia2eQMSi8i{enter}')
       .should(() => {
         expect(onApplySearch).to.have.been.callCount(1);
@@ -114,11 +112,9 @@ describe('StatefulTable', () => {
     );
     // 100 rows plus the header
     cy.get('tr').should('have.length', 101);
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
+
     cy.findByRole('searchbox')
-      .as('searchboxAlias')
-      .wait(1000)
-      .get('@searchboxAlias')
+      .focus()
       .type('Ia2eQMSi8i')
       .should(() => {
         expect(onApplySearch).to.have.been.callCount(10);
@@ -155,11 +151,9 @@ describe('StatefulTable', () => {
     );
     // 100 rows plus the header
     cy.get('tr').should('have.length', 101);
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
+
     cy.findByRole('searchbox')
-      .as('searchboxAlias')
-      .wait(1000)
-      .get('@searchboxAlias')
+      .focus()
       .type('Ia2eQMSi8i{enter}')
       .should(() => {
         expect(onApplySearch).to.have.been.callCount(1);
@@ -204,12 +198,7 @@ describe('StatefulTable', () => {
     // isn't open by default.
     cy.findByRole('search').should('not.have.class', `${prefix}--toolbar-search-container-active`);
 
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.findByRole('search')
-      .wait(1000)
-      .then(($el) => Cypress.dom.isAttached($el))
-      .findByRole('search')
-      .type('testing{enter}');
+    cy.findByRole('searchbox').focus().type('testing{enter}');
 
     // is open now that we have a search value.
     cy.findByRole('search').should('have.class', `${prefix}--toolbar-search-container-active`);
@@ -250,11 +239,8 @@ describe('StatefulTable', () => {
 
     cy.findByRole('search').should('have.class', `${prefix}--toolbar-search-container-active`);
 
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.findByRole('search')
-      .wait(1000)
-      .then(($el) => Cypress.dom.isAttached($el))
-      .findByRole('search')
+    cy.findByRole('searchbox')
+      .focus()
       .type('testing{enter}')
       .should(() => {
         expect(onApplySearch).to.have.been.called;

--- a/packages/react/src/components/Table/StatefulTable.test.jsx
+++ b/packages/react/src/components/Table/StatefulTable.test.jsx
@@ -504,6 +504,58 @@ describe('stateful table with real reducer', () => {
       }
     });
   });
+  it('should display empty table state when no search results', () => {
+    render(
+      <StatefulTable
+        columns={tableColumns}
+        data={[tableData[0]]}
+        actions={mockActions}
+        options={{
+          hasSearch: true,
+        }}
+        view={{
+          toolbar: {
+            search: {
+              defaultValue: '',
+            },
+          },
+        }}
+        id="table"
+      />
+    );
+    const searchField = screen.queryByRole('searchbox');
+    fireEvent.change(searchField, { target: { value: 'irrelevant search 123123' } });
+    expect(screen.getByTestId('EmptyState')).toBeInTheDocument();
+    expect(screen.getByTestId('EmptyState')).toBeVisible();
+  });
+  it('should apply callback when clear filter button clicked', async () => {
+    render(
+      <StatefulTable
+        columns={tableColumns}
+        data={[tableData[0]]}
+        actions={mockActions}
+        options={{
+          hasSearch: true,
+        }}
+        view={{
+          toolbar: {
+            search: {
+              defaultValue: 'irrelevant search 123123',
+            },
+          },
+        }}
+        id="table"
+        i18n={{
+          emptyButtonLabelWithFilters: 'Clear all filters',
+        }}
+      />
+    );
+    expect(screen.getByTestId('EmptyState')).toBeInTheDocument();
+    expect(screen.getByTestId('EmptyState')).toBeVisible();
+    const clearFiltersButton = screen.getByRole('button', { name: 'Clear all filters' });
+    fireEvent.click(clearFiltersButton);
+    expect(mockActions.toolbar.onClearAllFilters).toHaveBeenCalledTimes(1);
+  });
   it('should use callback fallbacks when props not passed', () => {
     expect(() =>
       render(

--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -658,6 +658,10 @@ const Table = (props) => {
     if (actions.toolbar && actions.toolbar.onApplySearch) {
       actions.toolbar.onApplySearch('');
     }
+
+    if (searchValue.current) {
+      searchValue.current = '';
+    }
   };
 
   const handleOnColumnResize = (resizedCols) => {

--- a/packages/react/src/components/Table/Table.test.jsx
+++ b/packages/react/src/components/Table/Table.test.jsx
@@ -603,6 +603,76 @@ describe('Table', () => {
     expect(screen.getByTestId(`${tableId}-table-toolbar-search`)).toHaveValue('ferrari');
   });
 
+  it('toolbar search should rerender with different search value', () => {
+    const tableId = 'table';
+
+    const { rerender } = render(
+      <Table
+        columns={tableColumns}
+        data={[tableData[0]]}
+        actions={mockActions}
+        options={{
+          hasSearch: true,
+        }}
+        view={{
+          toolbar: {
+            search: {
+              defaultValue: '',
+            },
+          },
+        }}
+        id={tableId}
+      />
+    );
+
+    expect(screen.getByTestId(`${tableId}-table-toolbar-search`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${tableId}-table-toolbar-search`)).toHaveValue('');
+
+    rerender(
+      <Table
+        columns={tableColumns}
+        data={[tableData[0]]}
+        actions={mockActions}
+        options={{
+          hasSearch: true,
+        }}
+        view={{
+          toolbar: {
+            search: {
+              defaultValue: 'ferrari',
+            },
+          },
+        }}
+        id={tableId}
+      />
+    );
+
+    expect(screen.getByTestId(`${tableId}-table-toolbar-search`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${tableId}-table-toolbar-search`)).toHaveValue('ferrari');
+
+    rerender(
+      <Table
+        columns={tableColumns}
+        data={[tableData[0]]}
+        actions={mockActions}
+        options={{
+          hasSearch: true,
+        }}
+        view={{
+          toolbar: {
+            search: {
+              defaultValue: '',
+            },
+          },
+        }}
+        id={tableId}
+      />
+    );
+
+    expect(screen.getByTestId(`${tableId}-table-toolbar-search`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${tableId}-table-toolbar-search`)).toHaveValue('');
+  });
+
   it('toolbar search should change value after typing', () => {
     render(
       <Table

--- a/packages/react/src/components/Table/Table.test.jsx
+++ b/packages/react/src/components/Table/Table.test.jsx
@@ -578,8 +578,33 @@ describe('Table', () => {
     expect(rowEditBarButton).toBeTruthy();
   });
 
-  it('toolbar search should render with default value', () => {
-    const wrapper = mount(
+  it('toolbar search should render with default value', async () => {
+    const tableId = 'table';
+
+    render(
+      <Table
+        columns={tableColumns}
+        data={[tableData[0]]}
+        actions={mockActions}
+        options={{
+          hasSearch: true,
+        }}
+        view={{
+          toolbar: {
+            search: {
+              defaultValue: 'ferrari',
+            },
+          },
+        }}
+        id={tableId}
+      />
+    );
+    expect(screen.getByTestId(`${tableId}-table-toolbar-search`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${tableId}-table-toolbar-search`)).toHaveValue('ferrari');
+  });
+
+  it('toolbar search should change value after typing', () => {
+    render(
       <Table
         columns={tableColumns}
         data={[tableData[0]]}
@@ -594,23 +619,13 @@ describe('Table', () => {
             },
           },
         }}
+        id="table"
       />
     );
-
-    expect(wrapper.find(`.${prefix}--search-input`)).toHaveLength(1);
-    expect(wrapper.find(`.${prefix}--search-input`).prop('value')).toEqual('');
-
-    wrapper.setProps({
-      view: { toolbar: { search: { defaultValue: 'ferrari' } } },
-    });
-    wrapper.update();
-
-    expect(wrapper.find(`.${prefix}--search-input`).prop('value')).toEqual('ferrari');
-
-    wrapper.setProps({ view: { toolbar: { search: { defaultValue: '' } } } });
-    wrapper.update();
-
-    expect(wrapper.find(`.${prefix}--search-input`).prop('value')).toEqual('');
+    expect(screen.getByTestId('table-table-toolbar-search')).toBeInTheDocument();
+    expect(screen.getByTestId('table-table-toolbar-search')).toHaveValue('');
+    userEvent.type(screen.getByTestId('table-table-toolbar-search'), 'ferrari');
+    expect(screen.getByTestId('table-table-toolbar-search')).toHaveValue('ferrari');
   });
 
   it('should call onApplySearch when typing in the search box with hasFastSearch:true', () => {

--- a/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -268,9 +268,7 @@ const TableToolbar = ({
       return;
     }
 
-    if (search.defaultValue === '') {
-      setForceRenderCount((prevValue) => prevValue + 1);
-    }
+    setForceRenderCount((prevValue) => prevValue + 1);
   }, [search.defaultValue]);
 
   const [isOpen, setIsOpen, renderToolbarOverflowActions] = useDynamicOverflowMenuItems({

--- a/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   Column20,
@@ -257,6 +257,22 @@ const TableToolbar = ({
   const langDir = useLangDirection();
   const { isExpanded: searchIsExpanded, ...search } = searchProp ?? {};
 
+  /**
+   * Needed to force update component if search input is cleared from outside of TableToolbar
+   * Reference: https://reactjs.org/docs/hooks-faq.html#is-there-something-like-forceupdate
+   */
+  const [forceRenderCount, setForceRenderCount] = useState(0);
+
+  useEffect(() => {
+    if (document.activeElement?.tagName === 'INPUT') {
+      return;
+    }
+
+    if (search.defaultValue === '') {
+      setForceRenderCount((prevValue) => prevValue + 1);
+    }
+  }, [search.defaultValue]);
+
   const [isOpen, setIsOpen, renderToolbarOverflowActions] = useDynamicOverflowMenuItems({
     actions: toolbarActions,
     className: `${iotPrefix}--table-toolbar-aggregations__overflow-menu-content`,
@@ -420,8 +436,8 @@ const TableToolbar = ({
                 // The userViewManagement also needs to be able to set the search.defaultValue
                 // while typing without loosing input focus.
                 hasUserViewManagement
-                  ? 'table-toolbar-search'
-                  : `table-toolbar-search${search.defaultValue}${search.value}`
+                  ? `table-toolbar-search-${forceRenderCount}`
+                  : `table-toolbar-search-user-view-${forceRenderCount}`
               }
               defaultValue={search.defaultValue || search.value}
               className="table-toolbar-search"

--- a/packages/react/src/components/Table/mdx/Searching.mdx
+++ b/packages/react/src/components/Table/mdx/Searching.mdx
@@ -112,3 +112,7 @@ return (
 
 Note! From a UX perspective it is not recommended to have both column filters and the built in search enabled at the
 same time.
+
+### Empty search results
+
+If table data does not contain any of the results from the particular search, then `EmptyTable` will be displayed. Reference to this component can be found [here](#empty-state). In order to clear search value from `EmptyTable` the prop `i18n.emptyButtonLabelWithFilters` should be provided to the `Table`, this would display a button with action to reset search value to an empty string.

--- a/packages/react/src/components/Table/mdx/Table.mdx
+++ b/packages/react/src/components/Table/mdx/Table.mdx
@@ -13,6 +13,7 @@ import TableUserViewManagementTOC from './TableUserViewManagementTOC.mdx';
 - [Searching](#searching)
   - [Simple search code example](#simple-search-code-example)
   - [Programmatic search](#programmatic-search)
+  - [Empty search results](#empty-search-results)
 - [Row expansion](#row-expansion)
   - [Programmatic expansion](#programmatic-expansion)
   - [Additional configuration](#additional-configuration)

--- a/packages/react/src/components/Table/tableReducer.js
+++ b/packages/react/src/components/Table/tableReducer.js
@@ -511,7 +511,7 @@ export const tableReducer = (state = {}, action) => {
         : get(view, 'table.ordering') || get(state, 'view.table.ordering');
 
       // update the search if a new one is passed
-      const searchFromState = get(state, 'view.toolbar.search');
+      const searchFromState = get(view, 'toolbar.search');
 
       // if hasUserViewManagement is active we rely on defaultValue
       const searchTermFromState = hasUserViewManagement

--- a/packages/react/src/components/TileCatalogNew/__snapshots__/TileCatalogNew.story.storyshot
+++ b/packages/react/src/components/TileCatalogNew/__snapshots__/TileCatalogNew.story.storyshot
@@ -31,7 +31,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               Product name
             </div>
             <div
-              aria-labelledby="56-search"
+              aria-labelledby="58-search"
               className="bx--search bx--search--xl iot--tile-catalog--tile-canvas--header--search bx--toolbar-search-container-expandable"
               role="search"
             >
@@ -56,8 +56,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <label
                 className="bx--label"
-                htmlFor="56"
-                id="56-search"
+                htmlFor="58"
+                id="58-search"
               >
                 Filter table
               </label>
@@ -65,7 +65,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                 autoComplete="off"
                 className="bx--search-input"
                 data-testid="tile-catalog-new-search-input"
-                id="56"
+                id="58"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -377,7 +377,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               Product name
             </div>
             <div
-              aria-labelledby="57-search"
+              aria-labelledby="59-search"
               className="bx--search bx--search--xl iot--tile-catalog--tile-canvas--header--search bx--toolbar-search-container-expandable"
               role="search"
             >
@@ -402,8 +402,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <label
                 className="bx--label"
-                htmlFor="57"
-                id="57-search"
+                htmlFor="59"
+                id="59-search"
               >
                 Filter table
               </label>
@@ -411,7 +411,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                 autoComplete="off"
                 className="bx--search-input"
                 data-testid="tile-catalog-new-search-input"
-                id="57"
+                id="59"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -626,7 +626,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               Product name
             </div>
             <div
-              aria-labelledby="59-search"
+              aria-labelledby="61-search"
               className="bx--search bx--search--xl iot--tile-catalog--tile-canvas--header--search bx--toolbar-search-container-expandable"
               role="search"
             >
@@ -651,8 +651,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <label
                 className="bx--label"
-                htmlFor="59"
-                id="59-search"
+                htmlFor="61"
+                id="61-search"
               >
                 Filter table
               </label>
@@ -660,7 +660,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                 autoComplete="off"
                 className="bx--search-input"
                 data-testid="tile-catalog-new-search-input"
-                id="59"
+                id="61"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -824,7 +824,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               Product name
             </div>
             <div
-              aria-labelledby="58-search"
+              aria-labelledby="60-search"
               className="bx--search bx--search--xl iot--tile-catalog--tile-canvas--header--search bx--toolbar-search-container-expandable"
               role="search"
             >
@@ -849,8 +849,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <label
                 className="bx--label"
-                htmlFor="58"
-                id="58-search"
+                htmlFor="60"
+                id="60-search"
               >
                 Filter table
               </label>
@@ -858,7 +858,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                 autoComplete="off"
                 className="bx--search-input"
                 data-testid="tile-catalog-new-search-input"
-                id="58"
+                id="60"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -1025,7 +1025,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               Product name
             </div>
             <div
-              aria-labelledby="62-search"
+              aria-labelledby="64-search"
               className="bx--search bx--search--xl iot--tile-catalog--tile-canvas--header--search bx--toolbar-search-container-expandable"
               role="search"
             >
@@ -1050,8 +1050,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <label
                 className="bx--label"
-                htmlFor="62"
-                id="62-search"
+                htmlFor="64"
+                id="64-search"
               >
                 Filter table
               </label>
@@ -1059,7 +1059,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                 autoComplete="off"
                 className="bx--search-input"
                 data-testid="tile-catalog-new-search-input"
-                id="62"
+                id="64"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -1485,7 +1485,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               Product name
             </div>
             <div
-              aria-labelledby="60-search"
+              aria-labelledby="62-search"
               className="bx--search bx--search--xl iot--tile-catalog--tile-canvas--header--search bx--toolbar-search-container-expandable"
               role="search"
             >
@@ -1510,8 +1510,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <label
                 className="bx--label"
-                htmlFor="60"
-                id="60-search"
+                htmlFor="62"
+                id="62-search"
               >
                 Filter table
               </label>
@@ -1519,7 +1519,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                 autoComplete="off"
                 className="bx--search-input"
                 data-testid="tile-catalog-new-search-input"
-                id="60"
+                id="62"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -2070,7 +2070,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               Product name
             </div>
             <div
-              aria-labelledby="61-search"
+              aria-labelledby="63-search"
               className="bx--search bx--search--xl iot--tile-catalog--tile-canvas--header--search bx--toolbar-search-container-expandable"
               role="search"
             >
@@ -2095,8 +2095,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <label
                 className="bx--label"
-                htmlFor="61"
-                id="61-search"
+                htmlFor="63"
+                id="63-search"
               >
                 Filter table
               </label>
@@ -2104,7 +2104,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                 autoComplete="off"
                 className="bx--search-input"
                 data-testid="tile-catalog-new-search-input"
-                id="61"
+                id="63"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}

--- a/packages/react/src/components/TileCatalogNew/__snapshots__/TileCatalogNew.story.storyshot
+++ b/packages/react/src/components/TileCatalogNew/__snapshots__/TileCatalogNew.story.storyshot
@@ -31,7 +31,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               Product name
             </div>
             <div
-              aria-labelledby="30-search"
+              aria-labelledby="56-search"
               className="bx--search bx--search--xl iot--tile-catalog--tile-canvas--header--search bx--toolbar-search-container-expandable"
               role="search"
             >
@@ -56,8 +56,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <label
                 className="bx--label"
-                htmlFor="30"
-                id="30-search"
+                htmlFor="56"
+                id="56-search"
               >
                 Filter table
               </label>
@@ -65,7 +65,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                 autoComplete="off"
                 className="bx--search-input"
                 data-testid="tile-catalog-new-search-input"
-                id="30"
+                id="56"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -377,7 +377,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               Product name
             </div>
             <div
-              aria-labelledby="31-search"
+              aria-labelledby="57-search"
               className="bx--search bx--search--xl iot--tile-catalog--tile-canvas--header--search bx--toolbar-search-container-expandable"
               role="search"
             >
@@ -402,8 +402,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <label
                 className="bx--label"
-                htmlFor="31"
-                id="31-search"
+                htmlFor="57"
+                id="57-search"
               >
                 Filter table
               </label>
@@ -411,7 +411,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                 autoComplete="off"
                 className="bx--search-input"
                 data-testid="tile-catalog-new-search-input"
-                id="31"
+                id="57"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -626,7 +626,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               Product name
             </div>
             <div
-              aria-labelledby="33-search"
+              aria-labelledby="59-search"
               className="bx--search bx--search--xl iot--tile-catalog--tile-canvas--header--search bx--toolbar-search-container-expandable"
               role="search"
             >
@@ -651,8 +651,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <label
                 className="bx--label"
-                htmlFor="33"
-                id="33-search"
+                htmlFor="59"
+                id="59-search"
               >
                 Filter table
               </label>
@@ -660,7 +660,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                 autoComplete="off"
                 className="bx--search-input"
                 data-testid="tile-catalog-new-search-input"
-                id="33"
+                id="59"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -824,7 +824,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               Product name
             </div>
             <div
-              aria-labelledby="32-search"
+              aria-labelledby="58-search"
               className="bx--search bx--search--xl iot--tile-catalog--tile-canvas--header--search bx--toolbar-search-container-expandable"
               role="search"
             >
@@ -849,8 +849,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <label
                 className="bx--label"
-                htmlFor="32"
-                id="32-search"
+                htmlFor="58"
+                id="58-search"
               >
                 Filter table
               </label>
@@ -858,7 +858,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                 autoComplete="off"
                 className="bx--search-input"
                 data-testid="tile-catalog-new-search-input"
-                id="32"
+                id="58"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -1025,7 +1025,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               Product name
             </div>
             <div
-              aria-labelledby="36-search"
+              aria-labelledby="62-search"
               className="bx--search bx--search--xl iot--tile-catalog--tile-canvas--header--search bx--toolbar-search-container-expandable"
               role="search"
             >
@@ -1050,8 +1050,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <label
                 className="bx--label"
-                htmlFor="36"
-                id="36-search"
+                htmlFor="62"
+                id="62-search"
               >
                 Filter table
               </label>
@@ -1059,7 +1059,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                 autoComplete="off"
                 className="bx--search-input"
                 data-testid="tile-catalog-new-search-input"
-                id="36"
+                id="62"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -1485,7 +1485,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               Product name
             </div>
             <div
-              aria-labelledby="34-search"
+              aria-labelledby="60-search"
               className="bx--search bx--search--xl iot--tile-catalog--tile-canvas--header--search bx--toolbar-search-container-expandable"
               role="search"
             >
@@ -1510,8 +1510,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <label
                 className="bx--label"
-                htmlFor="34"
-                id="34-search"
+                htmlFor="60"
+                id="60-search"
               >
                 Filter table
               </label>
@@ -1519,7 +1519,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                 autoComplete="off"
                 className="bx--search-input"
                 data-testid="tile-catalog-new-search-input"
-                id="34"
+                id="60"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -2070,7 +2070,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               Product name
             </div>
             <div
-              aria-labelledby="35-search"
+              aria-labelledby="61-search"
               className="bx--search bx--search--xl iot--tile-catalog--tile-canvas--header--search bx--toolbar-search-container-expandable"
               role="search"
             >
@@ -2095,8 +2095,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <label
                 className="bx--label"
-                htmlFor="35"
-                id="35-search"
+                htmlFor="61"
+                id="61-search"
               >
                 Filter table
               </label>
@@ -2104,7 +2104,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                 autoComplete="off"
                 className="bx--search-input"
                 data-testid="tile-catalog-new-search-input"
-                id="35"
+                id="61"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}


### PR DESCRIPTION
Closes #3368 

**Summary**

- Display `EmptyTable` if search results are empty

**Change List (commits, features, bugs, etc)**

- Adjust props in order to display `EmptyTable`
- Enable clearing search input by clicking on "Clear all filter" button in `EmptyTable`
- Update / Add tests
- Update docs

**Acceptance Test (how to verify the PR)**

- Go to [this story](https://deploy-preview-3557--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table--playground)
- In the Knobs section click on `Search` tab
- Enable `options.hasSearch` and `options.hasFastSearch` in order to display search input in the toolbar
- Type some irrelevant value in the search bar
- Verify that `EmptyTable` displayed
- Click on "Clear all filters" button in order to reset search input
- Verify that search input was cleared

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
