### PR TITLE
fix(table): preserve pagination state during row edit mode

### DIFF
--- a/packages/react/src/components/Table/StatefulTable.test.e2e.jsx
+++ b/packages/react/src/components/Table/StatefulTable.test.e2e.jsx
@@ -6,6 +6,7 @@ import { settings } from '../../constants/Settings';
 import StatefulTable from './StatefulTable';
 import {
   getAdvancedFilters,
+  getInitialState,
   getTableColumns as getStoryTableColumns,
   getTableData as getStoryTableData,
 } from './Table.story.helpers';
@@ -379,5 +380,17 @@ describe('StatefulTable', () => {
 
     cy.findAllByLabelText('Sort rows by this header in descending order').eq(0).click();
     cy.get('tr').eq(1).find('td').eq(0).should('have.text', 'scott pinocchio chocolate 89');
+  });
+
+  it('should preserve current page during rowEdit mode', () => {
+    const initialState = getInitialState();
+
+    mount(<StatefulTable id="pagination-table" {...initialState} />);
+
+    cy.findByTestId('pagination-table-table-pagination').findAllByRole('button').last().click();
+    cy.findByText('2 of 2 pages').should('be.visible');
+
+    cy.findByTestId('row-edit-button').click();
+    cy.findByText('2 of 2 pages').should('be.visible');
   });
 });

--- a/packages/react/src/components/Table/tableReducer.js
+++ b/packages/react/src/components/Table/tableReducer.js
@@ -523,6 +523,11 @@ export const tableReducer = (state = {}, action) => {
       const { view, totalItems, hasUserViewManagement } = action.payload;
       const { pageSize, pageSizes, page } = get(view, 'pagination') || {};
       const paginationFromState = get(state, 'view.pagination');
+
+      const activeBar = view?.toolbar?.activeBar;
+      const activeBarFromState = state.view?.toolbar?.activeBar;
+      const rowEditMode = activeBarFromState === 'rowEdit';
+
       const initialDefaultSearch =
         get(view, 'toolbar.search.defaultValue') || get(view, 'toolbar.search.value');
       // update the column ordering if I'm passed new columns
@@ -541,7 +546,7 @@ export const tableReducer = (state = {}, action) => {
 
       const nextPageSize = paginationFromState.pageSize || pageSize;
       const nextTotalItems = totalItems || updatedData.length;
-      const nextPage = page || 1;
+      const nextPage = rowEditMode ? paginationFromState.page : page || 1;
       const pagination = get(state, 'view.pagination')
         ? {
             totalItems: { $set: nextTotalItems },
@@ -588,7 +593,6 @@ export const tableReducer = (state = {}, action) => {
         return filter;
       });
 
-      const activeBar = view?.toolbar?.activeBar;
       return update(state, {
         data: {
           $set: updatedData,


### PR DESCRIPTION
Closes #3622

**Summary**

- Keep current page during `rowEdit` mode

**Change List (commits, features, bugs, etc)**

- Add condition check in `tableReducer` to determine if page has to be reset
- Add tests

**Acceptance Test (how to verify the PR)**

- Go to [this story]()
- Enable `options.hasPagination` in `Pagination` tab
- Enable `options.hasRowEdit` in `Data Editing` tab
- Using pagination button navigate to some page
- Click on Edit button in the table toolbar
- Verify that table state has changed to `rowEdit` mode but pagination state preserved

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
