### PR TITLE
fix(datetimepickerv2): remove extra padding for time picker

### DIFF
--- a/packages/react/src/components/DateTimePicker/_date-time-pickerv2.scss
+++ b/packages/react/src/components/DateTimePicker/_date-time-pickerv2.scss
@@ -141,9 +141,6 @@
       width: var(--wrapper-width);
       padding-top: $spacing-05;
       padding-bottom: $spacing-07;
-      .#{$iot-prefix}--time-picker-dropdown button {
-        padding-right: $spacing-02;
-      }
     }
   }
 

--- a/packages/react/src/components/TimePicker/_time-picker-dropdown.scss
+++ b/packages/react/src/components/TimePicker/_time-picker-dropdown.scss
@@ -195,6 +195,7 @@
   animation: fadeIn 0.25s forwards;
 
   &--24h {
+    width: 13.125rem;
     & .#{$iot-prefix}--list-spinner__section {
       width: 6rem;
     }


### PR DESCRIPTION
Closes #3601 

**Summary**

- Remove the extra padding we pass in DateTimePickerV2. Before, it was for a misalign on the button component. But I couldn't reproduce it anymore. 
- Also, reverse the width change on TimePickerDropDown. 

**Acceptance Test (how to verify the PR)**

- go to single select [story](https://deploy-preview-3607--carbon-addons-iot-react.netlify.app/?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-datetimepickerv2--single-select)
- check time spinner are aligned up with the input
- same for range select [story](https://deploy-preview-3607--carbon-addons-iot-react.netlify.app/?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-datetimepickerv2--selected-absolute-with-new-time-spinner) 

This is what look before
![image](https://user-images.githubusercontent.com/24279794/196274300-dff6afa2-0547-451b-b2ee-84c886d01e0c.png)
![image](https://user-images.githubusercontent.com/24279794/196274322-e948980f-2b9a-4485-9014-ec1a87c43b44.png)


After:
![image](https://user-images.githubusercontent.com/24279794/196274472-01715fb1-2f6f-4149-b643-99c5bf539064.png)

![image](https://user-images.githubusercontent.com/24279794/196274551-f4a60763-91bc-465f-9d1b-cffd182a19bc.png)

This should also remove the padding  on the right reported by @bakkireddi

![image](https://user-images.githubusercontent.com/24279794/196274735-fed04567-9e85-41e3-8801-a2a7a638d89e.png)


<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
