### PR TITLE
chore(styles): replace divide symbol to math.div

### DIFF
--- a/packages/react/src/components/ComboBox/_combo-box.scss
+++ b/packages/react/src/components/ComboBox/_combo-box.scss
@@ -45,34 +45,34 @@
       right: $spacing-03;
       z-index: z('overlay') + 1;
       // half the height of the input/first list item
-      bottom: calc(#{$ai-apps-combobox-input-negative-height} / 2);
+      bottom: calc(#{$ai-apps-combobox-input-negative-height} * 0.5);
       // offset bottom calculation by half the height of the text (so it's vertically centered)
       transform: translateY(50%);
     }
     // when helperText is present, it's height must be accounted for
     &.#{$iot-prefix}--combobox-helper-text::after {
       bottom: calc(
-        (#{$ai-apps-combobox-input-negative-height} / 2) + #{$ai-apps-combobox-helper-text-height}
+        (#{$ai-apps-combobox-input-negative-height} * 0.5) + #{$ai-apps-combobox-helper-text-height}
       );
     }
 
     // sm field size variant
     &.#{$iot-prefix}--combobox-size-sm::after {
-      bottom: calc(#{$ai-apps-combobox-input-negative-height-sm} / 2);
+      bottom: calc(#{$ai-apps-combobox-input-negative-height-sm} * 0.5);
     }
     &.#{$iot-prefix}--combobox-size-sm.#{$iot-prefix}--combobox-helper-text::after {
       bottom: calc(
-        (#{$ai-apps-combobox-input-negative-height-sm} / 2) + #{$ai-apps-combobox-helper-text-height}
+        (#{$ai-apps-combobox-input-negative-height-sm} * 0.5) + #{$ai-apps-combobox-helper-text-height}
       );
     }
 
     // xl field size variant
     &.#{$iot-prefix}--combobox-size-xl::after {
-      bottom: calc(#{$ai-apps-combobox-input-negative-height-xl} / 2);
+      bottom: calc(#{$ai-apps-combobox-input-negative-height-xl} * 0.5);
     }
     &.#{$iot-prefix}--combobox-size-xl.#{$iot-prefix}--combobox-helper-text::after {
       bottom: calc(
-        (#{$ai-apps-combobox-input-negative-height-xl} / 2) + #{$ai-apps-combobox-helper-text-height}
+        (#{$ai-apps-combobox-input-negative-height-xl} * 0.5) + #{$ai-apps-combobox-helper-text-height}
       );
     }
   }

--- a/packages/react/src/components/ImageCard/_hotspot.scss
+++ b/packages/react/src/components/ImageCard/_hotspot.scss
@@ -13,8 +13,8 @@ $selected-border: solid $selected-border-width $interactive-04;
   position: absolute;
   font-family: Sans-Serif;
   pointer-events: auto;
-  top: calc((var(--y-pos) * 1%) - ((var(--height) / 2) * 1px));
-  left: calc((var(--x-pos) * 1%) - ((var(--width) / 2) * 1px));
+  top: calc((var(--y-pos) * 1%) - ((var(--height) * 0.5) * 1px));
+  left: calc((var(--x-pos) * 1%) - ((var(--width) * 0.5) * 1px));
 }
 
 // FIXED OR DYNAMIC HOTSPOT (USING TOOLTIP)
@@ -27,10 +27,11 @@ $selected-border: solid $selected-border-width $interactive-04;
     border: $selected-border;
     padding: #{$padding};
     top: calc(
-      (var(--y-pos) * 1%) - (((var(--height) * 1px) / 2) + #{$padding} + #{$selected-border-width})
+      (var(--y-pos) * 1%) -
+        (((var(--height) * 1px) * 0.5) + #{$padding} + #{$selected-border-width})
     );
     left: calc(
-      (var(--x-pos) * 1%) - (((var(--width) * 1px) / 2) + #{$padding} + #{$selected-border-width})
+      (var(--x-pos) * 1%) - (((var(--width) * 1px) * 0.5) + #{$padding} + #{$selected-border-width})
     );
   }
   &.#{$iot-prefix}--hotspot-container--has-icon {
@@ -65,8 +66,8 @@ $selected-border: solid $selected-border-width $interactive-04;
   &.#{$iot-prefix}--hotspot-container--selected {
     box-sizing: border-box;
     border: $selected-border;
-    top: calc((var(--y-pos) * 1%) - (((var(--height) * 1px) / 2)));
-    left: calc((var(--x-pos) * 1%) - (((var(--width) * 1px) / 2)));
+    top: calc((var(--y-pos) * 1%) - (((var(--height) * 1px) * 0.5)));
+    left: calc((var(--x-pos) * 1%) - (((var(--width) * 1px) * 0.5)));
   }
 }
 

--- a/packages/react/src/components/MenuButton/_menu-button-shadow-blocker.scss
+++ b/packages/react/src/components/MenuButton/_menu-button-shadow-blocker.scss
@@ -148,7 +148,7 @@ $shadow-blocker-border-width: rem(1px);
     .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--btn--ghost:focus:not(:active) {
       @function calculate-middle($size) {
         @return calc(
-          ((#{$size} - #{$shadow-blocker-height}) / 2) - #{$shadow-blocker-border-width}
+          ((#{$size} - #{$shadow-blocker-height}) * 0.5) - #{$shadow-blocker-border-width}
         );
       }
 
@@ -172,7 +172,8 @@ $shadow-blocker-border-width: rem(1px);
       .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--btn--ghost:focus:not(:active) {
         @function calculate-negative-middle($size) {
           @return calc(
-            (((#{$size} - #{$shadow-blocker-height}) / 2) + #{$shadow-blocker-border-width}) * (-1)
+            (((#{$size} - #{$shadow-blocker-height}) * 0.5) + #{$shadow-blocker-border-width}) *
+              (-1)
           );
         }
 

--- a/packages/react/src/components/TileCatalog/_catalog-content.scss
+++ b/packages/react/src/components/TileCatalog/_catalog-content.scss
@@ -29,10 +29,10 @@
   padding-bottom: $spacing-03;
   max-width: calc(100vw - 20rem);
   @media screen and (min-width: $two-pane) {
-    max-width: calc(100vw / 2 - 15rem);
+    max-width: calc(math.div(100vw, 2) - 15rem);
   }
   @media screen and (min-width: $three-pane) {
-    max-width: calc(100vw / 3 - 15rem);
+    max-width: calc(math.div(100vw, 3) - 15rem);
   }
 }
 

--- a/packages/react/src/styles.scss
+++ b/packages/react/src/styles.scss
@@ -2,6 +2,12 @@
 // 🌍 Global
 //-------------------------
 
+// Enable math module to handle dividing operations due to deprecation of " / " operator
+// Reference https://sass-lang.com/documentation/breaking-changes/slash-div
+/* stylelint-disable */
+@use "sass:math";
+/* stylelint-enable */
+
 /// If true, includes font face mixins in `_css--font-face.scss` depending on the `css--plex` feature flag
 /// @access public
 /// @type Bool


### PR DESCRIPTION
Closes #3439 

**Summary**

- Replace "/" symbol to `Math.div` in `scss` files

**Change List (commits, features, bugs, etc)**

- Enable `sass:math` module (add `@use` directive to stylelint ignore)
- Affected component `ComboBox`
- Affected component `ImageCard`
- Affected component `MenuButton`
- Affected component `TileCatalog`

**Acceptance Test (how to verify the PR)**

- Go to [this commit](https://github.com/carbon-design-system/carbon-addons-iot-react/pull/3568/commits/54d1d17de2c4a6a443ee8937984c49613b6b8561)
- Verify that all "/" symbols have been replaced by `*` or `Math.div`

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
