### PR TITLE
fix(TableHead): add id prop on TableExpandHeader

### DIFF
--- a/packages/react/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
+++ b/packages/react/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
@@ -398,7 +398,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                           <th
                             className="bx--table-expand"
                             data-testid="null-table-head-row-expansion-column"
-                            id="expand"
+                            id="table-12-expand"
                             scope="col"
                           />
                           <th
@@ -1352,7 +1352,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                         >
                           <td
                             className="bx--table-expand"
-                            headers="expand"
+                            headers="table-12-expand"
                           >
                             <button
                               aria-label="Click to expand content"
@@ -1738,7 +1738,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                         >
                           <td
                             className="bx--table-expand"
-                            headers="expand"
+                            headers="table-12-expand"
                           >
                             <button
                               aria-label="Click to expand content"
@@ -2602,7 +2602,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                           <th
                             className="bx--table-expand"
                             data-testid="null-table-head-row-expansion-column"
-                            id="expand"
+                            id="table-13-expand"
                             scope="col"
                           />
                           <th
@@ -3556,7 +3556,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                         >
                           <td
                             className="bx--table-expand"
-                            headers="expand"
+                            headers="table-13-expand"
                           >
                             <button
                               aria-label="Click to expand content"
@@ -3942,7 +3942,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                         >
                           <td
                             className="bx--table-expand"
-                            headers="expand"
+                            headers="table-13-expand"
                           >
                             <button
                               aria-label="Click to expand content"

--- a/packages/react/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
+++ b/packages/react/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
@@ -398,6 +398,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                           <th
                             className="bx--table-expand"
                             data-testid="null-table-head-row-expansion-column"
+                            id="expand"
                             scope="col"
                           />
                           <th
@@ -2601,6 +2602,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                           <th
                             className="bx--table-expand"
                             data-testid="null-table-head-row-expansion-column"
+                            id="expand"
                             scope="col"
                           />
                           <th

--- a/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
+++ b/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
@@ -963,6 +963,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                     <th
                       className="bx--table-expand"
                       data-testid="null-table-head-row-expansion-column"
+                      id="expand"
                       scope="col"
                     />
                     <th

--- a/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
+++ b/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
@@ -963,7 +963,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                     <th
                       className="bx--table-expand"
                       data-testid="null-table-head-row-expansion-column"
-                      id="expand"
+                      id="table-19-expand"
                       scope="col"
                     />
                     <th
