### PR TITLE
Fix data filter for v2 device type

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditForm.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditForm.jsx
@@ -117,10 +117,10 @@ const defaultProps = {
   isSummaryDashboard: false,
   dataSeriesItemLinks: null,
   actions: {
-    onEditDataItem: null,
+    onEditDataItem: () => {},
     dataSeriesFormActions: {
-      hasAggregationsDropDown: null,
-      onAddAggregations: null,
+      hasAggregationsDropDown: () => {},
+      onAddAggregations: () => {},
     },
   },
 };

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditForm.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditForm.jsx
@@ -117,10 +117,11 @@ const defaultProps = {
   isSummaryDashboard: false,
   dataSeriesItemLinks: null,
   actions: {
-    onEditDataItem: () => {},
+    onEditDataItem: null,
     dataSeriesFormActions: {
-      hasAggregationsDropDown: () => {},
-      onAddAggregations: () => {},
+      hasAggregationsDropDown: null,
+      hasDataFilterDropdown: null,
+      onAddAggregations: null,
     },
   },
 };

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditForm.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditForm.jsx
@@ -119,7 +119,7 @@ const defaultProps = {
   actions: {
     onEditDataItem: null,
     dataSeriesFormActions: {
-      hideAggregationsDropDown: null,
+      hasAggregationsDropDown: null,
       onAddAggregations: null,
     },
   },

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
@@ -124,10 +124,10 @@ const defaultProps = {
   isSummaryDashboard: false,
   dataSeriesItemLinks: null,
   actions: {
-    onEditDataItem: null,
+    onEditDataItem: () => {},
     dataSeriesFormActions: {
-      hasAggregationsDropDown: null,
-      onAddAggregations: null,
+      hasAggregationsDropDown: () => {},
+      onAddAggregations: () => {},
     },
   },
 };

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
@@ -124,10 +124,11 @@ const defaultProps = {
   isSummaryDashboard: false,
   dataSeriesItemLinks: null,
   actions: {
-    onEditDataItem: () => {},
+    onEditDataItem: null,
     dataSeriesFormActions: {
-      hasAggregationsDropDown: () => {},
-      onAddAggregations: () => {},
+      hasAggregationsDropDown: null,
+      hasDataFilterDropdown: null,
+      onAddAggregations: null,
     },
   },
 };

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
@@ -126,7 +126,7 @@ const defaultProps = {
   actions: {
     onEditDataItem: null,
     dataSeriesFormActions: {
-      hideAggregationsDropDown: null,
+      hasAggregationsDropDown: null,
       onAddAggregations: null,
     },
   },

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
@@ -195,11 +195,11 @@ const defaultProps = {
   testId: 'aggregation-methods',
 
   actions: {
-    onEditDataItem: null,
+    onEditDataItem: () => {},
     dataSeriesFormActions: {
-      hasAggregationsDropDown: null,
-      hasDataFilterDropdown: null,
-      onAddAggregations: null,
+      hasAggregationsDropDown: () => {},
+      hasDataFilterDropdown: () => {},
+      onAddAggregations: () => {},
     },
   },
 };

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
@@ -197,8 +197,8 @@ const defaultProps = {
   actions: {
     onEditDataItem: null,
     dataSeriesFormActions: {
-      hideAggregationsDropDown: null,
-      hideDataFilterDropdown: null,
+      hasAggregationsDropDown: null,
+      hasDataFilterDropdown: null,
       onAddAggregations: null,
     },
   },
@@ -233,9 +233,8 @@ const DataSeriesFormItemModal = ({
   i18n,
   isLarge,
   testId,
-
   actions: {
-    dataSeriesFormActions: { hideAggregationsDropDown, onAddAggregations, hideDataFilterDropdown },
+    dataSeriesFormActions: { hasAggregationsDropDown, onAddAggregations, hasDataFilterDropdown },
   },
 }) => {
   const mergedI18n = { ...defaultProps.i18n, ...i18n };
@@ -302,7 +301,7 @@ const DataSeriesFormItemModal = ({
   const DataEditorContent = useMemo(
     () => (
       <>
-        {hideAggregationsDropDown(editDataItem) && (
+        {hasAggregationsDropDown(editDataItem) && (
           <div className={`${baseClassName}--input-group`}>
             {!initialAggregation || !isSummaryDashboard ? ( // selector should only be use-able in an instance dash or if there is no initial aggregation
               <div className={`${baseClassName}--input-group--item-half`}>
@@ -529,7 +528,7 @@ const DataSeriesFormItemModal = ({
           </div>
         )}
 
-        {hideDataFilterDropdown(cardConfig) && ( // only show data filter in summary dashboards or instance dashboard for DEVICE_TYPE
+        {hasDataFilterDropdown(cardConfig) && ( // only show data filter in summary dashboards or instance dashboard for DEVICE_TYPE
           <div className={`${baseClassName}--input-group ${baseClassName}--input-group--bottom `}>
             <div
               className={classnames({
@@ -622,8 +621,8 @@ const DataSeriesFormItemModal = ({
       cardConfig,
       editDataItem,
       handleTranslation,
-      hideAggregationsDropDown,
-      hideDataFilterDropdown,
+      hasAggregationsDropDown,
+      hasDataFilterDropdown,
       id,
       initialAggregation,
       initialGrain,

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
@@ -193,13 +193,12 @@ const defaultProps = {
   isLarge: false,
   validDataItems: [],
   testId: 'aggregation-methods',
-
   actions: {
-    onEditDataItem: () => {},
+    onEditDataItem: null,
     dataSeriesFormActions: {
-      hasAggregationsDropDown: () => {},
-      hasDataFilterDropdown: () => {},
-      onAddAggregations: () => {},
+      hasAggregationsDropDown: null,
+      hasDataFilterDropdown: null,
+      onAddAggregations: null,
     },
   },
 };
@@ -301,7 +300,7 @@ const DataSeriesFormItemModal = ({
   const DataEditorContent = useMemo(
     () => (
       <>
-        {hasAggregationsDropDown(editDataItem) && (
+        {hasAggregationsDropDown && hasAggregationsDropDown(editDataItem) && (
           <div className={`${baseClassName}--input-group`}>
             {!initialAggregation || !isSummaryDashboard ? ( // selector should only be use-able in an instance dash or if there is no initial aggregation
               <div className={`${baseClassName}--input-group--item-half`}>
@@ -528,71 +527,72 @@ const DataSeriesFormItemModal = ({
           </div>
         )}
 
-        {hasDataFilterDropdown(cardConfig) && ( // only show data filter in summary dashboards or instance dashboard for DEVICE_TYPE
-          <div className={`${baseClassName}--input-group ${baseClassName}--input-group--bottom `}>
-            <div
-              className={classnames({
-                [`${baseClassName}--input-group--item`]: !isEmpty(editDataItem.dataFilter),
-                [`${baseClassName}--input-group--item-half`]:
-                  isEmpty(editDataItem.dataFilter) ||
-                  (!isEmpty(editDataItem.dataFilter) &&
-                    !availableDimensions[selectedDimensionFilter]),
-              })}
-            >
-              <Dropdown
-                id={`${id}_data-filter-key`}
-                label=""
-                translateWithId={handleTranslation}
-                direction="bottom"
-                items={[mergedI18n.none, ...Object.keys(availableDimensions)]}
-                light
-                selectedItem={selectedDimensionFilter || mergedI18n.none}
-                onChange={({ selectedItem }) => {
-                  if (selectedItem !== mergedI18n.none) {
-                    const dataFilter = {
-                      [selectedItem]: availableDimensions[selectedItem].sort()[0],
-                    };
-                    setEditDataItem({
-                      ...editDataItem,
-                      dataFilter,
-                    });
-                  } else {
-                    setEditDataItem({
-                      ...omit(editDataItem, 'dataFilter'),
-                    });
-                  }
-                }}
-                titleText={mergedI18n.dataItemEditorDataItemFilter}
-              />
-            </div>
-            {!isEmpty(editDataItem.dataFilter) && availableDimensions[selectedDimensionFilter] && (
-              <div className={`${baseClassName}--input-group--item-end`}>
+        {hasDataFilterDropdown &&
+          hasDataFilterDropdown(cardConfig) && ( // only show data filter in summary dashboards or instance dashboard for DEVICE_TYPE
+            <div className={`${baseClassName}--input-group ${baseClassName}--input-group--bottom `}>
+              <div
+                className={classnames({
+                  [`${baseClassName}--input-group--item`]: !isEmpty(editDataItem.dataFilter),
+                  [`${baseClassName}--input-group--item-half`]:
+                    isEmpty(editDataItem.dataFilter) ||
+                    (!isEmpty(editDataItem.dataFilter) &&
+                      !availableDimensions[selectedDimensionFilter]),
+                })}
+              >
                 <Dropdown
-                  id={`${id}_data-filter-value`}
+                  id={`${id}_data-filter-key`}
                   label=""
+                  translateWithId={handleTranslation}
                   direction="bottom"
-                  items={availableDimensions[selectedDimensionFilter]?.sort()}
+                  items={[mergedI18n.none, ...Object.keys(availableDimensions)]}
                   light
-                  itemToString={(item) => item?.toString()}
-                  selectedItem={
-                    editDataItem.dataFilter
-                      ? editDataItem.dataFilter[selectedDimensionFilter]
-                      : undefined
-                  }
+                  selectedItem={selectedDimensionFilter || mergedI18n.none}
                   onChange={({ selectedItem }) => {
-                    const dataFilter = {
-                      [selectedDimensionFilter]: selectedItem,
-                    };
-                    setEditDataItem({
-                      ...editDataItem,
-                      dataFilter,
-                    });
+                    if (selectedItem !== mergedI18n.none) {
+                      const dataFilter = {
+                        [selectedItem]: availableDimensions[selectedItem].sort()[0],
+                      };
+                      setEditDataItem({
+                        ...editDataItem,
+                        dataFilter,
+                      });
+                    } else {
+                      setEditDataItem({
+                        ...omit(editDataItem, 'dataFilter'),
+                      });
+                    }
                   }}
+                  titleText={mergedI18n.dataItemEditorDataItemFilter}
                 />
               </div>
-            )}
-          </div>
-        )}
+              {!isEmpty(editDataItem.dataFilter) && availableDimensions[selectedDimensionFilter] && (
+                <div className={`${baseClassName}--input-group--item-end`}>
+                  <Dropdown
+                    id={`${id}_data-filter-value`}
+                    label=""
+                    direction="bottom"
+                    items={availableDimensions[selectedDimensionFilter]?.sort()}
+                    light
+                    itemToString={(item) => item?.toString()}
+                    selectedItem={
+                      editDataItem.dataFilter
+                        ? editDataItem.dataFilter[selectedDimensionFilter]
+                        : undefined
+                    }
+                    onChange={({ selectedItem }) => {
+                      const dataFilter = {
+                        [selectedDimensionFilter]: selectedItem,
+                      };
+                      setEditDataItem({
+                        ...editDataItem,
+                        dataFilter,
+                      });
+                    }}
+                  />
+                </div>
+              )}
+            </div>
+          )}
 
         {(type === CARD_TYPES.VALUE || type === CARD_TYPES.IMAGE || type === CARD_TYPES.TABLE) && (
           <ThresholdsFormItem

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.test.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.test.jsx
@@ -167,6 +167,7 @@ describe('DataSeriesFormItemModal', () => {
       onEditDataItem: jest.fn().mockImplementation(() => []),
       dataSeriesFormActions: {
         hideAggregationsDropDown: jest.fn(() => true),
+        hideDataFilterDropdown: jest.fn(() => true),
         onAddAggregations: jest.fn(),
       },
     },

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.test.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.test.jsx
@@ -166,8 +166,8 @@ describe('DataSeriesFormItemModal', () => {
     actions: {
       onEditDataItem: jest.fn().mockImplementation(() => []),
       dataSeriesFormActions: {
-        hideAggregationsDropDown: jest.fn(() => true),
-        hideDataFilterDropdown: jest.fn(() => true),
+        hasAggregationsDropDown: jest.fn(() => true),
+        hasDataFilterDropdown: jest.fn(() => true),
         onAddAggregations: jest.fn(),
       },
     },
@@ -188,6 +188,58 @@ describe('DataSeriesFormItemModal', () => {
     const legendColorLabel = screen.getByText('Line color');
     expect(label).toBeInTheDocument();
     expect(legendColorLabel).toBeInTheDocument();
+
+    const dataFilter = screen.getByRole('listbox', { name: 'Data filter' });
+    expect(dataFilter).toBeInTheDocument();
+
+    const aggregationDropdown = screen.getByRole('listbox', { name: 'Aggregation method' });
+    expect(aggregationDropdown).toBeInTheDocument();
+  });
+  it('Renders for timeseries card data without datafilter', () => {
+    render(
+      <DataSeriesFormItemModal
+        {...{
+          ...commonProps,
+          actions: {
+            ...commonProps.actions,
+            dataSeriesFormActions: {
+              ...commonProps.actions.dataSeriesFormActions,
+              hasDataFilterDropdown: jest.fn(() => false),
+            },
+          },
+        }}
+        showEditor
+        cardConfig={timeSeriesCardConfig}
+        editDataItem={editTimeseriesDataItem}
+        editDataSeries={editDataSeriesTimeSeries}
+      />
+    );
+
+    const dataFilter = screen.queryByText('Data filter');
+    expect(dataFilter).not.toBeInTheDocument();
+  });
+  it('Renders for timeseries card data without aggregation dropdown', () => {
+    render(
+      <DataSeriesFormItemModal
+        {...{
+          ...commonProps,
+          actions: {
+            ...commonProps.actions,
+            dataSeriesFormActions: {
+              ...commonProps.actions.dataSeriesFormActions,
+              hasAggregationsDropDown: jest.fn(() => false),
+            },
+          },
+        }}
+        showEditor
+        cardConfig={timeSeriesCardConfig}
+        editDataItem={editTimeseriesDataItem}
+        editDataSeries={editDataSeriesTimeSeries}
+      />
+    );
+
+    const dataFilter = screen.queryByText('Aggregation method');
+    expect(dataFilter).not.toBeInTheDocument();
   });
   it('Non-timebased simple bar should hide grain', () => {
     const simpleNonTimeBasedBar = {

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
@@ -156,7 +156,7 @@ const defaultProps = {
   actions: {
     onEditDataItem: null,
     dataSeriesFormActions: {
-      hideAggregationsDropDown: null,
+      hasAggregationsDropDown: null,
       onAddAggregations: null,
     },
   },

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
@@ -154,10 +154,11 @@ const defaultProps = {
   isSummaryDashboard: false,
   dataSeriesItemLinks: null,
   actions: {
-    onEditDataItem: () => {},
+    onEditDataItem: null,
     dataSeriesFormActions: {
-      hasAggregationsDropDown: () => {},
-      onAddAggregations: () => {},
+      hasAggregationsDropDown: null,
+      hasDataFilterDropdown: null,
+      onAddAggregations: null,
     },
   },
 };

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
@@ -154,10 +154,10 @@ const defaultProps = {
   isSummaryDashboard: false,
   dataSeriesItemLinks: null,
   actions: {
-    onEditDataItem: null,
+    onEditDataItem: () => {},
     dataSeriesFormActions: {
-      hasAggregationsDropDown: null,
-      onAddAggregations: null,
+      hasAggregationsDropDown: () => {},
+      onAddAggregations: () => {},
     },
   },
 };

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.test.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.test.jsx
@@ -108,6 +108,7 @@ const commonActions = {
         (editDataItem) =>
           editDataItem?.dataItemType !== 'DIMENSION' && editDataItem?.type !== 'TIMESTAMP'
       ),
+      hideDataFilterDropdown: jest.fn(),
       onAddAggregations: jest.fn(),
     },
   },

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.test.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.test.jsx
@@ -104,11 +104,11 @@ const commonActions = {
   actions: {
     onEditDataItem: jest.fn().mockImplementation(() => []),
     dataSeriesFormActions: {
-      hideAggregationsDropDown: jest.fn(
+      hasAggregationsDropDown: jest.fn(
         (editDataItem) =>
           editDataItem?.dataItemType !== 'DIMENSION' && editDataItem?.type !== 'TIMESTAMP'
       ),
-      hideDataFilterDropdown: jest.fn(),
+      hasDataFilterDropdown: jest.fn(),
       onAddAggregations: jest.fn(),
     },
   },

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ImageCardFormItems/ImageCardFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ImageCardFormItems/ImageCardFormContent.jsx
@@ -80,7 +80,7 @@ const defaultProps = {
   actions: {
     onEditDataItem: null,
     dataSeriesFormActions: {
-      hideAggregationsDropDown: null,
+      hasAggregationsDropDown: null,
       onAddAggregations: null,
     },
   },

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ImageCardFormItems/ImageCardFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ImageCardFormItems/ImageCardFormContent.jsx
@@ -78,10 +78,10 @@ const defaultProps = {
   availableDimensions: {},
   onFetchDynamicDemoHotspots: null,
   actions: {
-    onEditDataItem: null,
+    onEditDataItem: () => {},
     dataSeriesFormActions: {
-      hasAggregationsDropDown: null,
-      onAddAggregations: null,
+      hasAggregationsDropDown: () => {},
+      onAddAggregations: () => {},
     },
   },
 };

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ImageCardFormItems/ImageCardFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ImageCardFormItems/ImageCardFormContent.jsx
@@ -78,10 +78,11 @@ const defaultProps = {
   availableDimensions: {},
   onFetchDynamicDemoHotspots: null,
   actions: {
-    onEditDataItem: () => {},
+    onEditDataItem: null,
     dataSeriesFormActions: {
-      hasAggregationsDropDown: () => {},
-      onAddAggregations: () => {},
+      hasAggregationsDropDown: null,
+      hasDataFilterDropdown: null,
+      onAddAggregations: null,
     },
   },
 };

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -117,10 +117,10 @@ const defaultProps = {
   availableDimensions: {},
   dataSeriesItemLinks: null,
   actions: {
-    onEditDataItem: null,
+    onEditDataItem: () => {},
     dataSeriesFormActions: {
-      hasAggregationsDropDown: null,
-      onAddAggregations: null,
+      hasAggregationsDropDown: () => {},
+      onAddAggregations: () => {},
     },
   },
 };

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -119,7 +119,7 @@ const defaultProps = {
   actions: {
     onEditDataItem: null,
     dataSeriesFormActions: {
-      hideAggregationsDropDown: null,
+      hasAggregationsDropDown: null,
       onAddAggregations: null,
     },
   },

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -117,10 +117,11 @@ const defaultProps = {
   availableDimensions: {},
   dataSeriesItemLinks: null,
   actions: {
-    onEditDataItem: () => {},
+    onEditDataItem: null,
     dataSeriesFormActions: {
-      hasAggregationsDropDown: () => {},
-      onAddAggregations: () => {},
+      hasAggregationsDropDown: null,
+      hasDataFilterDropdown: null,
+      onAddAggregations: null,
     },
   },
 };

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
@@ -45,11 +45,11 @@ const commonProps = {
   actions: {
     onEditDataItem: jest.fn().mockImplementation(() => []),
     dataSeriesFormActions: {
-      hideAggregationsDropDown: jest.fn(
+      hasAggregationsDropDown: jest.fn(
         (editDataItem) =>
           editDataItem?.dataItemType !== 'DIMENSION' && editDataItem?.type !== 'TIMESTAMP'
       ),
-      hideDataFilterDropdown: jest.fn(),
+      hasDataFilterDropdown: jest.fn(),
       onAddAggregations: jest.fn(),
     },
   },

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
@@ -49,6 +49,7 @@ const commonProps = {
         (editDataItem) =>
           editDataItem?.dataItemType !== 'DIMENSION' && editDataItem?.type !== 'TIMESTAMP'
       ),
+      hideDataFilterDropdown: jest.fn(),
       onAddAggregations: jest.fn(),
     },
   },

--- a/packages/react/src/components/CardEditor/CardEditor.jsx
+++ b/packages/react/src/components/CardEditor/CardEditor.jsx
@@ -176,10 +176,10 @@ const defaultProps = {
   dataSeriesItemLinks: null,
   onEditDataItems: null,
   actions: {
-    onEditDataItem: null,
+    onEditDataItem: () => {},
     dataSeriesFormActions: {
-      hasAggregationsDropDown: null,
-      onAddAggregations: null,
+      hasAggregationsDropDown: () => {},
+      onAddAggregations: () => {},
     },
   },
 };

--- a/packages/react/src/components/CardEditor/CardEditor.jsx
+++ b/packages/react/src/components/CardEditor/CardEditor.jsx
@@ -178,7 +178,7 @@ const defaultProps = {
   actions: {
     onEditDataItem: null,
     dataSeriesFormActions: {
-      hideAggregationsDropDown: null,
+      hasAggregationsDropDown: null,
       onAddAggregations: null,
     },
   },

--- a/packages/react/src/components/CardEditor/CardEditor.jsx
+++ b/packages/react/src/components/CardEditor/CardEditor.jsx
@@ -176,10 +176,11 @@ const defaultProps = {
   dataSeriesItemLinks: null,
   onEditDataItems: null,
   actions: {
-    onEditDataItem: () => {},
+    onEditDataItem: null,
     dataSeriesFormActions: {
-      hasAggregationsDropDown: () => {},
-      onAddAggregations: () => {},
+      hasAggregationsDropDown: null,
+      hasDataFilterDropdown: null,
+      onAddAggregations: null,
     },
   },
 };

--- a/packages/react/src/components/CardEditor/CardEditor.story.jsx
+++ b/packages/react/src/components/CardEditor/CardEditor.story.jsx
@@ -29,6 +29,7 @@ const commonActions = {
   dataSeriesFormActions: {
     hideAggregationsDropDown: (editDataItem) =>
       editDataItem?.dataItemType !== 'DIMENSION' && editDataItem?.type !== 'TIMESTAMP',
+    hideDataFilterDropdown: action('hideDataFilterDropdown'),
     onAddAggregations: action('onAddAggregations'),
   },
 };

--- a/packages/react/src/components/CardEditor/CardEditor.story.jsx
+++ b/packages/react/src/components/CardEditor/CardEditor.story.jsx
@@ -27,9 +27,9 @@ const commonActions = {
         ]
       : [],
   dataSeriesFormActions: {
-    hideAggregationsDropDown: (editDataItem) =>
+    hasAggregationsDropDown: (editDataItem) =>
       editDataItem?.dataItemType !== 'DIMENSION' && editDataItem?.type !== 'TIMESTAMP',
-    hideDataFilterDropdown: action('hideDataFilterDropdown'),
+    hasDataFilterDropdown: action('hasDataFilterDropdown'),
     onAddAggregations: action('onAddAggregations'),
   },
 };

--- a/packages/react/src/components/CardEditor/__snapshots__/CardEditor.story.storyshot
+++ b/packages/react/src/components/CardEditor/__snapshots__/CardEditor.story.storyshot
@@ -1060,8 +1060,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       actions={
                         Object {
                           "dataSeriesFormActions": Object {
-                            "hideAggregationsDropDown": [Function],
-                            "hideDataFilterDropdown": [Function],
+                            "hasAggregationsDropDown": [Function],
+                            "hasDataFilterDropdown": [Function],
                             "onAddAggregations": [Function],
                           },
                           "onEditDataItem": [Function],
@@ -3678,8 +3678,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       actions={
                         Object {
                           "dataSeriesFormActions": Object {
-                            "hideAggregationsDropDown": [Function],
-                            "hideDataFilterDropdown": [Function],
+                            "hasAggregationsDropDown": [Function],
+                            "hasDataFilterDropdown": [Function],
                             "onAddAggregations": [Function],
                           },
                           "onEditDataItem": [Function],
@@ -4641,8 +4641,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       actions={
                         Object {
                           "dataSeriesFormActions": Object {
-                            "hideAggregationsDropDown": [Function],
-                            "hideDataFilterDropdown": [Function],
+                            "hasAggregationsDropDown": [Function],
+                            "hasDataFilterDropdown": [Function],
                             "onAddAggregations": [Function],
                           },
                           "onEditDataItem": [Function],

--- a/packages/react/src/components/CardEditor/__snapshots__/CardEditor.story.storyshot
+++ b/packages/react/src/components/CardEditor/__snapshots__/CardEditor.story.storyshot
@@ -1061,6 +1061,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         Object {
                           "dataSeriesFormActions": Object {
                             "hideAggregationsDropDown": [Function],
+                            "hideDataFilterDropdown": [Function],
                             "onAddAggregations": [Function],
                           },
                           "onEditDataItem": [Function],
@@ -3678,6 +3679,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         Object {
                           "dataSeriesFormActions": Object {
                             "hideAggregationsDropDown": [Function],
+                            "hideDataFilterDropdown": [Function],
                             "onAddAggregations": [Function],
                           },
                           "onEditDataItem": [Function],
@@ -4640,6 +4642,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         Object {
                           "dataSeriesFormActions": Object {
                             "hideAggregationsDropDown": [Function],
+                            "hideDataFilterDropdown": [Function],
                             "onAddAggregations": [Function],
                           },
                           "onEditDataItem": [Function],

--- a/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
@@ -389,7 +389,7 @@ const defaultProps = {
   actions: {
     onEditDataItem: null,
     dataSeriesFormActions: {
-      hideAggregationsDropDown: null,
+      hasAggregationsDropDown: null,
       onAddAggregations: null,
     },
   },

--- a/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
@@ -387,10 +387,10 @@ const defaultProps = {
   onEditDataItems: null,
   testId: 'dashboard-editor',
   actions: {
-    onEditDataItem: null,
+    onEditDataItem: () => {},
     dataSeriesFormActions: {
-      hasAggregationsDropDown: null,
-      onAddAggregations: null,
+      hasAggregationsDropDown: () => {},
+      onAddAggregations: () => {},
     },
   },
 };

--- a/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
@@ -387,10 +387,11 @@ const defaultProps = {
   onEditDataItems: null,
   testId: 'dashboard-editor',
   actions: {
-    onEditDataItem: () => {},
+    onEditDataItem: null,
     dataSeriesFormActions: {
-      hasAggregationsDropDown: () => {},
-      onAddAggregations: () => {},
+      hasAggregationsDropDown: null,
+      hasDataFilterDropdown: null,
+      onAddAggregations: null,
     },
   },
 };

--- a/packages/react/src/components/DashboardEditor/DashboardEditor.story.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.story.jsx
@@ -40,7 +40,7 @@ const commonActions = {
         ]
       : [],
   dataSeriesFormActions: {
-    hideAggregationsDropDown: (editDataItem) =>
+    hasAggregationsDropDown: (editDataItem) =>
       editDataItem?.dataItemType !== 'DIMENSION' && editDataItem?.type !== 'TIMESTAMP',
     onAddAggregations: action('onAddAggregations'),
   },
@@ -431,7 +431,7 @@ export const WithInitialValue = () => (
     onCancel={action('onCancel')}
     onSubmit={action('onSubmit')}
     onLayoutChange={action('onLayoutChange')}
-    hideAggregationsDropDown={action('hideAggregationsDropDown')}
+    hasAggregationsDropDown={action('hasAggregationsDropDown')}
     supportedCardTypes={[
       'TIMESERIES',
       'SIMPLE_BAR',

--- a/packages/react/src/components/DashboardEditor/DashboardEditor.test.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.test.jsx
@@ -40,11 +40,11 @@ const commonProps = {
   actions: {
     onEditDataItem: jest.fn().mockImplementation(() => []),
     dataSeriesFormActions: {
-      hideAggregationsDropDown: jest.fn(
+      hasAggregationsDropDown: jest.fn(
         (editDataItem) =>
           editDataItem?.dataItemType !== 'DIMENSION' && editDataItem?.type !== 'TIMESTAMP'
       ),
-      hideDataFilterDropdown: jest.fn(),
+      hasDataFilterDropdown: jest.fn(),
       onAddAggregations: jest.fn(),
     },
   },

--- a/packages/react/src/components/DashboardEditor/DashboardEditor.test.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.test.jsx
@@ -44,6 +44,7 @@ const commonProps = {
         (editDataItem) =>
           editDataItem?.dataItemType !== 'DIMENSION' && editDataItem?.type !== 'TIMESTAMP'
       ),
+      hideDataFilterDropdown: jest.fn(),
       onAddAggregations: jest.fn(),
     },
   },

--- a/packages/react/src/components/DashboardEditor/editorUtils.jsx
+++ b/packages/react/src/components/DashboardEditor/editorUtils.jsx
@@ -713,10 +713,41 @@ export const renderDefaultIconByName = (iconName, iconProps = {}) => {
 };
 
 export const DashboardEditorActionsPropTypes = PropTypes.shape({
+  /** Call back function for on click of edit button, returns aggregationMethods for a selcted dataSource
+   * onEditDataItem(cardConfig: card properties, dataItem: selected dataItem, dataItemWithMetaData: selected dataItem with meta data);
+   * return {object}: returns aggregationMethods for a selcted dataSource
+   * ex:
+   *[
+      {
+          "id": "none",
+          "text": "None"
+      },
+      {
+          "id": "mean",
+          "text": "Mean",
+      },
+      {
+          "id": "min",
+          "text": "Minimum",
+      }
+    ]
+   */
   onEditDataItem: PropTypes.func,
+  /** Form actions for dataSeries modal */
   dataSeriesFormActions: PropTypes.shape({
-    hideAggregationsDropDown: PropTypes.func,
-    hideDataFilterDropdown: PropTypes.func,
+    /** callback function to determine aggregation dropdown visibility
+     * hasAggregationsDropDown(editDataItem: selected dataSource)
+     * return {boolean} : true or false
+     */
+    hasAggregationsDropDown: PropTypes.func,
+    /** callback function to determine dataFilter dropdown visibility
+     * hasDataFilterDropdown(cardProps: card properties)
+     * return {boolean} : true or false
+     */
+    hasDataFilterDropdown: PropTypes.func,
+    /** callback function on click of Add aggregation method label
+     * onAddAggregations(editDataItem: selected dataSource)
+     */
     onAddAggregations: PropTypes.func,
   }),
 });

--- a/packages/react/src/components/DashboardEditor/editorUtils.jsx
+++ b/packages/react/src/components/DashboardEditor/editorUtils.jsx
@@ -716,6 +716,7 @@ export const DashboardEditorActionsPropTypes = PropTypes.shape({
   onEditDataItem: PropTypes.func,
   dataSeriesFormActions: PropTypes.shape({
     hideAggregationsDropDown: PropTypes.func,
+    hideDataFilterDropdown: PropTypes.func,
     onAddAggregations: PropTypes.func,
   }),
 });

--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/HotspotEditorDataSourceTab.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/HotspotEditorDataSourceTab.jsx
@@ -96,10 +96,10 @@ const defaultProps = {
   availableDimensions: {},
   testId: 'HotspotEditorDataSourceTab',
   actions: {
-    onEditDataItem: null,
+    onEditDataItem: () => {},
     dataSeriesFormActions: {
-      hasAggregationsDropDown: null,
-      onAddAggregations: null,
+      hasAggregationsDropDown: () => {},
+      onAddAggregations: () => {},
     },
   },
 };

--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/HotspotEditorDataSourceTab.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/HotspotEditorDataSourceTab.jsx
@@ -98,7 +98,7 @@ const defaultProps = {
   actions: {
     onEditDataItem: null,
     dataSeriesFormActions: {
-      hideAggregationsDropDown: null,
+      hasAggregationsDropDown: null,
       onAddAggregations: null,
     },
   },

--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/HotspotEditorDataSourceTab.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/HotspotEditorDataSourceTab.jsx
@@ -96,10 +96,11 @@ const defaultProps = {
   availableDimensions: {},
   testId: 'HotspotEditorDataSourceTab',
   actions: {
-    onEditDataItem: () => {},
+    onEditDataItem: null,
     dataSeriesFormActions: {
-      hasAggregationsDropDown: () => {},
-      onAddAggregations: () => {},
+      hasAggregationsDropDown: null,
+      hasDataFilterDropdown: null,
+      onAddAggregations: null,
     },
   },
 };

--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/HotspotEditorDataSourceTab.story.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/HotspotEditorDataSourceTab.story.jsx
@@ -19,9 +19,9 @@ const commonActions = {
         ]
       : [],
   dataSeriesFormActions: {
-    hideAggregationsDropDown: (editDataItem) =>
+    hasAggregationsDropDown: (editDataItem) =>
       editDataItem?.dataItemType !== 'DIMENSION' && editDataItem?.type !== 'TIMESTAMP',
-    hideDataFilterDropdown: action('hideDataFilterDropdown'),
+    hasDataFilterDropdown: action('hasDataFilterDropdown'),
     onAddAggregations: action('onAddAggregations'),
   },
 };

--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/HotspotEditorDataSourceTab.story.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/HotspotEditorDataSourceTab.story.jsx
@@ -21,6 +21,7 @@ const commonActions = {
   dataSeriesFormActions: {
     hideAggregationsDropDown: (editDataItem) =>
       editDataItem?.dataItemType !== 'DIMENSION' && editDataItem?.type !== 'TIMESTAMP',
+    hideDataFilterDropdown: action('hideDataFilterDropdown'),
     onAddAggregations: action('onAddAggregations'),
   },
 };

--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/HotspotEditorDataSourceTab.test.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/HotspotEditorDataSourceTab.test.jsx
@@ -59,11 +59,11 @@ const commonActions = {
   actions: {
     onEditDataItem: jest.fn().mockImplementation(() => []),
     dataSeriesFormActions: {
-      hideAggregationsDropDown: jest.fn(
+      hasAggregationsDropDown: jest.fn(
         (editDataItem) =>
           editDataItem?.dataItemType !== 'DIMENSION' && editDataItem?.type !== 'TIMESTAMP'
       ),
-      hideDataFilterDropdown: jest.fn(),
+      hasDataFilterDropdown: jest.fn(),
       onAddAggregations: jest.fn(),
     },
   },
@@ -187,11 +187,11 @@ describe('HotspotEditorDataSourceTab', () => {
           { id: 'min', text: 'Minimum' },
         ]),
         dataSeriesFormActions: {
-          hideAggregationsDropDown: jest.fn(
+          hasAggregationsDropDown: jest.fn(
             (editDataItem) =>
               editDataItem?.dataItemType !== 'DIMENSION' && editDataItem?.type !== 'TIMESTAMP'
           ),
-          hideDataFilterDropdown: jest.fn(),
+          hasDataFilterDropdown: jest.fn(),
           onAddAggregations: jest.fn(),
         },
       },

--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/HotspotEditorDataSourceTab.test.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorDataSourceTab/HotspotEditorDataSourceTab.test.jsx
@@ -63,6 +63,7 @@ const commonActions = {
         (editDataItem) =>
           editDataItem?.dataItemType !== 'DIMENSION' && editDataItem?.type !== 'TIMESTAMP'
       ),
+      hideDataFilterDropdown: jest.fn(),
       onAddAggregations: jest.fn(),
     },
   },
@@ -190,6 +191,7 @@ describe('HotspotEditorDataSourceTab', () => {
             (editDataItem) =>
               editDataItem?.dataItemType !== 'DIMENSION' && editDataItem?.type !== 'TIMESTAMP'
           ),
+          hideDataFilterDropdown: jest.fn(),
           onAddAggregations: jest.fn(),
         },
       },

--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.jsx
@@ -220,10 +220,11 @@ const defaultProps = {
   },
   testId: 'hotspot-editor-modal',
   actions: {
-    onEditDataItem: () => {},
+    onEditDataItem: null,
     dataSeriesFormActions: {
-      hasAggregationsDropDown: () => {},
-      onAddAggregations: () => {},
+      hasAggregationsDropDown: null,
+      hasDataFilterDropdown: null,
+      onAddAggregations: null,
     },
   },
 };

--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.jsx
@@ -222,7 +222,7 @@ const defaultProps = {
   actions: {
     onEditDataItem: null,
     dataSeriesFormActions: {
-      hideAggregationsDropDown: null,
+      hasAggregationsDropDown: null,
       onAddAggregations: null,
     },
   },

--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.jsx
@@ -220,10 +220,10 @@ const defaultProps = {
   },
   testId: 'hotspot-editor-modal',
   actions: {
-    onEditDataItem: null,
+    onEditDataItem: () => {},
     dataSeriesFormActions: {
-      hasAggregationsDropDown: null,
-      onAddAggregations: null,
+      hasAggregationsDropDown: () => {},
+      onAddAggregations: () => {},
     },
   },
 };

--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.story.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.story.jsx
@@ -22,7 +22,7 @@ const commonActions = {
         ]
       : [],
   dataSeriesFormActions: {
-    hideAggregationsDropDown: (editDataItem) =>
+    hasAggregationsDropDown: (editDataItem) =>
       editDataItem?.dataItemType !== 'DIMENSION' && editDataItem?.type !== 'TIMESTAMP',
     onAddAggregations: action('onAddAggregations'),
   },

--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.test.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.test.jsx
@@ -118,11 +118,11 @@ const commonActions = {
   actions: {
     onEditDataItem: jest.fn().mockImplementation(() => []),
     dataSeriesFormActions: {
-      hideAggregationsDropDown: jest.fn(
+      hasAggregationsDropDown: jest.fn(
         (editDataItem) =>
           editDataItem?.dataItemType !== 'DIMENSION' && editDataItem?.type !== 'TIMESTAMP'
       ),
-      hideDataFilterDropdown: jest.fn(),
+      hasDataFilterDropdown: jest.fn(),
       onAddAggregations: jest.fn(),
     },
   },

--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.test.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.test.jsx
@@ -122,6 +122,7 @@ const commonActions = {
         (editDataItem) =>
           editDataItem?.dataItemType !== 'DIMENSION' && editDataItem?.type !== 'TIMESTAMP'
       ),
+      hideDataFilterDropdown: jest.fn(),
       onAddAggregations: jest.fn(),
     },
   },

--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorTooltipTab/HotspotEditorTooltipTab.story.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorTooltipTab/HotspotEditorTooltipTab.story.jsx
@@ -18,7 +18,7 @@ const commonActions = {
         ]
       : [],
   dataSeriesFormActions: {
-    hideAggregationsDropDown: (editDataItem) =>
+    hasAggregationsDropDown: (editDataItem) =>
       editDataItem?.dataItemType !== 'DIMENSION' && editDataItem?.type !== 'TIMESTAMP',
     onAddAggregations: action('onAddAggregations'),
   },

--- a/packages/react/src/components/HotspotEditorModal/HotspotTextStyleTab/HotspotTextStyleTab.story.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotTextStyleTab/HotspotTextStyleTab.story.jsx
@@ -31,7 +31,7 @@ const commonActions = {
         ]
       : [],
   dataSeriesFormActions: {
-    hideAggregationsDropDown: (editDataItem) =>
+    hasAggregationsDropDown: (editDataItem) =>
       editDataItem?.dataItemType !== 'DIMENSION' && editDataItem?.type !== 'TIMESTAMP',
     onAddAggregations: action('onAddAggregations'),
   },

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -13876,10 +13876,11 @@ Map {
     "defaultProps": Object {
       "actions": Object {
         "dataSeriesFormActions": Object {
-          "hasAggregationsDropDown": [Function],
-          "onAddAggregations": [Function],
+          "hasAggregationsDropDown": null,
+          "hasDataFilterDropdown": null,
+          "onAddAggregations": null,
         },
-        "onEditDataItem": [Function],
+        "onEditDataItem": null,
       },
       "availableDimensions": Object {},
       "availableImages": Array [],
@@ -14663,10 +14664,11 @@ Map {
     "defaultProps": Object {
       "actions": Object {
         "dataSeriesFormActions": Object {
-          "hasAggregationsDropDown": [Function],
-          "onAddAggregations": [Function],
+          "hasAggregationsDropDown": null,
+          "hasDataFilterDropdown": null,
+          "onAddAggregations": null,
         },
-        "onEditDataItem": [Function],
+        "onEditDataItem": null,
       },
       "availableDimensions": Object {},
       "cardConfig": null,

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -13876,7 +13876,7 @@ Map {
     "defaultProps": Object {
       "actions": Object {
         "dataSeriesFormActions": Object {
-          "hideAggregationsDropDown": null,
+          "hasAggregationsDropDown": null,
           "onAddAggregations": null,
         },
         "onEditDataItem": null,
@@ -13970,10 +13970,10 @@ Map {
             "dataSeriesFormActions": Object {
               "args": Array [
                 Object {
-                  "hideAggregationsDropDown": Object {
+                  "hasAggregationsDropDown": Object {
                     "type": "func",
                   },
-                  "hideDataFilterDropdown": Object {
+                  "hasDataFilterDropdown": Object {
                     "type": "func",
                   },
                   "onAddAggregations": Object {
@@ -14663,7 +14663,7 @@ Map {
     "defaultProps": Object {
       "actions": Object {
         "dataSeriesFormActions": Object {
-          "hideAggregationsDropDown": null,
+          "hasAggregationsDropDown": null,
           "onAddAggregations": null,
         },
         "onEditDataItem": null,
@@ -14715,10 +14715,10 @@ Map {
             "dataSeriesFormActions": Object {
               "args": Array [
                 Object {
-                  "hideAggregationsDropDown": Object {
+                  "hasAggregationsDropDown": Object {
                     "type": "func",
                   },
-                  "hideDataFilterDropdown": Object {
+                  "hasDataFilterDropdown": Object {
                     "type": "func",
                   },
                   "onAddAggregations": Object {

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -13876,10 +13876,10 @@ Map {
     "defaultProps": Object {
       "actions": Object {
         "dataSeriesFormActions": Object {
-          "hasAggregationsDropDown": null,
-          "onAddAggregations": null,
+          "hasAggregationsDropDown": [Function],
+          "onAddAggregations": [Function],
         },
-        "onEditDataItem": null,
+        "onEditDataItem": [Function],
       },
       "availableDimensions": Object {},
       "availableImages": Array [],
@@ -14663,10 +14663,10 @@ Map {
     "defaultProps": Object {
       "actions": Object {
         "dataSeriesFormActions": Object {
-          "hasAggregationsDropDown": null,
-          "onAddAggregations": null,
+          "hasAggregationsDropDown": [Function],
+          "onAddAggregations": [Function],
         },
-        "onEditDataItem": null,
+        "onEditDataItem": [Function],
       },
       "availableDimensions": Object {},
       "cardConfig": null,

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -13973,6 +13973,9 @@ Map {
                   "hideAggregationsDropDown": Object {
                     "type": "func",
                   },
+                  "hideDataFilterDropdown": Object {
+                    "type": "func",
+                  },
                   "onAddAggregations": Object {
                     "type": "func",
                   },
@@ -14713,6 +14716,9 @@ Map {
               "args": Array [
                 Object {
                   "hideAggregationsDropDown": Object {
+                    "type": "func",
+                  },
+                  "hideDataFilterDropdown": Object {
                     "type": "func",
                   },
                   "onAddAggregations": Object {


### PR DESCRIPTION
Closes Monitor - https://github.ibm.com/wiotp/Maximo-Asset-Monitor/issues/4661

**Summary**

- Fixed DataFilter not available for V2 device types under dashboard editor

**Change List (commits, features, bugs, etc)**

- fix(dataseriesformcontentmodal): added datafilter for v2 devicetypes
- fix(dataseriesformitemmodal): updated test cases

**Acceptance Test (how to verify the PR)**

- Datafilter should be available for v2 device type on click of edit data item after adding it into a card in dashboard editor

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
