### PR TITLE
fix(datetimepickerv2): styles on DateTimePickerV2 and time picker spinner

### DIFF
--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
@@ -311,7 +311,6 @@ const DateTimePicker = ({
     }),
     [i18n]
   );
-  const updatedStyle = useMemo(() => ({ ...style, '--zIndex': style.zIndex ?? 0 }), [style]);
   const isSingleSelect = useMemo(() => datePickerType === 'single', [datePickerType]);
 
   // initialize the dayjs locale
@@ -905,10 +904,11 @@ const DateTimePicker = ({
               [`${iotPrefix}--date-time-picker--tooltip--icon`]: hasIconOnly,
             })}
             tooltipContentClassName={`${iotPrefix}--date-time-picker--menu`}
+            style={style}
           >
             <div
               className={`${iotPrefix}--date-time-picker__menu-scroll`}
-              style={{ ...updatedStyle, '--wrapper-width': '20rem' }}
+              style={{ '--wrapper-width': '20rem' }}
               role="listbox"
               onClick={(event) => event.stopPropagation()} // need to stop the event so that it will not close the menu
               onKeyDown={(event) => event.stopPropagation()} // need to stop the event so that it will not close the menu
@@ -1145,7 +1145,7 @@ const DateTimePicker = ({
                           }}
                           size="sm"
                           testId={testId}
-                          style={updatedStyle}
+                          style={{ zIndex: (style.zIndex ?? 0) + 6000 }}
                         />
                       ) : (
                         <div className={`${iotPrefix}--date-time-picker__no-formgroup`} />

--- a/packages/react/src/components/DateTimePicker/_date-time-pickerv2.scss
+++ b/packages/react/src/components/DateTimePicker/_date-time-pickerv2.scss
@@ -107,7 +107,6 @@
   .#{$iot-prefix}--date-time-picker__menu-scroll {
     overflow-y: auto;
     width: var(--wrapper-width);
-    z-index: calc(var(--zIndex) + 20);
 
     .#{$prefix}--list__item:before {
       display: none;
@@ -126,9 +125,6 @@
       width: var(--wrapper-width);
       padding-top: $spacing-05;
       padding-bottom: $spacing-07;
-      .#{$iot-prefix}--time-picker-dropdown {
-        z-index: calc(var(--zIndex) + 40);
-      }
       .#{$iot-prefix}--time-picker-dropdown button {
         padding-right: $spacing-02;
       }

