### PR TITLE
fix(card): tooltips enhacements

### DIFF
--- a/packages/react/src/components/Card/Card.test.e2e.jsx
+++ b/packages/react/src/components/Card/Card.test.e2e.jsx
@@ -69,4 +69,91 @@ describe('Card', () => {
 
     cy.findByRole('button', { name: aShortTitle }).should('not.exist');
   });
+
+  it('should close title tooltip in title if window is scrolled', () => {
+    cy.viewport(1680, 900);
+    const title =
+      'Card Title that should be truncated and presented in a tooltip while the cards also has an external tooltip.';
+
+    mount(
+      <div style={{ height: '1500px' }}>
+        <Card
+          style={{ width: '600px', height: '360px' }}
+          title={title}
+          subtitle="Lorem ipsum"
+          hasTitleWrap
+          id="facilitycard-basic"
+          size={CARD_SIZES.MEDIUM}
+          breakpoint="lg"
+          footerContent={() => <div>Footer Content</div>}
+        />
+      </div>
+    );
+
+    cy.findByRole('button', { name: title }).click();
+    cy.findByTestId('Card-title-tooltip').should('exist');
+    cy.findByTestId('Card-title-tooltip').should('be.visible');
+
+    cy.scrollTo(0, 50);
+
+    cy.findByTestId('Card-title-tooltip').should('not.exist');
+  });
+
+  it('should close subtitle tooltip in title if window is scrolled', () => {
+    cy.viewport(1680, 900);
+    const subtitle =
+      'Card Title that should be truncated and presented in a tooltip while the cards also has an external tooltip.';
+
+    mount(
+      <div style={{ height: '1500px' }}>
+        <Card
+          style={{ width: '600px', height: '360px' }}
+          title="Hello, world!"
+          subtitle={subtitle}
+          hasTitleWrap
+          id="facilitycard-basic"
+          size={CARD_SIZES.MEDIUM}
+          breakpoint="lg"
+          footerContent={() => <div>Footer Content</div>}
+          tooltip={<p>this is the external tooltip content</p>}
+        />
+      </div>
+    );
+
+    cy.findByRole('button', { name: subtitle }).click();
+    cy.findByTestId('Card-subtitle').should('exist');
+    cy.findByTestId('Card-subtitle').should('be.visible');
+
+    cy.scrollTo(0, 50);
+
+    cy.findByTestId('Card-subtitle').should('not.exist');
+  });
+
+  it('should close info icon tooltip in title if window is scrolled', () => {
+    cy.viewport(1680, 900);
+
+    mount(
+      <div style={{ height: '1500px' }}>
+        <Card
+          style={{ width: '600px', height: '360px' }}
+          title="Hello, world!"
+          subtitle="Subtitle"
+          hasTitleWrap
+          id="facilitycard-basic"
+          size={CARD_SIZES.MEDIUM}
+          breakpoint="lg"
+          footerContent={() => <div>Footer Content</div>}
+          tooltip={<p>this is the external tooltip content</p>}
+        />
+      </div>
+    );
+
+    cy.findByRole('button', { name: 'Tooltip info icon' }).click();
+    cy.findByTestId('Card-tooltip').should('exist');
+    cy.findByTestId('Card-tooltip').should('be.visible');
+
+    cy.scrollTo(0, 50);
+
+    cy.findByTestId('Card-tooltip').should('not.exist');
+  });
 });

