### PR TITLE
fix(dashboardEditor): send card JSON on card select

### DIFF
--- a/packages/react/src/components/DashboardEditor/DashboardEditor.test.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.test.jsx
@@ -226,7 +226,7 @@ describe('DashboardEditor', () => {
     // there should now be two cards with the same title
     expect(screen.getAllByText('value card')).toHaveLength(2);
     // card select should have been called
-    expect(commonProps.onCardSelect).toHaveBeenCalled();
+    expect(commonProps.onCardSelect).toHaveBeenCalledWith(mockValueCard);
   });
 
   it('selecting remove card should remove card', () => {
@@ -309,7 +309,14 @@ describe('DashboardEditor', () => {
     expect(addCardBtn).toBeInTheDocument();
     fireEvent.click(addCardBtn);
     // card select should have been called
-    expect(commonProps.onCardSelect).toHaveBeenCalled();
+    expect(commonProps.onCardSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: { allowNavigation: true, columns: [], showHeader: true },
+        size: 'LARGE',
+        title: 'Untitled',
+        type: 'TABLE',
+      })
+    );
   });
 
   it('selecting submit should fire onSubmit', () => {

--- a/packages/react/src/components/DashboardEditor/DashboardEditorCardRenderer.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditorCardRenderer.jsx
@@ -95,19 +95,19 @@ const DashboardEditorCardRenderer = React.memo(
 
     const handleOnCardKeyDown = useCallback(
       (e) => {
-        handleKeyDown(e, setSelectedCardId, cardConfig.id);
+        handleKeyDown(e, setSelectedCardId, cardConfig);
       },
-      [cardConfig.id, setSelectedCardId]
+      [cardConfig, setSelectedCardId]
     );
 
     const handleOnCardMouseDown = useCallback(
       (e) => {
-        handleOnClick(setSelectedCardId, cardConfig.id);
+        handleOnClick(setSelectedCardId, cardConfig);
         cardConfig.onMouseDown(e);
       },
       // Need to disable the eslint role because I don't want to regen if any other part of cardConfig changes
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      [cardConfig.id, cardConfig.onMouseDown, setSelectedCardId]
+      [cardConfig, cardConfig.onMouseDown, setSelectedCardId]
     );
     // Need to memoize these card props at this level to improve performance
     const cardProps = useMemo(

--- a/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -292,7 +292,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
               <div
                 className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
                 data-floating-menu-container={true}
-                data-testid="ComposedModal"
+                data-testid="dashboard-editor-image-gallery-modal"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onClose={[Function]}
@@ -404,7 +404,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           <input
                             autoComplete="off"
                             className="bx--search-input"
-                            data-testid="ComposedModal-search-input"
+                            data-testid="dashboard-editor-image-gallery-modal-search-input"
                             id="iot--image-gallery-modal--search"
                             onChange={[Function]}
                             onKeyDown={[Function]}
@@ -436,7 +436,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         </div>
                         <div
                           className="bx--content-switcher iot--image-gallery-modal__content-switcher"
-                          data-testid="ComposedModal-content-switcher"
+                          data-testid="dashboard-editor-image-gallery-modal-content-switcher"
                           onChange={[Function]}
                           role="tablist"
                         >
@@ -444,7 +444,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                             aria-describedby={null}
                             aria-pressed={null}
                             className="iot--icon-switch iot--icon-switch--large iot--icon-switch--selected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                            data-testid="ComposedModal-grid-switch"
+                            data-testid="dashboard-editor-image-gallery-modal-grid-switch"
                             disabled={false}
                             onBlur={[Function]}
                             onClick={[Function]}
@@ -486,7 +486,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                             aria-describedby={null}
                             aria-pressed={null}
                             className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                            data-testid="ComposedModal-list-switch"
+                            data-testid="dashboard-editor-image-gallery-modal-list-switch"
                             disabled={false}
                             onBlur={[Function]}
                             onClick={[Function]}
@@ -542,7 +542,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       aria-describedby={null}
                       aria-pressed={null}
                       className="iot--btn bx--btn bx--btn--secondary"
-                      data-testid="ComposedModal-modal-secondary-button"
+                      data-testid="dashboard-editor-image-gallery-modal-modal-secondary-button"
                       disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -558,7 +558,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       aria-describedby={null}
                       aria-pressed={null}
                       className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                      data-testid="ComposedModal-modal-primary-button"
+                      data-testid="dashboard-editor-image-gallery-modal-modal-primary-button"
                       disabled={true}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -3124,7 +3124,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
             <div
               className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
               data-floating-menu-container={true}
-              data-testid="ComposedModal"
+              data-testid="dashboard-editor-image-gallery-modal"
               onBlur={[Function]}
               onClick={[Function]}
               onClose={[Function]}
@@ -3236,7 +3236,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         <input
                           autoComplete="off"
                           className="bx--search-input"
-                          data-testid="ComposedModal-search-input"
+                          data-testid="dashboard-editor-image-gallery-modal-search-input"
                           id="iot--image-gallery-modal--search"
                           onChange={[Function]}
                           onKeyDown={[Function]}
@@ -3268,7 +3268,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       </div>
                       <div
                         className="bx--content-switcher iot--image-gallery-modal__content-switcher"
-                        data-testid="ComposedModal-content-switcher"
+                        data-testid="dashboard-editor-image-gallery-modal-content-switcher"
                         onChange={[Function]}
                         role="tablist"
                       >
@@ -3276,7 +3276,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           aria-describedby={null}
                           aria-pressed={null}
                           className="iot--icon-switch iot--icon-switch--large iot--icon-switch--selected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                          data-testid="ComposedModal-grid-switch"
+                          data-testid="dashboard-editor-image-gallery-modal-grid-switch"
                           disabled={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -3318,7 +3318,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           aria-describedby={null}
                           aria-pressed={null}
                           className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                          data-testid="ComposedModal-list-switch"
+                          data-testid="dashboard-editor-image-gallery-modal-list-switch"
                           disabled={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -3374,7 +3374,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     aria-describedby={null}
                     aria-pressed={null}
                     className="iot--btn bx--btn bx--btn--secondary"
-                    data-testid="ComposedModal-modal-secondary-button"
+                    data-testid="dashboard-editor-image-gallery-modal-modal-secondary-button"
                     disabled={false}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -3390,7 +3390,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     aria-describedby={null}
                     aria-pressed={null}
                     className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                    data-testid="ComposedModal-modal-primary-button"
+                    data-testid="dashboard-editor-image-gallery-modal-modal-primary-button"
                     disabled={true}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -4475,7 +4475,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
             <div
               className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
               data-floating-menu-container={true}
-              data-testid="ComposedModal"
+              data-testid="dashboard-editor-image-gallery-modal"
               onBlur={[Function]}
               onClick={[Function]}
               onClose={[Function]}
@@ -4587,7 +4587,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         <input
                           autoComplete="off"
                           className="bx--search-input"
-                          data-testid="ComposedModal-search-input"
+                          data-testid="dashboard-editor-image-gallery-modal-search-input"
                           id="iot--image-gallery-modal--search"
                           onChange={[Function]}
                           onKeyDown={[Function]}
@@ -4619,7 +4619,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       </div>
                       <div
                         className="bx--content-switcher iot--image-gallery-modal__content-switcher"
-                        data-testid="ComposedModal-content-switcher"
+                        data-testid="dashboard-editor-image-gallery-modal-content-switcher"
                         onChange={[Function]}
                         role="tablist"
                       >
@@ -4627,7 +4627,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           aria-describedby={null}
                           aria-pressed={null}
                           className="iot--icon-switch iot--icon-switch--large iot--icon-switch--selected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                          data-testid="ComposedModal-grid-switch"
+                          data-testid="dashboard-editor-image-gallery-modal-grid-switch"
                           disabled={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -4669,7 +4669,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           aria-describedby={null}
                           aria-pressed={null}
                           className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                          data-testid="ComposedModal-list-switch"
+                          data-testid="dashboard-editor-image-gallery-modal-list-switch"
                           disabled={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -4728,7 +4728,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-assemblyline"
+                        data-testid="dashboard-editor-image-gallery-modal-assemblyline"
                         htmlFor="assemblyline"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -4757,7 +4757,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-assemblyline-title"
+                            data-testid="dashboard-editor-image-gallery-modal-assemblyline-title"
                           >
                             <span>
                               custom title assemblyline that is very long a and must be managed.
@@ -4771,13 +4771,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="assemblyline"
-                              data-testid="ComposedModal-assemblyline-image"
+                              data-testid="dashboard-editor-image-gallery-modal-assemblyline-image"
                               src="assemblyline.jpg"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-assemblyline-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-assemblyline-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -4829,7 +4829,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-floow_plan"
+                        data-testid="dashboard-editor-image-gallery-modal-floow_plan"
                         htmlFor="floow_plan"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -4858,7 +4858,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-floow_plan-title"
+                            data-testid="dashboard-editor-image-gallery-modal-floow_plan-title"
                           >
                             <span>
                               floow_plan
@@ -4869,13 +4869,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="floow plan"
-                              data-testid="ComposedModal-floow_plan-image"
+                              data-testid="dashboard-editor-image-gallery-modal-floow_plan-image"
                               src="floow_plan.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-floow_plan-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-floow_plan-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -4927,7 +4927,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-manufacturing_plant"
+                        data-testid="dashboard-editor-image-gallery-modal-manufacturing_plant"
                         htmlFor="manufacturing_plant"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -4956,7 +4956,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-manufacturing_plant-title"
+                            data-testid="dashboard-editor-image-gallery-modal-manufacturing_plant-title"
                           >
                             <span>
                               Manufacturing_plant
@@ -4967,13 +4967,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="manufacturing plant"
-                              data-testid="ComposedModal-manufacturing_plant-image"
+                              data-testid="dashboard-editor-image-gallery-modal-manufacturing_plant-image"
                               src="Manufacturing_plant.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-manufacturing_plant-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-manufacturing_plant-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -5025,7 +5025,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-robot_arm"
+                        data-testid="dashboard-editor-image-gallery-modal-robot_arm"
                         htmlFor="robot_arm"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -5054,7 +5054,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-robot_arm-title"
+                            data-testid="dashboard-editor-image-gallery-modal-robot_arm-title"
                           >
                             <span>
                               robot_arm
@@ -5065,13 +5065,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="robot arm"
-                              data-testid="ComposedModal-robot_arm-image"
+                              data-testid="dashboard-editor-image-gallery-modal-robot_arm-image"
                               src="robot_arm.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-robot_arm-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-robot_arm-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -5123,7 +5123,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-tankmodal"
+                        data-testid="dashboard-editor-image-gallery-modal-tankmodal"
                         htmlFor="tankmodal"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -5152,7 +5152,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-tankmodal-title"
+                            data-testid="dashboard-editor-image-gallery-modal-tankmodal-title"
                           >
                             <span>
                               tankmodal
@@ -5163,13 +5163,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="tankmodal"
-                              data-testid="ComposedModal-tankmodal-image"
+                              data-testid="dashboard-editor-image-gallery-modal-tankmodal-image"
                               src="tankmodal.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-tankmodal-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-tankmodal-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -5221,7 +5221,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-turbines"
+                        data-testid="dashboard-editor-image-gallery-modal-turbines"
                         htmlFor="turbines"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -5250,7 +5250,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-turbines-title"
+                            data-testid="dashboard-editor-image-gallery-modal-turbines-title"
                           >
                             <span>
                               turbines
@@ -5261,13 +5261,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="turbines"
-                              data-testid="ComposedModal-turbines-image"
+                              data-testid="dashboard-editor-image-gallery-modal-turbines-image"
                               src="turbines.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-turbines-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-turbines-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -5319,7 +5319,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-extra-wide-image"
+                        data-testid="dashboard-editor-image-gallery-modal-extra-wide-image"
                         htmlFor="extra-wide-image"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -5348,7 +5348,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-extra-wide-image-title"
+                            data-testid="dashboard-editor-image-gallery-modal-extra-wide-image-title"
                           >
                             <span>
                               extra-wide-image
@@ -5359,13 +5359,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="extra wide image"
-                              data-testid="ComposedModal-extra-wide-image-image"
+                              data-testid="dashboard-editor-image-gallery-modal-extra-wide-image-image"
                               src="extra-wide-image.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-extra-wide-image-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-extra-wide-image-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -5417,7 +5417,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-large"
+                        data-testid="dashboard-editor-image-gallery-modal-large"
                         htmlFor="large"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -5446,7 +5446,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-large-title"
+                            data-testid="dashboard-editor-image-gallery-modal-large-title"
                           >
                             <span>
                               large
@@ -5457,13 +5457,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="large image"
-                              data-testid="ComposedModal-large-image"
+                              data-testid="dashboard-editor-image-gallery-modal-large-image"
                               src="large.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-large-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-large-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -5515,7 +5515,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-large_portrait"
+                        data-testid="dashboard-editor-image-gallery-modal-large_portrait"
                         htmlFor="large_portrait"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -5544,7 +5544,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-large_portrait-title"
+                            data-testid="dashboard-editor-image-gallery-modal-large_portrait-title"
                           >
                             <span>
                               large_portrait
@@ -5555,13 +5555,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="large image portrait"
-                              data-testid="ComposedModal-large_portrait-image"
+                              data-testid="dashboard-editor-image-gallery-modal-large_portrait-image"
                               src="large_portrait.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-large_portrait-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-large_portrait-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -5611,7 +5611,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     aria-describedby={null}
                     aria-pressed={null}
                     className="iot--btn bx--btn bx--btn--secondary"
-                    data-testid="ComposedModal-modal-secondary-button"
+                    data-testid="dashboard-editor-image-gallery-modal-modal-secondary-button"
                     disabled={false}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -5627,7 +5627,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     aria-describedby={null}
                     aria-pressed={null}
                     className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                    data-testid="ComposedModal-modal-primary-button"
+                    data-testid="dashboard-editor-image-gallery-modal-modal-primary-button"
                     disabled={true}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -7793,7 +7793,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
             <div
               className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
               data-floating-menu-container={true}
-              data-testid="ComposedModal"
+              data-testid="dashboard-editor-image-gallery-modal"
               onBlur={[Function]}
               onClick={[Function]}
               onClose={[Function]}
@@ -7905,7 +7905,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         <input
                           autoComplete="off"
                           className="bx--search-input"
-                          data-testid="ComposedModal-search-input"
+                          data-testid="dashboard-editor-image-gallery-modal-search-input"
                           id="iot--image-gallery-modal--search"
                           onChange={[Function]}
                           onKeyDown={[Function]}
@@ -7937,7 +7937,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       </div>
                       <div
                         className="bx--content-switcher iot--image-gallery-modal__content-switcher"
-                        data-testid="ComposedModal-content-switcher"
+                        data-testid="dashboard-editor-image-gallery-modal-content-switcher"
                         onChange={[Function]}
                         role="tablist"
                       >
@@ -7945,7 +7945,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           aria-describedby={null}
                           aria-pressed={null}
                           className="iot--icon-switch iot--icon-switch--large iot--icon-switch--selected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                          data-testid="ComposedModal-grid-switch"
+                          data-testid="dashboard-editor-image-gallery-modal-grid-switch"
                           disabled={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -7987,7 +7987,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           aria-describedby={null}
                           aria-pressed={null}
                           className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                          data-testid="ComposedModal-list-switch"
+                          data-testid="dashboard-editor-image-gallery-modal-list-switch"
                           disabled={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -8046,7 +8046,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-assemblyline"
+                        data-testid="dashboard-editor-image-gallery-modal-assemblyline"
                         htmlFor="assemblyline"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -8075,7 +8075,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-assemblyline-title"
+                            data-testid="dashboard-editor-image-gallery-modal-assemblyline-title"
                           >
                             <span>
                               custom title assemblyline that is very long a and must be managed.
@@ -8089,13 +8089,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="assemblyline"
-                              data-testid="ComposedModal-assemblyline-image"
+                              data-testid="dashboard-editor-image-gallery-modal-assemblyline-image"
                               src="assemblyline.jpg"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-assemblyline-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-assemblyline-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -8147,7 +8147,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-floow_plan"
+                        data-testid="dashboard-editor-image-gallery-modal-floow_plan"
                         htmlFor="floow_plan"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -8176,7 +8176,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-floow_plan-title"
+                            data-testid="dashboard-editor-image-gallery-modal-floow_plan-title"
                           >
                             <span>
                               floow_plan
@@ -8187,13 +8187,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="floow plan"
-                              data-testid="ComposedModal-floow_plan-image"
+                              data-testid="dashboard-editor-image-gallery-modal-floow_plan-image"
                               src="floow_plan.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-floow_plan-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-floow_plan-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -8245,7 +8245,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-manufacturing_plant"
+                        data-testid="dashboard-editor-image-gallery-modal-manufacturing_plant"
                         htmlFor="manufacturing_plant"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -8274,7 +8274,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-manufacturing_plant-title"
+                            data-testid="dashboard-editor-image-gallery-modal-manufacturing_plant-title"
                           >
                             <span>
                               Manufacturing_plant
@@ -8285,13 +8285,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="manufacturing plant"
-                              data-testid="ComposedModal-manufacturing_plant-image"
+                              data-testid="dashboard-editor-image-gallery-modal-manufacturing_plant-image"
                               src="Manufacturing_plant.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-manufacturing_plant-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-manufacturing_plant-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -8343,7 +8343,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-robot_arm"
+                        data-testid="dashboard-editor-image-gallery-modal-robot_arm"
                         htmlFor="robot_arm"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -8372,7 +8372,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-robot_arm-title"
+                            data-testid="dashboard-editor-image-gallery-modal-robot_arm-title"
                           >
                             <span>
                               robot_arm
@@ -8383,13 +8383,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="robot arm"
-                              data-testid="ComposedModal-robot_arm-image"
+                              data-testid="dashboard-editor-image-gallery-modal-robot_arm-image"
                               src="robot_arm.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-robot_arm-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-robot_arm-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -8441,7 +8441,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-tankmodal"
+                        data-testid="dashboard-editor-image-gallery-modal-tankmodal"
                         htmlFor="tankmodal"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -8470,7 +8470,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-tankmodal-title"
+                            data-testid="dashboard-editor-image-gallery-modal-tankmodal-title"
                           >
                             <span>
                               tankmodal
@@ -8481,13 +8481,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="tankmodal"
-                              data-testid="ComposedModal-tankmodal-image"
+                              data-testid="dashboard-editor-image-gallery-modal-tankmodal-image"
                               src="tankmodal.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-tankmodal-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-tankmodal-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -8539,7 +8539,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-turbines"
+                        data-testid="dashboard-editor-image-gallery-modal-turbines"
                         htmlFor="turbines"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -8568,7 +8568,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-turbines-title"
+                            data-testid="dashboard-editor-image-gallery-modal-turbines-title"
                           >
                             <span>
                               turbines
@@ -8579,13 +8579,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="turbines"
-                              data-testid="ComposedModal-turbines-image"
+                              data-testid="dashboard-editor-image-gallery-modal-turbines-image"
                               src="turbines.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-turbines-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-turbines-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -8637,7 +8637,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-extra-wide-image"
+                        data-testid="dashboard-editor-image-gallery-modal-extra-wide-image"
                         htmlFor="extra-wide-image"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -8666,7 +8666,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-extra-wide-image-title"
+                            data-testid="dashboard-editor-image-gallery-modal-extra-wide-image-title"
                           >
                             <span>
                               extra-wide-image
@@ -8677,13 +8677,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="extra wide image"
-                              data-testid="ComposedModal-extra-wide-image-image"
+                              data-testid="dashboard-editor-image-gallery-modal-extra-wide-image-image"
                               src="extra-wide-image.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-extra-wide-image-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-extra-wide-image-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -8735,7 +8735,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-large"
+                        data-testid="dashboard-editor-image-gallery-modal-large"
                         htmlFor="large"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -8764,7 +8764,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-large-title"
+                            data-testid="dashboard-editor-image-gallery-modal-large-title"
                           >
                             <span>
                               large
@@ -8775,13 +8775,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="large image"
-                              data-testid="ComposedModal-large-image"
+                              data-testid="dashboard-editor-image-gallery-modal-large-image"
                               src="large.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-large-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-large-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -8833,7 +8833,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-large_portrait"
+                        data-testid="dashboard-editor-image-gallery-modal-large_portrait"
                         htmlFor="large_portrait"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -8862,7 +8862,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-large_portrait-title"
+                            data-testid="dashboard-editor-image-gallery-modal-large_portrait-title"
                           >
                             <span>
                               large_portrait
@@ -8873,13 +8873,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="large image portrait"
-                              data-testid="ComposedModal-large_portrait-image"
+                              data-testid="dashboard-editor-image-gallery-modal-large_portrait-image"
                               src="large_portrait.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-large_portrait-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-large_portrait-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -8929,7 +8929,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     aria-describedby={null}
                     aria-pressed={null}
                     className="iot--btn bx--btn bx--btn--secondary"
-                    data-testid="ComposedModal-modal-secondary-button"
+                    data-testid="dashboard-editor-image-gallery-modal-modal-secondary-button"
                     disabled={false}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -8945,7 +8945,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     aria-describedby={null}
                     aria-pressed={null}
                     className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                    data-testid="ComposedModal-modal-primary-button"
+                    data-testid="dashboard-editor-image-gallery-modal-modal-primary-button"
                     disabled={true}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -9464,7 +9464,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
             <div
               className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
               data-floating-menu-container={true}
-              data-testid="ComposedModal"
+              data-testid="dashboard-editor-image-gallery-modal"
               onBlur={[Function]}
               onClick={[Function]}
               onClose={[Function]}
@@ -9576,7 +9576,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         <input
                           autoComplete="off"
                           className="bx--search-input"
-                          data-testid="ComposedModal-search-input"
+                          data-testid="dashboard-editor-image-gallery-modal-search-input"
                           id="iot--image-gallery-modal--search"
                           onChange={[Function]}
                           onKeyDown={[Function]}
@@ -9608,7 +9608,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       </div>
                       <div
                         className="bx--content-switcher iot--image-gallery-modal__content-switcher"
-                        data-testid="ComposedModal-content-switcher"
+                        data-testid="dashboard-editor-image-gallery-modal-content-switcher"
                         onChange={[Function]}
                         role="tablist"
                       >
@@ -9616,7 +9616,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           aria-describedby={null}
                           aria-pressed={null}
                           className="iot--icon-switch iot--icon-switch--large iot--icon-switch--selected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                          data-testid="ComposedModal-grid-switch"
+                          data-testid="dashboard-editor-image-gallery-modal-grid-switch"
                           disabled={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -9658,7 +9658,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           aria-describedby={null}
                           aria-pressed={null}
                           className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                          data-testid="ComposedModal-list-switch"
+                          data-testid="dashboard-editor-image-gallery-modal-list-switch"
                           disabled={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -9714,7 +9714,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     aria-describedby={null}
                     aria-pressed={null}
                     className="iot--btn bx--btn bx--btn--secondary"
-                    data-testid="ComposedModal-modal-secondary-button"
+                    data-testid="dashboard-editor-image-gallery-modal-modal-secondary-button"
                     disabled={false}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -9730,7 +9730,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     aria-describedby={null}
                     aria-pressed={null}
                     className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                    data-testid="ComposedModal-modal-primary-button"
+                    data-testid="dashboard-editor-image-gallery-modal-modal-primary-button"
                     disabled={true}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -10899,7 +10899,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
               <div
                 className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
                 data-floating-menu-container={true}
-                data-testid="ComposedModal"
+                data-testid="dashboard-editor-image-gallery-modal"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onClose={[Function]}
@@ -11011,7 +11011,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           <input
                             autoComplete="off"
                             className="bx--search-input"
-                            data-testid="ComposedModal-search-input"
+                            data-testid="dashboard-editor-image-gallery-modal-search-input"
                             id="iot--image-gallery-modal--search"
                             onChange={[Function]}
                             onKeyDown={[Function]}
@@ -11043,7 +11043,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         </div>
                         <div
                           className="bx--content-switcher iot--image-gallery-modal__content-switcher"
-                          data-testid="ComposedModal-content-switcher"
+                          data-testid="dashboard-editor-image-gallery-modal-content-switcher"
                           onChange={[Function]}
                           role="tablist"
                         >
@@ -11051,7 +11051,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                             aria-describedby={null}
                             aria-pressed={null}
                             className="iot--icon-switch iot--icon-switch--large iot--icon-switch--selected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                            data-testid="ComposedModal-grid-switch"
+                            data-testid="dashboard-editor-image-gallery-modal-grid-switch"
                             disabled={false}
                             onBlur={[Function]}
                             onClick={[Function]}
@@ -11093,7 +11093,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                             aria-describedby={null}
                             aria-pressed={null}
                             className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                            data-testid="ComposedModal-list-switch"
+                            data-testid="dashboard-editor-image-gallery-modal-list-switch"
                             disabled={false}
                             onBlur={[Function]}
                             onClick={[Function]}
@@ -11149,7 +11149,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       aria-describedby={null}
                       aria-pressed={null}
                       className="iot--btn bx--btn bx--btn--secondary"
-                      data-testid="ComposedModal-modal-secondary-button"
+                      data-testid="dashboard-editor-image-gallery-modal-modal-secondary-button"
                       disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -11165,7 +11165,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       aria-describedby={null}
                       aria-pressed={null}
                       className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                      data-testid="ComposedModal-modal-primary-button"
+                      data-testid="dashboard-editor-image-gallery-modal-modal-primary-button"
                       disabled={true}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -12251,7 +12251,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
             <div
               className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
               data-floating-menu-container={true}
-              data-testid="ComposedModal"
+              data-testid="dashboard-editor-image-gallery-modal"
               onBlur={[Function]}
               onClick={[Function]}
               onClose={[Function]}
@@ -12363,7 +12363,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         <input
                           autoComplete="off"
                           className="bx--search-input"
-                          data-testid="ComposedModal-search-input"
+                          data-testid="dashboard-editor-image-gallery-modal-search-input"
                           id="iot--image-gallery-modal--search"
                           onChange={[Function]}
                           onKeyDown={[Function]}
@@ -12395,7 +12395,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       </div>
                       <div
                         className="bx--content-switcher iot--image-gallery-modal__content-switcher"
-                        data-testid="ComposedModal-content-switcher"
+                        data-testid="dashboard-editor-image-gallery-modal-content-switcher"
                         onChange={[Function]}
                         role="tablist"
                       >
@@ -12403,7 +12403,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           aria-describedby={null}
                           aria-pressed={null}
                           className="iot--icon-switch iot--icon-switch--large iot--icon-switch--selected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                          data-testid="ComposedModal-grid-switch"
+                          data-testid="dashboard-editor-image-gallery-modal-grid-switch"
                           disabled={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -12445,7 +12445,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           aria-describedby={null}
                           aria-pressed={null}
                           className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                          data-testid="ComposedModal-list-switch"
+                          data-testid="dashboard-editor-image-gallery-modal-list-switch"
                           disabled={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -12504,7 +12504,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-assemblyline"
+                        data-testid="dashboard-editor-image-gallery-modal-assemblyline"
                         htmlFor="assemblyline"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -12533,7 +12533,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-assemblyline-title"
+                            data-testid="dashboard-editor-image-gallery-modal-assemblyline-title"
                           >
                             <span>
                               custom title assemblyline that is very long a and must be managed.
@@ -12547,13 +12547,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="assemblyline"
-                              data-testid="ComposedModal-assemblyline-image"
+                              data-testid="dashboard-editor-image-gallery-modal-assemblyline-image"
                               src="assemblyline.jpg"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-assemblyline-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-assemblyline-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -12605,7 +12605,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-floow_plan"
+                        data-testid="dashboard-editor-image-gallery-modal-floow_plan"
                         htmlFor="floow_plan"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -12634,7 +12634,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-floow_plan-title"
+                            data-testid="dashboard-editor-image-gallery-modal-floow_plan-title"
                           >
                             <span>
                               floow_plan
@@ -12645,13 +12645,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="floow plan"
-                              data-testid="ComposedModal-floow_plan-image"
+                              data-testid="dashboard-editor-image-gallery-modal-floow_plan-image"
                               src="floow_plan.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-floow_plan-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-floow_plan-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -12703,7 +12703,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-manufacturing_plant"
+                        data-testid="dashboard-editor-image-gallery-modal-manufacturing_plant"
                         htmlFor="manufacturing_plant"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -12732,7 +12732,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-manufacturing_plant-title"
+                            data-testid="dashboard-editor-image-gallery-modal-manufacturing_plant-title"
                           >
                             <span>
                               Manufacturing_plant
@@ -12743,13 +12743,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="manufacturing plant"
-                              data-testid="ComposedModal-manufacturing_plant-image"
+                              data-testid="dashboard-editor-image-gallery-modal-manufacturing_plant-image"
                               src="Manufacturing_plant.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-manufacturing_plant-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-manufacturing_plant-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -12801,7 +12801,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-robot_arm"
+                        data-testid="dashboard-editor-image-gallery-modal-robot_arm"
                         htmlFor="robot_arm"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -12830,7 +12830,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-robot_arm-title"
+                            data-testid="dashboard-editor-image-gallery-modal-robot_arm-title"
                           >
                             <span>
                               robot_arm
@@ -12841,13 +12841,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="robot arm"
-                              data-testid="ComposedModal-robot_arm-image"
+                              data-testid="dashboard-editor-image-gallery-modal-robot_arm-image"
                               src="robot_arm.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-robot_arm-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-robot_arm-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -12899,7 +12899,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-tankmodal"
+                        data-testid="dashboard-editor-image-gallery-modal-tankmodal"
                         htmlFor="tankmodal"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -12928,7 +12928,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-tankmodal-title"
+                            data-testid="dashboard-editor-image-gallery-modal-tankmodal-title"
                           >
                             <span>
                               tankmodal
@@ -12939,13 +12939,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="tankmodal"
-                              data-testid="ComposedModal-tankmodal-image"
+                              data-testid="dashboard-editor-image-gallery-modal-tankmodal-image"
                               src="tankmodal.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-tankmodal-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-tankmodal-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -12997,7 +12997,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-turbines"
+                        data-testid="dashboard-editor-image-gallery-modal-turbines"
                         htmlFor="turbines"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -13026,7 +13026,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-turbines-title"
+                            data-testid="dashboard-editor-image-gallery-modal-turbines-title"
                           >
                             <span>
                               turbines
@@ -13037,13 +13037,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="turbines"
-                              data-testid="ComposedModal-turbines-image"
+                              data-testid="dashboard-editor-image-gallery-modal-turbines-image"
                               src="turbines.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-turbines-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-turbines-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -13095,7 +13095,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-extra-wide-image"
+                        data-testid="dashboard-editor-image-gallery-modal-extra-wide-image"
                         htmlFor="extra-wide-image"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -13124,7 +13124,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-extra-wide-image-title"
+                            data-testid="dashboard-editor-image-gallery-modal-extra-wide-image-title"
                           >
                             <span>
                               extra-wide-image
@@ -13135,13 +13135,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="extra wide image"
-                              data-testid="ComposedModal-extra-wide-image-image"
+                              data-testid="dashboard-editor-image-gallery-modal-extra-wide-image-image"
                               src="extra-wide-image.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-extra-wide-image-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-extra-wide-image-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -13193,7 +13193,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-large"
+                        data-testid="dashboard-editor-image-gallery-modal-large"
                         htmlFor="large"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -13222,7 +13222,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-large-title"
+                            data-testid="dashboard-editor-image-gallery-modal-large-title"
                           >
                             <span>
                               large
@@ -13233,13 +13233,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="large image"
-                              data-testid="ComposedModal-large-image"
+                              data-testid="dashboard-editor-image-gallery-modal-large-image"
                               src="large.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-large-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-large-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -13291,7 +13291,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-large_portrait"
+                        data-testid="dashboard-editor-image-gallery-modal-large_portrait"
                         htmlFor="large_portrait"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -13320,7 +13320,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-large_portrait-title"
+                            data-testid="dashboard-editor-image-gallery-modal-large_portrait-title"
                           >
                             <span>
                               large_portrait
@@ -13331,13 +13331,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="large image portrait"
-                              data-testid="ComposedModal-large_portrait-image"
+                              data-testid="dashboard-editor-image-gallery-modal-large_portrait-image"
                               src="large_portrait.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-large_portrait-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-large_portrait-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -13387,7 +13387,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     aria-describedby={null}
                     aria-pressed={null}
                     className="iot--btn bx--btn bx--btn--secondary"
-                    data-testid="ComposedModal-modal-secondary-button"
+                    data-testid="dashboard-editor-image-gallery-modal-modal-secondary-button"
                     disabled={false}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -13403,7 +13403,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     aria-describedby={null}
                     aria-pressed={null}
                     className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                    data-testid="ComposedModal-modal-primary-button"
+                    data-testid="dashboard-editor-image-gallery-modal-modal-primary-button"
                     disabled={true}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -14636,7 +14636,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
             <div
               className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
               data-floating-menu-container={true}
-              data-testid="ComposedModal"
+              data-testid="dashboard-editor-image-gallery-modal"
               onBlur={[Function]}
               onClick={[Function]}
               onClose={[Function]}
@@ -14748,7 +14748,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         <input
                           autoComplete="off"
                           className="bx--search-input"
-                          data-testid="ComposedModal-search-input"
+                          data-testid="dashboard-editor-image-gallery-modal-search-input"
                           id="iot--image-gallery-modal--search"
                           onChange={[Function]}
                           onKeyDown={[Function]}
@@ -14780,7 +14780,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       </div>
                       <div
                         className="bx--content-switcher iot--image-gallery-modal__content-switcher"
-                        data-testid="ComposedModal-content-switcher"
+                        data-testid="dashboard-editor-image-gallery-modal-content-switcher"
                         onChange={[Function]}
                         role="tablist"
                       >
@@ -14788,7 +14788,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           aria-describedby={null}
                           aria-pressed={null}
                           className="iot--icon-switch iot--icon-switch--large iot--icon-switch--selected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                          data-testid="ComposedModal-grid-switch"
+                          data-testid="dashboard-editor-image-gallery-modal-grid-switch"
                           disabled={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -14830,7 +14830,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           aria-describedby={null}
                           aria-pressed={null}
                           className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                          data-testid="ComposedModal-list-switch"
+                          data-testid="dashboard-editor-image-gallery-modal-list-switch"
                           disabled={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -14889,7 +14889,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-assemblyline"
+                        data-testid="dashboard-editor-image-gallery-modal-assemblyline"
                         htmlFor="assemblyline"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -14918,7 +14918,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-assemblyline-title"
+                            data-testid="dashboard-editor-image-gallery-modal-assemblyline-title"
                           >
                             <span>
                               custom title assemblyline that is very long a and must be managed.
@@ -14932,13 +14932,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="assemblyline"
-                              data-testid="ComposedModal-assemblyline-image"
+                              data-testid="dashboard-editor-image-gallery-modal-assemblyline-image"
                               src="assemblyline.jpg"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-assemblyline-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-assemblyline-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -14990,7 +14990,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-floow_plan"
+                        data-testid="dashboard-editor-image-gallery-modal-floow_plan"
                         htmlFor="floow_plan"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -15019,7 +15019,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-floow_plan-title"
+                            data-testid="dashboard-editor-image-gallery-modal-floow_plan-title"
                           >
                             <span>
                               floow_plan
@@ -15030,13 +15030,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="floow plan"
-                              data-testid="ComposedModal-floow_plan-image"
+                              data-testid="dashboard-editor-image-gallery-modal-floow_plan-image"
                               src="floow_plan.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-floow_plan-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-floow_plan-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -15088,7 +15088,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-manufacturing_plant"
+                        data-testid="dashboard-editor-image-gallery-modal-manufacturing_plant"
                         htmlFor="manufacturing_plant"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -15117,7 +15117,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-manufacturing_plant-title"
+                            data-testid="dashboard-editor-image-gallery-modal-manufacturing_plant-title"
                           >
                             <span>
                               Manufacturing_plant
@@ -15128,13 +15128,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="manufacturing plant"
-                              data-testid="ComposedModal-manufacturing_plant-image"
+                              data-testid="dashboard-editor-image-gallery-modal-manufacturing_plant-image"
                               src="Manufacturing_plant.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-manufacturing_plant-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-manufacturing_plant-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -15186,7 +15186,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-robot_arm"
+                        data-testid="dashboard-editor-image-gallery-modal-robot_arm"
                         htmlFor="robot_arm"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -15215,7 +15215,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-robot_arm-title"
+                            data-testid="dashboard-editor-image-gallery-modal-robot_arm-title"
                           >
                             <span>
                               robot_arm
@@ -15226,13 +15226,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="robot arm"
-                              data-testid="ComposedModal-robot_arm-image"
+                              data-testid="dashboard-editor-image-gallery-modal-robot_arm-image"
                               src="robot_arm.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-robot_arm-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-robot_arm-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -15284,7 +15284,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-tankmodal"
+                        data-testid="dashboard-editor-image-gallery-modal-tankmodal"
                         htmlFor="tankmodal"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -15313,7 +15313,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-tankmodal-title"
+                            data-testid="dashboard-editor-image-gallery-modal-tankmodal-title"
                           >
                             <span>
                               tankmodal
@@ -15324,13 +15324,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="tankmodal"
-                              data-testid="ComposedModal-tankmodal-image"
+                              data-testid="dashboard-editor-image-gallery-modal-tankmodal-image"
                               src="tankmodal.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-tankmodal-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-tankmodal-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -15382,7 +15382,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-turbines"
+                        data-testid="dashboard-editor-image-gallery-modal-turbines"
                         htmlFor="turbines"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -15411,7 +15411,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-turbines-title"
+                            data-testid="dashboard-editor-image-gallery-modal-turbines-title"
                           >
                             <span>
                               turbines
@@ -15422,13 +15422,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="turbines"
-                              data-testid="ComposedModal-turbines-image"
+                              data-testid="dashboard-editor-image-gallery-modal-turbines-image"
                               src="turbines.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-turbines-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-turbines-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -15480,7 +15480,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-extra-wide-image"
+                        data-testid="dashboard-editor-image-gallery-modal-extra-wide-image"
                         htmlFor="extra-wide-image"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -15509,7 +15509,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-extra-wide-image-title"
+                            data-testid="dashboard-editor-image-gallery-modal-extra-wide-image-title"
                           >
                             <span>
                               extra-wide-image
@@ -15520,13 +15520,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="extra wide image"
-                              data-testid="ComposedModal-extra-wide-image-image"
+                              data-testid="dashboard-editor-image-gallery-modal-extra-wide-image-image"
                               src="extra-wide-image.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-extra-wide-image-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-extra-wide-image-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -15578,7 +15578,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-large"
+                        data-testid="dashboard-editor-image-gallery-modal-large"
                         htmlFor="large"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -15607,7 +15607,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-large-title"
+                            data-testid="dashboard-editor-image-gallery-modal-large-title"
                           >
                             <span>
                               large
@@ -15618,13 +15618,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="large image"
-                              data-testid="ComposedModal-large-image"
+                              data-testid="dashboard-editor-image-gallery-modal-large-image"
                               src="large.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-large-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-large-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -15676,7 +15676,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       />
                       <label
                         className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                        data-testid="ComposedModal-large_portrait"
+                        data-testid="dashboard-editor-image-gallery-modal-large_portrait"
                         htmlFor="large_portrait"
                         onClick={[Function]}
                         onKeyDown={[Function]}
@@ -15705,7 +15705,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <div
                             className="iot--image-tile__title"
-                            data-testid="ComposedModal-large_portrait-title"
+                            data-testid="dashboard-editor-image-gallery-modal-large_portrait-title"
                           >
                             <span>
                               large_portrait
@@ -15716,13 +15716,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <img
                               alt="large image portrait"
-                              data-testid="ComposedModal-large_portrait-image"
+                              data-testid="dashboard-editor-image-gallery-modal-large_portrait-image"
                               src="large_portrait.png"
                             />
                             <button
                               aria-describedby={null}
                               className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                              data-testid="ComposedModal-large_portrait-delete-button"
+                              data-testid="dashboard-editor-image-gallery-modal-large_portrait-delete-button"
                               disabled={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -15772,7 +15772,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     aria-describedby={null}
                     aria-pressed={null}
                     className="iot--btn bx--btn bx--btn--secondary"
-                    data-testid="ComposedModal-modal-secondary-button"
+                    data-testid="dashboard-editor-image-gallery-modal-modal-secondary-button"
                     disabled={false}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -15788,7 +15788,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     aria-describedby={null}
                     aria-pressed={null}
                     className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                    data-testid="ComposedModal-modal-primary-button"
+                    data-testid="dashboard-editor-image-gallery-modal-modal-primary-button"
                     disabled={true}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -17057,7 +17057,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
               <div
                 className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
                 data-floating-menu-container={true}
-                data-testid="ComposedModal"
+                data-testid="dashboard-editor-image-gallery-modal"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onClose={[Function]}
@@ -17169,7 +17169,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           <input
                             autoComplete="off"
                             className="bx--search-input"
-                            data-testid="ComposedModal-search-input"
+                            data-testid="dashboard-editor-image-gallery-modal-search-input"
                             id="iot--image-gallery-modal--search"
                             onChange={[Function]}
                             onKeyDown={[Function]}
@@ -17201,7 +17201,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         </div>
                         <div
                           className="bx--content-switcher iot--image-gallery-modal__content-switcher"
-                          data-testid="ComposedModal-content-switcher"
+                          data-testid="dashboard-editor-image-gallery-modal-content-switcher"
                           onChange={[Function]}
                           role="tablist"
                         >
@@ -17209,7 +17209,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                             aria-describedby={null}
                             aria-pressed={null}
                             className="iot--icon-switch iot--icon-switch--large iot--icon-switch--selected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                            data-testid="ComposedModal-grid-switch"
+                            data-testid="dashboard-editor-image-gallery-modal-grid-switch"
                             disabled={false}
                             onBlur={[Function]}
                             onClick={[Function]}
@@ -17251,7 +17251,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                             aria-describedby={null}
                             aria-pressed={null}
                             className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                            data-testid="ComposedModal-list-switch"
+                            data-testid="dashboard-editor-image-gallery-modal-list-switch"
                             disabled={false}
                             onBlur={[Function]}
                             onClick={[Function]}
@@ -17307,7 +17307,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       aria-describedby={null}
                       aria-pressed={null}
                       className="iot--btn bx--btn bx--btn--secondary"
-                      data-testid="ComposedModal-modal-secondary-button"
+                      data-testid="dashboard-editor-image-gallery-modal-modal-secondary-button"
                       disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -17323,7 +17323,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       aria-describedby={null}
                       aria-pressed={null}
                       className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                      data-testid="ComposedModal-modal-primary-button"
+                      data-testid="dashboard-editor-image-gallery-modal-modal-primary-button"
                       disabled={true}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -18312,7 +18312,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
             <div
               className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
               data-floating-menu-container={true}
-              data-testid="ComposedModal"
+              data-testid="dashboard-editor-image-gallery-modal"
               onBlur={[Function]}
               onClick={[Function]}
               onClose={[Function]}
@@ -18424,7 +18424,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         <input
                           autoComplete="off"
                           className="bx--search-input"
-                          data-testid="ComposedModal-search-input"
+                          data-testid="dashboard-editor-image-gallery-modal-search-input"
                           id="iot--image-gallery-modal--search"
                           onChange={[Function]}
                           onKeyDown={[Function]}
@@ -18456,7 +18456,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       </div>
                       <div
                         className="bx--content-switcher iot--image-gallery-modal__content-switcher"
-                        data-testid="ComposedModal-content-switcher"
+                        data-testid="dashboard-editor-image-gallery-modal-content-switcher"
                         onChange={[Function]}
                         role="tablist"
                       >
@@ -18464,7 +18464,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           aria-describedby={null}
                           aria-pressed={null}
                           className="iot--icon-switch iot--icon-switch--large iot--icon-switch--selected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                          data-testid="ComposedModal-grid-switch"
+                          data-testid="dashboard-editor-image-gallery-modal-grid-switch"
                           disabled={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -18506,7 +18506,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           aria-describedby={null}
                           aria-pressed={null}
                           className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                          data-testid="ComposedModal-list-switch"
+                          data-testid="dashboard-editor-image-gallery-modal-list-switch"
                           disabled={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -18562,7 +18562,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     aria-describedby={null}
                     aria-pressed={null}
                     className="iot--btn bx--btn bx--btn--secondary"
-                    data-testid="ComposedModal-modal-secondary-button"
+                    data-testid="dashboard-editor-image-gallery-modal-modal-secondary-button"
                     disabled={false}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -18578,7 +18578,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     aria-describedby={null}
                     aria-pressed={null}
                     className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                    data-testid="ComposedModal-modal-primary-button"
+                    data-testid="dashboard-editor-image-gallery-modal-modal-primary-button"
                     disabled={true}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -19687,7 +19687,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
             <div
               className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
               data-floating-menu-container={true}
-              data-testid="ComposedModal"
+              data-testid="dashboard-editor-image-gallery-modal"
               onBlur={[Function]}
               onClick={[Function]}
               onClose={[Function]}
@@ -19799,7 +19799,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         <input
                           autoComplete="off"
                           className="bx--search-input"
-                          data-testid="ComposedModal-search-input"
+                          data-testid="dashboard-editor-image-gallery-modal-search-input"
                           id="iot--image-gallery-modal--search"
                           onChange={[Function]}
                           onKeyDown={[Function]}
@@ -19831,7 +19831,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       </div>
                       <div
                         className="bx--content-switcher iot--image-gallery-modal__content-switcher"
-                        data-testid="ComposedModal-content-switcher"
+                        data-testid="dashboard-editor-image-gallery-modal-content-switcher"
                         onChange={[Function]}
                         role="tablist"
                       >
@@ -19839,7 +19839,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           aria-describedby={null}
                           aria-pressed={null}
                           className="iot--icon-switch iot--icon-switch--large iot--icon-switch--selected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                          data-testid="ComposedModal-grid-switch"
+                          data-testid="dashboard-editor-image-gallery-modal-grid-switch"
                           disabled={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -19881,7 +19881,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           aria-describedby={null}
                           aria-pressed={null}
                           className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                          data-testid="ComposedModal-list-switch"
+                          data-testid="dashboard-editor-image-gallery-modal-list-switch"
                           disabled={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -19937,7 +19937,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     aria-describedby={null}
                     aria-pressed={null}
                     className="iot--btn bx--btn bx--btn--secondary"
-                    data-testid="ComposedModal-modal-secondary-button"
+                    data-testid="dashboard-editor-image-gallery-modal-modal-secondary-button"
                     disabled={false}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -19953,7 +19953,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     aria-describedby={null}
                     aria-pressed={null}
                     className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                    data-testid="ComposedModal-modal-primary-button"
+                    data-testid="dashboard-editor-image-gallery-modal-modal-primary-button"
                     disabled={true}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -22988,7 +22988,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
             <div
               className="bx--modal iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
               data-floating-menu-container={true}
-              data-testid="ComposedModal"
+              data-testid="dashboard-editor-image-gallery-modal"
               onBlur={[Function]}
               onClick={[Function]}
               onClose={[Function]}
@@ -23100,7 +23100,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         <input
                           autoComplete="off"
                           className="bx--search-input"
-                          data-testid="ComposedModal-search-input"
+                          data-testid="dashboard-editor-image-gallery-modal-search-input"
                           id="iot--image-gallery-modal--search"
                           onChange={[Function]}
                           onKeyDown={[Function]}
@@ -23132,7 +23132,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                       </div>
                       <div
                         className="bx--content-switcher iot--image-gallery-modal__content-switcher"
-                        data-testid="ComposedModal-content-switcher"
+                        data-testid="dashboard-editor-image-gallery-modal-content-switcher"
                         onChange={[Function]}
                         role="tablist"
                       >
@@ -23140,7 +23140,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           aria-describedby={null}
                           aria-pressed={null}
                           className="iot--icon-switch iot--icon-switch--large iot--icon-switch--selected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                          data-testid="ComposedModal-grid-switch"
+                          data-testid="dashboard-editor-image-gallery-modal-grid-switch"
                           disabled={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -23182,7 +23182,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           aria-describedby={null}
                           aria-pressed={null}
                           className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                          data-testid="ComposedModal-list-switch"
+                          data-testid="dashboard-editor-image-gallery-modal-list-switch"
                           disabled={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -23238,7 +23238,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     aria-describedby={null}
                     aria-pressed={null}
                     className="iot--btn bx--btn bx--btn--secondary"
-                    data-testid="ComposedModal-modal-secondary-button"
+                    data-testid="dashboard-editor-image-gallery-modal-modal-secondary-button"
                     disabled={false}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -23254,7 +23254,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                     aria-describedby={null}
                     aria-pressed={null}
                     className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-                    data-testid="ComposedModal-modal-primary-button"
+                    data-testid="dashboard-editor-image-gallery-modal-modal-primary-button"
                     disabled={true}
                     onBlur={[Function]}
                     onClick={[Function]}

--- a/packages/react/src/components/ImageGalleryModal/ImageGalleryModal.jsx
+++ b/packages/react/src/components/ImageGalleryModal/ImageGalleryModal.jsx
@@ -96,9 +96,7 @@ const defaultProps = {
   modalSecondaryButtonLabelText: 'Cancel',
   modalCloseIconDescriptionText: 'Close',
   searchPlaceHolderText: 'Search image by file name',
-  // TODO: update this default in v3 to match the component.
-  // kept here for backwards compat.
-  testId: 'ComposedModal',
+  testId: 'image-gallery-modal',
 };
 
 const ImageGalleryModal = ({

--- a/packages/react/src/components/ImageGalleryModal/__snapshots__/ImageGalleryModal.story.storyshot
+++ b/packages/react/src/components/ImageGalleryModal/__snapshots__/ImageGalleryModal.story.storyshot
@@ -8,7 +8,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
     <div
       className="bx--modal is-visible iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
       data-floating-menu-container={true}
-      data-testid="ComposedModal"
+      data-testid="image-gallery-modal"
       onBlur={[Function]}
       onClick={[Function]}
       onClose={[Function]}
@@ -121,7 +121,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                 <input
                   autoComplete="off"
                   className="bx--search-input"
-                  data-testid="ComposedModal-search-input"
+                  data-testid="image-gallery-modal-search-input"
                   id="iot--image-gallery-modal--search"
                   onChange={[Function]}
                   onKeyDown={[Function]}
@@ -153,7 +153,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
               </div>
               <div
                 className="bx--content-switcher iot--image-gallery-modal__content-switcher"
-                data-testid="ComposedModal-content-switcher"
+                data-testid="image-gallery-modal-content-switcher"
                 onChange={[Function]}
                 role="tablist"
               >
@@ -161,7 +161,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   aria-describedby={null}
                   aria-pressed={null}
                   className="iot--icon-switch iot--icon-switch--large iot--icon-switch--selected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                  data-testid="ComposedModal-grid-switch"
+                  data-testid="image-gallery-modal-grid-switch"
                   disabled={false}
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -203,7 +203,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   aria-describedby={null}
                   aria-pressed={null}
                   className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                  data-testid="ComposedModal-list-switch"
+                  data-testid="image-gallery-modal-list-switch"
                   disabled={false}
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -262,7 +262,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
               />
               <label
                 className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                data-testid="ComposedModal-assemblyline"
+                data-testid="image-gallery-modal-assemblyline"
                 htmlFor="assemblyline"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -291,7 +291,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                 >
                   <div
                     className="iot--image-tile__title"
-                    data-testid="ComposedModal-assemblyline-title"
+                    data-testid="image-gallery-modal-assemblyline-title"
                   >
                     <span>
                       custom title assemblyline that is very long a and must be managed.
@@ -305,13 +305,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   >
                     <img
                       alt="assemblyline"
-                      data-testid="ComposedModal-assemblyline-image"
+                      data-testid="image-gallery-modal-assemblyline-image"
                       src="assemblyline.jpg"
                     />
                     <button
                       aria-describedby={null}
                       className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                      data-testid="ComposedModal-assemblyline-delete-button"
+                      data-testid="image-gallery-modal-assemblyline-delete-button"
                       disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -363,7 +363,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
               />
               <label
                 className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                data-testid="ComposedModal-floow_plan"
+                data-testid="image-gallery-modal-floow_plan"
                 htmlFor="floow_plan"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -392,7 +392,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                 >
                   <div
                     className="iot--image-tile__title"
-                    data-testid="ComposedModal-floow_plan-title"
+                    data-testid="image-gallery-modal-floow_plan-title"
                   >
                     <span>
                       floow_plan
@@ -403,13 +403,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   >
                     <img
                       alt="floow plan"
-                      data-testid="ComposedModal-floow_plan-image"
+                      data-testid="image-gallery-modal-floow_plan-image"
                       src="floow_plan.png"
                     />
                     <button
                       aria-describedby={null}
                       className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                      data-testid="ComposedModal-floow_plan-delete-button"
+                      data-testid="image-gallery-modal-floow_plan-delete-button"
                       disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -461,7 +461,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
               />
               <label
                 className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                data-testid="ComposedModal-manufacturing_plant"
+                data-testid="image-gallery-modal-manufacturing_plant"
                 htmlFor="manufacturing_plant"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -490,7 +490,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                 >
                   <div
                     className="iot--image-tile__title"
-                    data-testid="ComposedModal-manufacturing_plant-title"
+                    data-testid="image-gallery-modal-manufacturing_plant-title"
                   >
                     <span>
                       Manufacturing_plant
@@ -501,13 +501,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   >
                     <img
                       alt="manufacturing plant"
-                      data-testid="ComposedModal-manufacturing_plant-image"
+                      data-testid="image-gallery-modal-manufacturing_plant-image"
                       src="Manufacturing_plant.png"
                     />
                     <button
                       aria-describedby={null}
                       className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                      data-testid="ComposedModal-manufacturing_plant-delete-button"
+                      data-testid="image-gallery-modal-manufacturing_plant-delete-button"
                       disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -559,7 +559,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
               />
               <label
                 className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                data-testid="ComposedModal-robot_arm"
+                data-testid="image-gallery-modal-robot_arm"
                 htmlFor="robot_arm"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -588,7 +588,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                 >
                   <div
                     className="iot--image-tile__title"
-                    data-testid="ComposedModal-robot_arm-title"
+                    data-testid="image-gallery-modal-robot_arm-title"
                   >
                     <span>
                       robot_arm
@@ -599,13 +599,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   >
                     <img
                       alt="robot arm"
-                      data-testid="ComposedModal-robot_arm-image"
+                      data-testid="image-gallery-modal-robot_arm-image"
                       src="robot_arm.png"
                     />
                     <button
                       aria-describedby={null}
                       className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                      data-testid="ComposedModal-robot_arm-delete-button"
+                      data-testid="image-gallery-modal-robot_arm-delete-button"
                       disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -657,7 +657,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
               />
               <label
                 className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                data-testid="ComposedModal-tankmodal"
+                data-testid="image-gallery-modal-tankmodal"
                 htmlFor="tankmodal"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -686,7 +686,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                 >
                   <div
                     className="iot--image-tile__title"
-                    data-testid="ComposedModal-tankmodal-title"
+                    data-testid="image-gallery-modal-tankmodal-title"
                   >
                     <span>
                       tankmodal
@@ -697,13 +697,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   >
                     <img
                       alt="tankmodal"
-                      data-testid="ComposedModal-tankmodal-image"
+                      data-testid="image-gallery-modal-tankmodal-image"
                       src="tankmodal.png"
                     />
                     <button
                       aria-describedby={null}
                       className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                      data-testid="ComposedModal-tankmodal-delete-button"
+                      data-testid="image-gallery-modal-tankmodal-delete-button"
                       disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -755,7 +755,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
               />
               <label
                 className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                data-testid="ComposedModal-turbines"
+                data-testid="image-gallery-modal-turbines"
                 htmlFor="turbines"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -784,7 +784,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                 >
                   <div
                     className="iot--image-tile__title"
-                    data-testid="ComposedModal-turbines-title"
+                    data-testid="image-gallery-modal-turbines-title"
                   >
                     <span>
                       turbines
@@ -795,13 +795,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   >
                     <img
                       alt="turbines"
-                      data-testid="ComposedModal-turbines-image"
+                      data-testid="image-gallery-modal-turbines-image"
                       src="turbines.png"
                     />
                     <button
                       aria-describedby={null}
                       className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                      data-testid="ComposedModal-turbines-delete-button"
+                      data-testid="image-gallery-modal-turbines-delete-button"
                       disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -853,7 +853,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
               />
               <label
                 className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                data-testid="ComposedModal-extra-wide-image"
+                data-testid="image-gallery-modal-extra-wide-image"
                 htmlFor="extra-wide-image"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -882,7 +882,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                 >
                   <div
                     className="iot--image-tile__title"
-                    data-testid="ComposedModal-extra-wide-image-title"
+                    data-testid="image-gallery-modal-extra-wide-image-title"
                   >
                     <span>
                       extra-wide-image
@@ -893,13 +893,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   >
                     <img
                       alt="extra wide image"
-                      data-testid="ComposedModal-extra-wide-image-image"
+                      data-testid="image-gallery-modal-extra-wide-image-image"
                       src="extra-wide-image.png"
                     />
                     <button
                       aria-describedby={null}
                       className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                      data-testid="ComposedModal-extra-wide-image-delete-button"
+                      data-testid="image-gallery-modal-extra-wide-image-delete-button"
                       disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -951,7 +951,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
               />
               <label
                 className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                data-testid="ComposedModal-large"
+                data-testid="image-gallery-modal-large"
                 htmlFor="large"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -980,7 +980,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                 >
                   <div
                     className="iot--image-tile__title"
-                    data-testid="ComposedModal-large-title"
+                    data-testid="image-gallery-modal-large-title"
                   >
                     <span>
                       large
@@ -991,13 +991,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   >
                     <img
                       alt="large image"
-                      data-testid="ComposedModal-large-image"
+                      data-testid="image-gallery-modal-large-image"
                       src="large.png"
                     />
                     <button
                       aria-describedby={null}
                       className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                      data-testid="ComposedModal-large-delete-button"
+                      data-testid="image-gallery-modal-large-delete-button"
                       disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -1049,7 +1049,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
               />
               <label
                 className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                data-testid="ComposedModal-large_portrait"
+                data-testid="image-gallery-modal-large_portrait"
                 htmlFor="large_portrait"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -1078,7 +1078,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                 >
                   <div
                     className="iot--image-tile__title"
-                    data-testid="ComposedModal-large_portrait-title"
+                    data-testid="image-gallery-modal-large_portrait-title"
                   >
                     <span>
                       large_portrait
@@ -1089,13 +1089,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   >
                     <img
                       alt="large image portrait"
-                      data-testid="ComposedModal-large_portrait-image"
+                      data-testid="image-gallery-modal-large_portrait-image"
                       src="large_portrait.png"
                     />
                     <button
                       aria-describedby={null}
                       className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                      data-testid="ComposedModal-large_portrait-delete-button"
+                      data-testid="image-gallery-modal-large_portrait-delete-button"
                       disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -1145,7 +1145,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
             aria-describedby={null}
             aria-pressed={null}
             className="iot--btn bx--btn bx--btn--secondary"
-            data-testid="ComposedModal-modal-secondary-button"
+            data-testid="image-gallery-modal-modal-secondary-button"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
@@ -1161,7 +1161,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
             aria-describedby={null}
             aria-pressed={null}
             className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-            data-testid="ComposedModal-modal-primary-button"
+            data-testid="image-gallery-modal-modal-primary-button"
             disabled={true}
             onBlur={[Function]}
             onClick={[Function]}
@@ -1195,7 +1195,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
     <div
       className="bx--modal is-visible iot--image-gallery-modal iot--composed-modal--large iot--composed-modal"
       data-floating-menu-container={true}
-      data-testid="ComposedModal"
+      data-testid="image-gallery-modal"
       onBlur={[Function]}
       onClick={[Function]}
       onClose={[Function]}
@@ -1308,7 +1308,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                 <input
                   autoComplete="off"
                   className="bx--search-input"
-                  data-testid="ComposedModal-search-input"
+                  data-testid="image-gallery-modal-search-input"
                   id="iot--image-gallery-modal--search"
                   onChange={[Function]}
                   onKeyDown={[Function]}
@@ -1340,7 +1340,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
               </div>
               <div
                 className="bx--content-switcher iot--image-gallery-modal__content-switcher"
-                data-testid="ComposedModal-content-switcher"
+                data-testid="image-gallery-modal-content-switcher"
                 onChange={[Function]}
                 role="tablist"
               >
@@ -1348,7 +1348,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   aria-describedby={null}
                   aria-pressed={null}
                   className="iot--icon-switch iot--icon-switch--large iot--icon-switch--selected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                  data-testid="ComposedModal-grid-switch"
+                  data-testid="image-gallery-modal-grid-switch"
                   disabled={false}
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -1390,7 +1390,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   aria-describedby={null}
                   aria-pressed={null}
                   className="iot--icon-switch iot--icon-switch--large iot--icon-switch--unselected bx--btn bx--btn--secondary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                  data-testid="ComposedModal-list-switch"
+                  data-testid="image-gallery-modal-list-switch"
                   disabled={false}
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -1449,7 +1449,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
               />
               <label
                 className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                data-testid="ComposedModal-assemblyline"
+                data-testid="image-gallery-modal-assemblyline"
                 htmlFor="assemblyline"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -1478,7 +1478,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                 >
                   <div
                     className="iot--image-tile__title"
-                    data-testid="ComposedModal-assemblyline-title"
+                    data-testid="image-gallery-modal-assemblyline-title"
                   >
                     <span>
                       custom title assemblyline that is very long a and must be managed.
@@ -1492,13 +1492,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   >
                     <img
                       alt="assemblyline"
-                      data-testid="ComposedModal-assemblyline-image"
+                      data-testid="image-gallery-modal-assemblyline-image"
                       src="assemblyline.jpg"
                     />
                     <button
                       aria-describedby={null}
                       className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                      data-testid="ComposedModal-assemblyline-delete-button"
+                      data-testid="image-gallery-modal-assemblyline-delete-button"
                       disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -1550,7 +1550,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
               />
               <label
                 className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                data-testid="ComposedModal-floow_plan"
+                data-testid="image-gallery-modal-floow_plan"
                 htmlFor="floow_plan"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -1579,7 +1579,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                 >
                   <div
                     className="iot--image-tile__title"
-                    data-testid="ComposedModal-floow_plan-title"
+                    data-testid="image-gallery-modal-floow_plan-title"
                   >
                     <span>
                       floow_plan
@@ -1590,13 +1590,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   >
                     <img
                       alt="floow plan"
-                      data-testid="ComposedModal-floow_plan-image"
+                      data-testid="image-gallery-modal-floow_plan-image"
                       src="floow_plan.png"
                     />
                     <button
                       aria-describedby={null}
                       className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                      data-testid="ComposedModal-floow_plan-delete-button"
+                      data-testid="image-gallery-modal-floow_plan-delete-button"
                       disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -1648,7 +1648,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
               />
               <label
                 className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                data-testid="ComposedModal-manufacturing_plant"
+                data-testid="image-gallery-modal-manufacturing_plant"
                 htmlFor="manufacturing_plant"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -1677,7 +1677,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                 >
                   <div
                     className="iot--image-tile__title"
-                    data-testid="ComposedModal-manufacturing_plant-title"
+                    data-testid="image-gallery-modal-manufacturing_plant-title"
                   >
                     <span>
                       Manufacturing_plant
@@ -1688,13 +1688,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   >
                     <img
                       alt="manufacturing plant"
-                      data-testid="ComposedModal-manufacturing_plant-image"
+                      data-testid="image-gallery-modal-manufacturing_plant-image"
                       src="Manufacturing_plant.png"
                     />
                     <button
                       aria-describedby={null}
                       className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                      data-testid="ComposedModal-manufacturing_plant-delete-button"
+                      data-testid="image-gallery-modal-manufacturing_plant-delete-button"
                       disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -1746,7 +1746,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
               />
               <label
                 className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                data-testid="ComposedModal-robot_arm"
+                data-testid="image-gallery-modal-robot_arm"
                 htmlFor="robot_arm"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -1775,7 +1775,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                 >
                   <div
                     className="iot--image-tile__title"
-                    data-testid="ComposedModal-robot_arm-title"
+                    data-testid="image-gallery-modal-robot_arm-title"
                   >
                     <span>
                       robot_arm
@@ -1786,13 +1786,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   >
                     <img
                       alt="robot arm"
-                      data-testid="ComposedModal-robot_arm-image"
+                      data-testid="image-gallery-modal-robot_arm-image"
                       src="robot_arm.png"
                     />
                     <button
                       aria-describedby={null}
                       className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                      data-testid="ComposedModal-robot_arm-delete-button"
+                      data-testid="image-gallery-modal-robot_arm-delete-button"
                       disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -1844,7 +1844,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
               />
               <label
                 className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                data-testid="ComposedModal-tankmodal"
+                data-testid="image-gallery-modal-tankmodal"
                 htmlFor="tankmodal"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -1873,7 +1873,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                 >
                   <div
                     className="iot--image-tile__title"
-                    data-testid="ComposedModal-tankmodal-title"
+                    data-testid="image-gallery-modal-tankmodal-title"
                   >
                     <span>
                       tankmodal
@@ -1884,13 +1884,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   >
                     <img
                       alt="tankmodal"
-                      data-testid="ComposedModal-tankmodal-image"
+                      data-testid="image-gallery-modal-tankmodal-image"
                       src="tankmodal.png"
                     />
                     <button
                       aria-describedby={null}
                       className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                      data-testid="ComposedModal-tankmodal-delete-button"
+                      data-testid="image-gallery-modal-tankmodal-delete-button"
                       disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -1942,7 +1942,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
               />
               <label
                 className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                data-testid="ComposedModal-turbines"
+                data-testid="image-gallery-modal-turbines"
                 htmlFor="turbines"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -1971,7 +1971,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                 >
                   <div
                     className="iot--image-tile__title"
-                    data-testid="ComposedModal-turbines-title"
+                    data-testid="image-gallery-modal-turbines-title"
                   >
                     <span>
                       turbines
@@ -1982,13 +1982,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   >
                     <img
                       alt="turbines"
-                      data-testid="ComposedModal-turbines-image"
+                      data-testid="image-gallery-modal-turbines-image"
                       src="turbines.png"
                     />
                     <button
                       aria-describedby={null}
                       className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                      data-testid="ComposedModal-turbines-delete-button"
+                      data-testid="image-gallery-modal-turbines-delete-button"
                       disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -2040,7 +2040,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
               />
               <label
                 className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                data-testid="ComposedModal-extra-wide-image"
+                data-testid="image-gallery-modal-extra-wide-image"
                 htmlFor="extra-wide-image"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -2069,7 +2069,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                 >
                   <div
                     className="iot--image-tile__title"
-                    data-testid="ComposedModal-extra-wide-image-title"
+                    data-testid="image-gallery-modal-extra-wide-image-title"
                   >
                     <span>
                       extra-wide-image
@@ -2080,13 +2080,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   >
                     <img
                       alt="extra wide image"
-                      data-testid="ComposedModal-extra-wide-image-image"
+                      data-testid="image-gallery-modal-extra-wide-image-image"
                       src="extra-wide-image.png"
                     />
                     <button
                       aria-describedby={null}
                       className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                      data-testid="ComposedModal-extra-wide-image-delete-button"
+                      data-testid="image-gallery-modal-extra-wide-image-delete-button"
                       disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -2138,7 +2138,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
               />
               <label
                 className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                data-testid="ComposedModal-large"
+                data-testid="image-gallery-modal-large"
                 htmlFor="large"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -2167,7 +2167,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                 >
                   <div
                     className="iot--image-tile__title"
-                    data-testid="ComposedModal-large-title"
+                    data-testid="image-gallery-modal-large-title"
                   >
                     <span>
                       large
@@ -2178,13 +2178,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   >
                     <img
                       alt="large image"
-                      data-testid="ComposedModal-large-image"
+                      data-testid="image-gallery-modal-large-image"
                       src="large.png"
                     />
                     <button
                       aria-describedby={null}
                       className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                      data-testid="ComposedModal-large-delete-button"
+                      data-testid="image-gallery-modal-large-delete-button"
                       disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -2236,7 +2236,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
               />
               <label
                 className="bx--tile bx--tile--selectable bx--tile--light iot--image-tile"
-                data-testid="ComposedModal-large_portrait"
+                data-testid="image-gallery-modal-large_portrait"
                 htmlFor="large_portrait"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -2265,7 +2265,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                 >
                   <div
                     className="iot--image-tile__title"
-                    data-testid="ComposedModal-large_portrait-title"
+                    data-testid="image-gallery-modal-large_portrait-title"
                   >
                     <span>
                       large_portrait
@@ -2276,13 +2276,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
                   >
                     <img
                       alt="large image portrait"
-                      data-testid="ComposedModal-large_portrait-image"
+                      data-testid="image-gallery-modal-large_portrait-image"
                       src="large_portrait.png"
                     />
                     <button
                       aria-describedby={null}
                       className="iot--image-tile__title__delete iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-                      data-testid="ComposedModal-large_portrait-delete-button"
+                      data-testid="image-gallery-modal-large_portrait-delete-button"
                       disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
@@ -2332,7 +2332,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
             aria-describedby={null}
             aria-pressed={null}
             className="iot--btn bx--btn bx--btn--secondary"
-            data-testid="ComposedModal-modal-secondary-button"
+            data-testid="image-gallery-modal-modal-secondary-button"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
@@ -2348,7 +2348,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/M
             aria-describedby={null}
             aria-pressed={null}
             className="iot--btn bx--btn bx--btn--primary bx--btn--disabled"
-            data-testid="ComposedModal-modal-primary-button"
+            data-testid="image-gallery-modal-modal-primary-button"
             disabled={true}
             onBlur={[Function]}
             onClick={[Function]}

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -10340,7 +10340,7 @@ Map {
       "onDelete": null,
       "searchPlaceHolderText": "Search image by file name",
       "searchProperty": "id",
-      "testId": "ComposedModal",
+      "testId": "image-gallery-modal",
     },
     "propTypes": Object {
       "children": Object {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-addons-iot-react/issues/3555

**Summary**

- send card configuration on card select instead of card id

**Change List (commits, features, bugs, etc)**

- feat(dashboardeditor): send card configuration on card select

**Acceptance Test (how to verify the PR)**

- on card select the callback function should get the cardConfig instead of just card id

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
