### PR TITLE
fix(sass): remove @use declaration

### DIFF
--- a/packages/react/src/components/TileCatalog/_catalog-content.scss
+++ b/packages/react/src/components/TileCatalog/_catalog-content.scss
@@ -29,10 +29,10 @@
   padding-bottom: $spacing-03;
   max-width: calc(100vw - 20rem);
   @media screen and (min-width: $two-pane) {
-    max-width: calc(math.div(100vw, 2) - 15rem);
+    max-width: calc(100vw * 0.5 - 15rem);
   }
   @media screen and (min-width: $three-pane) {
-    max-width: calc(math.div(100vw, 3) - 15rem);
+    max-width: calc(100vw / 3 - 15rem);
   }
 }
 

--- a/packages/react/src/styles.scss
+++ b/packages/react/src/styles.scss
@@ -2,12 +2,6 @@
 // 🌍 Global
 //-------------------------
 
-// Enable math module to handle dividing operations due to deprecation of " / " operator
-// Reference https://sass-lang.com/documentation/breaking-changes/slash-div
-/* stylelint-disable */
-@use "sass:math";
-/* stylelint-enable */
-
 /// If true, includes font face mixins in `_css--font-face.scss` depending on the `css--plex` feature flag
 /// @access public
 /// @type Bool


### PR DESCRIPTION
Closes #3581 

**Summary**

- Remove `@use "sass:math"`

**Change List (commits, features, bugs, etc)**

- Replace `math.div` to `*` or `/` operators
- Delete `@use "sass:math"` from root stylesheet

**Acceptance Test (how to verify the PR)**

- Go to [this story](https://deploy-preview-3582--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-catalog-marketplace-tilecatalog--default)
- Change screen width and verify that `max-width` property in `iot--sample-tile-title` is changing accordingly

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
