### PR TITLE
fix(datetimepickerv2): move invalid text out of flyout menu

### DIFF
--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
@@ -1934,6 +1934,8 @@ describe('DateTimePickerV2', () => {
         .getByTestId(`${dateTimePickerProps.testId}-datepicker-flyout-button`)
         .classList.contains(`${iotPrefix}--date-time-picker--trigger-button-invalid`)
     ).toBe(true);
+    userEvent.click(screen.getByText(i18n.invalidText));
+    expect(screen.queryByRole('dialog', { 'aria-labelledby': 'flyout-tooltip' })).toBeNull();
   });
 
   it('should show invalid text when in invalid state (new time spinner)', () => {
@@ -1944,6 +1946,8 @@ describe('DateTimePickerV2', () => {
         .getByTestId(`${dateTimePickerProps.testId}-datepicker-flyout-button`)
         .classList.contains(`${iotPrefix}--date-time-picker--trigger-button-invalid`)
     ).toBe(true);
+    userEvent.click(screen.getByText(i18n.invalidText));
+    expect(screen.queryByRole('dialog', { 'aria-labelledby': 'flyout-tooltip' })).toBeNull();
   });
 
   it('should disable menu button when disabled is set', () => {

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
@@ -1195,17 +1195,17 @@ const DateTimePicker = ({
             </div>
           </FlyoutMenu>
         </div>
-        {invalidState && !hasIconOnly ? (
-          <p
-            className={classnames(
-              `${prefix}--form__helper-text`,
-              `${iotPrefix}--date-time-picker__helper-text--invalid`
-            )}
-          >
-            {mergedI18n.invalidText}
-          </p>
-        ) : null}
       </div>
+      {invalidState && !hasIconOnly ? (
+        <p
+          className={classnames(
+            `${prefix}--form__helper-text`,
+            `${iotPrefix}--date-time-picker__helper-text--invalid`
+          )}
+        >
+          {mergedI18n.invalidText}
+        </p>
+      ) : null}
     </div>
   );
 };

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithoutTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithoutTimeSpinner.jsx
@@ -1040,17 +1040,17 @@ const DateTimePicker = ({
             </div>
           </FlyoutMenu>
         </div>
-        {invalidState && !hasIconOnly ? (
-          <p
-            className={classnames(
-              `${prefix}--form__helper-text`,
-              `${iotPrefix}--date-time-picker__helper-text--invalid`
-            )}
-          >
-            {mergedI18n.invalidText}
-          </p>
-        ) : null}
       </div>
+      {invalidState && !hasIconOnly ? (
+        <p
+          className={classnames(
+            `${prefix}--form__helper-text`,
+            `${iotPrefix}--date-time-picker__helper-text--invalid`
+          )}
+        >
+          {mergedI18n.invalidText}
+        </p>
+      ) : null}
     </div>
   );
 };

--- a/packages/react/src/components/DateTimePicker/_date-time-pickerv2.scss
+++ b/packages/react/src/components/DateTimePicker/_date-time-pickerv2.scss
@@ -101,13 +101,13 @@
     outline: 2px solid $danger-01;
   }
 
-  .#{$iot-prefix}--date-time-picker__helper-text--invalid {
-    color: $text-error;
-  }
-
   .#{$iot-prefix}--date-time-picker__box--disabled {
     border: none;
   }
+}
+
+.#{$iot-prefix}--date-time-picker__helper-text--invalid {
+  color: $text-error;
 }
 
 .#{$iot-prefix}--date-time-pickerv2__wrapper--disabled {


### PR DESCRIPTION
Closes #3599 

**Summary**

- invalid text was clickable since it was inside of flyout menu. 
- moved it out so that it is not clickable. 

**Change List (commits, features, bugs, etc)**

- fix(DateTimePickerV2WithTimeSpinner): move invalid text out of flyout menu
- fix(DateTimePickerV2WithoutTimeSpinner): move invalid text out of flyout menu
- added unit tests

**Acceptance Test (how to verify the PR)**

- go to single select story
- enable invalid prop
- click on invalid text, make sure it does not open the flyout menu.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
