### PR TITLE
fix(tablecardformcontent): remove duplicate thresholds

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -230,8 +230,18 @@ const TableCardFormContent = ({
   // need to handle thresholds from the DataSeriesFormItemModal and convert it to the right format
   const handleDataItemModalChanges = useCallback(
     (card) => {
-      // Consider existing thresholds outside columns
-      const allThresholds = thresholds?.map((threshold) => ({ ...threshold })) || [];
+      // Get datasource from columns with thresholds
+      const columnThresholdDataSource =
+        card?.content?.columns
+          ?.filter((column) => column?.thresholds?.length)
+          ?.map((column) => column.dataSourceId) || [];
+
+      // Consider existing thresholds outside columns and filter existing thresholds from edited column
+      const allThresholds =
+        thresholds
+          ?.filter(({ dataSourceId }) => !columnThresholdDataSource.includes(dataSourceId))
+          ?.map((threshold) => ({ ...threshold })) || [];
+
       // the table card is looking for the thresholds on the main content object
       const updatedColumns = card?.content?.columns?.map(
         // eslint-disable-next-line no-unused-vars

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -320,6 +320,7 @@ const TableCardFormContent = ({
         ({ dataItemId }) => dataItemId === dataItem.dataItemId
       );
       // Call back function for on click of edit button
+      /* istanbul ignore else */
       if (onEditDataItem) {
         const aggregationMethods = await onEditDataItem(cardConfig, dataItem, dataItemWithMetaData);
         if (!isEmpty(aggregationMethods)) {

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
@@ -558,6 +558,88 @@ describe('TableCardFormContent', () => {
       },
     });
   });
+
+  it('edit mode with dataitems edits threshold correctly', async () => {
+    const mockOnChange = jest.fn();
+    const mockCardConfig = {
+      ...commonCardConfig,
+      content: {
+        columns: [
+          {
+            label: 'Timestamp',
+            dataSourceId: 'timestamp',
+            type: 'TIMESTAMP',
+          },
+          {
+            label: 'Manufacturer',
+            dataSourceId: 'manufacturer',
+            dataItemType: 'DIMENSION',
+          },
+          {
+            label: 'Temperature',
+            dataSourceId: 'temperature',
+          },
+        ],
+        thresholds: [
+          {
+            color: '#da1e28',
+            comparison: '<',
+            dataSourceId: 'temperature',
+            icon: 'Warning alt',
+            value: 10,
+          },
+          {
+            color: '#da1e28',
+            comparison: '<',
+            dataSourceId: 'manufacturer',
+            icon: 'Warning alt',
+            value: 0,
+          },
+        ],
+      },
+    };
+    render(
+      <TableCardFormContent {...commonProps} onChange={mockOnChange} cardConfig={mockCardConfig} />
+    );
+
+    const th1Expected = expect.objectContaining({
+      color: '#da1e28',
+      comparison: '<',
+      dataSourceId: 'temperature',
+      icon: 'Warning alt',
+      value: 10,
+    });
+
+    const th2Expected = expect.objectContaining({
+      color: '#da1e28',
+      comparison: '<',
+      dataSourceId: 'manufacturer',
+      icon: 'Warning alt',
+      value: 0,
+    });
+
+    const th3Expected = expect.objectContaining({
+      color: '#da1e28',
+      comparison: '>',
+      dataSourceId: 'manufacturer',
+      icon: 'Warning alt',
+      value: 0,
+    });
+
+    // Ensure save does not duplicate thresholds
+    await fireEvent.click(screen.queryAllByLabelText('Edit')[1]);
+    expect(screen.queryByText('Customize data series')).toBeDefined();
+    fireEvent.click(screen.queryByText(/Add threshold/));
+    fireEvent.click(screen.queryByText('Save'));
+    expect(mockOnChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.objectContaining({
+          thresholds: expect.arrayContaining([th1Expected, th2Expected, th3Expected]),
+        }),
+      })
+    );
+  });
+
   it('edit mode with dataitems leaves threshold blank correctly', async () => {
     const mockOnChange = jest.fn();
     const mockCardConfig = {


### PR DESCRIPTION
Closes #3609

**Summary**

- Remove thresholds of edited column from outer context.

**Change List (commits, features, bugs, etc)**

- TableCardFormContent

**Acceptance Test (how to verify the PR)**

Go to Setup page in Monitor;
Find an device type;
Click on Setup device type;
Select Dashboards tab;
Create a dashboard;
Add Data table card type;
Add a column;
Click on edit button of the new column;
Add threshold and save it;
Click again on edit button;

Check no duplicate threshold added to list

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
