### PR TITLE
fix(datetimepickerv2): set overflow:hidden on hidden tooltip

### DIFF
--- a/packages/react/src/components/Card/__snapshots__/Card.story.storyshot
+++ b/packages/react/src/components/Card/__snapshots__/Card.story.storyshot
@@ -5383,7 +5383,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   <button
                     aria-describedby={null}
                     aria-label="Calendar"
-                    className="iot--flyout-menu--trigger-button iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                    className="iot--flyout-menu--trigger-button iot--date-time-picker--trigger-button iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
                     data-testid="date-time-picker-datepicker-flyout-button"
                     disabled={false}
                     onBlur={[Function]}
@@ -5543,7 +5543,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   <button
                     aria-describedby={null}
                     aria-label="Calendar"
-                    className="iot--flyout-menu--trigger-button iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                    className="iot--flyout-menu--trigger-button iot--date-time-picker--trigger-button iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
                     data-testid="date-time-picker-datepicker-flyout-button"
                     disabled={false}
                     onBlur={[Function]}

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
@@ -1860,7 +1860,7 @@ describe('DateTimePickerV2', () => {
     expect(
       screen
         .getByTestId(`${dateTimePickerProps.testId}-datepicker-flyout-button`)
-        .classList.contains(`${iotPrefix}--date-time-picker--trigger-button-invalid`)
+        .classList.contains(`${iotPrefix}--date-time-picker--trigger-button--invalid`)
     ).toBe(true);
   });
 
@@ -1870,7 +1870,7 @@ describe('DateTimePickerV2', () => {
     expect(
       screen
         .getByTestId(`${dateTimePickerProps.testId}-datepicker-flyout-button`)
-        .classList.contains(`${iotPrefix}--date-time-picker--trigger-button-invalid`)
+        .classList.contains(`${iotPrefix}--date-time-picker--trigger-button--invalid`)
     ).toBe(true);
   });
 
@@ -1879,7 +1879,7 @@ describe('DateTimePickerV2', () => {
     expect(
       screen
         .getByTestId(`${dateTimePickerProps.testId}-datepicker-flyout-button`)
-        .classList.contains(`${iotPrefix}--date-time-picker--trigger-button-disabled`)
+        .classList.contains(`${iotPrefix}--date-time-picker--trigger-button--disabled`)
     ).toBe(true);
   });
 
