### PR TITLE
feat(datetimepickerv2): support both 12 and 24 hours time format

### DIFF
--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
@@ -29,7 +29,6 @@ const DateTimePicker = ({
   hasIconOnly,
   menuOffset,
   datePickerType,
-  is24hours,
   style,
   ...others
 }) => {
@@ -57,7 +56,6 @@ const DateTimePicker = ({
       hasIconOnly={hasIconOnly}
       menuOffset={menuOffset}
       datePickerType={datePickerType}
-      is24hours={is24hours}
       style={style}
       others={others}
     />

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
@@ -29,6 +29,7 @@ const DateTimePicker = ({
   hasIconOnly,
   menuOffset,
   datePickerType,
+  is24hours,
   style,
   ...others
 }) => {
@@ -56,6 +57,7 @@ const DateTimePicker = ({
       hasIconOnly={hasIconOnly}
       menuOffset={menuOffset}
       datePickerType={datePickerType}
+      is24hours={is24hours}
       style={style}
       others={others}
     />

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.story.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.story.jsx
@@ -121,7 +121,6 @@ export const SelectedAbsolute = () => {
     <DateTimePicker
       id="datetimepicker"
       useNewTimeSpinner={boolean('useNewTimeSpinner', false)}
-      is24hours={boolean('is24hours', true)}
       defaultValue={defaultAbsoluteValue}
       dateTimeMask={text('dateTimeMask', 'YYYY-MM-DD HH:mm')}
       hasTimeInput={boolean('hasTimeInput', true)}
@@ -143,12 +142,12 @@ export const SelectedAbsolute = () => {
 SelectedAbsolute.storyName = 'Selected absolute';
 
 export const SingleSelect = () => {
-  const is24hours = boolean('is24hours', true);
+  const dateTimeMask = text('dateTimeMask', 'YYYY-MM-DD HH:mm');
   return (
     <DateTimePicker
       id="datetimepicker"
+      key={dateTimeMask}
       useNewTimeSpinner
-      is24hours={is24hours}
       defaultValue={{
         timeRangeKind: PICKER_KINDS.SINGLE,
         timeSingleValue: {
@@ -156,7 +155,7 @@ export const SingleSelect = () => {
           startTime: '12:34',
         },
       }}
-      dateTimeMask={text('dateTimeMask', 'YYYY-MM-DD HH:mm')}
+      dateTimeMask={dateTimeMask}
       hasTimeInput={boolean('hasTimeInput', true)}
       onApply={action('onApply')}
       onCancel={action('onCancel')}
@@ -176,14 +175,14 @@ export const SingleSelect = () => {
 SingleSelect.storyName = 'Single select with new time spinner';
 
 export const SelectedAbsoluteWithNewTimeSpinner = () => {
-  const is24hours = boolean('is24hours', false);
+  const dateTimeMask = text('dateTimeMask', 'YYYY-MM-DD HH:mm');
   return (
     <DateTimePicker
       id="datetimepicker"
+      key={dateTimeMask}
       useNewTimeSpinner
-      is24hours={is24hours}
       defaultValue={defaultAbsoluteValue}
-      dateTimeMask={text('dateTimeMask', 'YYYY-MM-DD HH:mm')}
+      dateTimeMask={dateTimeMask}
       hasTimeInput={boolean('hasTimeInput', true)}
       onApply={action('onApply')}
       onCancel={action('onCancel')}

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.story.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.story.jsx
@@ -50,6 +50,8 @@ export const Default = () => {
     <DateTimePicker
       id="datetimepicker"
       dateTimeMask={text('dateTimeMask', 'YYYY-MM-DD HH:mm')}
+      useNewTimeSpinner={boolean('useNewTimeSpinner', true)}
+      is24hours={boolean('is24hours', true)}
       relatives={[
         {
           label: 'Yesterday',
@@ -120,6 +122,7 @@ export const SelectedAbsolute = () => {
     <DateTimePicker
       id="datetimepicker"
       useNewTimeSpinner={boolean('useNewTimeSpinner', false)}
+      is24hours={boolean('is24hours', true)}
       defaultValue={defaultAbsoluteValue}
       dateTimeMask={text('dateTimeMask', 'YYYY-MM-DD HH:mm')}
       hasTimeInput={boolean('hasTimeInput', true)}
@@ -141,10 +144,12 @@ export const SelectedAbsolute = () => {
 SelectedAbsolute.storyName = 'Selected absolute';
 
 export const SingleSelect = () => {
+  const is24hours = boolean('is24hours', true);
   return (
     <DateTimePicker
       id="datetimepicker"
       useNewTimeSpinner
+      is24hours={is24hours}
       defaultValue={{
         timeRangeKind: PICKER_KINDS.SINGLE,
         timeSingleValue: {
@@ -152,7 +157,7 @@ export const SingleSelect = () => {
           startTime: '12:34',
         },
       }}
-      dateTimeMask="YYYY-MM-DD hh:mm A"
+      dateTimeMask={is24hours ? 'YYYY-MM-DD HH:mm' : 'YYYY-MM-DD hh:mm A'}
       hasTimeInput={boolean('hasTimeInput', true)}
       onApply={action('onApply')}
       onCancel={action('onCancel')}
@@ -172,12 +177,22 @@ export const SingleSelect = () => {
 SingleSelect.storyName = 'Single select with new time spinner';
 
 export const SelectedAbsoluteWithNewTimeSpinner = () => {
+  const is24hours = boolean('is24hours', false);
   return (
     <DateTimePicker
       id="datetimepicker"
       useNewTimeSpinner
-      defaultValue={defaultAbsoluteValue}
-      dateTimeMask={text('dateTimeMask', 'YYYY-MM-DD HH:mm')}
+      is24hours={is24hours}
+      defaultValue={{
+        timeRangeKind: PICKER_KINDS.ABSOLUTE,
+        timeRangeValue: {
+          startDate: '2020-04-01',
+          startTime: '12:34',
+          endDate: '2020-04-06',
+          endTime: '10:49',
+        },
+      }}
+      dateTimeMask={is24hours ? 'YYYY-MM-DD HH:mm' : 'YYYY-MM-DD hh:mm A'}
       hasTimeInput={boolean('hasTimeInput', true)}
       onApply={action('onApply')}
       onCancel={action('onCancel')}

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.story.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.story.jsx
@@ -51,7 +51,6 @@ export const Default = () => {
       id="datetimepicker"
       dateTimeMask={text('dateTimeMask', 'YYYY-MM-DD HH:mm')}
       useNewTimeSpinner={boolean('useNewTimeSpinner', true)}
-      is24hours={boolean('is24hours', true)}
       relatives={[
         {
           label: 'Yesterday',
@@ -157,7 +156,7 @@ export const SingleSelect = () => {
           startTime: '12:34',
         },
       }}
-      dateTimeMask={is24hours ? 'YYYY-MM-DD HH:mm' : 'YYYY-MM-DD hh:mm A'}
+      dateTimeMask={text('dateTimeMask', 'YYYY-MM-DD HH:mm')}
       hasTimeInput={boolean('hasTimeInput', true)}
       onApply={action('onApply')}
       onCancel={action('onCancel')}
@@ -183,16 +182,8 @@ export const SelectedAbsoluteWithNewTimeSpinner = () => {
       id="datetimepicker"
       useNewTimeSpinner
       is24hours={is24hours}
-      defaultValue={{
-        timeRangeKind: PICKER_KINDS.ABSOLUTE,
-        timeRangeValue: {
-          startDate: '2020-04-01',
-          startTime: '12:34',
-          endDate: '2020-04-06',
-          endTime: '10:49',
-        },
-      }}
-      dateTimeMask={is24hours ? 'YYYY-MM-DD HH:mm' : 'YYYY-MM-DD hh:mm A'}
+      defaultValue={defaultAbsoluteValue}
+      dateTimeMask={text('dateTimeMask', 'YYYY-MM-DD HH:mm')}
       hasTimeInput={boolean('hasTimeInput', true)}
       onApply={action('onApply')}
       onCancel={action('onCancel')}

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.e2e.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.e2e.jsx
@@ -115,13 +115,14 @@ describe('DateTimePickerV2', () => {
       });
   });
 
-  it('should pick a new absolute ranges (new time spinner)', () => {
+  it('should pick a new absolute ranges (new time spinner 24 hours with AM/PM)', () => {
     const onApply = cy.stub();
     const onCancel = cy.stub();
     mount(
       <div style={{ justifyContent: 'center' }}>
         <DateTimePicker
           useNewTimeSpinner
+          dateTimeMask="YYYY-MM-DD HH:mm A"
           onApply={onApply}
           onCancel={onCancel}
           id="picker-test"
@@ -138,7 +139,66 @@ describe('DateTimePickerV2', () => {
       </div>
     );
 
-    cy.findByText('2021-08-01 12:34 to 2021-08-06 10:49').should('be.visible').click();
+    cy.findByText('2021-08-01 12:34 PM to 2021-08-06 10:49 AM').should('be.visible').click();
+
+    cy.findByText('Custom range').should('be.visible');
+    cy.findByText('August').should('be.visible');
+    cy.findByLabelText('Year').should('have.value', '2021');
+    cy.findByLabelText('August 8, 2021').click();
+    cy.findByLabelText('August 8, 2021').should('have.class', 'selected');
+    cy.findByLabelText('August 6, 2021').should('have.class', 'selected');
+    cy.get('#picker-test-1').clear();
+    cy.get('#picker-test-1').click().focus().type('{moveToStart}{del}{del}13');
+
+    cy.get('#picker-test-2')
+      .click()
+      .focus()
+      .type('{backspace}{backspace}{backspace}{backspace}{backspace}12:34');
+    cy.findByText('Apply')
+      .click()
+      .should(() => {
+        expect(onApply).to.be.calledWith({
+          timeRangeKind: 'ABSOLUTE',
+          timeRangeValue: {
+            end: Cypress.sinon.match.any,
+            endDate: '08/08/2021',
+            endTime: '12:34',
+            start: Cypress.sinon.match.any,
+            startDate: '08/06/2021',
+            startTime: '13:34',
+            humanValue: '2021-08-06 13:34 PM to 2021-08-08 12:34 PM',
+            tooltipValue: '2021-08-06 13:34 PM to 2021-08-08 12:34 PM',
+          },
+          timeSingleValue: null,
+        });
+      });
+  });
+
+  it('should pick a new absolute ranges (new time spinner 12 hours with AM/PM)', () => {
+    const onApply = cy.stub();
+    const onCancel = cy.stub();
+    mount(
+      <div style={{ justifyContent: 'center' }}>
+        <DateTimePicker
+          useNewTimeSpinner
+          dateTimeMask="YYYY-MM-DD hh:mm A"
+          onApply={onApply}
+          onCancel={onCancel}
+          id="picker-test"
+          hasTimeInput
+          defaultValue={{
+            timeRangeKind: PICKER_KINDS.ABSOLUTE,
+            timeRangeValue: {
+              start: new Date(2021, 7, 1, 12, 34, 0),
+              end: new Date(2021, 7, 6, 10, 49, 0),
+            },
+          }}
+          style={{ zIndex: 6000 }}
+        />
+      </div>
+    );
+
+    cy.findByText('2021-08-01 12:34 PM to 2021-08-06 10:49 AM').should('be.visible').click();
 
     cy.findByText('Custom range').should('be.visible');
     cy.findByText('August').should('be.visible');
@@ -163,12 +223,12 @@ describe('DateTimePickerV2', () => {
           timeRangeValue: {
             end: Cypress.sinon.match.any,
             endDate: '08/08/2021',
-            endTime: '12:34',
+            endTime: '12:34 PM',
             start: Cypress.sinon.match.any,
             startDate: '08/06/2021',
-            startTime: '13:34',
-            humanValue: '2021-08-06 13:34 to 2021-08-08 12:34',
-            tooltipValue: '2021-08-06 13:34 to 2021-08-08 12:34',
+            startTime: '01:34 PM',
+            humanValue: '2021-08-06 01:34 PM to 2021-08-08 12:34 PM',
+            tooltipValue: '2021-08-06 01:34 PM to 2021-08-08 12:34 PM',
           },
           timeSingleValue: null,
         });
@@ -245,6 +305,7 @@ describe('DateTimePickerV2', () => {
     mount(
       <DateTimePicker
         useNewTimeSpinner
+        dateTimeMask="YYYY-MM-DD HH:mm A"
         onApply={onApply}
         onCancel={onCancel}
         id="picker-test"
@@ -261,21 +322,15 @@ describe('DateTimePickerV2', () => {
       />
     );
 
-    cy.findByText('2021-08-01 12:34 to 2021-08-06 10:49').should('be.visible').click();
-    cy.get('#picker-test-1').type(
-      '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}91:35 AM'
-    );
+    cy.findByText('2021-08-01 12:34 PM to 2021-08-06 10:49 AM').should('be.visible').click();
+    cy.get('#picker-test-1').type('{backspace}{backspace}{backspace}{backspace}{backspace}91:35');
     cy.findByText(i18n.applyBtnLabel).should('be.disabled');
 
-    cy.get('#picker-test-1').type(
-      '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}11:35 AM'
-    );
+    cy.get('#picker-test-1').type('{backspace}{backspace}{backspace}{backspace}{backspace}11:35');
 
     cy.findByText(i18n.applyBtnLabel).should('not.be.disabled');
 
-    cy.get('#picker-test-2').type(
-      '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}11:61 AM'
-    );
+    cy.get('#picker-test-2').type('{backspace}{backspace}{backspace}{backspace}{backspace}11:61');
     cy.findByText(i18n.applyBtnLabel).should('be.disabled');
   });
 
@@ -574,12 +629,12 @@ describe('DateTimePickerV2', () => {
           timeRangeValue: {
             end: Cypress.sinon.match.any,
             endDate: '08/13/2021',
-            endTime: '00:49',
-            humanValue: '2021-08-06 14:34 to 2021-08-13 00:49',
+            endTime: '12:49',
+            humanValue: '2021-08-06 02:34 to 2021-08-13 12:49',
             start: Cypress.sinon.match.any,
             startDate: '08/06/2021',
-            startTime: '14:34',
-            tooltipValue: '2021-08-06 14:34 to 2021-08-13 00:49',
+            startTime: '02:34',
+            tooltipValue: '2021-08-06 02:34 to 2021-08-13 12:49',
           },
           timeSingleValue: null,
         });

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
@@ -437,7 +437,54 @@ describe('DateTimePickerV2', () => {
     expect(dateTimePickerProps.onApply).toHaveBeenCalled();
   });
 
-  it('should render with a predefined single select date and time', () => {
+  it('should render with a predefined absolute range (new time spinner and 24 hour format time)', () => {
+    render(
+      <DateTimePicker
+        useNewTimeSpinner
+        is24hours
+        {...dateTimePickerProps}
+        defaultValue={defaultAbsoluteValue}
+      />
+    );
+
+    // default value starts at   '2020-04-01' at 12:34 to 2020-04-06 at 10:49
+    expect(screen.getByText('2020-04-01 12:34 to 2020-04-06 10:49')).toBeVisible();
+
+    // first open the menu
+    userEvent.click(screen.getAllByLabelText('Calendar')[0]);
+
+    // open start time picker
+    fireEvent.focus(screen.getByTestId('date-time-picker-input-1'));
+
+    // select hour
+    userEvent.click(
+      within(screen.getByTestId('date-time-picker-spinner-list-spinner-1')).getByText('13')
+    );
+    // select miniute
+    userEvent.click(
+      within(screen.getByTestId('date-time-picker-spinner-list-spinner-2')).getByText('34')
+    );
+
+    screen.getByTestId('date-time-picker-spinner').blur();
+
+    // open end time picker
+    fireEvent.focus(screen.getByTestId('date-time-picker-input-2'));
+    // select hour
+    userEvent.click(
+      within(screen.getByTestId('date-time-picker-spinner-list-spinner-1')).getByText('11')
+    );
+    // select minute
+    userEvent.click(
+      within(screen.getByTestId('date-time-picker-spinner-list-spinner-2')).getByText('49')
+    );
+
+    screen.getByTestId('date-time-picker-spinner').blur();
+    expect(screen.getByText('2020-04-01 13:34 to 2020-04-06 11:49')).toBeVisible();
+    userEvent.click(screen.getByText('Apply'));
+    expect(dateTimePickerProps.onApply).toHaveBeenCalled();
+  });
+
+  it('should render with a predefined single select date and 12 hours time format time', () => {
     const { i18n } = DateTimePicker.defaultProps;
     render(
       <DateTimePicker
@@ -482,6 +529,51 @@ describe('DateTimePickerV2', () => {
 
     expect(startTime).toHaveValue('05:03 PM');
     expect(screen.getByText('2020-04-01 05:03 PM')).toBeVisible();
+    expect(screen.getByText(i18n.applyBtnLabel)).toBeEnabled();
+  });
+
+  it('should render with a predefined single select date and 24 hours time format time', () => {
+    const { i18n } = DateTimePicker.defaultProps;
+    render(
+      <DateTimePicker
+        {...dateTimePickerProps}
+        useNewTimeSpinner
+        is24hours
+        onApply={jest.fn()}
+        datePickerType="single"
+        dateTimeMask="YYYY-MM-DD HH:mm"
+        hasTimeInput
+        showRelativeOption={false}
+        defaultValue={{
+          timeRangeKind: PICKER_KINDS.SINGLE,
+          timeSingleValue: {
+            startDate: '2020-04-01',
+            startTime: '12:34',
+          },
+        }}
+      />
+    );
+
+    // default value is 2020-04-01 12:34 AM
+    expect(screen.getByText('2020-04-01 12:34')).toBeVisible();
+
+    // first open the menu
+    userEvent.click(screen.getAllByText(/2020-04-01 12:34/i)[0]);
+
+    const startTime = screen.getByTestId('date-time-picker-input');
+    // open time picker
+    fireEvent.focus(screen.getByTestId('date-time-picker-input'));
+    // select hour
+    userEvent.click(
+      within(screen.getByTestId('date-time-picker-spinner-list-spinner-1')).getByText('05')
+    );
+    // select miniute
+    userEvent.click(
+      within(screen.getByTestId('date-time-picker-spinner-list-spinner-2')).getByText('03')
+    );
+
+    expect(startTime).toHaveValue('05:03');
+    expect(screen.getByText('2020-04-01 05:03')).toBeVisible();
     expect(screen.getByText(i18n.applyBtnLabel)).toBeEnabled();
   });
 

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
@@ -389,61 +389,8 @@ describe('DateTimePickerV2', () => {
     render(
       <DateTimePicker
         useNewTimeSpinner
-        {...dateTimePickerProps}
-        defaultValue={defaultAbsoluteValue}
-      />
-    );
-
-    // default value starts at   '2020-04-01' at 12:34 to 2020-04-06 at 10:49
-    expect(screen.getByText('2020-04-01 12:34 to 2020-04-06 10:49')).toBeVisible();
-
-    // first open the menu
-    userEvent.click(screen.getAllByLabelText('Calendar')[0]);
-
-    // open start time picker
-    fireEvent.focus(screen.getByTestId('date-time-picker-input-1'));
-
-    // select hour
-    userEvent.click(
-      within(screen.getByTestId('date-time-picker-spinner-list-spinner-1')).getByText('05')
-    );
-    // select miniute
-    userEvent.click(
-      within(screen.getByTestId('date-time-picker-spinner-list-spinner-2')).getByText('03')
-    );
-    // select AM/PM
-    userEvent.click(
-      within(screen.getByTestId('date-time-picker-spinner-list-spinner-3')).getByText('AM')
-    );
-
-    screen.getByTestId('date-time-picker-spinner').blur();
-
-    // open end time picker
-    fireEvent.focus(screen.getByTestId('date-time-picker-input-2'));
-    // select hour
-    userEvent.click(
-      within(screen.getByTestId('date-time-picker-spinner-list-spinner-1')).getByText('05')
-    );
-    // select minute
-    userEvent.click(
-      within(screen.getByTestId('date-time-picker-spinner-list-spinner-2')).getByText('03')
-    );
-    // select AM/PM
-    userEvent.click(
-      within(screen.getByTestId('date-time-picker-spinner-list-spinner-3')).getByText('PM')
-    );
-    screen.getByTestId('date-time-picker-spinner').blur();
-    userEvent.click(screen.getByText('Apply'));
-    expect(dateTimePickerProps.onApply).toHaveBeenCalled();
-  });
-
-  it('should respect datetimemask prior to is24hours for range select', () => {
-    render(
-      <DateTimePicker
-        useNewTimeSpinner
-        is24hours
-        {...dateTimePickerProps}
         dateTimeMask="YYYY-MM-DD hh:mm A"
+        {...dateTimePickerProps}
         defaultValue={defaultAbsoluteValue}
       />
     );
@@ -495,7 +442,6 @@ describe('DateTimePickerV2', () => {
     render(
       <DateTimePicker
         useNewTimeSpinner
-        is24hours
         {...dateTimePickerProps}
         defaultValue={defaultAbsoluteValue}
       />
@@ -586,62 +532,12 @@ describe('DateTimePickerV2', () => {
     expect(screen.getByText(i18n.applyBtnLabel)).toBeEnabled();
   });
 
-  it('should respect datetimemask prior to is24hours for single select', () => {
-    const { i18n } = DateTimePicker.defaultProps;
-    render(
-      <DateTimePicker
-        {...dateTimePickerProps}
-        useNewTimeSpinner
-        is24hours
-        onApply={jest.fn()}
-        datePickerType="single"
-        dateTimeMask="YYYY-MM-DD hh:mm A"
-        hasTimeInput
-        showRelativeOption={false}
-        defaultValue={{
-          timeRangeKind: PICKER_KINDS.SINGLE,
-          timeSingleValue: {
-            startDate: '2020-04-01',
-            startTime: '12:34 AM',
-          },
-        }}
-      />
-    );
-
-    // default value is 2020-04-01 12:34 AM
-    expect(screen.getByText('2020-04-01 12:34 AM')).toBeVisible();
-
-    // first open the menu
-    userEvent.click(screen.getAllByText(/2020-04-01 12:34 AM/i)[0]);
-
-    const startTime = screen.getByTestId('date-time-picker-input');
-    // open time picker
-    fireEvent.focus(screen.getByTestId('date-time-picker-input'));
-    // select hour
-    userEvent.click(
-      within(screen.getByTestId('date-time-picker-spinner-list-spinner-1')).getByText('05')
-    );
-    // select miniute
-    userEvent.click(
-      within(screen.getByTestId('date-time-picker-spinner-list-spinner-2')).getByText('03')
-    );
-    // select AM/PM
-    userEvent.click(
-      within(screen.getByTestId('date-time-picker-spinner-list-spinner-3')).getByText('PM')
-    );
-
-    expect(startTime).toHaveValue('05:03 PM');
-    expect(screen.getByText('2020-04-01 05:03 PM')).toBeVisible();
-    expect(screen.getByText(i18n.applyBtnLabel)).toBeEnabled();
-  });
-
   it('should render with a predefined single select date and 24 hours time format time', () => {
     const { i18n } = DateTimePicker.defaultProps;
     render(
       <DateTimePicker
         {...dateTimePickerProps}
         useNewTimeSpinner
-        is24hours
         onApply={jest.fn()}
         datePickerType="single"
         dateTimeMask="YYYY-MM-DD HH:mm"
@@ -657,7 +553,7 @@ describe('DateTimePickerV2', () => {
       />
     );
 
-    // default value is 2020-04-01 12:34 AM
+    // default value is 2020-04-01 12:34
     expect(screen.getByText('2020-04-01 12:34')).toBeVisible();
 
     // first open the menu
@@ -668,15 +564,15 @@ describe('DateTimePickerV2', () => {
     fireEvent.focus(screen.getByTestId('date-time-picker-input'));
     // select hour
     userEvent.click(
-      within(screen.getByTestId('date-time-picker-spinner-list-spinner-1')).getByText('05')
+      within(screen.getByTestId('date-time-picker-spinner-list-spinner-1')).getByText('23')
     );
     // select miniute
     userEvent.click(
       within(screen.getByTestId('date-time-picker-spinner-list-spinner-2')).getByText('03')
     );
 
-    expect(startTime).toHaveValue('05:03');
-    expect(screen.getByText('2020-04-01 05:03')).toBeVisible();
+    expect(startTime).toHaveValue('23:03');
+    expect(screen.getByText('2020-04-01 23:03')).toBeVisible();
     expect(screen.getByText(i18n.applyBtnLabel)).toBeEnabled();
   });
 
@@ -1036,7 +932,7 @@ describe('DateTimePickerV2', () => {
     );
     screen.getByTestId('date-time-picker-spinner').blur();
 
-    expect(screen.getByText('2020-04-01 13:34 to 2020-04-06 10:49')).toBeVisible();
+    expect(screen.getByText('2020-04-01 01:34 to 2020-04-06 10:49')).toBeVisible();
 
     userEvent.click(screen.getByText('Back'));
     userEvent.click(screen.getByText('Cancel'));
@@ -1729,6 +1625,7 @@ describe('DateTimePickerV2', () => {
       <DateTimePicker
         {...dateTimePickerProps}
         useNewTimeSpinner
+        dateTimeMask="YYYY-MM-DD HH:mm A"
         id="picker-test"
         hasTimeInput
         defaultValue={{
@@ -1752,68 +1649,47 @@ describe('DateTimePickerV2', () => {
     const startTime = screen.getByTestId('date-time-picker-input-1');
     const endTime = screen.getByTestId('date-time-picker-input-2');
 
-    expect(timeRange).toHaveTextContent('2020-04-01 12:34 to 2020-04-01 11:49');
+    expect(timeRange).toHaveTextContent('2020-04-01 12:34 PM to 2020-04-01 11:49 AM');
     expect(screen.getByText(i18n.applyBtnLabel)).toBeDisabled();
 
     // 2020-04-01 13:34 to 2020-04-01 11:49
     fireEvent.focus(startTime);
-    userEvent.type(
-      startTime,
-      '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}01:34 PM'
-    );
-    expect(startTime).toHaveValue('01:34 PM');
-    expect(endTime).toHaveValue('11:49 AM');
-    expect(timeRange).toHaveTextContent('2020-04-01 13:34 to 2020-04-01 11:49');
+    userEvent.type(startTime, '{backspace}{backspace}{backspace}{backspace}{backspace}13:34');
+    expect(startTime).toHaveValue('13:34');
+    expect(endTime).toHaveValue('11:49');
+    expect(timeRange).toHaveTextContent('2020-04-01 13:34 PM to 2020-04-01 11:49 AM');
     expect(screen.getByText(i18n.applyBtnLabel)).toBeDisabled();
 
     // 2020-04-01 13:34 to 2020-04-01 12:49
     fireEvent.focus(endTime);
-    userEvent.type(
-      endTime,
-      '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}12:49 PM'
-    );
-    expect(startTime).toHaveValue('01:34 PM');
-    expect(endTime).toHaveValue('12:49 PM');
-    expect(timeRange).toHaveTextContent('2020-04-01 13:34 to 2020-04-01 12:49');
+    userEvent.type(endTime, '{backspace}{backspace}{backspace}{backspace}{backspace}12:49');
+    expect(startTime).toHaveValue('13:34');
+    expect(endTime).toHaveValue('12:49');
+    expect(timeRange).toHaveTextContent('2020-04-01 13:34 PM to 2020-04-01 12:49 PM');
     expect(screen.getByText(i18n.applyBtnLabel)).toBeDisabled();
 
     // 2020-04-01 13:34 to 2020-04-01 13:49
-    userEvent.type(
-      endTime,
-      '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}01:49 PM'
-    );
+    userEvent.type(endTime, '{backspace}{backspace}{backspace}{backspace}{backspace}13:49');
     endTime.blur();
-    expect(startTime).toHaveValue('01:34 PM');
-    expect(endTime).toHaveValue('01:49 PM');
-    expect(timeRange).toHaveTextContent('2020-04-01 13:34 to 2020-04-01 13:49');
+    expect(startTime).toHaveValue('13:34');
+    expect(endTime).toHaveValue('13:49');
+    expect(timeRange).toHaveTextContent('2020-04-01 13:34 PM to 2020-04-01 13:49 PM');
     expect(screen.getByText(i18n.applyBtnLabel)).toBeEnabled();
 
     // 2020-04-01 13:50 to 2020-04-01 13:49
     fireEvent.focus(startTime);
-    userEvent.type(
-      startTime,
-      '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}01:50 PM'
-    );
-    expect(startTime).toHaveValue('01:50 PM');
-    expect(endTime).toHaveValue('01:49 PM');
-    expect(timeRange).toHaveTextContent('2020-04-01 13:50 to 2020-04-01 13:49');
+    userEvent.type(startTime, '{backspace}{backspace}{backspace}{backspace}{backspace}13:50');
+    expect(startTime).toHaveValue('13:50');
+    expect(endTime).toHaveValue('13:49');
+    expect(timeRange).toHaveTextContent('2020-04-01 13:50 PM to 2020-04-01 13:49 PM');
     expect(screen.getByText(i18n.applyBtnLabel)).toBeDisabled();
 
-    // userEvent.type(screen.getByTestId('date-time-picker-input-1'), '{backspace}');
-    // userEvent.type(screen.getByTestId('date-time-picker-input-2'), '{backspace}');
-    // expect(screen.getByTestId('date-time-picker-input-1')).toHaveValue('Invalid Date');
-    // expect(screen.getByTestId('date-time-picker-input-2')).toHaveValue('Invalid Date');
-    // expect(screen.getByText(i18n.applyBtnLabel)).toBeDisabled();
-
-    userEvent.type(startTime, '{backspace}{backspace}{backspace}{backspace}{backspace}51 PM');
+    userEvent.type(startTime, '{backspace}{backspace}51');
 
     fireEvent.focus(endTime);
-    userEvent.type(
-      endTime,
-      '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}9999'
-    );
+    userEvent.type(endTime, '{backspace}{backspace}{backspace}{backspace}{backspace}9999');
     endTime.blur();
-    expect(startTime).toHaveValue('01:51 PM');
+    expect(startTime).toHaveValue('13:51');
     expect(endTime).toHaveValue('9999');
     expect(screen.getByText(i18n.applyBtnLabel)).toBeDisabled();
   });
@@ -1893,6 +1769,7 @@ describe('DateTimePickerV2', () => {
       <DateTimePicker
         {...dateTimePickerProps}
         useNewTimeSpinner
+        dateTimeMask="YYYY-MM-DD hh:mm A"
         id="picker-test"
         testId="date-time-picker"
         hasTimeInput
@@ -1918,7 +1795,7 @@ describe('DateTimePickerV2', () => {
     const startTime = screen.getByTestId('date-time-picker-input-1');
     const endTime = screen.getByTestId('date-time-picker-input-2');
 
-    expect(timeRange).toHaveTextContent('2020-04-01 12:34 to 2020-04-06 11:49');
+    expect(timeRange).toHaveTextContent('2020-04-01 12:34 PM to 2020-04-06 11:49 AM');
     expect(screen.getByText(i18n.applyBtnLabel)).toBeEnabled();
 
     // 2020-04-01 13:34 to 2020-04-06 11:49
@@ -1930,7 +1807,7 @@ describe('DateTimePickerV2', () => {
 
     expect(startTime).toHaveValue('01:34 PM');
     expect(endTime).toHaveValue('11:49 AM');
-    expect(timeRange).toHaveTextContent('2020-04-01 13:34 to 2020-04-06 11:49');
+    expect(timeRange).toHaveTextContent('2020-04-01 01:34 PM to 2020-04-06 11:49 AM');
 
     // 2020-04-01 13:34 to 2020-04-06 12:49
     fireEvent.focus(endTime);
@@ -1941,7 +1818,7 @@ describe('DateTimePickerV2', () => {
     endTime.blur();
     expect(startTime).toHaveValue('01:34 PM');
     expect(endTime).toHaveValue('12:49 PM');
-    expect(timeRange).toHaveTextContent('2020-04-01 13:34 to 2020-04-06 12:49');
+    expect(timeRange).toHaveTextContent('2020-04-01 01:34 PM to 2020-04-06 12:49 PM');
     expect(screen.getByText(i18n.applyBtnLabel)).toBeEnabled();
 
     // 2020-04-01 13:34 to 2020-04-06 13:49
@@ -1952,7 +1829,7 @@ describe('DateTimePickerV2', () => {
     );
     expect(startTime).toHaveValue('01:34 PM');
     expect(endTime).toHaveValue('01:49 PM');
-    expect(timeRange).toHaveTextContent('2020-04-01 13:34 to 2020-04-06 13:49');
+    expect(timeRange).toHaveTextContent('2020-04-01 01:34 PM to 2020-04-06 01:49 PM');
     expect(screen.getByText(i18n.applyBtnLabel)).toBeEnabled();
 
     // 2020-04-01 13:50 to 2020-04-06 13:49
@@ -1963,7 +1840,7 @@ describe('DateTimePickerV2', () => {
     );
     expect(screen.getByTestId('date-time-picker-input-1')).toHaveValue('01:50 PM');
     expect(screen.getByTestId('date-time-picker-input-2')).toHaveValue('01:49 PM');
-    expect(timeRange).toHaveTextContent('2020-04-01 13:50 to 2020-04-06 13:49');
+    expect(timeRange).toHaveTextContent('2020-04-01 01:50 PM to 2020-04-06 01:49 PM');
     expect(screen.getByText(i18n.applyBtnLabel)).toBeEnabled();
 
     fireEvent.focus(startTime);

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
@@ -385,7 +385,7 @@ describe('DateTimePickerV2', () => {
     expect(dateTimePickerProps.onApply).toHaveBeenCalled();
   });
 
-  it('should render with a predefined absolute range (new time spinner)', () => {
+  it('should render with a predefined absolute range (new time spinner and 12 hours time)', () => {
     render(
       <DateTimePicker
         useNewTimeSpinner
@@ -437,7 +437,61 @@ describe('DateTimePickerV2', () => {
     expect(dateTimePickerProps.onApply).toHaveBeenCalled();
   });
 
-  it('should render with a predefined absolute range (new time spinner and 24 hour format time)', () => {
+  it('should respect datetimemask prior to is24hours for range select', () => {
+    render(
+      <DateTimePicker
+        useNewTimeSpinner
+        is24hours
+        {...dateTimePickerProps}
+        dateTimeMask="YYYY-MM-DD hh:mm A"
+        defaultValue={defaultAbsoluteValue}
+      />
+    );
+
+    // default value starts at   '2020-04-01' at 12:34 to 2020-04-06 at 10:49
+    expect(screen.getByText('2020-04-01 12:34 PM to 2020-04-06 10:49 AM')).toBeVisible();
+
+    // first open the menu
+    userEvent.click(screen.getAllByLabelText('Calendar')[0]);
+
+    // open start time picker
+    fireEvent.focus(screen.getByTestId('date-time-picker-input-1'));
+
+    // select hour
+    userEvent.click(
+      within(screen.getByTestId('date-time-picker-spinner-list-spinner-1')).getByText('05')
+    );
+    // select miniute
+    userEvent.click(
+      within(screen.getByTestId('date-time-picker-spinner-list-spinner-2')).getByText('03')
+    );
+    // select AM/PM
+    userEvent.click(
+      within(screen.getByTestId('date-time-picker-spinner-list-spinner-3')).getByText('AM')
+    );
+
+    screen.getByTestId('date-time-picker-spinner').blur();
+
+    // open end time picker
+    fireEvent.focus(screen.getByTestId('date-time-picker-input-2'));
+    // select hour
+    userEvent.click(
+      within(screen.getByTestId('date-time-picker-spinner-list-spinner-1')).getByText('05')
+    );
+    // select minute
+    userEvent.click(
+      within(screen.getByTestId('date-time-picker-spinner-list-spinner-2')).getByText('03')
+    );
+    // select AM/PM
+    userEvent.click(
+      within(screen.getByTestId('date-time-picker-spinner-list-spinner-3')).getByText('PM')
+    );
+    screen.getByTestId('date-time-picker-spinner').blur();
+    userEvent.click(screen.getByText('Apply'));
+    expect(dateTimePickerProps.onApply).toHaveBeenCalled();
+  });
+
+  it('should render with a predefined absolute range (new time spinner and 24 hours format time)', () => {
     render(
       <DateTimePicker
         useNewTimeSpinner
@@ -490,6 +544,55 @@ describe('DateTimePickerV2', () => {
       <DateTimePicker
         {...dateTimePickerProps}
         useNewTimeSpinner
+        onApply={jest.fn()}
+        datePickerType="single"
+        dateTimeMask="YYYY-MM-DD hh:mm A"
+        hasTimeInput
+        showRelativeOption={false}
+        defaultValue={{
+          timeRangeKind: PICKER_KINDS.SINGLE,
+          timeSingleValue: {
+            startDate: '2020-04-01',
+            startTime: '12:34 AM',
+          },
+        }}
+      />
+    );
+
+    // default value is 2020-04-01 12:34 AM
+    expect(screen.getByText('2020-04-01 12:34 AM')).toBeVisible();
+
+    // first open the menu
+    userEvent.click(screen.getAllByText(/2020-04-01 12:34 AM/i)[0]);
+
+    const startTime = screen.getByTestId('date-time-picker-input');
+    // open time picker
+    fireEvent.focus(screen.getByTestId('date-time-picker-input'));
+    // select hour
+    userEvent.click(
+      within(screen.getByTestId('date-time-picker-spinner-list-spinner-1')).getByText('05')
+    );
+    // select miniute
+    userEvent.click(
+      within(screen.getByTestId('date-time-picker-spinner-list-spinner-2')).getByText('03')
+    );
+    // select AM/PM
+    userEvent.click(
+      within(screen.getByTestId('date-time-picker-spinner-list-spinner-3')).getByText('PM')
+    );
+
+    expect(startTime).toHaveValue('05:03 PM');
+    expect(screen.getByText('2020-04-01 05:03 PM')).toBeVisible();
+    expect(screen.getByText(i18n.applyBtnLabel)).toBeEnabled();
+  });
+
+  it('should respect datetimemask prior to is24hours for single select', () => {
+    const { i18n } = DateTimePicker.defaultProps;
+    render(
+      <DateTimePicker
+        {...dateTimePickerProps}
+        useNewTimeSpinner
+        is24hours
         onApply={jest.fn()}
         datePickerType="single"
         dateTimeMask="YYYY-MM-DD hh:mm A"

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
@@ -321,6 +321,13 @@ const DateTimePicker = ({
     }),
     [i18n]
   );
+
+  const amPmModifier = dateTimeMask.split(' ')[2];
+  const is24hoursFormat = useMemo(() => (amPmModifier ? false : is24hours), [
+    amPmModifier,
+    is24hours,
+  ]);
+
   const isSingleSelect = useMemo(() => datePickerType === 'single', [datePickerType]);
 
   // initialize the dayjs locale
@@ -423,12 +430,12 @@ const DateTimePicker = ({
         value.absolute = {
           ...absoluteValue,
           startTime: hasTimeInput
-            ? is24hours
+            ? is24hoursFormat
               ? rangeStartTimeValue
               : format12hourTo24hour(rangeStartTimeValue)
             : '00:00',
           endTime: hasTimeInput
-            ? is24hours
+            ? is24hoursFormat
               ? rangeEndTimeValue
               : format12hourTo24hour(rangeEndTimeValue)
             : '00:00',
@@ -438,7 +445,7 @@ const DateTimePicker = ({
           ...singleDateValue,
           startTime:
             hasTimeInput && singleTimeValue !== ''
-              ? is24hours
+              ? is24hoursFormat
                 ? singleTimeValue
                 : format12hourTo24hour(singleTimeValue)
               : null,
@@ -599,11 +606,11 @@ const DateTimePicker = ({
           absolute.end = dayjs(`${absolute.endDate} ${absolute.endTime}`).valueOf();
         }
         absolute.startDate = dayjs(absolute.start).format('MM/DD/YYYY');
-        absolute.startTime = is24hours
+        absolute.startTime = is24hoursFormat
           ? dayjs(absolute.start).format('HH:mm')
           : dayjs(absolute.start).format('hh:mm A');
         absolute.endDate = dayjs(absolute.end).format('MM/DD/YYYY');
-        absolute.endTime = is24hours
+        absolute.endTime = is24hoursFormat
           ? dayjs(absolute.end).format('HH:mm')
           : dayjs(absolute.end).format('hh:mm A');
         setAbsoluteValue(absolute);
@@ -622,7 +629,7 @@ const DateTimePicker = ({
         }
         single.startDate = single.start ? dayjs(single.start).format('MM/DD/YYYY') : null;
         single.startTime = single.start
-          ? is24hours
+          ? is24hoursFormat
             ? dayjs(single.start).format('HH:mm')
             : dayjs(single.start).format('hh:mm A')
           : null;
@@ -823,18 +830,18 @@ const DateTimePicker = ({
     setRangeEndTimeValue(endState);
     setInvalidRangeStartTime(
       (absoluteValue && invalidStartDate(startState, endState, absoluteValue)) ||
-        (is24hours ? !isValid24HourTime(startState) : !isValid12HourTime(startState))
+        (is24hoursFormat ? !isValid24HourTime(startState) : !isValid12HourTime(startState))
     );
     setInvalidRangeEndTime(
       (absoluteValue && invalidEndDate(startState, endState, absoluteValue)) ||
-        (is24hours ? !isValid24HourTime(endState) : !isValid12HourTime(endState))
+        (is24hoursFormat ? !isValid24HourTime(endState) : !isValid12HourTime(endState))
     );
   };
 
   const handleSingleTimeValueChange = (startState) => {
     setSingleTimeValue(startState);
     setInvalidRangeStartTime(
-      is24hours ? !isValid24HourTime(startState) : !isValid12HourTime(startState)
+      is24hoursFormat ? !isValid24HourTime(startState) : !isValid12HourTime(startState)
     );
   };
 
@@ -1191,7 +1198,7 @@ const DateTimePicker = ({
                           size="sm"
                           testId={testId}
                           style={{ zIndex: (style.zIndex ?? 0) + 6000 }}
-                          is24hours={is24hours}
+                          is24hours={is24hoursFormat}
                         />
                       ) : (
                         <div className={`${iotPrefix}--date-time-picker__no-formgroup`} />

--- a/packages/react/src/components/DateTimePicker/__snapshots__/DateTimePickerV2.story.storyshot
+++ b/packages/react/src/components/DateTimePicker/__snapshots__/DateTimePickerV2.story.storyshot
@@ -515,9 +515,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
         >
           <span
             className=""
-            title="2020-04-01 12:34 to 2020-04-06 10:49"
+            title="2020-04-01 12:34 PM to 2020-04-06 10:49 AM"
           >
-            2020-04-01 12:34 to 2020-04-06 10:49
+            2020-04-01 12:34 PM to 2020-04-06 10:49 AM
           </span>
         </div>
         <div
@@ -983,9 +983,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
         >
           <span
             className=""
-            title="2020-04-01 12:34 PM"
+            title="2020-04-01 12:34"
           >
-            2020-04-01 12:34 PM
+            2020-04-01 12:34
           </span>
         </div>
         <div

--- a/packages/react/src/components/DateTimePicker/__snapshots__/DateTimePickerV2.story.storyshot
+++ b/packages/react/src/components/DateTimePicker/__snapshots__/DateTimePickerV2.story.storyshot
@@ -515,9 +515,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
         >
           <span
             className=""
-            title="2020-04-01 12:34 PM to 2020-04-06 10:49 AM"
+            title="2020-04-01 12:34 to 2020-04-06 10:49"
           >
-            2020-04-01 12:34 PM to 2020-04-06 10:49 AM
+            2020-04-01 12:34 to 2020-04-06 10:49
           </span>
         </div>
         <div

--- a/packages/react/src/components/DateTimePicker/dateTimePickerUtils.js
+++ b/packages/react/src/components/DateTimePicker/dateTimePickerUtils.js
@@ -8,7 +8,7 @@ import dayjs from '../../utils/dayjs';
 
 const { iotPrefix } = settings;
 
-/** convert time from format hh:mm A to HH:mm
+/** convert time from 12 hours to 24 hours, if time12hour is 24 hours format, return immediately
  * *
  * @param {Object} object hh:mm A time oject
  * @returns HH:mm time object
@@ -18,6 +18,10 @@ export const format12hourTo24hour = (time12hour) => {
     return '00:00';
   }
   const [time, modifier] = time12hour.split(' ');
+
+  if (!modifier) {
+    return time12hour;
+  }
 
   // eslint-disable-next-line prefer-const
   let [hours, minutes] = time.split(':');

--- a/packages/react/src/components/DateTimePicker/dateTimePickerUtils.js
+++ b/packages/react/src/components/DateTimePicker/dateTimePickerUtils.js
@@ -264,6 +264,17 @@ export const isValid12HourTime = (time) => {
 };
 
 /**
+ * 24 hour time validator
+ *
+ * @param {string} time The time string to check
+ * @returns bool
+ */
+export const isValid24HourTime = (time) => {
+  const isValid24HoursRegex = /^(2[0-3]|[01]?[0-9]):([0-5]?[0-9])$/;
+  return isValid24HoursRegex.test(time) || time === '';
+};
+
+/**
  * Simple function to handle keeping flatpickr open when it would normally close
  *
  * @param {*} range unused
@@ -389,6 +400,7 @@ export const useAbsoluteDateTimeValue = () => {
     changeAbsolutePropertyValue,
     format12hourTo24hour,
     isValid12HourTime,
+    isValid24HourTime,
   };
 };
 

--- a/packages/react/src/components/TimePicker/TimePickerDropdown.jsx
+++ b/packages/react/src/components/TimePicker/TimePickerDropdown.jsx
@@ -98,7 +98,7 @@ const defaultProps = {
     warnText: undefined,
     timeIconText: 'Open time picker',
     placeholderText: 'hh:mm XM',
-    placeholderText24h: 'hh:mm',
+    placeholderText24h: 'HH:mm',
     readOnlyBtnText: 'Read only',
   },
   size: 'md',

--- a/packages/react/src/components/TimePicker/_time-picker-dropdown.scss
+++ b/packages/react/src/components/TimePicker/_time-picker-dropdown.scss
@@ -195,8 +195,6 @@
   animation: fadeIn 0.25s forwards;
 
   &--24h {
-    width: 13.125rem;
-
     & .#{$iot-prefix}--list-spinner__section {
       width: 6rem;
     }

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -8829,7 +8829,7 @@ Map {
       "i18n": Object {
         "invalidText": "The time entered is invalid",
         "placeholderText": "hh:mm XM",
-        "placeholderText24h": "hh:mm",
+        "placeholderText24h": "HH:mm",
         "readOnlyBtnText": "Read only",
         "timeIconText": "Open time picker",
         "warnText": undefined,
@@ -9525,6 +9525,7 @@ Map {
         },
       ],
       "invalid": false,
+      "is24hours": false,
       "light": false,
       "locale": "en",
       "menuOffset": undefined,
@@ -9921,6 +9922,9 @@ Map {
         "type": "arrayOf",
       },
       "invalid": Object {
+        "type": "bool",
+      },
+      "is24hours": Object {
         "type": "bool",
       },
       "light": Object {

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -9525,7 +9525,6 @@ Map {
         },
       ],
       "invalid": false,
-      "is24hours": false,
       "light": false,
       "locale": "en",
       "menuOffset": undefined,
@@ -9922,9 +9921,6 @@ Map {
         "type": "arrayOf",
       },
       "invalid": Object {
-        "type": "bool",
-      },
-      "is24hours": Object {
         "type": "bool",
       },
       "light": Object {


### PR DESCRIPTION
Closes #3595 

**Summary**

- indicate 12 hours or 24 hours by the definition of prop `dateTimeMask`, specifically if the hour mask is `HH`, it means 24 hours, and `hh` means 12 hours , despite of whether  `dateTimeMask` has AM/PM for not. 
- make sure both 12 hours and 24 hours are supported for single select and range select
- updated stories and tests

For example,

If `dateTimeMask` is `YYYY-MM-DD HH:mm` this is 24 hours. The field shows value like `2020-04-01 13:34`. `TimePickerDropDown` is 24hours format like `13:34`.

If `dateTimeMask` is `YYYY-MM-DD HH:mm A` this is 24 hours with AM/PM. The field shows value like `2020-04-01 13:34 PM`. `TimePickerDropDown` is 24hours format like `13:34`.

If `dateTimeMask` is `YYYY-MM-DD hh:mm A` this is 12 hours with AM/PM.  The field shows value like `2020-04-01 01:34 PM `. `TimePickerDropDown` is 24hours format like `01:34 PM`.


**Acceptance Test (how to verify the PR)**

For single select
- go to single select [story](https://deploy-preview-3596--carbon-addons-iot-react.netlify.app/?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-datetimepickerv2--single-select)
- make sure is24hours is checked
- click on menu button to open flyout menu
- the time format on time picker should be 24 hours
- click on clock button to open time spinner
- the spinner should only show hours and minutes

For range select
- go to range select [story](https://deploy-preview-3596--carbon-addons-iot-react.netlify.app/?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-datetimepickerv2--selected-absolute-with-new-time-spinner)
- make sure is24hours is checked
- click on menu button to open flyout menu
- the time format on time picker should be 24 hours
- click on clock button to open time spinner
- the spinner should only show hours and minutes



<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
