### PR TITLE
fix(table): preserve search filter after resetting sorting

### DIFF
--- a/packages/react/src/components/Table/tableReducer.js
+++ b/packages/react/src/components/Table/tableReducer.js
@@ -482,7 +482,13 @@ export const tableReducer = (state = {}, action) => {
                   nextSortDir,
                   isTimestampColumn
                 )
-            : filterData(state.data, state.view.filters, state.columns); // reset to original filters
+            : filterSearchAndSort(
+                state.data,
+                null,
+                { value: state.view.toolbar.search?.defaultValue },
+                get(state, 'view.filters'),
+                get(state, 'columns')
+              );
       }
       return baseTableReducer(
         update(state, {

--- a/packages/react/src/components/Table/tableReducer.test.jsx
+++ b/packages/react/src/components/Table/tableReducer.test.jsx
@@ -258,6 +258,41 @@ describe('table reducer', () => {
       );
     });
 
+    it('TABLE_COLUMN_SORT with search', () => {
+      const searchString = 'toyota';
+      const sortColumnAction = tableColumnSort(tableColumns[0].id);
+
+      const tableFiltered = tableReducer(initialState, tableSearchApply(searchString));
+      expect(tableFiltered.view.toolbar.search.defaultValue).toEqual(searchString);
+      expect(tableFiltered.view.pagination.page).toEqual(1);
+
+      // First sort ASC
+      expect(tableFiltered.view.table.sort).toBeUndefined();
+      const tableSorted = tableReducer(tableFiltered, sortColumnAction);
+      expect(tableSorted.view.table.sort.columnId).toEqual(tableColumns[0].id);
+      expect(tableSorted.view.table.sort.direction).toEqual('ASC');
+      // Order should be changed in the filteredData
+      expect(tableFiltered.data).not.toEqual(tableSorted.view.table.filteredData);
+
+      // Then sort DESC
+      const tableSortedDesc = tableReducer(tableSorted, sortColumnAction);
+      expect(tableSortedDesc.view.table.sort.columnId).toEqual(tableColumns[0].id);
+      expect(tableSortedDesc.view.table.sort.direction).toEqual('DESC');
+      // The previous sorted data shouldn't match
+      expect(tableSorted.data).not.toEqual(tableSortedDesc.view.table.filteredData);
+
+      // Then sort by default
+      const tableSortedNone = tableReducer(tableSortedDesc, sortColumnAction);
+      const filteredTable = tableReducer(initialState, tableRegister({ data: initialState.data }));
+      const filteredTableSearch = tableReducer(filteredTable, tableSearchApply(searchString));
+
+      expect(tableSortedNone.view.table.sort).toBeUndefined();
+      // Data should no longer be sorted but should be filtered
+      expect(filteredTableSearch.view.table.filteredData).toEqual(
+        tableSortedNone.view.table.filteredData
+      );
+    });
+
     it('TABLE_COLUMN_SORT multisort', () => {
       const multiSortState = merge({}, initialState, {
         view: {


### PR DESCRIPTION
Closes #3491 

**Summary**

- Preserve filtering by search after sorting reset

**Change List (commits, features, bugs, etc)**

- Replace sorting function in table reducer to sorting with filtering

**Acceptance Test (how to verify the PR)**

- Go to [this story](https://deploy-preview-3640--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table--playground)
- In the `Sort & filter` knobs enable `isSortable`
- In the `Search` knobs enable `hasSearch` and `hasFastSearch`
- Type some word in the search bar
- Click on some column to sort it
- Verify that column was sorted by ascending on the first click, by descending on the second click and returned back to default sort value on the third click

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
