### PR TITLE
fix(DateTimePickerV2): :focus not working in firefox

### DIFF
--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.story.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.story.jsx
@@ -148,33 +148,36 @@ SelectedAbsolute.storyName = 'Selected absolute';
 export const SingleSelect = () => {
   const dateTimeMask = text('dateTimeMask', 'YYYY-MM-DD HH:mm');
   return (
-    <DateTimePicker
-      id="datetimepicker"
-      key={dateTimeMask}
-      useNewTimeSpinner
-      useAutoPositioning={boolean('useAutoPositioning', true)}
-      defaultValue={{
-        timeRangeKind: PICKER_KINDS.SINGLE,
-        timeSingleValue: {
-          startDate: '2020-04-01',
-          startTime: '12:34',
-        },
-      }}
-      dateTimeMask={dateTimeMask}
-      hasTimeInput={boolean('hasTimeInput', true)}
-      onApply={action('onApply')}
-      onCancel={action('onCancel')}
-      datePickerType="single"
-      showRelativeOption={boolean('show relative option', false)}
-      invalid={boolean('invalid', false)}
-      disabled={boolean('disabled', false)}
-      i18n={object('i18n', {
-        timePickerInvalidText: 'A valid value is required',
-        invalidText: 'The date time entered is invalid',
-      })}
-      style={{ zIndex: number('zIndex', 0) }}
-      renderInPortal={boolean('renderInPortal', true)}
-    />
+    <div>
+      <div style={{ paddingBottom: '1rem' }}> DateTimePickerV2 Single Select </div>
+      <DateTimePicker
+        id="datetimepicker"
+        key={dateTimeMask}
+        useNewTimeSpinner
+        useAutoPositioning={boolean('useAutoPositioning', true)}
+        defaultValue={{
+          timeRangeKind: PICKER_KINDS.SINGLE,
+          timeSingleValue: {
+            startDate: '2020-04-01',
+            startTime: '12:34',
+          },
+        }}
+        dateTimeMask={dateTimeMask}
+        hasTimeInput={boolean('hasTimeInput', true)}
+        onApply={action('onApply')}
+        onCancel={action('onCancel')}
+        datePickerType="single"
+        showRelativeOption={boolean('show relative option', false)}
+        invalid={boolean('invalid', false)}
+        disabled={boolean('disabled', false)}
+        i18n={object('i18n', {
+          timePickerInvalidText: 'A valid value is required',
+          invalidText: 'The date time entered is invalid',
+        })}
+        style={{ zIndex: number('zIndex', 0) }}
+        renderInPortal={boolean('renderInPortal', true)}
+      />
+    </div>
   );
 };
 

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
@@ -845,6 +845,7 @@ const DateTimePicker = ({
         id={`${id}-${iotPrefix}--date-time-pickerv2__wrapper`}
         className={classnames(`${iotPrefix}--date-time-pickerv2__wrapper`, {
           [`${iotPrefix}--date-time-pickerv2__wrapper--disabled`]: disabled,
+          [`${iotPrefix}--date-time-pickerv2__wrapper--invalid`]: invalidState,
         })}
         style={{ '--wrapper-width': hasIconOnly ? '3rem' : '20rem' }}
         role="button"
@@ -873,7 +874,6 @@ const DateTimePicker = ({
           className={classnames({
             [`${iotPrefix}--date-time-picker__box--full`]: !hasIconOnly,
             [`${iotPrefix}--date-time-picker__box--light`]: light,
-            [`${iotPrefix}--date-time-picker__box--invalid`]: invalidState,
             [`${iotPrefix}--date-time-picker__box--disabled`]: disabled,
           })}
         >

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
@@ -875,6 +875,7 @@ const DateTimePicker = ({
             [`${iotPrefix}--date-time-picker__box--full`]: !hasIconOnly,
             [`${iotPrefix}--date-time-picker__box--light`]: light,
             [`${iotPrefix}--date-time-picker__box--disabled`]: disabled,
+            [`${iotPrefix}--date-time-picker__box--invalid`]: invalidState,
           })}
         >
           {!hasIconOnly ? (

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithoutTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithoutTimeSpinner.jsx
@@ -729,6 +729,7 @@ const DateTimePicker = ({
             [`${iotPrefix}--date-time-picker__box--full`]: !hasIconOnly,
             [`${iotPrefix}--date-time-picker__box--light`]: light,
             [`${iotPrefix}--date-time-picker__box--disabled`]: disabled,
+            [`${iotPrefix}--date-time-picker__box--invalid`]: invalidState,
           })}
         >
           {!hasIconOnly ? (

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithoutTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithoutTimeSpinner.jsx
@@ -699,6 +699,7 @@ const DateTimePicker = ({
         id={`${id}-${iotPrefix}--date-time-pickerv2__wrapper`}
         className={classnames(`${iotPrefix}--date-time-pickerv2__wrapper`, {
           [`${iotPrefix}--date-time-pickerv2__wrapper--disabled`]: disabled,
+          [`${iotPrefix}--date-time-pickerv2__wrapper--invalid`]: invalidState,
         })}
         style={{ '--wrapper-width': hasIconOnly ? '3rem' : '20rem' }}
         role="button"
@@ -727,7 +728,6 @@ const DateTimePicker = ({
           className={classnames({
             [`${iotPrefix}--date-time-picker__box--full`]: !hasIconOnly,
             [`${iotPrefix}--date-time-picker__box--light`]: light,
-            [`${iotPrefix}--date-time-picker__box--invalid`]: invalidState,
             [`${iotPrefix}--date-time-picker__box--disabled`]: disabled,
           })}
         >

--- a/packages/react/src/components/DateTimePicker/__snapshots__/DateTimePickerV2.story.storyshot
+++ b/packages/react/src/components/DateTimePicker/__snapshots__/DateTimePickerV2.story.storyshot
@@ -953,107 +953,118 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
 <div
   className="storybook-container"
 >
-  <div
-    className="iot--date-time-pickerv2"
-  >
+  <div>
     <div
-      className="iot--date-time-pickerv2__wrapper"
-      data-testid="date-time-picker"
-      id="datetimepicker-iot--date-time-pickerv2__wrapper"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      role="button"
       style={
         Object {
-          "--wrapper-width": "20rem",
+          "paddingBottom": "1rem",
         }
       }
-      tabIndex={0}
+    >
+       DateTimePickerV2 Single Select 
+    </div>
+    <div
+      className="iot--date-time-pickerv2"
     >
       <div
-        className="iot--date-time-picker__box--full"
+        className="iot--date-time-pickerv2__wrapper"
+        data-testid="date-time-picker"
+        id="datetimepicker-iot--date-time-pickerv2__wrapper"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        role="button"
+        style={
+          Object {
+            "--wrapper-width": "20rem",
+          }
+        }
+        tabIndex={0}
       >
         <div
-          className="iot--date-time-picker__field"
-          data-testid="date-time-picker__field"
+          className="iot--date-time-picker__box--full"
         >
-          <span
-            className=""
-            title="2020-04-01 12:34"
-          >
-            2020-04-01 12:34
-          </span>
-        </div>
-        <div
-          className="iot--flyout-menu iot--flyout-menu__bottom"
-          data-testid="date-time-picker-datepicker-flyout-container"
-          style={
-            Object {
-              "--tooltip-visibility": "hidden",
-            }
-          }
-        >
-          <button
-            aria-describedby={null}
-            aria-label="Calendar"
-            className="iot--flyout-menu--trigger-button iot--date-time-picker--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
-            data-testid="date-time-picker-datepicker-flyout-button"
-            disabled={false}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            tabIndex={-1}
-            type="button"
-          >
-            <div
-              className="bx--assistive-text"
-              onMouseEnter={[Function]}
-            >
-              Calendar
-            </div>
-            <svg
-              aria-hidden="true"
-              aria-label="Calendar"
-              className="bx--btn__icon"
-              fill="currentColor"
-              focusable="false"
-              height={16}
-              preserveAspectRatio="xMidYMid meet"
-              role="img"
-              viewBox="0 0 32 32"
-              width={16}
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M26,4h-4V2h-2v2h-8V2h-2v2H6C4.9,4,4,4.9,4,6v20c0,1.1,0.9,2,2,2h20c1.1,0,2-0.9,2-2V6C28,4.9,27.1,4,26,4z M26,26H6V12h20	V26z M26,10H6V6h4v2h2V6h8v2h2V6h4V10z"
-              />
-            </svg>
-          </button>
           <div
-            className="iot--flyout-menu--tooltip-anchor"
+            className="iot--date-time-picker__field"
+            data-testid="date-time-picker__field"
           >
-            <div
+            <span
+              className=""
+              title="2020-04-01 12:34"
+            >
+              2020-04-01 12:34
+            </span>
+          </div>
+          <div
+            className="iot--flyout-menu iot--flyout-menu__bottom"
+            data-testid="date-time-picker-datepicker-flyout-container"
+            style={
+              Object {
+                "--tooltip-visibility": "hidden",
+              }
+            }
+          >
+            <button
               aria-describedby={null}
-              aria-expanded={false}
               aria-label="Calendar"
-              className="bx--tooltip__label"
-              id="test-trigger-id-2"
+              className="iot--flyout-menu--trigger-button iot--date-time-picker--trigger-button iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+              data-testid="date-time-picker-datepicker-flyout-button"
+              disabled={false}
               onBlur={[Function]}
               onClick={[Function]}
-              onContextMenu={[Function]}
               onFocus={[Function]}
-              onKeyDown={[Function]}
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
-              role="button"
-              tabIndex={0}
-            />
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              tabIndex={-1}
+              type="button"
+            >
+              <div
+                className="bx--assistive-text"
+                onMouseEnter={[Function]}
+              >
+                Calendar
+              </div>
+              <svg
+                aria-hidden="true"
+                aria-label="Calendar"
+                className="bx--btn__icon"
+                fill="currentColor"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M26,4h-4V2h-2v2h-8V2h-2v2H6C4.9,4,4,4.9,4,6v20c0,1.1,0.9,2,2,2h20c1.1,0,2-0.9,2-2V6C28,4.9,27.1,4,26,4z M26,26H6V12h20	V26z M26,10H6V6h4v2h2V6h8v2h2V6h4V10z"
+                />
+              </svg>
+            </button>
+            <div
+              className="iot--flyout-menu--tooltip-anchor"
+            >
+              <div
+                aria-describedby={null}
+                aria-expanded={false}
+                aria-label="Calendar"
+                className="bx--tooltip__label"
+                id="test-trigger-id-2"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                role="button"
+                tabIndex={0}
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/packages/react/src/components/DateTimePicker/_date-time-pickerv2.scss
+++ b/packages/react/src/components/DateTimePicker/_date-time-pickerv2.scss
@@ -97,10 +97,6 @@
     background-color: $field-02;
   }
 
-  .#{$iot-prefix}--date-time-picker__box--invalid {
-    outline: 2px solid $danger-01;
-  }
-
   .#{$iot-prefix}--date-time-picker__box--disabled {
     border: none;
   }
@@ -112,6 +108,10 @@
 
 .#{$iot-prefix}--date-time-pickerv2__wrapper--disabled {
   pointer-events: none;
+}
+
+.#{$iot-prefix}--date-time-pickerv2__wrapper--invalid {
+  outline: 2px solid $danger-01;
 }
 
 // open menu content


### PR DESCRIPTION
Closes #3619 

**Summary**

- If a child element sets `outline`, css` :focus `does not work on either child or parent element anymore in firefox.  

- The previous invalid style was applied to `${iotPrefix}--date-time-picker__box`, it sets `outline` to `$danger-01`. If I set :focus or :focus-visible on the same element. The outline stays `$danger-01`. And the parent `:focus outline` not working either. 
- I have to move the invalid style to the parent wrapper to make it work in firefox.

**Change List (commits, features, bugs, etc)**

- move class to the wrapper element
- update the single select story to make sure tab key works

**Acceptance Test (how to verify the PR)**
Tab key
- go to single select story
- check the invalid check box in knobs
- click on the text "DateTimePickerV2 Single Select"
- push tab key
- make sure the input is in focus with blue outline

Mouse click
- go to single select story
- check the invalid check box in knobs
- click on the datetime input
- make sure the input is in focus with blue outline

Mouse click
- go to Selected absolute story
- check the invalid check box in knobs
- click on the datetime input
- make sure the input is in focus with blue outline


https://user-images.githubusercontent.com/24279794/204611689-b735dcbd-5927-41d0-b42b-2c239014118f.mov



<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
