### PR TITLE
fix(datetimepickerv2): enable to clear value in new time spinner

### DIFF
--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.e2e.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.e2e.jsx
@@ -147,12 +147,8 @@ describe('DateTimePickerV2', () => {
     cy.findByLabelText('August 8, 2021').should('have.class', 'selected');
     cy.findByLabelText('August 6, 2021').should('have.class', 'selected');
     cy.get('#picker-test-1').clear();
-    cy.get('#picker-test-1')
-      .click()
-      .focus()
-      .type(
-        '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}01:34 PM'
-      );
+    cy.get('#picker-test-1').click().focus().type('{moveToStart}{del}{del}01');
+
     cy.get('#picker-test-2')
       .click()
       .focus()
@@ -267,18 +263,18 @@ describe('DateTimePickerV2', () => {
 
     cy.findByText('2021-08-01 12:34 to 2021-08-06 10:49').should('be.visible').click();
     cy.get('#picker-test-1').type(
-      '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}9:35 AM'
+      '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}91:35 AM'
     );
     cy.findByText(i18n.applyBtnLabel).should('be.disabled');
 
     cy.get('#picker-test-1').type(
-      '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}1:35 AM'
+      '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}11:35 AM'
     );
 
     cy.findByText(i18n.applyBtnLabel).should('not.be.disabled');
 
     cy.get('#picker-test-2').type(
-      '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}1:61 AM'
+      '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}11:61 AM'
     );
     cy.findByText(i18n.applyBtnLabel).should('be.disabled');
   });

--- a/packages/react/src/components/TimePicker/TimePickerDropdown.jsx
+++ b/packages/react/src/components/TimePicker/TimePickerDropdown.jsx
@@ -202,17 +202,6 @@ const TimePickerDropdown = ({
       } else {
         setPosition([left, bottom + scrollOffset]);
       }
-
-      const currentTimeFormat = is24hours ? '24' : '12';
-      if (focusedInput === 0 && !value) {
-        setValueState((prevValue) => prevValue || dayjs().format(TIME_FORMAT[currentTimeFormat]));
-      }
-
-      if (focusedInput === 1 && !secondaryValue) {
-        setSecondaryValueState(
-          (prevValue) => prevValue || dayjs().format(TIME_FORMAT[currentTimeFormat])
-        );
-      }
     }
   }, [container, openState, focusedInput, is24hours, value, secondaryValue]);
 
@@ -229,6 +218,17 @@ const TimePickerDropdown = ({
     setFocusedInput(index);
     if (!readOnly) {
       handleOpenDropdown(index);
+
+      const currentTimeFormat = is24hours ? '24' : '12';
+      if (index === 0 && !value) {
+        setValueState((prevValue) => prevValue || dayjs().format(TIME_FORMAT[currentTimeFormat]));
+      }
+
+      if (index === 1 && !secondaryValue) {
+        setSecondaryValueState(
+          (prevValue) => prevValue || dayjs().format(TIME_FORMAT[currentTimeFormat])
+        );
+      }
     }
   };
 

--- a/packages/react/src/components/TimePicker/TimePickerDropdown.jsx
+++ b/packages/react/src/components/TimePicker/TimePickerDropdown.jsx
@@ -552,12 +552,12 @@ const TimePickerDropdown = ({
   );
 };
 
-const listItemsForVertical24Hours = Array.from(Array(23)).map((el, i) => {
-  const index = i + 1 < 10 ? `0${i + 1}` : `${i + 1}`;
+const listItemsForVertical24Hours = Array.from(Array(24)).map((el, i) => {
+  const index = i < 10 ? `0${i}` : `${i}`;
   return { id: index, value: index };
 });
 
-const listItemsForVertical12Hours = listItemsForVertical24Hours.slice(0, 12);
+const listItemsForVertical12Hours = listItemsForVertical24Hours.slice(1, 13);
 
 const listItemsForVerticalMinutes = Array.from(Array(60)).map((el, i) => {
   const index = i < 10 ? `0${i}` : `${i}`;

--- a/packages/react/src/components/TimePicker/_time-picker-dropdown.scss
+++ b/packages/react/src/components/TimePicker/_time-picker-dropdown.scss
@@ -19,7 +19,7 @@
     position: relative;
 
     &--selected input {
-      outline: 0.0625rem solid $interactive-02;
+      outline: 0.0625rem solid $ui-05;
     }
   }
 


### PR DESCRIPTION
Closes #3585 

**Summary**

- Allow user to clean time input value

**Change List (commits, features, bugs, etc)**

- Move function to populate current time from `useEffect` hook to `onFocus` callback
- Update test
- Fix recent updates from design audit

**Acceptance Test (how to verify the PR)**

- Go to [this story](https://deploy-preview-3586--carbon-addons-iot-react.netlify.app/?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-datetimepickerv2--selected-absolute)
- Enable knob `useNewTimeSpinner`
- Click on input to display dropdown
- Focus on some input
- Press `Backspace` to clear input
- Verify that input was cleared

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
