### PR TITLE
fix(timeseriescard): overlay alert for the specific line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ packages/react/cypress/snapshots/
 packages/react/cypress-visual-report/
 packages/react/cypress-visual-screenshots/comparison/
 packages/react/cypress-visual-screenshots/diff
+
+# ignore local python virtual environement
+localvenv/

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
@@ -328,9 +328,17 @@ export const HighlightAlertRanges = () => {
               label: 'Temperature',
               dataSourceId: 'temperature',
             },
+            {
+              label: 'Pressure',
+              dataSourceId: 'pressure',
+            },
+            {
+              label: 'Humidity',
+              dataSourceId: 'humidity',
+            },
           ],
           xLabel: 'Time',
-          yLabel: 'Temperature (˚F)',
+          yLabel: 'Temperature and Pressure',
           includeZeroOnXaxis: true,
           includeZeroOnYaxis: true,
           timeDataSourceId: 'timestamp',
@@ -340,12 +348,27 @@ export const HighlightAlertRanges = () => {
               endTimestamp: 1572486422000,
               color: '#FF0000',
               details: 'Alert name',
+              inputSource: {
+                dataSourceIds: ['pressure'],
+              },
             },
             {
               startTimestamp: 1572313622000,
               endTimestamp: 1572824320000,
               color: '#FFCC00',
               details: 'Less severe',
+              inputSource: {
+                dataSourceIds: ['temperature'],
+              },
+            },
+            {
+              startTimestamp: 1572651520000,
+              endTimestamp: 1572651520000,
+              color: '#00FF00',
+              details: 'Check humidity Alert',
+              inputSource: {
+                dataSourceIds: ['humidity'],
+              },
             },
           ],
           addSpaceOnEdges: 1,

--- a/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.js
+++ b/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.js
@@ -240,6 +240,7 @@ export const formatChartData = (timeDataSourceId = 'timestamp', series, values) 
                     : new Date(dataItem[timeDataSourceId]),
                 value: dataItem[dataSourceId],
                 group: label,
+                dataSourceId,
               });
             }
           });
