### PR TITLE
fix(SuiteHeader): Protecting the idle timer logic to avoid the creation of a cookie with an empty domain

### DIFF
--- a/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.jsx
+++ b/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.jsx
@@ -113,7 +113,12 @@ const IdleLogoutConfirmationModal = ({
   const [stayLoggedInButtonDisabled, setStayLoggedInButtonDisabled] = useState(false);
   // eslint-disable-next-line consistent-return
   useEffect(() => {
-    if (idleTimeoutData && idleTimeoutData?.timeout > 0 && routes?.domain) {
+    if (
+      idleTimeoutData &&
+      idleTimeoutData?.timeout > 0 &&
+      routes?.domain !== null &&
+      routes?.domain !== undefined
+    ) {
       const timer = new IdleTimer({
         timeout: idleTimeoutData.timeout,
         countdown: idleTimeoutData.countdown,

--- a/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.jsx
+++ b/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.jsx
@@ -113,7 +113,7 @@ const IdleLogoutConfirmationModal = ({
   const [stayLoggedInButtonDisabled, setStayLoggedInButtonDisabled] = useState(false);
   // eslint-disable-next-line consistent-return
   useEffect(() => {
-    if (idleTimeoutData && idleTimeoutData?.timeout > 0 && routes) {
+    if (idleTimeoutData && idleTimeoutData?.timeout > 0 && routes?.domain) {
       const timer = new IdleTimer({
         timeout: idleTimeoutData.timeout,
         countdown: idleTimeoutData.countdown,

--- a/packages/react/src/components/SuiteHeader/MultiWorkspaceSuiteHeader.test.jsx
+++ b/packages/react/src/components/SuiteHeader/MultiWorkspaceSuiteHeader.test.jsx
@@ -117,6 +117,7 @@ const adminPageCommonProps = {
     requestEnhancement: 'https://www.ibm.com/request',
     support: 'https://www.ibm.com/support',
     about: 'https://www.ibm.com/about',
+    domain: '',
   },
   workspaces: adminPageWorkspaces,
   globalApplications: [

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
@@ -278,7 +278,7 @@ const SuiteHeader = ({
           onCloseButtonClick={() => setShowToast(false)}
         />
       ) : null}
-      {idleTimeoutData ? (
+      {idleTimeoutData && routes?.domain !== null && routes?.domain !== undefined ? (
         <IdleLogoutConfirmationModal
           idleTimeoutData={idleTimeoutData}
           routes={routes}

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
@@ -31,6 +31,7 @@ const commonProps = {
     requestEnhancement: 'https://www.ibm.com/request',
     support: 'https://www.ibm.com/support',
     about: 'https://www.ibm.com/about',
+    domain: '',
   },
   applications: [
     {


### PR DESCRIPTION
**Summary**

- When rendering the `IdleLogoutConfirmationModal` component, check if the domain is set. Otherwise the `IdleTimer` may be instantiated with an undefined domain, which will create a cookie in the wrong domain.

**Change List (commits, features, bugs, etc)**

- Checking if domain is null or undefined before instantiating the `IdleLogoutConfirmationModal` and `IdleTimer`.

**Acceptance Test (how to verify the PR)**

- No functional changes expected in this fix.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- No functional changes expected in this fix.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
