### PR TITLE
fix(datetimepicker): adjust regexp validation for midnight

### DIFF
--- a/packages/react/src/components/TimePicker/TimePickerDropdown.jsx
+++ b/packages/react/src/components/TimePicker/TimePickerDropdown.jsx
@@ -27,7 +27,7 @@ const timeUtils = {
       ? selectedTime.substring(0, 2)
       : currentTime.substring(0, 2),
   get24Hours: (selectedTime, currentTime) =>
-    /(0[1-9]|1[0-9]|2[0-3])/.test(selectedTime.substring(0, 2))
+    /^(2[0-3]|[01]?[0-9])$/.test(selectedTime.substring(0, 2))
       ? selectedTime.substring(0, 2)
       : currentTime.substring(2, 4),
   getMinutes: (selectedTime, currentTime) =>

--- a/packages/react/src/components/TimePicker/TimePickerDropdown.test.jsx
+++ b/packages/react/src/components/TimePicker/TimePickerDropdown.test.jsx
@@ -442,4 +442,31 @@ describe('TimePickerDropdown', () => {
     expect(input).toHaveFocus();
     expect(spinnerDropdown).not.toBeInTheDocument();
   });
+
+  it('should allow to pick midnight', async () => {
+    render(<TimePickerDropdown {...timePickerProps} value="23:59" is24hours />);
+    const input = screen.getByTestId('time-picker-test-input');
+    input.focus();
+    expect(input.value).toEqual('23:59');
+
+    userEvent.type(
+      screen.getByTestId('time-picker-test-spinner-list-spinner-1-selected-item'),
+      '{arrowdown}'
+    );
+
+    userEvent.type(
+      screen.getByTestId('time-picker-test-spinner-list-spinner-2-selected-item'),
+      '{arrowdown}'
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('time-picker-test-spinner-list-spinner-1-selected-item').textContent
+      ).toBe('00');
+      expect(
+        screen.getByTestId('time-picker-test-spinner-list-spinner-2-selected-item').textContent
+      ).toBe('00');
+      expect(input.value).toEqual('00:00');
+    });
+  });
 });


### PR DESCRIPTION
Closes #3630 

**Summary**

- Fix selecting midnight in dropdown

**Change List (commits, features, bugs, etc)**

- Adjust regexp validation for 24 hours format

**Acceptance Test (how to verify the PR)**

- Go to [this story](https://deploy-preview-3634--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-timepickerdropdown--default)
- Open knobs panel and select 24-hour format (is24hours)
- Open dropdown and scroll to `00` in the hours scroller
- Verify that time in input and dropdown synced

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