@@ -271,10 +272,10 @@ export const formatColors = (series) => {
 
 /**
  * Determines the dot stroke color (the border of the data point)
- * @param {string} datasetLabel
- * @param {string} label
- * @param {Object} data
- * @param {string} originalStrokeColor from carbon charts
+ * @param {string} datasetLabel --> map to group property
+ * @param {string} label --> map to key property
+ * @param {Object} data --> map to value property
+ * @param {string} originalStrokeColor --> map to defaultStrokeColor. Default setting from carbon charts
  * @returns {string} stroke color
  */
 export const applyStrokeColor = (alertRanges) => (
@@ -292,10 +293,10 @@ export const applyStrokeColor = (alertRanges) => (
 
 /**
  * Determines the dot fill color based on matching alerts
- * @param {string} datasetLabel
- * @param {string} label
- * @param {Object} data
- * @param {string} originalFillColor from carbon charts
+ * @param {string} datasetLabel --> map to group property
+ * @param {string} label --> map to key property
+ * @param {Object} data --> map to value property
+ * @param {string} originalFillColor --> map to defaultFillColor property. Default setting from carbon charts
  * @returns {string} fill color
  */
 export const applyFillColor = (alertRanges) => (datasetLabel, label, data, originalFillColor) => {
@@ -308,10 +309,10 @@ export const applyFillColor = (alertRanges) => (datasetLabel, label, data, origi
 
 /**
  * Determines if the dot is filled based on matching alerts
- * @param {string} datasetLabel
- * @param {string} label
- * @param {Object} data
- * @param {Boolean} isFilled default setting from carbon charts
+ * @param {string} datasetLabel --> map to group property
+ * @param {string} label --> map to key property
+ * @param {Object} data --> map to value property
+ * @param {Boolean} isFilled  --> map to defaultFilled property. Default setting from carbon charts
  * @returns {Boolean}
  */
 export const applyIsFilled = (alertRanges) => (datasetLabel, label, data, isFilled) => {

--- a/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.test.js
+++ b/packages/react/src/components/TimeSeriesCard/timeSeriesUtils.test.js
@@ -3,7 +3,6 @@ import { every, omit } from 'lodash-es';
 import { COLORS } from '../../constants/LayoutConstants';
 import { CHART_COLORS } from '../../constants/CardPropTypes';
 import { barChartData } from '../../utils/barChartDataSample';
-import { findMatchingAlertRange, handleTooltip } from '../../utils/cardUtilityFunctions';
 import dayjs from '../../utils/dayjs';
 
 import {
@@ -250,88 +249,6 @@ describe('timeSeriesUtils', () => {
     );
   });
 
-  it('findMatchingAlertRange', () => {
-    const data = {
-      date: new Date(1573073951),
-    };
-    const alertRange = [
-      {
-        startTimestamp: 1573073950,
-        endTimestamp: 1573073951,
-        color: '#FF0000',
-        details: 'Alert details',
-      },
-    ];
-    const matchingAlertRange = findMatchingAlertRange(alertRange, data);
-    expect(matchingAlertRange).toHaveLength(1);
-    expect(matchingAlertRange[0].color).toEqual('#FF0000');
-    expect(matchingAlertRange[0].details).toEqual('Alert details');
-  });
-
-  describe('handleTooltip', () => {
-    // handle edge case were there is no date data available for the tooltip to increase
-    // branch testing coverage
-    it('should not add date if missing', () => {
-      const defaultTooltip = '<ul><li>existing tooltip</li></ul>';
-      const updatedTooltip = handleTooltip([], defaultTooltip, [], 'Detected alert:');
-      expect(updatedTooltip).toEqual(defaultTooltip);
-    });
-    it('should not throw error if dataOrHoveredElement is undefined', () => {
-      const defaultTooltip = '<ul><li>existing tooltip</li></ul>';
-      const updatedTooltip = handleTooltip(undefined, defaultTooltip, [], 'Detected alert:');
-      expect(updatedTooltip).toEqual(defaultTooltip);
-    });
-    it('should add date', () => {
-      const defaultTooltip = '<ul><li>existing tooltip</li></ul>';
-      // the date is from 2017
-      const updatedTooltip = handleTooltip(
-        { date: new Date(1500000000000) },
-        defaultTooltip,
-        [],
-        'Detected alert:'
-      );
-      expect(updatedTooltip).not.toEqual(defaultTooltip);
-      expect(updatedTooltip).toContain('<ul');
-      expect(updatedTooltip).toContain('2017');
-    });
-    it('with __data__ and GMT', () => {
-      const defaultTooltip = '<ul><li>existing tooltip</li></ul>';
-      // the date is from 2017
-      const updatedTooltip = handleTooltip(
-        { __data__: { date: new Date(1500000000000) } },
-        defaultTooltip,
-        [],
-        'Detected alert:',
-        true,
-        'dddd' // custom format
-      );
-      expect(updatedTooltip).not.toEqual(defaultTooltip);
-      expect(updatedTooltip).toContain('<ul');
-      expect(updatedTooltip).toContain('Friday');
-    });
-    it('should add alert ranges if they exist', () => {
-      const defaultTooltip = '<ul><li>existing tooltip</li></ul>';
-      // the date is from 2017
-      const updatedTooltip = handleTooltip(
-        [{ date: new Date(1573073950) }],
-        defaultTooltip,
-        [
-          {
-            startTimestamp: 1573073950,
-            endTimestamp: 1573073951,
-            color: '#FF0000',
-            details: 'Alert details',
-          },
-        ],
-        'Detected alert:'
-      );
-      expect(updatedTooltip).not.toEqual(defaultTooltip);
-      expect(updatedTooltip).toContain('<ul');
-      expect(updatedTooltip).toContain('Detected alert:');
-      expect(updatedTooltip).toContain('Alert details');
-    });
-  });
-
   describe('formatChartData', () => {
     it("handles series that aren't an array", () => {
       const series = {
@@ -347,21 +264,25 @@ describe('timeSeriesUtils', () => {
         )
       ).toEqual([
         {
+          dataSourceId: 'particles',
           date: new Date('2020-02-09T16:23:45.000Z'),
           group: 'Amsterdam',
           value: 447,
         },
         {
+          dataSourceId: 'particles',
           date: new Date('2020-02-10T16:23:45.000Z'),
           group: 'Amsterdam',
           value: 450,
         },
         {
+          dataSourceId: 'particles',
           date: new Date('2020-02-11T16:23:45.000Z'),
           group: 'Amsterdam',
           value: 512,
         },
         {
+          dataSourceId: 'particles',
           date: new Date('2020-02-12T16:23:45.000Z'),
           group: 'Amsterdam',
           value: 565,
@@ -384,21 +305,25 @@ describe('timeSeriesUtils', () => {
         )
       ).toEqual([
         {
+          dataSourceId: 'particles',
           date: new Date('2020-02-09T16:23:45.000Z'),
           group: 'Amsterdam',
           value: 447,
         },
         {
+          dataSourceId: 'particles',
           date: new Date('2020-02-10T16:23:45.000Z'),
           group: 'Amsterdam',
           value: 450,
         },
         {
+          dataSourceId: 'particles',
           date: new Date('2020-02-11T16:23:45.000Z'),
           group: 'Amsterdam',
           value: 512,
         },
         {
+          dataSourceId: 'particles',
           date: new Date('2020-02-12T16:23:45.000Z'),
           group: 'Amsterdam',
           value: 565,
@@ -423,21 +348,25 @@ describe('timeSeriesUtils', () => {
         )
       ).toEqual([
         {
+          dataSourceId: 'particles',
           date: new Date('2020-02-09T16:23:45.000Z'),
           group: 'Amsterdam',
           value: 447,
         },
         {
+          dataSourceId: 'particles',
           date: new Date('2020-02-10T16:23:45.000Z'),
           group: 'Amsterdam',
           value: 450,
         },
         {
+          dataSourceId: 'particles',
           date: new Date('2020-02-11T16:23:45.000Z'),
           group: 'Amsterdam',
           value: 512,
         },
         {
+          dataSourceId: 'particles',
           date: new Date('2020-02-12T16:23:45.000Z'),
           group: 'Amsterdam',
           value: 565,
@@ -466,41 +395,49 @@ describe('timeSeriesUtils', () => {
 
       expect(formatChartData('timestamp', series, barChartData.timestamps)).toEqual([
         {
+          dataSourceId: 'particles',
           date: new Date('2020-02-09T16:23:45.000Z'),
           group: 'Amsterdam',
           value: 447,
         },
         {
+          dataSourceId: 'particles',
           date: new Date('2020-02-10T16:23:45.000Z'),
           group: 'Amsterdam',
           value: 450,
         },
         {
+          dataSourceId: 'particles',
           date: new Date('2020-02-11T16:23:45.000Z'),
           group: 'Amsterdam',
           value: 512,
         },
         {
+          dataSourceId: 'particles',
           date: new Date('2020-02-12T16:23:45.000Z'),
           group: 'Amsterdam',
           value: 565,
         },
         {
+          dataSourceId: 'particles',
           date: new Date('2020-02-09T16:23:45.000Z'),
           group: 'New York',
           value: 528,
         },
         {
+          dataSourceId: 'particles',
           date: new Date('2020-02-10T16:23:45.000Z'),
           group: 'New York',
           value: 365,
         },
         {
+          dataSourceId: 'particles',
           date: new Date('2020-02-11T16:23:45.000Z'),
           group: 'New York',
           value: 442,
         },
         {
+          dataSourceId: 'particles',
           date: new Date('2020-02-12T16:23:45.000Z'),
           group: 'New York',
           value: 453,

--- a/packages/react/src/utils/cardUtilityFunctions.js
+++ b/packages/react/src/utils/cardUtilityFunctions.js
@@ -456,10 +456,12 @@ export const findMatchingThresholds = (thresholds, item, columnId) => {
 
 /** compare the current datapoint to a list of alert ranges */
 export const findMatchingAlertRange = (alertRanges, data) => {
-  const currentDataPoint = Array.isArray(data) ? data[0]?.date : data?.date;
+  const currentData = Array.isArray(data) ? data[0] : data;
+
+  const { date: currentDataPoint, dataSourceId } = currentData || {};
 
   if (!currentDataPoint) {
-    return false;
+    return [];
   }
 
   const currentDatapointTimestamp = currentDataPoint.valueOf();
@@ -468,7 +470,10 @@ export const findMatchingAlertRange = (alertRanges, data) => {
     alertRanges.filter(
       (alert) =>
         currentDatapointTimestamp <= alert.endTimestamp &&
-        currentDatapointTimestamp >= alert.startTimestamp
+        currentDatapointTimestamp >= alert.startTimestamp &&
+        (alert?.inputSource?.dataSourceIds && dataSourceId // If there is input data sources provided use them to do the filter
+          ? alert.inputSource.dataSourceIds.includes(dataSourceId)
+          : true)
     )
   );
 };


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-addons-iot-react/issues/3574

**Summary**
- If there are a number of lines in the time series graph then the alerts are getting displayed on all the lines. Whereas the alerts need to be displayed on specific lines, on which alerts are generated. 

**Change List (commits, features, bugs, etc)**

- fix([cardUtilityFunctions) : update the `findMatchingAlertRange` method and added a alertRange filter machanisum
- fix([cardUtilityFunctions.test): moved the `findMatchingAlertRange` and `handleTooltip` test cases from timeSeriesUtil.test and updated the `findMatchingAlertRange` testcases to handle above changes.

**Acceptance Test (how to verify the PR)**

- Go to the TimeSeriesCard with alert ranges story --> **Alert ranges are getting overwritten all over the lines**
- Earlier:  
  * ADDON storybook
https://next.carbon-addons-iot-react.com/?path=/story/1-watson-iot-card-timeseriescard--highlight-alert-ranges
![image](https://user-images.githubusercontent.com/18572477/192746668-449a7843-38b1-417f-a8fe-5aff81d53142.png)
  * (Multiline example: Monitor dashboard)
![image](https://user-images.githubusercontent.com/18572477/192743166-acf9a2fb-d19a-4144-96ff-9136e35f300b.png)
- Now: **Alert ranges are filtered based on specific data**
https://deploy-preview-3573--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-card-timeseriescard--highlight-alert-ranges
![image](https://user-images.githubusercontent.com/18572477/192746300-1d1c41b5-a7be-4bb0-b81a-b4a2b02a75bf.png)


**Regression Test (how to make sure this PR doesn't break old functionality)**

- All the dashboard features should work without any issues. 

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [x] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [x] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [x] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [x] All strings should be translatable.
- [x] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [x] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [x] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [x] Changes or new components should either write new or update existing documentation.
- [x] PR should link and close out an existing issue
