### PR TITLE
fix(table): add prop to hide clear all filters button

### DIFF
--- a/packages/react/src/components/CardCodeEditor/CardCodeEditor.test.e2e.jsx
+++ b/packages/react/src/components/CardCodeEditor/CardCodeEditor.test.e2e.jsx
@@ -59,7 +59,7 @@ describe('CardCodeEditor loaded editor test', () => {
     );
     // wait for script to load. fails intermittently without
     /* eslint-disable-next-line cypress/no-unnecessary-waiting */
-    cy.wait(500);
+    cy.wait(1500);
     cy.findByText(/\/\* write your code here \*\//).should('be.visible');
 
     // This component throws a network error with too many calls to the cdn script it loads so adding snapshot to existing instance

--- a/packages/react/src/components/Table/StatefulTable.jsx
+++ b/packages/react/src/components/Table/StatefulTable.jsx
@@ -106,6 +106,7 @@ const StatefulTable = ({ data: initialData, expandedData, ...other }) => {
     initialState.toolbar.initialDefaultSearch,
     initialState.toolbar.search,
     initialState.toolbar.isDisabled,
+    initialState.toolbar.hideClearAllFiltersButton,
     initialState.table.isSelectAllSelected,
     initialState.table.isSelectAllIndeterminate,
     initialState.table.selectedIds,

--- a/packages/react/src/components/Table/StatefulTable.test.jsx
+++ b/packages/react/src/components/Table/StatefulTable.test.jsx
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme';
 import React from 'react';
-import { merge, pick } from 'lodash-es';
+import { merge, pick, cloneDeep } from 'lodash-es';
 import { screen, render, fireEvent, act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Screen16, ViewOff16 } from '@carbon/icons-react';
@@ -602,6 +602,50 @@ describe('stateful table with real reducer', () => {
       )
     ).not.toThrowError();
   });
+  it('should hide "Clear all filters" button if prop hideClearAllFiltersButton enabled', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const initialStateCopy = cloneDeep(initialState);
+    initialStateCopy.view.toolbar.hideClearAllFiltersButton = true;
+
+    render(<StatefulTable {...initialStateCopy} actions={mockActions} />);
+
+    const whiteboardFilter = await screen.findByDisplayValue('whiteboard');
+    expect(whiteboardFilter).toBeInTheDocument();
+    expect(screen.getByDisplayValue('option-B')).toBeInTheDocument();
+    expect(screen.queryByText('Clear all filters')).toBeNull();
+  });
+
+  it('should hide "Clear all filters" button if prop hideClearAllFiltersButton enabled and activeBar is undefined', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const initialStateCopy = cloneDeep(initialState);
+    initialStateCopy.view.toolbar.hideClearAllFiltersButton = true;
+    initialStateCopy.view.toolbar.activeBar = undefined;
+
+    render(<StatefulTable {...initialStateCopy} actions={mockActions} />);
+
+    expect(screen.queryByText('Clear all filters')).toBeNull();
+  });
+
+  it('should hide "Clear all filters" after rerender with new props', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { rerender } = render(<StatefulTable {...initialState} actions={mockActions} />);
+
+    const whiteboardFilter = await screen.findByDisplayValue('whiteboard');
+    expect(whiteboardFilter).toBeInTheDocument();
+    expect(screen.getByDisplayValue('option-B')).toBeInTheDocument();
+    expect(screen.getByText('Clear all filters')).toBeInTheDocument();
+
+    const initialStateCopy = cloneDeep(initialState);
+    initialStateCopy.view.toolbar.hideClearAllFiltersButton = true;
+
+    rerender(<StatefulTable {...initialStateCopy} actions={mockActions} />);
+
+    expect(whiteboardFilter).toBeInTheDocument();
+    expect(screen.getByDisplayValue('option-B')).toBeInTheDocument();
+    expect(screen.queryByText('Clear all filters')).toBeNull();
+  });
+
   describe('AdvancedFilters', () => {
     it('properly filters the table when advancedRules have simple logic', async () => {
       const { container } = render(

--- a/packages/react/src/components/Table/StatefulTable.test.jsx
+++ b/packages/react/src/components/Table/StatefulTable.test.jsx
@@ -587,6 +587,34 @@ describe('stateful table with real reducer', () => {
     fireEvent.click(clearFiltersButton);
     expect(mockActions.toolbar.onClearAllFilters).toHaveBeenCalledTimes(1);
   });
+  it('should preserve search when all filters has been cleared', async () => {
+    const initialStateCopy = cloneDeep(initialState);
+    initialStateCopy.view.toolbar.search = {
+      defaultValue: 'irrelevant search 123123',
+    };
+    render(<StatefulTable {...initialStateCopy} actions={mockActions} />);
+
+    const emptyState = screen.getByTestId('EmptyState');
+    const clearAllFiltersButton = screen.getByText('Clear all filters');
+    const whiteboardFilter = await screen.findByDisplayValue('whiteboard');
+    const comboBoxFilter = screen.getByDisplayValue('option-B');
+
+    expect(emptyState).toBeInTheDocument();
+    expect(clearAllFiltersButton).toBeInTheDocument();
+    expect(whiteboardFilter).toBeInTheDocument();
+    expect(comboBoxFilter).toBeInTheDocument();
+
+    const clearFiltersButton = screen.getByRole('button', { name: 'Clear all filters' });
+    fireEvent.click(clearFiltersButton);
+
+    // Filtering by search has been preserved
+    expect(emptyState).toBeInTheDocument();
+
+    // Column filters has been reset
+    expect(clearAllFiltersButton).not.toBeInTheDocument();
+    expect(whiteboardFilter).not.toBeInTheDocument();
+    expect(comboBoxFilter).not.toBeInTheDocument();
+  });
   it('should use callback fallbacks when props not passed', () => {
     expect(() =>
       render(

--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -239,6 +239,8 @@ const propTypes = {
       rowEditBarButtons: PropTypes.node,
       /** extra actions that can appear in an overflow menu in the toolbar (same menu as toggle aggregations) */
       toolbarActions: TableToolbarActionsPropType,
+      /** force hide Clear all filters button in toolbar */
+      hideClearAllFiltersButton: PropTypes.bool,
     }),
     table: PropTypes.shape({
       isSelectAllSelected: PropTypes.bool,
@@ -417,6 +419,7 @@ export const defaultProps = (baseProps) => ({
       advancedFilterFlyoutOpen: false,
       batchActions: [],
       search: {},
+      hideClearAllFiltersButton: false,
     },
     table: {
       expandedIds: [],
@@ -924,6 +927,7 @@ const Table = (props) => {
                 'advancedFilterFlyoutOpen',
                 'toolbarActions'
               ),
+              hideClearAllFiltersButton: view.toolbar.hideClearAllFiltersButton,
             }}
             data={data}
             // TODO: remove id in V3.

--- a/packages/react/src/components/Table/Table.main.story.jsx
+++ b/packages/react/src/components/Table/Table.main.story.jsx
@@ -155,6 +155,7 @@ export const Playground = () => {
     batchActions,
     searchIsExpanded,
     useRadioButtonSingleSelect,
+    hideClearAllFiltersButton,
   } = getTableKnobs({
     getDefaultValue: (name) =>
       // For this story always disable the following knobs by default
@@ -179,6 +180,7 @@ export const Playground = () => {
         'demoColumnOverflowMenuItems',
         'hasOnlyPageData',
         'useRadioButtonSingleSelect',
+        'hideClearAllFiltersButton',
       ].includes(name)
         ? false
         : // For this story always enable the following knobs by default
@@ -368,6 +370,7 @@ export const Playground = () => {
               defaultExpanded: searchFieldDefaultExpanded,
               isExpanded: searchIsExpanded,
             },
+            hideClearAllFiltersButton,
           },
           table: {
             emptyState,
@@ -697,9 +700,29 @@ WithAggregations.parameters = {
 };
 
 export const WithFiltering = () => {
-  const { selectedTableType, hasFilter, hasAdvancedFilter } = getTableKnobs({
-    knobsToCreate: ['selectedTableType', 'hasFilter', 'hasAdvancedFilter'],
-    getDefaultValue: (knobName) => knobName !== 'hasAdvancedFilter',
+  const {
+    selectedTableType,
+    hasFilter,
+    hasAdvancedFilter,
+    hideClearAllFiltersButton,
+  } = getTableKnobs({
+    knobsToCreate: [
+      'selectedTableType',
+      'hasFilter',
+      'hasAdvancedFilter',
+      'hideClearAllFiltersButton',
+    ],
+    getDefaultValue: (knobName) => {
+      if (knobName === 'hasAdvancedFilter') {
+        return false;
+      }
+
+      if (knobName === 'hideClearAllFiltersButton') {
+        return false;
+      }
+
+      return true;
+    },
   });
 
   const MyTable = selectedTableType === 'StatefulTable' ? StatefulTable : Table;
@@ -800,6 +823,7 @@ export const WithFiltering = () => {
           toolbar: {
             activeBar,
             advancedFilterFlyoutOpen,
+            hideClearAllFiltersButton,
           },
         }}
       />

--- a/packages/react/src/components/Table/Table.story.helpers.jsx
+++ b/packages/react/src/components/Table/Table.story.helpers.jsx
@@ -1049,6 +1049,13 @@ export const getTableKnobs = ({ knobsToCreate, getDefaultValue, useGroups = fals
           SORT_FILTER_GROUP
         )
       : null,
+    hideClearAllFiltersButton: shouldCreate('hideClearAllFiltersButton')
+      ? boolean(
+          'Hide clear all filters button (view.toolbar.hideClearAllFiltersButton)',
+          getDefaultValue('hideClearAllFiltersButton'),
+          SORT_FILTER_GROUP
+        )
+      : null,
 
     // SEARCH_GROUP
     hasSearch: shouldCreate('hasSearch')

--- a/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -173,6 +173,8 @@ const propTypes = {
     selectedAdvancedFilterIds: PropTypes.arrayOf(PropTypes.string),
     /** toolbar actions that can appear in an overflow menu in the toolbar (same menu as toggle aggregations) */
     toolbarActions: TableToolbarActionsPropType,
+    /** force hide Clear all filters button in toolbar */
+    hideClearAllFiltersButton: PropTypes.bool,
   }).isRequired,
   /** Row value data for the body of the table */
   data: TableRowsPropTypes.isRequired,
@@ -249,6 +251,7 @@ const TableToolbar = ({
     columns,
     ordering,
     toolbarActions,
+    hideClearAllFiltersButton,
   },
   data,
   // TODO: remove deprecated 'testID' in v3
@@ -476,7 +479,7 @@ const TableToolbar = ({
               }}
             />
           ) : null}
-          {totalFilters > 0 ? (
+          {totalFilters > 0 && !hideClearAllFiltersButton ? (
             <Button
               kind="secondary"
               onClick={onClearAllFilters}

--- a/packages/react/src/components/Table/tableReducer.js
+++ b/packages/react/src/components/Table/tableReducer.js
@@ -265,7 +265,8 @@ export const filterSearchAndSort = (
   columns,
   advancedFilters = []
 ) => {
-  const { value: searchValue } = search;
+  const { value, defaultValue } = search;
+  const searchValue = value ?? defaultValue;
   const filteredData = filterData(data, filters, columns, advancedFilters);
   const searchedData =
     searchValue && searchValue !== '' ? searchData(filteredData, searchValue) : filteredData;

--- a/packages/react/src/components/Table/tableReducer.js
+++ b/packages/react/src/components/Table/tableReducer.js
@@ -566,6 +566,7 @@ export const tableReducer = (state = {}, action) => {
               $set: activeBar,
             },
             rowEditBarButtons: { $set: get(view, 'toolbar.rowEditBarButtons') },
+            hideClearAllFiltersButton: { $set: get(view, 'toolbar.hideClearAllFiltersButton') },
           },
           table: {
             ordering: { $set: ordering },

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -781,6 +781,7 @@ Map {
         "toolbar": Object {
           "advancedFilterFlyoutOpen": false,
           "batchActions": Array [],
+          "hideClearAllFiltersButton": false,
           "search": Object {},
         },
       },
@@ -2148,6 +2149,9 @@ Map {
                   },
                   "customToolbarContent": Object {
                     "type": "node",
+                  },
+                  "hideClearAllFiltersButton": Object {
+                    "type": "bool",
                   },
                   "isDisabled": Object {
                     "type": "bool",
@@ -5082,6 +5086,9 @@ Map {
                 ],
               ],
               "type": "oneOf",
+            },
+            "hideClearAllFiltersButton": Object {
+              "type": "bool",
             },
             "isDisabled": Object {
               "type": "bool",


### PR DESCRIPTION
Closes #3597 

**Summary**

- Add prop to `Table` to hide `Clear all filters` button
- Preserve filtering by search when `Clear all filters` button is clicked

**Change List (commits, features, bugs, etc)**

- Add `hideClearAllFiltersButton` prop to `Table`
- Update `publicAPI` snapshot
- Modify `tableReducer` to preserve search after all filters have been cleared
- Update tests

**Acceptance Test (how to verify the PR)**

- Go to [this story](https://deploy-preview-3600--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table--playground)
- Disable `hasAdvancedFilter` in the `Sort & filter` knobs tab
- Select `hasFilter` to be `true` in the `Sort & filter` knobs tab
- Enable `hasSearch` and `hasFastSearch` in the `Search` knobs tab
- Type `toyota` in the table search bar
- Click on filter icon button in the table toolbar
- Type some common value in the `String` column filter (for example `5`) and press `Enter` to apply filter
- Verify that `Clear all filters` button has appeared
- Click on `Clear all filters` button
- Verify that column filters have been cleared and table is still filtered **only** by search value (before this fix both filters and search were reset after click on `Clear all filters`)

</br>

- In the same story
- Enable `hideClearAllFiltersButton` in the `Sort & filter` knobs tab (note that table state is updated)
- Click on filter icon button in the table toolbar
- Type some common value in the `String` column filter (for example `5`) and press `Enter` to apply filter
- Verify that `Clear all filters` button hasn't appeared

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
