### PR TITLE
feat(emptystate): add prop for arrangement and size

### DIFF
--- a/packages/react/src/components/EmptyState/EmptyState.jsx
+++ b/packages/react/src/components/EmptyState/EmptyState.jsx
@@ -69,6 +69,8 @@ const props = {
   testId: PropTypes.string,
   /** Size of the empty state */
   size: PropTypes.oneOf([DEFAULT_SIZE, SMALL_SIZE]),
+  /** Arrangement of the empty state */
+  arrangement: PropTypes.oneOf(['stacked', 'inline']),
 };
 
 const defaultProps = {
@@ -78,6 +80,7 @@ const defaultProps = {
   className: '',
   testId: 'EmptyState',
   size: 'default',
+  arrangement: 'stacked',
 };
 
 /**
@@ -94,15 +97,22 @@ const EmptyState = ({
   testId,
   testID,
   size,
+  arrangement,
 }) => {
   const isSmall = size === SMALL_SIZE;
   return (
     <div
-      className={classnames(`${iotPrefix}--empty-state`, className)}
+      className={classnames(`${iotPrefix}--empty-state`, className, {
+        [`${iotPrefix}--empty-state--inline`]: arrangement === 'inline',
+      })}
       // TODO: remove deprecated testID in v3.
       data-testid={testID || testId}
     >
-      <div className={`${iotPrefix}--empty-state--content`}>
+      <div
+        className={classnames(`${iotPrefix}--empty-state--content`, {
+          [`${iotPrefix}--empty-state--content--with-gap`]: !!icon,
+        })}
+      >
         {icon &&
           React.createElement(typeof icon === 'string' ? icons[icon] : icon, {
             className: classnames(`${iotPrefix}--empty-state--icon`, {

--- a/packages/react/src/components/EmptyState/EmptyState.jsx
+++ b/packages/react/src/components/EmptyState/EmptyState.jsx
@@ -27,6 +27,15 @@ const icons = {
   success: SuccessImage,
 };
 
+const smallIconProps = {
+  width: 64,
+  height: 64,
+  viewBox: '0 0 80 80',
+};
+
+const SMALL_SIZE = 'small';
+const DEFAULT_SIZE = 'default';
+
 const props = {
   /** Title of empty state */
   title: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
@@ -58,6 +67,8 @@ const props = {
   ),
   /** Specify a testid for testing this component */
   testId: PropTypes.string,
+  /** Size of the empty state */
+  size: PropTypes.oneOf([DEFAULT_SIZE, SMALL_SIZE]),
 };
 
 const defaultProps = {
@@ -66,13 +77,25 @@ const defaultProps = {
   icon: '',
   className: '',
   testId: 'EmptyState',
+  size: 'default',
 };
 
 /**
  * Component to set empty states
  * For reference, visit https://pages.github.ibm.com/ai-applications/design/components/empty-states/usage/
  */
-const EmptyState = ({ title, icon, body, action, secondaryAction, className, testId, testID }) => {
+const EmptyState = ({
+  title,
+  icon,
+  body,
+  action,
+  secondaryAction,
+  className,
+  testId,
+  testID,
+  size,
+}) => {
+  const isSmall = size === SMALL_SIZE;
   return (
     <div
       className={classnames(`${iotPrefix}--empty-state`, className)}
@@ -82,12 +105,17 @@ const EmptyState = ({ title, icon, body, action, secondaryAction, className, tes
       <div className={`${iotPrefix}--empty-state--content`}>
         {icon &&
           React.createElement(typeof icon === 'string' ? icons[icon] : icon, {
-            className: `${iotPrefix}--empty-state--icon`,
+            className: classnames(`${iotPrefix}--empty-state--icon`, {
+              [`${iotPrefix}--empty-state--icon--sm`]: isSmall,
+            }),
             alt: '',
             'data-testid': `${testID || testId}-icon`,
+            ...(isSmall && smallIconProps),
           })}
         <h3
-          className={`${iotPrefix}--empty-state--title`}
+          className={classnames(`${iotPrefix}--empty-state--title`, {
+            [`${iotPrefix}--empty-state--title--sm`]: isSmall,
+          })}
           // TODO: remove deprecated testID in v3.
           data-testid={`${testID || testId}-title`}
         >
@@ -110,7 +138,11 @@ const EmptyState = ({ title, icon, body, action, secondaryAction, className, tes
             // TODO: remove deprecated testID in v3.
             data-testid={`${testID || testId}-action`}
           >
-            <Button kind={action.kind} onClick={action.onClick} size="field">
+            <Button
+              kind={action.kind}
+              onClick={action.onClick}
+              size={isSmall ? SMALL_SIZE : 'field'}
+            >
               {action.label}
             </Button>
           </div>

--- a/packages/react/src/components/EmptyState/EmptyState.jsx
+++ b/packages/react/src/components/EmptyState/EmptyState.jsx
@@ -110,7 +110,7 @@ const EmptyState = ({
     >
       <div
         className={classnames(`${iotPrefix}--empty-state--content`, {
-          [`${iotPrefix}--empty-state--content--with-gap`]: !!icon,
+          [`${iotPrefix}--empty-state--content--with-gap`]: arrangement === 'inline' && !!icon,
         })}
       >
         {icon &&

--- a/packages/react/src/components/EmptyState/EmptyState.story.jsx
+++ b/packages/react/src/components/EmptyState/EmptyState.story.jsx
@@ -218,5 +218,6 @@ export const Playground = () => (
       label: text('secondaryAction.label', 'Secondary action'),
       onClick: action('secondaryAction onClick'),
     }}
+    size={select('size', ['default', 'small'], 'default')}
   />
 );

--- a/packages/react/src/components/EmptyState/EmptyState.story.jsx
+++ b/packages/react/src/components/EmptyState/EmptyState.story.jsx
@@ -219,5 +219,6 @@ export const Playground = () => (
       onClick: action('secondaryAction onClick'),
     }}
     size={select('size', ['default', 'small'], 'default')}
+    arrangement={select('arrangement', ['stacked', 'inline'], 'stacked')}
   />
 );

--- a/packages/react/src/components/EmptyState/EmptyState.test.jsx
+++ b/packages/react/src/components/EmptyState/EmptyState.test.jsx
@@ -11,8 +11,11 @@ import {
   EmptystateNoresultsIcon as NoResultImage,
 } from '../../icons/static';
 import { DashboardIcon as CustomIcon } from '../../icons/components';
+import { settings } from '../../constants/Settings';
 
 import EmptyState from './EmptyState';
+
+const { prefix, iotPrefix } = settings;
 
 const title = 'Titletest';
 const body = 'Titlebody';
@@ -142,6 +145,42 @@ describe('EmptyState', () => {
 
     expect(screen.getByText('This is a node body')).toBeVisible();
     expect(console.error).not.toHaveBeenCalled();
+    jest.resetAllMocks();
+  });
+
+  it('should add class for inline arrangement', () => {
+    render(<EmptyState {...commonProps} arrangement="inline" testId={testID} />);
+
+    expect(screen.getByTestId(testID)).toHaveClass(`${iotPrefix}--empty-state--inline`);
+  });
+
+  it('should add column gap for layout if icon is present', () => {
+    render(<EmptyState {...commonProps} arrangement="inline" testId={testID} icon="empty" />);
+
+    expect(screen.getByTestId(testID).firstChild).toHaveClass(
+      `${iotPrefix}--empty-state--content--with-gap`
+    );
+  });
+
+  it('should add class for small empty state', () => {
+    const actionLabel = 'TestButton';
+    const actionOnClick = jest.fn();
+
+    render(
+      <EmptyState
+        {...commonProps}
+        action={{ ...action(actionLabel, actionOnClick) }}
+        size="small"
+        testId={testID}
+        icon="empty"
+      />
+    );
+
+    expect(screen.getByTestId(`${testID}-icon`)).toHaveClass(`${iotPrefix}--empty-state--icon--sm`);
+    expect(screen.getByTestId(`${testID}-title`)).toHaveClass(
+      `${iotPrefix}--empty-state--title--sm`
+    );
+    expect(screen.getByTestId(`${testID}-action`).firstChild).toHaveClass(`${prefix}--btn--sm`);
     jest.resetAllMocks();
   });
 });

--- a/packages/react/src/components/EmptyState/_emptystate.scss
+++ b/packages/react/src/components/EmptyState/_emptystate.scss
@@ -14,6 +14,10 @@
     width: auto;
   }
 
+  &--icon--sm {
+    height: 64px;
+  }
+
   &--content {
     max-width: 30rem;
     overflow-wrap: break-word;
@@ -24,6 +28,11 @@
     color: $text-01;
     margin-bottom: $spacing-03;
     word-break: break-word;
+  }
+
+  &--title--sm {
+    @include type-style('productive-heading-02');
+    margin-bottom: $spacing-02;
   }
 
   &--text {

--- a/packages/react/src/components/EmptyState/_emptystate.scss
+++ b/packages/react/src/components/EmptyState/_emptystate.scss
@@ -3,6 +3,8 @@
 @import '../../globals/typography';
 
 .#{$iot-prefix}--empty-state {
+  $parent-container: &;
+
   display: flex;
   flex-flow: column;
   justify-content: center;
@@ -12,6 +14,11 @@
     margin-bottom: $spacing-05;
     height: 80px;
     width: auto;
+
+    #{$parent-container}--inline & {
+      grid-row: 1/5;
+      grid-column: 1/2;
+    }
   }
 
   &--icon--sm {
@@ -21,6 +28,14 @@
   &--content {
     max-width: 30rem;
     overflow-wrap: break-word;
+
+    #{$parent-container}--inline & {
+      display: grid;
+    }
+
+    #{$parent-container}--inline &--with-gap {
+      column-gap: $spacing-05;
+    }
   }
 
   &--title {
@@ -28,6 +43,10 @@
     color: $text-01;
     margin-bottom: $spacing-03;
     word-break: break-word;
+
+    #{$parent-container}--inline & {
+      grid-column: 2/2;
+    }
   }
 
   &--title--sm {
@@ -38,15 +57,27 @@
   &--text {
     color: $text-01;
     @include type-style('body-short-01');
+
+    #{$parent-container}--inline & {
+      grid-column: 2/2;
+    }
   }
 
   &--action {
     margin-top: $spacing-05;
+
+    #{$parent-container}--inline & {
+      grid-column: 2/2;
+    }
   }
 
   &--link {
     margin-top: $spacing-05;
     @include type-style('body-short-01');
     color: $interactive-01;
+
+    #{$parent-container}--inline & {
+      grid-column: 2/2;
+    }
   }
 }

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -10370,9 +10370,11 @@ Map {
   "EmptyState" => Object {
     "defaultProps": Object {
       "action": null,
+      "arrangement": "stacked",
       "className": "",
       "icon": "",
       "secondaryAction": null,
+      "size": "default",
       "testId": "EmptyState",
     },
     "propTypes": Object {
@@ -10416,6 +10418,15 @@ Map {
           },
         ],
         "type": "shape",
+      },
+      "arrangement": Object {
+        "args": Array [
+          Array [
+            "stacked",
+            "inline",
+          ],
+        ],
+        "type": "oneOf",
       },
       "body": Object {
         "args": Array [
@@ -10472,6 +10483,15 @@ Map {
           },
         ],
         "type": "shape",
+      },
+      "size": Object {
+        "args": Array [
+          Array [
+            "default",
+            "small",
+          ],
+        ],
+        "type": "oneOf",
       },
       "testID": [Function],
       "testId": Object {


### PR DESCRIPTION
Closes #3545 

**Summary**

- Add 2 new props for arrangement and size

**Change List (commits, features, bugs, etc)**

- Add css styles for new props
- Add tests
- Update storyshot

**Acceptance Test (how to verify the PR)**

- Go to [this story](https://deploy-preview-3612--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-empty-states--playground)
- Change size from `default` to `small` in the knobs
- Verify applied changes according to [design guidelines](https://pages.github.ibm.com/ai-applications/design/components/empty-states/style)
- Change arrangement from `stacked` to `inline` in the knobs
- Verify applied changes according to [design guidelines](https://pages.github.ibm.com/ai-applications/design/components/empty-states/style)

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
