### PR TITLE
fix(tablecardformcontent): discard threshold from columns

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -142,7 +142,7 @@ const TableCardFormContent = ({
   const { onEditDataItem } = actions;
   const mergedI18n = { ...defaultProps.i18n, ...i18n };
   const {
-    content: { columns },
+    content: { columns, thresholds },
   } = cardConfig;
 
   const [showEditor, setShowEditor] = useState(false);
@@ -151,15 +151,23 @@ const TableCardFormContent = ({
   const [removedDataItems, setRemovedDataItems] = useState([]);
 
   // Initialize the selected columns if its not currently set
-  const dataSection = useMemo(
-    () =>
-      Array.isArray(columns)
-        ? columns.map((column) => ({
+  const dataSection = useMemo(() => {
+    const a = Array.isArray(columns)
+      ? columns.map((column) => {
+          const filteredThresholds =
+            thresholds?.filter((threshold) => column.dataSourceId === threshold.dataSourceId) || [];
+          return {
             ...column, // dataSection expects the thresholds to be in the column definition, though the table expects them to be in content
-          }))
-        : [],
-    [columns]
-  );
+            ...(!isEmpty(filteredThresholds) // only set thresholds if they exist
+              ? {
+                  thresholds: filteredThresholds,
+                }
+              : {}),
+          };
+        })
+      : [];
+    return a;
+  }, [columns, thresholds]);
 
   const baseClassName = `${iotPrefix}--card-edit-form`;
 
@@ -276,6 +284,7 @@ const TableCardFormContent = ({
         columns: filteredColumns,
       };
 
+      /* istanbul ignore else */
       if (isEmpty(filteredThresholds)) {
         delete updatedContent.thresholds;
       }

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -226,7 +226,8 @@ const TableCardFormContent = ({
   // need to handle thresholds from the DataSeriesFormItemModal and convert it to the right format
   const handleDataItemModalChanges = useCallback(
     (card) => {
-      const allThresholds = [];
+      // Consider existing thresholds outside columns
+      const allThresholds = thresholds?.map((threshold) => ({ ...threshold })) || [];
       // the table card is looking for the thresholds on the main content object
       const updatedColumns = card?.content?.columns?.map(
         // eslint-disable-next-line no-unused-vars
@@ -251,7 +252,7 @@ const TableCardFormContent = ({
         },
       });
     },
-    [onChange]
+    [onChange, thresholds]
   );
 
   const handleRemoveButton = useCallback(
@@ -282,6 +283,7 @@ const TableCardFormContent = ({
       const updatedContent = {
         ...cardConfig.content,
         columns: filteredColumns,
+        thresholds: filteredThresholds,
       };
 
       /* istanbul ignore else */

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -142,7 +142,7 @@ const TableCardFormContent = ({
   const { onEditDataItem } = actions;
   const mergedI18n = { ...defaultProps.i18n, ...i18n };
   const {
-    content: { columns, thresholds },
+    content: { columns },
   } = cardConfig;
 
   const [showEditor, setShowEditor] = useState(false);
@@ -156,16 +156,9 @@ const TableCardFormContent = ({
       Array.isArray(columns)
         ? columns.map((column) => ({
             ...column, // dataSection expects the thresholds to be in the column definition, though the table expects them to be in content
-            ...(!isEmpty(thresholds) // only set thresholds if they exist
-              ? {
-                  thresholds: thresholds?.filter(
-                    (threshold) => column.dataSourceId === threshold.dataSourceId
-                  ),
-                }
-              : {}),
           }))
         : [],
-    [columns, thresholds]
+    [columns]
   );
 
   const baseClassName = `${iotPrefix}--card-edit-form`;
@@ -258,6 +251,10 @@ const TableCardFormContent = ({
       const filteredColumns = dataSection.filter(
         (item) => item.dataSourceId !== dataItem.dataSourceId
       );
+      // Filter existing thresholds
+      const filteredThresholds = cardConfig?.content?.thresholds?.filter(
+        (item) => item.dataSourceId !== dataItem.dataSourceId
+      );
       // Need to determine whether we should remove these from the groupBy section
       const filteredGroupBy = cardConfig?.dataSource?.groupBy?.filter(
         (groupByItem) => groupByItem !== dataItem.dataSourceId
@@ -274,12 +271,18 @@ const TableCardFormContent = ({
         updatedDataSource = { dataSource: { ...omit(cardConfig.dataSource, 'groupBy') } };
       }
 
+      const updatedContent = {
+        ...cardConfig.content,
+        columns: filteredColumns,
+      };
+
+      if (isEmpty(filteredThresholds)) {
+        delete updatedContent.thresholds;
+      }
+
       onChange({
         ...cardConfig,
-        content: {
-          ...cardConfig.content,
-          columns: filteredColumns,
-        },
+        content: updatedContent,
         ...updatedDataSource,
       });
     },

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
@@ -441,6 +441,73 @@ describe('TableCardFormContent', () => {
       },
     });
   });
+  it('should remove threshold attribute from content when last threshold gets deleted', () => {
+    render(
+      <TableCardFormContent
+        {...commonProps}
+        cardConfig={{
+          ...commonCardConfig,
+          content: {
+            columns: [
+              {
+                label: 'Timestamp',
+                dataSourceId: 'timestamp',
+                type: 'TIMESTAMP',
+              },
+              {
+                label: 'Manufacturer',
+                dataSourceId: 'manufacturer',
+                dataItemId: 'manufacturer',
+                dataItemType: 'DIMENSION',
+              },
+              { label: 'Temperature', dataSourceId: 'temperature' },
+            ],
+            thresholds: [
+              {
+                dataSourceId: 'manufacturer',
+                comparison: '>',
+                value: 5,
+                icon: 'Warning alt',
+                color: '#da1e28',
+                severity: 1,
+              },
+            ],
+          },
+          dataSource: {
+            attributes: [
+              {
+                id: 'manufacturer',
+                attribute: 'manufacturer',
+                eventName: 'event1',
+              },
+            ],
+          },
+        }}
+      />
+    );
+
+    const removeTemperatureButton = screen.getAllByRole('button', { name: 'Remove' })[1];
+    expect(removeTemperatureButton).toBeInTheDocument();
+
+    fireEvent.click(removeTemperatureButton);
+
+    expect(mockOnChange).toHaveBeenCalledWith({
+      ...commonCardConfig,
+      content: {
+        columns: [
+          {
+            label: 'Timestamp',
+            dataSourceId: 'timestamp',
+            type: 'TIMESTAMP',
+          },
+          {
+            label: 'Temperature',
+            dataSourceId: 'temperature',
+          },
+        ],
+      },
+    });
+  });
   it('edit mode with dataitems adds threshold correctly', async () => {
     const mockOnChange = jest.fn();
     const mockCardConfig = {


### PR DESCRIPTION
Closes #3563
Closes https://github.com/carbon-design-system/carbon-addons-iot-react/issues/3389

**Summary**

- Remove threshold attribute for empty threshold lists

**Change List (commits, features, bugs, etc)**

- Remove threshold attribute for empty list from content
- Remove unnecessary threshold attribute from content.columns

**Acceptance Test (how to verify the PR)**

- Go to 'Dashboard'
- Create new dashboard
- Add 3 data items
- Add some threshold to the data item (Save the dashboard)
- Remove the data item that has threshold
- goto Open JSON editor
- Click save 
- No errors displayed.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
