### PR TITLE
feat(listitem): accept hover text

### DIFF
--- a/packages/react/src/components/List/ListContent/ListContent.jsx
+++ b/packages/react/src/components/List/ListContent/ListContent.jsx
@@ -190,7 +190,7 @@ const ListContent = ({
     const isIndeterminate = indeterminateIds.includes(item.id);
 
     const {
-      content: { value, secondaryValue, icon, rowActions, tags },
+      content: { value, title, secondaryValue, icon, rowActions, tags },
       isSelectable,
       isCategory,
       disabled,
@@ -208,6 +208,7 @@ const ListContent = ({
           index={index}
           key={`${item.id}-list-item-${level}-${value}`}
           nestingLevel={item?.children && item.children.length > 0 ? level - 1 : level}
+          title={title}
           value={value}
           icon={
             editingStyleIsMultiple(editingStyle) || (isSelectable && isCheckboxMultiSelect) ? (

--- a/packages/react/src/components/List/ListItem/ListItem.jsx
+++ b/packages/react/src/components/List/ListItem/ListItem.jsx
@@ -38,8 +38,9 @@ const ListItemPropTypes = {
   selected: PropTypes.bool,
   expanded: PropTypes.bool,
   value: PropTypes.string.isRequired,
-  /** string value or callback render function */
+  /** text displayed on hover */
   title: PropTypes.string,
+  /** string value or callback render function */
   secondaryValue: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.func,

--- a/packages/react/src/components/List/ListItem/ListItem.jsx
+++ b/packages/react/src/components/List/ListItem/ListItem.jsx
@@ -331,7 +331,7 @@ const ListItem = ({
                 [`${iotPrefix}--list-item--category`]: isCategory,
                 [`${iotPrefix}--list-item--content--values__disabled`]: disabled,
               })}
-              title={title ?? value}
+              title={title || value}
             >
               {value}
             </div>

--- a/packages/react/src/components/List/ListItem/ListItem.jsx
+++ b/packages/react/src/components/List/ListItem/ListItem.jsx
@@ -39,6 +39,7 @@ const ListItemPropTypes = {
   expanded: PropTypes.bool,
   value: PropTypes.string.isRequired,
   /** string value or callback render function */
+  title: PropTypes.string,
   secondaryValue: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.func,
@@ -110,6 +111,7 @@ const ListItemDefaultProps = {
   selectedItemRef: null,
   tags: null,
   preventRowFocus: false,
+  title: null,
 };
 
 const ListItem = ({
@@ -124,6 +126,7 @@ const ListItem = ({
   selected,
   disabled,
   value,
+  title,
   secondaryValue,
   rowActions,
   renderDropTargets,
@@ -328,7 +331,7 @@ const ListItem = ({
                 [`${iotPrefix}--list-item--category`]: isCategory,
                 [`${iotPrefix}--list-item--content--values__disabled`]: disabled,
               })}
-              title={value}
+              title={title ?? value}
             >
               {value}
             </div>

--- a/packages/react/src/components/List/ListItem/ListItem.story.jsx
+++ b/packages/react/src/components/List/ListItem/ListItem.story.jsx
@@ -35,6 +35,7 @@ export default {
 
 export const BasicWKnobs = () => {
   const value = text('value', 'List Item');
+  const title = text('title', 'List Item title/hover text');
   const secondaryValue = text('secondaryValue', undefined);
   const iconName = select('icon', ['none', 'Star16', 'StarFilled16']);
   const iconComponent =
@@ -89,6 +90,7 @@ export const BasicWKnobs = () => {
         {...dndProps}
         id="list-item"
         value={value}
+        title={title}
         secondaryValue={secondaryValue}
         icon={iconComponent ? React.createElement(iconComponent) : null}
         iconPosition={select('iconPosition', ['left', 'right'], 'right')}

--- a/packages/react/src/components/List/ListItem/__snapshots__/ListItem.story.storyshot
+++ b/packages/react/src/components/List/ListItem/__snapshots__/ListItem.story.storyshot
@@ -25,7 +25,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/L
           >
             <div
               className="iot--list-item--content--values--value"
-              title="List Item"
+              title="List Item title/hover text"
             >
               List Item
             </div>

--- a/packages/react/src/components/List/ListPropTypes.js
+++ b/packages/react/src/components/List/ListPropTypes.js
@@ -16,6 +16,7 @@ export const ListItemPropTypes = {
     /** The nodes should be Carbon Tags components */
     tags: PropTypes.arrayOf(PropTypes.node),
     value: PropTypes.string,
+    title: PropTypes.string,
   }),
   /** boolean to define load more row is needed */
   hasLoadMore: PropTypes.bool,

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -6663,6 +6663,9 @@ Map {
                         ],
                         "type": "arrayOf",
                       },
+                      "title": Object {
+                        "type": "string",
+                      },
                       "value": Object {
                         "type": "string",
                       },
@@ -6944,6 +6947,9 @@ Map {
                           },
                         ],
                         "type": "arrayOf",
+                      },
+                      "title": Object {
+                        "type": "string",
                       },
                       "value": Object {
                         "type": "string",
@@ -7245,6 +7251,9 @@ Map {
                           },
                         ],
                         "type": "arrayOf",
+                      },
+                      "title": Object {
+                        "type": "string",
                       },
                       "value": Object {
                         "type": "string",
@@ -29848,6 +29857,9 @@ Map {
                           },
                         ],
                         "type": "arrayOf",
+                      },
+                      "title": Object {
+                        "type": "string",
                       },
                       "value": Object {
                         "type": "string",


### PR DESCRIPTION
Closes #3572

**Summary**

- List item to accept new property to display as hover text.

**Change List (commits, features, bugs, etc)**

- ListContent to accept `title` and drill prop to ListItem
- ListItem to accept new property `title` and use as hover text
- ListItem to use name when title is empty (null or undefined)

**Acceptance Test (how to verify the PR)**

- Set `value` and `title` with different texts.
- Hover over the list item component
- Title content should be displayed as tooltip and Value should be displayed as regular text

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