--- a/packages/react/src/components/Card/Card.test.jsx
+++ b/packages/react/src/components/Card/Card.test.jsx
@@ -376,6 +376,25 @@ describe('Card', () => {
   });
 
   describe('tooltips', () => {
+    const originalGetBoundingClientRect = HTMLDivElement.prototype.getBoundingClientRect;
+
+    beforeEach(() => {
+      HTMLDivElement.prototype.getBoundingClientRect = jest.fn(() => ({
+        bottom: 76,
+        height: 68,
+        left: 122,
+        right: 410,
+        top: 8,
+        width: 288,
+        x: 122,
+        y: 8,
+      }));
+    });
+
+    afterEach(() => {
+      HTMLDivElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+    });
+
     it('should warn on combining tooltip and titleTextTooltip', () => {
       const { __DEV__ } = global;
       global.__DEV__ = true;

--- a/packages/react/src/components/Card/Card.test.jsx
+++ b/packages/react/src/components/Card/Card.test.jsx
@@ -564,6 +564,86 @@ describe('Card', () => {
         expect(screen.getByTestId('Card-subtitle')).toBeVisible();
         expect(tooltipButton).toHaveAttribute('aria-expanded', 'true');
       });
+
+      it('should display tooltip on card title click', () => {
+        const title =
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
+        const testId = 'Card-title-tooltip';
+
+        render(
+          <Card
+            style={{ width: '600px', height: '360px' }}
+            title={title}
+            subtitle="Lorem ipsum"
+            hasTitleWrap
+            id="facilitycard-basic"
+            size={CARD_SIZES.MEDIUM}
+            breakpoint="lg"
+          />
+        );
+
+        expect(screen.queryByTestId(testId)).toBeNull();
+
+        userEvent.click(screen.getByRole('button', { name: title }));
+        expect(screen.getByTestId(testId)).toBeDefined();
+        expect(screen.getByTestId(testId)).toBeInTheDocument();
+
+        userEvent.click(document.body);
+        expect(screen.queryByTestId(testId)).toBeNull();
+      });
+
+      it('should display tooltip on card subtitle click', () => {
+        const testId = 'Card-subtitle';
+        const subtitle =
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
+
+        render(
+          <Card
+            style={{ width: '600px', height: '360px' }}
+            title="Lorem ipsum"
+            subtitle={subtitle}
+            hasTitleWrap
+            id="facilitycard-basic"
+            size={CARD_SIZES.MEDIUM}
+            breakpoint="lg"
+          />
+        );
+
+        expect(screen.queryByTestId(testId)).toBeNull();
+
+        userEvent.click(screen.getByRole('button', { name: subtitle }));
+        expect(screen.getByTestId(testId)).toBeDefined();
+        expect(screen.getByTestId(testId)).toBeInTheDocument();
+
+        userEvent.click(document.body);
+        expect(screen.queryByTestId(testId)).toBeNull();
+      });
+
+      it('should display tooltip on card info icon click', () => {
+        const testId = 'Card-tooltip';
+
+        render(
+          <Card
+            style={{ width: '600px', height: '360px' }}
+            title="Lorem ipsum"
+            subtitle="Lorem ipsum dolor"
+            hasTitleWrap
+            id="facilitycard-basic"
+            size={CARD_SIZES.MEDIUM}
+            breakpoint="lg"
+            tooltip={<p>this is the external tooltip content</p>}
+          />
+        );
+
+        expect(screen.queryByTestId(testId)).toBeNull();
+
+        userEvent.click(screen.getByRole('button', { name: 'Tooltip info icon' }));
+        expect(screen.getByTestId(testId)).toBeDefined();
+        expect(screen.getByTestId(testId)).toBeInTheDocument();
+
+        userEvent.click(document.body);
+        expect(screen.queryByTestId(testId)).toBeNull();
+      });
     });
   });
 

