### PR TITLE
fix(tearsheet): doc not generate props

### DIFF
--- a/packages/react/src/components/TearSheet/TearSheet.story.jsx
+++ b/packages/react/src/components/TearSheet/TearSheet.story.jsx
@@ -173,5 +173,5 @@ export const Default = () => <StandardTearSheet />;
 export default {
   title: '1 - Watson IoT/TearSheet',
   decorators: [withKnobs],
-  component: Default,
+  component: TearSheet,
 };


### PR DESCRIPTION
Closes #3373 

**Summary**

- Storybook was not generating argsTable for `TearSheet` component

**Change List (commits, features, bugs, etc)**

- Fix the bug in `TearSheet` story to make sure props show up in storybook doc.

**Acceptance Test (how to verify the PR)**

- Go to TearSheet story
- Click on Doc tab
- Check argsTable should show component props and descriptions

![image](https://user-images.githubusercontent.com/24279794/194901477-8ee4e798-42bd-4c99-b181-9e88cf526dc2.png)


**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