@@ -1917,7 +1917,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-19-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -2303,7 +2303,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-19-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -2656,7 +2656,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-19-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -3009,7 +3009,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-19-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -3395,7 +3395,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-19-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -3781,7 +3781,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-19-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -4167,7 +4167,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-19-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -4553,7 +4553,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-19-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -4906,7 +4906,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-19-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -5292,7 +5292,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-19-expand"
                     >
                       <button
                         aria-label="Click to expand content"

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -364,7 +364,6 @@ const TableBodyRow = ({
     isExpanded ? (
       <Fragment key={id}>
         <TableExpandRow
-          expandHeader={`${id}-row-expand`}
           className={classnames(`${iotPrefix}--expandable-tablerow--expanded`, {
             [`${iotPrefix}--expandable-tablerow--indented`]: parseInt(nestingOffset, 10) > 0,
           })}

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -364,6 +364,7 @@ const TableBodyRow = ({
     isExpanded ? (
       <Fragment key={id}>
         <TableExpandRow
+          expandHeader={`${tableId}-expand`}
           className={classnames(`${iotPrefix}--expandable-tablerow--expanded`, {
             [`${iotPrefix}--expandable-tablerow--indented`]: parseInt(nestingOffset, 10) > 0,
           })}
@@ -409,6 +410,7 @@ const TableBodyRow = ({
     ) : (
       <TableExpandRow
         key={id}
+        expandHeader={`${tableId}-expand`}
         className={classnames(`${iotPrefix}--expandable-tablerow`, {
           [`${iotPrefix}--expandable-tablerow--parent`]:
             hasRowNesting && hasRowNesting?.hasSingleNestedHierarchy && nestingChildCount > 0,

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -364,6 +364,7 @@ const TableBodyRow = ({
     isExpanded ? (
       <Fragment key={id}>
         <TableExpandRow
+          expandHeader={`${id}-row-expand`}
           className={classnames(`${iotPrefix}--expandable-tablerow--expanded`, {
             [`${iotPrefix}--expandable-tablerow--indented`]: parseInt(nestingOffset, 10) > 0,
           })}

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/__snapshots__/TableBodyRow.story.storyshot
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/__snapshots__/TableBodyRow.story.storyshot
@@ -366,7 +366,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           >
             <td
               className="bx--table-expand"
-              headers="expand"
+              headers="tableId-expand"
             >
               <button
                 aria-label="Click to expand."
@@ -506,7 +506,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           >
             <td
               className="bx--table-expand"
-              headers="expand"
+              headers="tableId-expand"
             >
               <button
                 aria-label="Click to expand."
@@ -691,7 +691,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           >
             <td
               className="bx--table-expand"
-              headers="expand"
+              headers="tableId-expand"
             >
               <button
                 aria-label="Click to expand."
@@ -836,7 +836,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           >
             <td
               className="bx--table-expand"
-              headers="expand"
+              headers="tableId-expand"
             >
               <button
                 aria-label="Click to expand."

--- a/packages/react/src/components/Table/TableHead/TableHead.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.jsx
@@ -436,6 +436,7 @@ const TableHead = ({
       >
         {hasRowExpansion || hasRowNesting ? (
           <TableExpandHeader
+            id="expand"
             // TODO: remove deprecated 'testID' in v3
             data-testid={`${testID || testId}-row-expansion-column`}
             className={classnames({

--- a/packages/react/src/components/Table/TableHead/TableHead.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.jsx
@@ -436,7 +436,7 @@ const TableHead = ({
       >
         {hasRowExpansion || hasRowNesting ? (
           <TableExpandHeader
-            id="expand"
+            id={`${tableId}-expand`}
             // TODO: remove deprecated 'testID' in v3
             data-testid={`${testID || testId}-row-expansion-column`}
             className={classnames({

--- a/packages/react/src/components/Table/__snapshots__/Table.main.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/Table.main.story.storyshot
@@ -36750,7 +36750,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               <th
                 className="bx--table-expand"
                 data-testid="null-table-head-row-expansion-column"
-                id="expand"
+                id="table-23-expand"
                 scope="col"
               />
               <th
@@ -37000,7 +37000,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             >
               <td
                 className="bx--table-expand"
-                headers="expand"
+                headers="table-23-expand"
               >
                 <button
                   aria-label="Click to expand content"
@@ -37272,7 +37272,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               <td
                 className="bx--table-expand"
                 data-previous-value="collapsed"
-                headers="expand"
+                headers="table-23-expand"
               >
                 <button
                   aria-label="Click to collapse content"
@@ -37560,7 +37560,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             >
               <td
                 className="bx--table-expand"
-                headers="expand"
+                headers="table-23-expand"
               >
                 <button
                   aria-label="Click to expand content"
@@ -37839,7 +37839,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             >
               <td
                 className="bx--table-expand"
-                headers="expand"
+                headers="table-23-expand"
               >
                 <button
                   aria-label="Click to expand content"
@@ -38111,7 +38111,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             >
               <td
                 className="bx--table-expand"
-                headers="expand"
+                headers="table-23-expand"
               >
                 <button
                   aria-label="Click to expand content"
@@ -38390,7 +38390,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             >
               <td
                 className="bx--table-expand"
-                headers="expand"
+                headers="table-23-expand"
               >
                 <button
                   aria-label="Click to expand content"
@@ -38669,7 +38669,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             >
               <td
                 className="bx--table-expand"
-                headers="expand"
+                headers="table-23-expand"
               >
                 <button
                   aria-label="Click to expand content"
@@ -38941,7 +38941,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             >
               <td
                 className="bx--table-expand"
-                headers="expand"
+                headers="table-23-expand"
               >
                 <button
                   aria-label="Click to expand content"
@@ -39220,7 +39220,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             >
               <td
                 className="bx--table-expand"
-                headers="expand"
+                headers="table-23-expand"
               >
                 <button
                   aria-label="Click to expand content"
@@ -39499,7 +39499,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             >
               <td
                 className="bx--table-expand"
-                headers="expand"
+                headers="table-23-expand"
               >
                 <button
                   aria-label="Click to expand content"
@@ -39792,7 +39792,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               <th
                 className="bx--table-expand"
                 data-testid="null-table-head-row-expansion-column"
-                id="expand"
+                id="table-24-expand"
                 scope="col"
               />
               <th
@@ -40042,7 +40042,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             >
               <td
                 className="bx--table-expand"
-                headers="expand"
+                headers="table-24-expand"
               >
                 <button
                   aria-label="Click to expand content"
@@ -40314,7 +40314,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               <td
                 className="bx--table-expand"
                 data-previous-value="collapsed"
-                headers="expand"
+                headers="table-24-expand"
               >
                 <button
                   aria-label="Click to collapse content"
@@ -40593,7 +40593,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             >
               <td
                 className="bx--table-expand"
-                headers="expand"
+                headers="table-24-expand"
               >
                 <button
                   aria-label="Click to expand content"
@@ -40872,7 +40872,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             >
               <td
                 className="bx--table-expand"
-                headers="expand"
+                headers="table-24-expand"
               >
                 <button
                   aria-label="Click to expand content"
@@ -41175,7 +41175,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             >
               <td
                 className="bx--table-expand"
-                headers="expand"
+                headers="table-24-expand"
               >
                 <button
                   aria-label="Click to expand content"
@@ -41454,7 +41454,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             >
               <td
                 className="bx--table-expand"
-                headers="expand"
+                headers="table-24-expand"
               >
                 <button
                   aria-label="Click to expand content"
@@ -41726,7 +41726,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             >
               <td
                 className="bx--table-expand"
-                headers="expand"
+                headers="table-24-expand"
               >
                 <button
                   aria-label="Click to expand content"
@@ -42005,7 +42005,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             >
               <td
                 className="bx--table-expand"
-                headers="expand"
+                headers="table-24-expand"
               >
                 <button
                   aria-label="Click to expand content"
@@ -42284,7 +42284,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             >
               <td
                 className="bx--table-expand"
-                headers="expand"
+                headers="table-24-expand"
               >
                 <button
                   aria-label="Click to expand content"
@@ -42556,7 +42556,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             >
               <td
                 className="bx--table-expand"
-                headers="expand"
+                headers="table-24-expand"
               >
                 <button
                   aria-label="Click to expand content"
@@ -42835,7 +42835,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             >
               <td
                 className="bx--table-expand"
-                headers="expand"
+                headers="table-24-expand"
               >
                 <button
                   aria-label="Click to expand content"
@@ -43114,7 +43114,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             >
               <td
                 className="bx--table-expand"
-                headers="expand"
+                headers="table-24-expand"
               >
                 <button
                   aria-label="Click to expand content"

--- a/packages/react/src/components/Table/__snapshots__/Table.main.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/Table.main.story.storyshot
@@ -36750,6 +36750,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               <th
                 className="bx--table-expand"
                 data-testid="null-table-head-row-expansion-column"
+                id="expand"
                 scope="col"
               />
               <th
@@ -37271,7 +37272,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               <td
                 className="bx--table-expand"
                 data-previous-value="collapsed"
-                headers="row-1-row-expand"
+                headers="expand"
               >
                 <button
                   aria-label="Click to collapse content"
@@ -39791,6 +39792,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               <th
                 className="bx--table-expand"
                 data-testid="null-table-head-row-expansion-column"
+                id="expand"
                 scope="col"
               />
               <th
@@ -40312,7 +40314,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               <td
                 className="bx--table-expand"
                 data-previous-value="collapsed"
-                headers="row-1-row-expand"
+                headers="expand"
               >
                 <button
                   aria-label="Click to collapse content"

--- a/packages/react/src/components/Table/__snapshots__/Table.main.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/Table.main.story.storyshot
@@ -37271,7 +37271,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               <td
                 className="bx--table-expand"
                 data-previous-value="collapsed"
-                headers="expand"
+                headers="row-1-row-expand"
               >
                 <button
                   aria-label="Click to collapse content"
@@ -40312,7 +40312,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               <td
                 className="bx--table-expand"
                 data-previous-value="collapsed"
-                headers="expand"
+                headers="row-1-row-expand"
               >
                 <button
                   aria-label="Click to collapse content"

--- a/packages/react/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/packages/react/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -295,7 +295,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                     <th
                       className="bx--table-expand"
                       data-testid="table-for-card-table-list-table-head-row-expansion-column"
-                      id="expand"
+                      id="table-for-card-table-list-expand"
                       scope="col"
                     />
                     <th
@@ -580,7 +580,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -724,7 +724,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -868,7 +868,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -1012,7 +1012,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -1156,7 +1156,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -1300,7 +1300,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -1444,7 +1444,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -8626,7 +8626,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                     <th
                       className="bx--table-expand"
                       data-testid="table-for-card-table-list-table-head-row-expansion-column"
-                      id="expand"
+                      id="table-for-card-table-list-expand"
                       scope="col"
                     />
                     <th
@@ -8911,7 +8911,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -9099,7 +9099,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -9285,7 +9285,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -9473,7 +9473,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -9661,7 +9661,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -9847,7 +9847,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -10033,7 +10033,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -12873,7 +12873,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                     <th
                       className="bx--table-expand"
                       data-testid="table-for-card-table-list-table-head-row-expansion-column"
-                      id="expand"
+                      id="table-for-card-table-list-expand"
                       scope="col"
                     />
                     <th
@@ -13093,7 +13093,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -13212,7 +13212,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -13331,7 +13331,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -13450,7 +13450,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -13569,7 +13569,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -13688,7 +13688,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -13807,7 +13807,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -16371,7 +16371,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                     <th
                       className="bx--table-expand"
                       data-testid="table-for-card-table-list-table-head-row-expansion-column"
-                      id="expand"
+                      id="table-for-card-table-list-expand"
                       scope="col"
                     />
                     <th
@@ -16786,7 +16786,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -16974,7 +16974,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -17162,7 +17162,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -17350,7 +17350,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -17538,7 +17538,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -17802,7 +17802,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"
@@ -18021,7 +18021,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   >
                     <td
                       className="bx--table-expand"
-                      headers="expand"
+                      headers="table-for-card-table-list-expand"
                     >
                       <button
                         aria-label="Click to expand content"

--- a/packages/react/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/packages/react/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -295,6 +295,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                     <th
                       className="bx--table-expand"
                       data-testid="table-for-card-table-list-table-head-row-expansion-column"
+                      id="expand"
                       scope="col"
                     />
                     <th
@@ -8625,6 +8626,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                     <th
                       className="bx--table-expand"
                       data-testid="table-for-card-table-list-table-head-row-expansion-column"
+                      id="expand"
                       scope="col"
                     />
                     <th
@@ -12871,6 +12873,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                     <th
                       className="bx--table-expand"
                       data-testid="table-for-card-table-list-table-head-row-expansion-column"
+                      id="expand"
                       scope="col"
                     />
                     <th
@@ -16368,6 +16371,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                     <th
                       className="bx--table-expand"
                       data-testid="table-for-card-table-list-table-head-row-expansion-column"
+                      id="expand"
                       scope="col"
                     />
                     <th


### PR DESCRIPTION
Closes #3485 

**Summary**

- fix the a11y violation by adding id prop on `TableExpandHeader`

According to the rule [H43: Using id and headers attributes to associate data cells with header cells in data tables](https://www.w3.org/TR/WCAG20-TECHS/H43) 

Header should use `id` prop for the any table cell to reference with. The default header for the first cell in `TableExpandRow` is set to `headers='expand'`. But we did not set an `id` on `TableExpandHeader` for the cell to refer to. 

The solution is to set ` id={`${tableId}-expand`} `on `TableExpandHeader` and `expandHeader={`${tableId}-expand`}` on `TableExpandRow`:


**Change List (commits, features, bugs, etc)**

-fix(TableBodyRow): add id prop on TableExpandHeader

**Acceptance Test (how to verify the PR)**

- go to table story [with row expansion](https://deploy-preview-3611--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table--with-row-expansion)
- scan with IBM Equal Access Accessibility
- check no errors shows like `'The 'headers' attribute value "expand" does not reference a valid 'id' in this document'`

before:
![image](https://user-images.githubusercontent.com/24279794/196791121-6dc5e57b-5964-4ba3-b823-7c960fd9a6b4.png)

after:
![image](https://user-images.githubusercontent.com/24279794/196794365-1cb3780b-ebba-4d57-b7b4-7573ed61f29e.png)


**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
