### PR TITLE
feat(contentformitemtitle): new tab for tooltip link

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ContentFormItemTitle.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ContentFormItemTitle.jsx
@@ -33,7 +33,12 @@ const ContentFormItemTitle = ({ title, tooltip }) => {
             tooltipId={`card-edit-form-${title}`}
           >
             <p>
-              {tooltipText} {href && linkText ? <Link href={href}>{linkText}</Link> : null}
+              {tooltipText}{' '}
+              {href && linkText ? (
+                <Link href={href} target="_blank" rel="noopener noreferrer">
+                  {linkText}
+                </Link>
+              ) : null}
             </p>
           </Tooltip>
         ) : null}


### PR DESCRIPTION
Closes #3637

**Summary**

- Links from tooltips to open in new tab instead of the same

**Change List (commits, features, bugs, etc)**

- contentFormItemTitle: add target="_blank" to Link component

**Acceptance Test (how to verify the PR)**

- From DashboardEditor.
- Open a CardEditor with tooltip link
- Click the link
Expected: New tab to open link's resource

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
