### PR TITLE
fix(editorUtils): update card JSON when group by multiselect changes

### DIFF
--- a/packages/react/src/components/DashboardEditor/editorUtils.test.jsx
+++ b/packages/react/src/components/DashboardEditor/editorUtils.test.jsx
@@ -533,6 +533,82 @@ describe('editorUtils', () => {
         },
       });
     });
+    it('handleDataSeriesChange should correctly update dataSource groupBy', () => {
+      const selectedItems = [
+        {
+          dataItemId: 'manufacturer',
+          dataSourceId: 'manufacturer',
+          label: 'Manufacturer',
+          dataItemType: 'DIMENSION',
+        },
+      ];
+      const mockedGroupedbyTableCard = {
+        ...mockTableCard,
+        content: {
+          columns: [
+            {
+              columnType: 'TIMESTAMP',
+              dataItemId: 'timestamp',
+              dataSourceId: 'timestamp',
+              label: 'Timestamp',
+              type: 'TIMESTAMP',
+              sort: 'DESC',
+            },
+            {
+              dataItemId: 'manufacturer',
+              dataSourceId: 'manufacturer',
+              label: 'Manufacturer',
+              dataItemType: 'DIMENSION',
+            },
+            {
+              dataItemId: 'firmware',
+              dataSourceId: 'firmware',
+              label: 'Firmware',
+              dataItemType: 'DIMENSION',
+              destination: 'groupBy',
+            },
+          ],
+        },
+      };
+      const newCard = handleDataSeriesChange(
+        selectedItems,
+        mockedGroupedbyTableCard,
+        () => {},
+        null,
+        true
+      );
+      expect(newCard).toEqual({
+        ...mockTableCard,
+        content: {
+          columns: [
+            {
+              columnType: 'TIMESTAMP',
+              dataItemId: 'timestamp',
+              dataSourceId: 'timestamp',
+              label: 'Timestamp',
+              type: 'TIMESTAMP',
+              sort: 'DESC',
+            },
+            {
+              dataItemId: 'manufacturer',
+              dataSourceId: 'manufacturer',
+              label: 'Manufacturer',
+              dataItemType: 'DIMENSION',
+              destination: 'groupBy',
+            },
+            {
+              dataItemId: 'firmware',
+              dataSourceId: 'firmware',
+              label: 'Firmware',
+              dataItemType: 'DIMENSION',
+            },
+          ],
+        },
+        dataSource: {
+          groupBy: ['manufacturer'],
+        },
+      });
+    });
     it('handleDataSeriesChange existing card should correctly add the columns for new table card dimensions', () => {
       const selectedItems = [
         { id: 'manufacturer', text: 'Manufacturer', dataItemType: 'DIMENSION' },


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-addons-iot-react/issues/3674

**Summary**

- Within Dashboard Editor, a data table card with existing columns does not update the card JSON when the "Group by" multi-select has new items selected which are also added as columns. Similarly, when unchecking items from "Group by" multi-select they are not removed from groupBy array.

**Change List (commits, features, bugs, etc)**

- fix(editorutils): update columns destination property when group by multiselect changes
- fix(editorutils): add test scenario for data table card data grouping

**Acceptance Test (how to verify the PR)**

- adding/removing group by data items should correctly reflect in the card json

**Regression Test (how to make sure this PR doesn't break old functionality)**

- columns are added to the table when group by data items is selected

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
