### PR TITLE
fix(table): callback onRowSelected if radio buttons exist

### DIFF
--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -452,6 +452,7 @@ const TableBodyRow = ({
     <TableRow
       className={classnames(`${iotPrefix}--table__row`, {
         [`${iotPrefix}--table__row--singly-selected`]: isSelected && !useRadioButtonSingleSelect,
+        [`${iotPrefix}--table__row--background`]: isSelected,
       })}
       key={id}
       onClick={() => {

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -249,7 +249,6 @@ const TableBodyRow = ({
       <TableCell
         className={`${prefix}--radiobutton-table-cell`}
         key={`${id}-row-selection-cell`}
-        onChange={isSelectable !== false ? () => onRowSelected(id, !isSelected) : null}
         onClick={(e) => e.stopPropagation()}
       >
         <span

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -457,7 +457,9 @@ const TableBodyRow = ({
       onClick={() => {
         if (isSelectable !== false) {
           onRowClicked(id);
-          onRowSelected(id, !isSelected);
+          if (hasRowSelection === 'single' && !useRadioButtonSingleSelect) {
+            onRowSelected(id, !isSelected);
+          }
         }
       }}
     >
@@ -474,7 +476,7 @@ const TableBodyRow = ({
       key={id}
       onClick={() => {
         if (isSelectable !== false) {
-          if (hasRowSelection === 'single') {
+          if (hasRowSelection === 'single' && !useRadioButtonSingleSelect) {
             onRowSelected(id, true);
           }
           onRowClicked(id);

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.test.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.test.jsx
@@ -419,8 +419,8 @@ describe('TableBodyRow', () => {
     expect(mockActions.onRowClicked).toHaveBeenCalledWith(tableRowProps.id);
   });
 
-  it('calls onRowSelected & onRowClicked when selected rows with hasRowSelection:"single" and radio buttoon are clicked', () => {
-    render(
+  it('calls only onRowSelected when selected rows with hasRowSelection:"single" and radio button are clicked', () => {
+    const { container } = render(
       <TableBodyRow
         {...tableRowProps}
         tableActions={mockActions}
@@ -438,9 +438,10 @@ describe('TableBodyRow', () => {
     );
     expect(mockActions.onRowSelected).not.toHaveBeenCalled();
     expect(mockActions.onRowClicked).not.toHaveBeenCalled();
-    userEvent.click(screen.getByRole('cell', { name: 'value1' }));
+    userEvent.click(container.querySelector('input'));
     expect(mockActions.onRowSelected).toHaveBeenCalledWith(tableRowProps.id, true);
-    expect(mockActions.onRowClicked).toHaveBeenCalledWith(tableRowProps.id);
+    // Click on radio button does not fire onRowClicked
+    expect(mockActions.onRowClicked).not.toHaveBeenCalledWith(tableRowProps.id);
   });
 
   it('does not call onRowSelected when expanded rows with hasRowSelection:"single" are clicked if isSelectable:"false"', () => {

--- a/packages/react/src/components/Table/_table.scss
+++ b/packages/react/src/components/Table/_table.scss
@@ -132,6 +132,10 @@ button.#{$prefix}--btn.#{$iot-prefix}--tooltip-svg-wrapper.#{$prefix}--btn--ghos
   }
 }
 
+.#{$iot-prefix}--table__row--background td {
+  background-color: $ui-03;
+}
+
 .#{$iot-prefix}--table__row--singly-selected,
 .#{$iot-prefix}--expandable-tablerow--singly-selected {
   cursor: pointer;


### PR DESCRIPTION
Closes #3616 

**Summary**

- Resolve `onRowSelected` callback issues

**Change List (commits, features, bugs, etc)**

- Remove duplication `onRowSelected` callback when radio buttons present
- Disable row selection on clicking the row outside of radio button (_note:_ this applies only with radio buttons)
- Add background for row selected state
- Update test

**Acceptance Test (how to verify the PR)**

- Go to this story
- Select `hasRowSelection` to `single`
- Enable `useRadioButtonSingleSelect`
- Open `Actions` tab
- Click on some radio button
- Verify `background-color` change for selected row
- Verify that `onRowSelected` has been called only once
- _Note:_ Verify that `onRowClicked` has NOT been called

</br>

- In the same story
- Select `hasRowSelection` to `single`
- Disable `useRadioButtonSingleSelect`
- Open `Actions` tab
- Click on some row
- Verify `background-color` change for selected row
- Verify that `onRowSelected` has been called only once
- _Note:_ Verify that `onRowClicked` has been called once

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
