### PR TITLE
REPO: upgrade `css-what` past vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "react-test-renderer": "16.14.0",
     "react-dom": "16.14.0",
     "react": "16.14.0",
-    "webpack": "4"
+    "webpack": "4",
+    "css-what": "2.1.3"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -343,6 +343,7 @@
   "version": "2.152.0-next.13",
   "resolutions": {
     "chokidar": "3.3.1",
-    "react-grid-layout": "1.2.2"
+    "react-grid-layout": "1.2.2",
+    "css-what": "2.1.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11686,13 +11686,10 @@ css-url-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/css-url-regex/-/css-url-regex-1.1.0.tgz#83834230cc9f74c457de59eebd1543feeb83b7ec"
 
-css-what@2.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
-
-css-what@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.2.tgz#c0876d9d0480927d7d4920dcd72af3595649554d"
+css-what@2.1, css-what@2.1.3, css-what@^2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
+  integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
 css.escape@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
Closes #

**Summary**

css-what package has a vulnerability. This is a dep to a few packages. 

**Change List (commits, features, bugs, etc)**

- added resolution to `packages/react/package.json` and `package.json`

All checks should pass