### PR TITLE
fix(datetimepickerv2): not show tooltip for single select

### DIFF
--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
@@ -894,7 +894,7 @@ const DateTimePicker = ({
                   {humanValue}
                 </TooltipDefinition>
               ) : null}
-              {!isExpanded && isTooltipOpen ? (
+              {!isExpanded && isTooltipOpen && !isSingleSelect ? (
                 <Tooltip
                   open={isTooltipOpen}
                   showIcon={false}


### PR DESCRIPTION
Closes #3605 

**Summary**

- humanValue on for single select is not too long, we will not show the tooltip which is for the case when humanValue is too long and is overflowed in the dateTimePicker field. 

**Change List (commits, features, bugs, etc)**

- added check for single select on the tool tip

**Acceptance Test (how to verify the PR)**

- go to single select [story](https://deploy-preview-3606--carbon-addons-iot-react.netlify.app/?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-datetimepickerv2--single-select)
- hover on the field
- make sure no tooltip showed up

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