@@ -1888,7 +1888,7 @@ describe('DateTimePickerV2', () => {
     expect(
       screen
         .getByTestId(`${dateTimePickerProps.testId}-datepicker-flyout-button`)
-        .classList.contains(`${iotPrefix}--date-time-picker--trigger-button-disabled`)
+        .classList.contains(`${iotPrefix}--date-time-picker--trigger-button--disabled`)
     ).toBe(true);
   });
 });

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
@@ -902,11 +902,10 @@ const DateTimePicker = ({
             buttonProps={{
               tooltipPosition: 'top',
               tabIndex: -1,
-              className: invalidState
-                ? `${iotPrefix}--date-time-picker--trigger-button-invalid`
-                : disabled
-                ? `${iotPrefix}--date-time-picker--trigger-button-disabled`
-                : '',
+              className: classnames(`${iotPrefix}--date-time-picker--trigger-button`, {
+                [`${iotPrefix}--date-time-picker--trigger-button--invalid`]: invalid,
+                [`${iotPrefix}--date-time-picker--trigger-button--disabled`]: disabled,
+              }),
             }}
             hideTooltip
             iconDescription={mergedI18n.calendarLabel}

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithoutTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithoutTimeSpinner.jsx
@@ -770,11 +770,10 @@ const DateTimePicker = ({
             buttonProps={{
               tooltipPosition: 'top',
               tabIndex: -1,
-              className: invalidState
-                ? `${iotPrefix}--date-time-picker--trigger-button-invalid`
-                : disabled
-                ? `${iotPrefix}--date-time-picker--trigger-button-disabled`
-                : '',
+              className: classnames(`${iotPrefix}--date-time-picker--trigger-button`, {
+                [`${iotPrefix}--date-time-picker--trigger-button--invalid`]: invalid,
+                [`${iotPrefix}--date-time-picker--trigger-button--disabled`]: disabled,
+              }),
             }}
             hideTooltip
             iconDescription={mergedI18n.calendarLabel}

--- a/packages/react/src/components/DateTimePicker/__snapshots__/DateTimePickerV2.story.storyshot
+++ b/packages/react/src/components/DateTimePicker/__snapshots__/DateTimePickerV2.story.storyshot
@@ -67,7 +67,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
           <button
             aria-describedby={null}
             aria-label="Calendar"
-            className="iot--flyout-menu--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+            className="iot--flyout-menu--trigger-button iot--date-time-picker--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
             data-testid="date-time-picker-datepicker-flyout-button"
             disabled={false}
             onBlur={[Function]}
@@ -176,7 +176,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
             <button
               aria-describedby={null}
               aria-label="Calendar"
-              className="iot--flyout-menu--trigger-button iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+              className="iot--flyout-menu--trigger-button iot--date-time-picker--trigger-button iot--btn bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
               data-testid="date-time-picker-datepicker-flyout-button"
               disabled={false}
               onBlur={[Function]}
@@ -306,7 +306,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
           <button
             aria-describedby={null}
             aria-label="Calendar"
-            className="iot--flyout-menu--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+            className="iot--flyout-menu--trigger-button iot--date-time-picker--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
             data-testid="date-time-picker-datepicker-flyout-button"
             disabled={false}
             onBlur={[Function]}
@@ -419,7 +419,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
           <button
             aria-describedby={null}
             aria-label="Calendar"
-            className="iot--flyout-menu--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+            className="iot--flyout-menu--trigger-button iot--date-time-picker--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
             data-testid="date-time-picker-datepicker-flyout-button"
             disabled={false}
             onBlur={[Function]}
@@ -532,7 +532,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
           <button
             aria-describedby={null}
             aria-label="Calendar"
-            className="iot--flyout-menu--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+            className="iot--flyout-menu--trigger-button iot--date-time-picker--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
             data-testid="date-time-picker-datepicker-flyout-button"
             disabled={false}
             onBlur={[Function]}
@@ -645,7 +645,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
           <button
             aria-describedby={null}
             aria-label="Calendar"
-            className="iot--flyout-menu--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+            className="iot--flyout-menu--trigger-button iot--date-time-picker--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
             data-testid="date-time-picker-datepicker-flyout-button"
             disabled={false}
             onBlur={[Function]}
@@ -774,7 +774,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
           <button
             aria-describedby={null}
             aria-label="Calendar"
-            className="iot--flyout-menu--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+            className="iot--flyout-menu--trigger-button iot--date-time-picker--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
             data-testid="date-time-picker-datepicker-flyout-button"
             disabled={false}
             onBlur={[Function]}
@@ -887,7 +887,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
           <button
             aria-describedby={null}
             aria-label="Calendar"
-            className="iot--flyout-menu--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+            className="iot--flyout-menu--trigger-button iot--date-time-picker--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
             data-testid="date-time-picker-datepicker-flyout-button"
             disabled={false}
             onBlur={[Function]}
@@ -1000,7 +1000,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
           <button
             aria-describedby={null}
             aria-label="Calendar"
-            className="iot--flyout-menu--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+            className="iot--flyout-menu--trigger-button iot--date-time-picker--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
             data-testid="date-time-picker-datepicker-flyout-button"
             disabled={false}
             onBlur={[Function]}
@@ -1129,7 +1129,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
           <button
             aria-describedby={null}
             aria-label="Calendar"
-            className="iot--flyout-menu--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+            className="iot--flyout-menu--trigger-button iot--date-time-picker--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
             data-testid="date-time-picker-datepicker-flyout-button"
             disabled={false}
             onBlur={[Function]}
@@ -1258,7 +1258,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
           <button
             aria-describedby={null}
             aria-label="Calendar"
-            className="iot--flyout-menu--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+            className="iot--flyout-menu--trigger-button iot--date-time-picker--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
             data-testid="date-time-picker-datepicker-flyout-button"
             disabled={false}
             onBlur={[Function]}

--- a/packages/react/src/components/DateTimePicker/_date-time-pickerv2.scss
+++ b/packages/react/src/components/DateTimePicker/_date-time-pickerv2.scss
@@ -269,13 +269,17 @@
   margin-top: -0.35rem;
 }
 
-.#{$iot-prefix}--date-time-picker--trigger-button-invalid.#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--tooltip__trigger
+.#{$iot-prefix}--date-time-picker--trigger-button.#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--tooltip__trigger {
+  overflow: hidden;
+}
+
+.#{$iot-prefix}--date-time-picker--trigger-button--invalid.#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--tooltip__trigger
   svg.bx--btn__icon
   path {
   fill: $danger-01;
 }
 
-.#{$iot-prefix}--date-time-picker--trigger-button-disabled.#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--tooltip__trigger
+.#{$iot-prefix}--date-time-picker--trigger-button--disabled.#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--tooltip__trigger
   svg.bx--btn__icon
   path {
   fill: $disabled-02;


### PR DESCRIPTION
Closes #3571 

**Summary**

- There is a hidden ToolTip on the `FlyoutMenu`. We decide to set `overflow:hidden` on the `ToolTip` to make sure it does not take extra space .

**Change List (commits, features, bugs, etc)**

- set `overflow:hidden` on ` iot--date-time-picker--trigger-button` and pass it in `FlyoutMenu` as part of the `buttonProps`
- changes in both `DateTimePickerV2WithTimeSpinner` and `DateTimePickerV2WithoutTimeSpinner`

**Acceptance Test (how to verify the PR)**

- go to DateTimePickerV2 single select [story](https://deploy-preview-3602--carbon-addons-iot-react.netlify.app/?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-datetimepickerv2--single-select)
- removed `padding: 3rem` on storybook-container 
- set width to 100% on `datetimepicker-iot--date-time-pickerv2__wrapper`
- check horizontal bar should not exist

![image](https://user-images.githubusercontent.com/24279794/195901871-c348a7e9-cf6d-479b-83b5-db1beed5a750.png)


<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
