### PR TITLE
fix(imagehotspot): image hotspots label left align

### DIFF
--- a/packages/react/src/components/ImageCard/_hotspot-content.scss
+++ b/packages/react/src/components/ImageCard/_hotspot-content.scss
@@ -20,6 +20,7 @@
   &-label-section {
     flex: 1;
     padding-right: $spacing-05;
+    text-align: left;
   }
   &-label {
     font-weight: bold;

--- a/packages/styles/src/components/ImageCard/_hotspot-content.scss
+++ b/packages/styles/src/components/ImageCard/_hotspot-content.scss
@@ -20,6 +20,7 @@
   &-label-section {
     flex: 1;
     padding-right: $spacing-05;
+    text-align: left;
   }
   &-label {
     font-weight: bold;


### PR DESCRIPTION
Closes [#4444](https://zenhub.ibm.com/workspaces/maximo-asset-monitor-5cd44ce4baded506ba8ddd5f/issues/wiotp/maximo-asset-monitor/4444)

**Summary**

- Image card - left align hotspot labels

**Change List (commits, features, bugs, etc)**

- fix(imagehotspot): image hotspots label left align

**Acceptance Test (how to verify the PR)**

- Image card > hotspot data item labels should be left aligned, with the values right aligned

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