--- a/packages/react/src/components/FlyoutMenu/FlyoutMenu.jsx
+++ b/packages/react/src/components/FlyoutMenu/FlyoutMenu.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useMemo } from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { SettingsAdjust16 as SettingsAdjust } from '@carbon/icons-react';
@@ -106,10 +106,12 @@ const FlyoutMenu = ({
   onChange,
   isOpen,
   renderInPortal,
+  style,
 }) => {
   const [isControlledOpen, setIsOpen] = useState(defaultOpen);
   const [tooltipDirection, setTooltipDirection] = useState(getTooltipDirection(direction));
   const buttonRef = useRef(null);
+  const updatedStyle = useMemo(() => ({ ...style, '--zIndex': style.zIndex ?? 0 }), [style]);
 
   const getFlyoutMenuOffset = React.useCallback(
     (tooltipElement, flyoutDirection, tooltipButtonElement, flipped) => {
@@ -222,9 +224,7 @@ const FlyoutMenu = ({
   return (
     <div
       data-testid={`${testId}-container`}
-      style={{
-        '--tooltip-visibility': hideTooltip ? 'hidden' : 'visible',
-      }}
+      style={{ '--tooltip-visibility': hideTooltip ? 'hidden' : 'visible' }}
       ref={buttonRef}
       className={classnames(
         [`${iotPrefix}--flyout-menu`],
@@ -287,6 +287,7 @@ const FlyoutMenu = ({
           >
             <div
               className={classnames(`${iotPrefix}--flyout-menu--content`, tooltipContentClassName)}
+              style={updatedStyle}
             >
               {children}
             </div>
@@ -432,6 +433,8 @@ const propTypes = {
 
   /** by default the flyout menu will render as a child, if you set this to true it will render outside of the current DOM in a portal */
   renderInPortal: PropTypes.bool,
+
+  style: PropTypes.objectOf(PropTypes.string),
 };
 
 const defaultProps = {
@@ -467,6 +470,7 @@ const defaultProps = {
   useAutoPositioning: false,
   onChange: () => {},
   renderInPortal: false,
+  style: {},
 };
 
 FlyoutMenu.propTypes = propTypes;

--- a/packages/react/src/components/FlyoutMenu/__snapshots__/FlyoutMenu.story.storyshot
+++ b/packages/react/src/components/FlyoutMenu/__snapshots__/FlyoutMenu.story.storyshot
@@ -125,6 +125,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
             >
               <div
                 className="iot--flyout-menu--content"
+                style={
+                  Object {
+                    "--zIndex": 0,
+                  }
+                }
               >
                 <div>
                   <h2>

--- a/packages/react/src/components/TimePicker/TimePickerDropdown.jsx
+++ b/packages/react/src/components/TimePicker/TimePickerDropdown.jsx
@@ -488,7 +488,7 @@ const spinnerPropTypes = {
   value: PropTypes.string,
   onChange: PropTypes.func,
   testId: PropTypes.string,
-  style: PropTypes.objectOf(propTypes.string),
+  style: PropTypes.objectOf(PropTypes.string),
 };
 
 /* istanbul ignore next */

--- a/packages/react/src/components/TimePicker/_time-picker-dropdown.scss
+++ b/packages/react/src/components/TimePicker/_time-picker-dropdown.scss
@@ -170,6 +170,8 @@
 }
 
 .#{$iot-prefix}--time-picker-spinner {
+  --zIndex: 0;
+  z-index: var(--zIndex);
   background-color: $ui-01;
   box-shadow: 0 7px 10px 2px #ddd;
   display: flex;

--- a/packages/react/src/components/TimePicker/list-spinner.scss
+++ b/packages/react/src/components/TimePicker/list-spinner.scss
@@ -3,8 +3,6 @@
 $layer-hover-01: #e5e5e5;
 
 .#{$iot-prefix}--list-spinner {
-  --zIndex: 0;
-  z-index: calc(var(--zIndex) + 20);
   &__section {
     align-items: flex-start;
     display: flex;

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -30580,6 +30580,7 @@ Map {
         "render": [Function],
       },
       "renderInPortal": false,
+      "style": Object {},
       "tabIndex": 0,
       "testId": "flyout-menu",
       "tooltipClassName": "",
@@ -30709,6 +30710,14 @@ Map {
       },
       "renderInPortal": Object {
         "type": "bool",
+      },
+      "style": Object {
+        "args": Array [
+          Object {
+            "type": "string",
+          },
+        ],
+        "type": "objectOf",
       },
       "tabIndex": Object {
         "type": "number",


### PR DESCRIPTION
Closes #3559 

**Summary**

- clean up styles and make sure style works on dropdown menu ( in FlyOutMenu) and on time spinner ( in TimePickerDropDown). 

If `zIndex` is not passed in on `DateTimePickerV2`, then `zIndex` on time spinner is set to 6000 by default to make sure it show up above the menu

Menu
![image](https://user-images.githubusercontent.com/24279794/191611871-30cfbade-cd6d-47fa-9c49-9d9a389f04b4.png)

Time spinner
![image](https://user-images.githubusercontent.com/24279794/191611995-f7b5429b-a1a1-4edb-aa56-3245f32352c3.png)

If `zIndex` is passed in on `DateTimePickerV2`, then `zIndex` on time spinner is set to 600+ 6000 to make sure it show up above the menu

![image](https://user-images.githubusercontent.com/24279794/191612165-95a5e589-0604-4912-b4ee-cfbed7eacd7a.png)

![image](https://user-images.githubusercontent.com/24279794/191612306-8f2e5053-2a23-492f-a025-fc2baf177733.png)


**Change List (commits, features, bugs, etc)**

- `tooltipContentClassName` is defined in `DateTimePickerV2` but used in `<FlyOutMenu>`
-  make sure `tooltipContentClassName` class has --zIndex attribute and make we pass style in `<FlyOutMenu>`
- same for `TimePickerSpinner` inside `TimePickerDropDown`

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