--- a/packages/react/src/components/Card/CardTitle.jsx
+++ b/packages/react/src/components/Card/CardTitle.jsx
@@ -63,6 +63,7 @@ export const CardTitle = (
         triggerClassName={classnames(
           `${iotPrefix}--card--title--text__overflow`,
           `${iotPrefix}--card--title--text`,
+          `${iotPrefix}--card-heading-clickable`,
           {
             [`${iotPrefix}--card--title--text--wrapped`]:
               hasTitleWrap && !subtitle && !hasExternalTitleTextTooltip,
@@ -110,9 +111,13 @@ export const CardTitle = (
         data-testid={`${testId}-subtitle`}
         ref={subTitleRef}
         showIcon={false}
-        triggerClassName={classnames(`${iotPrefix}--card--subtitle--text`, {
-          [`${iotPrefix}--card--subtitle--text--padded`]: hasInfoIconTooltip,
-        })}
+        triggerClassName={classnames(
+          `${iotPrefix}--card--subtitle--text`,
+          `${iotPrefix}--card-heading-clickable`,
+          {
+            [`${iotPrefix}--card--subtitle--text--padded`]: hasInfoIconTooltip,
+          }
+        )}
         triggerText={subtitle}
       >
         {subtitle}

--- a/packages/react/src/components/Card/CardTitle.jsx
+++ b/packages/react/src/components/Card/CardTitle.jsx
@@ -100,7 +100,7 @@ export const CardTitle = (
     }
   }, []);
 
-  // Ignore window event listeners from Jest testing
+  // ignore due to window event listeners
   /* istanbul ignore next */
   useEffect(() => {
     const handleScroll = () => {

--- a/packages/react/src/components/Card/CardTitle.jsx
+++ b/packages/react/src/components/Card/CardTitle.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import { Tooltip } from 'carbon-components-react';
 
 import useHasTextOverflow from '../../hooks/useHasTextOverflow';
+import { usePopoverPositioning } from '../../hooks/usePopoverPositioning';
+import { getTooltipMenuOffset } from '../Tooltip';
 import { settings } from '../../constants/Settings';
 
 const { iotPrefix } = settings;
@@ -54,6 +56,13 @@ export const CardTitle = (
   const hasTitleTooltipFromTruncation = truncatesTitle && !titleTextTooltip;
   const hasInfoIconTooltip = infoIconTooltip && !hasExternalTitleTextTooltip;
   const hasSubTitleTooltip = useHasTextOverflow(subTitleRef, subtitle);
+
+  const [calculateMenuOffset, { adjustedDirection }] = usePopoverPositioning({
+    direction: 'bottom',
+    menuOffset: getTooltipMenuOffset,
+    useAutoPositioning: true,
+    isOverflowMenu: true, // Needed to preserve default direction (bottom)
+  });
 
   const [tooltipsState, setTooltipsState] = useState({
     title: false,
@@ -121,7 +130,9 @@ export const CardTitle = (
   const renderMainTitle = () =>
     hasTitleTooltipFromTruncation || hasExternalTitleTextTooltip ? (
       <Tooltip
-        autoOrientation
+        align="center"
+        menuOffset={calculateMenuOffset}
+        direction={adjustedDirection}
         data-testid={`${testId}-title-tooltip`}
         ref={titleRef}
         showIcon={false}

--- a/packages/react/src/components/Card/CardTitle.jsx
+++ b/packages/react/src/components/Card/CardTitle.jsx
@@ -100,7 +100,7 @@ export const CardTitle = (
     }
   }, []);
 
-  // Hide window event listeners from Jest testing
+  // Ignore window event listeners from Jest testing
   /* istanbul ignore next */
   useEffect(() => {
     const handleScroll = () => {

--- a/packages/react/src/components/Card/__snapshots__/Card.story.storyshot
+++ b/packages/react/src/components/Card/__snapshots__/Card.story.storyshot
@@ -5667,6 +5667,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
             
             <div
               aria-describedby={null}
+              aria-expanded={false}
               aria-label="Tooltip info icon"
               className="bx--tooltip__trigger"
               onBlur={[Function]}

--- a/packages/react/src/components/Card/_card-title.scss
+++ b/packages/react/src/components/Card/_card-title.scss
@@ -83,3 +83,7 @@ p.#{$iot-prefix}--card-title__title-text-tooltip-full-title {
     margin-right: unset;
   }
 }
+
+.#{$iot-prefix}--card-heading-clickable {
+  cursor: pointer;
+}

--- a/packages/react/src/components/ComboChartCard/__snapshots__/ComboChartCard.story.storyshot
+++ b/packages/react/src/components/ComboChartCard/__snapshots__/ComboChartCard.story.storyshot
@@ -2378,6 +2378,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
             
             <div
               aria-describedby={null}
+              aria-expanded={false}
               aria-label="Tooltip info icon"
               className="bx--tooltip__trigger"
               onBlur={[Function]}
@@ -2829,6 +2830,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
             
             <div
               aria-describedby={null}
+              aria-expanded={false}
               aria-label="Tooltip info icon"
               className="bx--tooltip__trigger"
               onBlur={[Function]}

--- a/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -1174,6 +1174,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                     
                     <div
                       aria-describedby={null}
+                      aria-expanded={false}
                       aria-label="Tooltip info icon"
                       className="bx--tooltip__trigger"
                       onBlur={[Function]}
@@ -4067,6 +4068,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                     
                     <div
                       aria-describedby={null}
+                      aria-expanded={false}
                       aria-label="Tooltip info icon"
                       className="bx--tooltip__trigger"
                       onBlur={[Function]}
@@ -6995,6 +6997,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                     
                     <div
                       aria-describedby={null}
+                      aria-expanded={false}
                       aria-label="Tooltip info icon"
                       className="bx--tooltip__trigger"
                       onBlur={[Function]}
@@ -12343,6 +12346,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                     
                     <div
                       aria-describedby={null}
+                      aria-expanded={false}
                       aria-label="Tooltip info icon"
                       className="bx--tooltip__trigger"
                       onBlur={[Function]}
@@ -29976,6 +29980,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                     
                     <div
                       aria-describedby={null}
+                      aria-expanded={false}
                       aria-label="Tooltip info icon"
                       className="bx--tooltip__trigger"
                       onBlur={[Function]}

--- a/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
@@ -879,6 +879,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                 
                 <div
                   aria-describedby={null}
+                  aria-expanded={false}
                   aria-label="Tooltip info icon"
                   className="bx--tooltip__trigger"
                   onBlur={[Function]}

--- a/packages/react/src/components/GaugeCard/__snapshots__/GaugeCard.story.storyshot
+++ b/packages/react/src/components/GaugeCard/__snapshots__/GaugeCard.story.storyshot
@@ -45,6 +45,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
             
             <div
               aria-describedby={null}
+              aria-expanded={false}
               aria-label="Tooltip info icon"
               className="bx--tooltip__trigger"
               onBlur={[Function]}
@@ -210,6 +211,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
             
             <div
               aria-describedby={null}
+              aria-expanded={false}
               aria-label="Tooltip info icon"
               className="bx--tooltip__trigger"
               onBlur={[Function]}
@@ -416,6 +418,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
             
             <div
               aria-describedby={null}
+              aria-expanded={false}
               aria-label="Tooltip info icon"
               className="bx--tooltip__trigger"
               onBlur={[Function]}
@@ -578,6 +581,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
             
             <div
               aria-describedby={null}
+              aria-expanded={false}
               aria-label="Tooltip info icon"
               className="bx--tooltip__trigger"
               onBlur={[Function]}

--- a/packages/react/src/components/Tooltip/index.jsx
+++ b/packages/react/src/components/Tooltip/index.jsx
@@ -15,7 +15,7 @@ const DIRECTION_TOP = 'top';
  * @returns {FloatingMenu~offset} The adjustment of the floating menu position, upon the position of the menu arrow.
  * @private
  */
-const getTooltipMenuOffset = (menuBody, menuDirection) => {
+export const getTooltipMenuOffset = (menuBody, menuDirection) => {
   const arrowStyle = menuBody.ownerDocument.defaultView.getComputedStyle(menuBody, ':before');
   const arrowPositionProp = {
     [DIRECTION_LEFT]: 'right',


### PR DESCRIPTION
Closes #3645 

**Summary**

- Updates for tooltips inside `CardTitle` component

**Change List (commits, features, bugs, etc)**

1. Add `cursor: pointer` for truncated card title and subtitle with tooltip
2. Add window scroll listener to close tooltips
3. Replace `autoOrientation` prop in Carbon `Tooltip` to custom hook in order to adjust positioning

**Acceptance Test (how to verify the PR)**

1. Go to the story [Card / Card / with ellipsed title tooltip & external tooltip](https://deploy-preview-3649--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-card-card--with-ellipsed-title-tooltip-external-tooltip)
  1.1 Hover on card title and subtitle
  1.2 Verify that cursor has changed to `pointer`

2. Go to the story [Card / Card / with ellipsed title tooltip & external tooltip](https://deploy-preview-3649--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-card-card--with-ellipsed-title-tooltip-external-tooltip)
  2.1 Resize the window vertically in order to display vertical scrollbar
  2.2 Click on card or subtitle to show tooltip
  2.3 Scroll windows vertically
  2.4 Verify that tooltip was removed after the scrolling event

3. Go to the story [Card / Card / with ellipsed title tooltip & external tooltip](https://deploy-preview-3649--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-card-card--with-ellipsed-title-tooltip-external-tooltip)
  3.1 Click on card or subtitle to show tooltip
  3.2 Resize screen vertically till the vertical size of the screen will be less than tooltip's height
  3.3 Verify that no error appeared (tooltip does not adjusts its position if screen height is not enough)

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
