### PR TITLE
fix(suiteheader): Including some new query parameters to the logout URL in SuiteHeader and adding support to appId parameter in uiresources API

### DIFF
--- a/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.jsx
+++ b/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.jsx
@@ -33,6 +33,7 @@ export const IdleLogoutConfirmationModalI18NPropTypes = {
 };
 
 const defaultProps = {
+  appId: null,
   className: null,
   idleTimeoutData: {
     timeout: 1800, // 30 minutes
@@ -52,6 +53,8 @@ const defaultProps = {
 };
 
 const propTypes = {
+  /** Application ID in suite */
+  appId: PropTypes.string,
   /** Add class name to the rendered Modal component */
   className: PropTypes.string,
   /** User inactivity timeout data */
@@ -67,6 +70,7 @@ const propTypes = {
 };
 
 const IdleLogoutConfirmationModal = ({
+  appId,
   className,
   idleTimeoutData,
   routes,
@@ -82,14 +86,17 @@ const IdleLogoutConfirmationModal = ({
     []
   );
 
-  // Append originHref query parameter to the logout routes
+  // Append originHref query parameter (and, optionally, originAppId) to the logout routes
   let logoutRoute = routes?.logout;
   try {
     const url = new URL(routes.logout);
     if (window.location.href) {
       url.searchParams.append('originHref', window.location.href);
-      logoutRoute = url.href;
     }
+    if (appId) {
+      url.searchParams.append('originAppId', appId);
+    }
+    logoutRoute = url.href;
   } catch (e) {
     logoutRoute = routes?.logout;
   }
@@ -99,8 +106,11 @@ const IdleLogoutConfirmationModal = ({
     const url = new URL(routes.logoutInactivity);
     if (window.location.href) {
       url.searchParams.append('originHref', window.location.href);
-      logoutInactivityRoute = url.href;
     }
+    if (appId) {
+      url.searchParams.append('originAppId', appId);
+    }
+    logoutInactivityRoute = url.href;
   } catch (e) {
     logoutInactivityRoute = routes?.logoutInactivity;
   }

--- a/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.jsx
+++ b/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.jsx
@@ -94,7 +94,7 @@ const IdleLogoutConfirmationModal = ({
     []
   );
 
-  // Append originHref query parameter (and, optionally, originAppId) to the logout routes
+  // Append originHref query parameter (and, optionally, originIsAdmin, originWorkspaceId and originAppId) to the logout routes
   let logoutRoute = routes?.logout;
   try {
     const url = new URL(routes.logout);

--- a/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.jsx
+++ b/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.jsx
@@ -55,7 +55,7 @@ const defaultProps = {
 };
 
 const propTypes = {
-  /** If true, includes the originIsAdmin query param in the logout URL */
+  /** If true, include the originIsAdmin query param in the logout URL */
   isAdminView: PropTypes.bool,
   /** Application ID in suite */
   appId: PropTypes.string,

--- a/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.jsx
+++ b/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.jsx
@@ -33,6 +33,7 @@ export const IdleLogoutConfirmationModalI18NPropTypes = {
 };
 
 const defaultProps = {
+  isAdminView: null,
   appId: null,
   workspaceId: null,
   className: null,
@@ -54,6 +55,8 @@ const defaultProps = {
 };
 
 const propTypes = {
+  /** If true, includes the originIsAdmin query param in the logout URL */
+  isAdminView: PropTypes.bool,
   /** Application ID in suite */
   appId: PropTypes.string,
   /** Workspace ID in suite */
@@ -73,6 +76,7 @@ const propTypes = {
 };
 
 const IdleLogoutConfirmationModal = ({
+  isAdminView,
   appId,
   workspaceId,
   className,
@@ -103,6 +107,9 @@ const IdleLogoutConfirmationModal = ({
     if (workspaceId) {
       url.searchParams.append('originWorkspaceId', workspaceId);
     }
+    if (isAdminView) {
+      url.searchParams.append('originIsAdmin', isAdminView);
+    }
     logoutRoute = url.href;
   } catch (e) {
     logoutRoute = routes?.logout;
@@ -119,6 +126,9 @@ const IdleLogoutConfirmationModal = ({
     }
     if (workspaceId) {
       url.searchParams.append('originWorkspaceId', workspaceId);
+    }
+    if (isAdminView) {
+      url.searchParams.append('originIsAdmin', isAdminView);
     }
     logoutInactivityRoute = url.href;
   } catch (e) {

--- a/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.jsx
+++ b/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.jsx
@@ -34,6 +34,7 @@ export const IdleLogoutConfirmationModalI18NPropTypes = {
 
 const defaultProps = {
   appId: null,
+  workspaceId: null,
   className: null,
   idleTimeoutData: {
     timeout: 1800, // 30 minutes
@@ -55,6 +56,8 @@ const defaultProps = {
 const propTypes = {
   /** Application ID in suite */
   appId: PropTypes.string,
+  /** Workspace ID in suite */
+  workspaceId: PropTypes.string,
   /** Add class name to the rendered Modal component */
   className: PropTypes.string,
   /** User inactivity timeout data */
@@ -71,6 +74,7 @@ const propTypes = {
 
 const IdleLogoutConfirmationModal = ({
   appId,
+  workspaceId,
   className,
   idleTimeoutData,
   routes,
@@ -96,6 +100,9 @@ const IdleLogoutConfirmationModal = ({
     if (appId) {
       url.searchParams.append('originAppId', appId);
     }
+    if (workspaceId) {
+      url.searchParams.append('originWorkspaceId', workspaceId);
+    }
     logoutRoute = url.href;
   } catch (e) {
     logoutRoute = routes?.logout;
@@ -109,6 +116,9 @@ const IdleLogoutConfirmationModal = ({
     }
     if (appId) {
       url.searchParams.append('originAppId', appId);
+    }
+    if (workspaceId) {
+      url.searchParams.append('originWorkspaceId', workspaceId);
     }
     logoutInactivityRoute = url.href;
   } catch (e) {

--- a/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.test.jsx
+++ b/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.test.jsx
@@ -156,7 +156,7 @@ describe('IdleLogoutConfirmationModal', () => {
     await userEvent.click(modalLogoutButton);
     expect(window.location.href).toBe(expectedAdminPageLogoutRoute);
   });
-  it('user clicks Log Out on the idle logout confirmation dialog (workspac-based page)', async () => {
+  it('user clicks Log Out on the idle logout confirmation dialog (workspace-based page)', async () => {
     render(<IdleLogoutConfirmationModal {...commonProps} onRouteChange={async () => true} />);
     // Simulate a timestamp cookie that is in the past
     Object.defineProperty(window.document, 'cookie', {

--- a/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.test.jsx
+++ b/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.test.jsx
@@ -8,8 +8,12 @@ import SuiteHeaderI18N from '../i18n';
 
 import IdleLogoutConfirmationModal from './IdleLogoutConfirmationModal';
 
+const appId = 'someapp';
+const workspaceId = 'someworkspace';
+
 const commonProps = {
-  appId: 'someapp',
+  appId,
+  workspaceId,
   routes: {
     logout: 'https://www.ibm.com/logout',
     logoutInactivity: 'https://www.ibm.com/inactivity',
@@ -21,14 +25,15 @@ const commonProps = {
 const TIME_INTERVAL = 1000;
 
 describe('IdleLogoutConfirmationModal', () => {
-  const appId = 'someapp';
   const originHref = 'https://ibm.com';
   const expectedLogoutRoute = `${commonProps.routes.logout}?originHref=${encodeURIComponent(
     originHref
-  )}&originAppId=${appId}`;
+  )}&originAppId=${appId}&originWorkspaceId=${workspaceId}`;
   const expectedLogoutInactivityRoute = `${
     commonProps.routes.logoutInactivity
-  }?originHref=${encodeURIComponent(originHref)}&originAppId=${appId}`;
+  }?originHref=${encodeURIComponent(
+    originHref
+  )}&originAppId=${appId}&originWorkspaceId=${workspaceId}`;
 
   let originalWindowLocation;
   let originalWindowDocumentCookie;
@@ -135,12 +140,13 @@ describe('IdleLogoutConfirmationModal', () => {
     await userEvent.click(modalLogoutButton);
     expect(window.location.href).toBe(expectedLogoutRoute);
   });
-  it('user clicks Log Out on the idle logout confirmation dialog (no originHref and no originAppId)', async () => {
+  it('user clicks Log Out on the idle logout confirmation dialog (no originHref, no originAppId and no workspaceId)', async () => {
     window.location = { href: '' };
     render(
       <IdleLogoutConfirmationModal
         {...commonProps}
         appId={undefined}
+        workspaceId={undefined}
         onRouteChange={async () => true}
       />
     );
@@ -188,12 +194,13 @@ describe('IdleLogoutConfirmationModal', () => {
     });
     await waitFor(() => expect(window.location.href).toBe(expectedLogoutInactivityRoute));
   });
-  it('idle user waits for the logout confirmation dialog countdown to finish (no originHref and no originAppId)', async () => {
+  it('idle user waits for the logout confirmation dialog countdown to finish (no originHref, no originAppId and no workspaceId)', async () => {
     window.location = { href: '' };
     render(
       <IdleLogoutConfirmationModal
         {...commonProps}
         appId={undefined}
+        workspaceId={undefined}
         onRouteChange={async () => true}
       />
     );

--- a/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.test.jsx
+++ b/packages/react/src/components/SuiteHeader/IdleLogoutConfirmationModal/IdleLogoutConfirmationModal.test.jsx
@@ -9,6 +9,7 @@ import SuiteHeaderI18N from '../i18n';
 import IdleLogoutConfirmationModal from './IdleLogoutConfirmationModal';
 
 const commonProps = {
+  appId: 'someapp',
   routes: {
     logout: 'https://www.ibm.com/logout',
     logoutInactivity: 'https://www.ibm.com/inactivity',
@@ -20,13 +21,14 @@ const commonProps = {
 const TIME_INTERVAL = 1000;
 
 describe('IdleLogoutConfirmationModal', () => {
+  const appId = 'someapp';
   const originHref = 'https://ibm.com';
   const expectedLogoutRoute = `${commonProps.routes.logout}?originHref=${encodeURIComponent(
     originHref
-  )}`;
+  )}&originAppId=${appId}`;
   const expectedLogoutInactivityRoute = `${
     commonProps.routes.logoutInactivity
-  }?originHref=${encodeURIComponent(originHref)}`;
+  }?originHref=${encodeURIComponent(originHref)}&originAppId=${appId}`;
 
   let originalWindowLocation;
   let originalWindowDocumentCookie;
@@ -133,9 +135,15 @@ describe('IdleLogoutConfirmationModal', () => {
     await userEvent.click(modalLogoutButton);
     expect(window.location.href).toBe(expectedLogoutRoute);
   });
-  it('user clicks Log Out on the idle logout confirmation dialog (no originHref)', async () => {
+  it('user clicks Log Out on the idle logout confirmation dialog (no originHref and no originAppId)', async () => {
     window.location = { href: '' };
-    render(<IdleLogoutConfirmationModal {...commonProps} onRouteChange={async () => true} />);
+    render(
+      <IdleLogoutConfirmationModal
+        {...commonProps}
+        appId={undefined}
+        onRouteChange={async () => true}
+      />
+    );
     // Simulate a timestamp cookie that is in the past
     Object.defineProperty(window.document, 'cookie', {
       writable: true,
@@ -180,9 +188,15 @@ describe('IdleLogoutConfirmationModal', () => {
     });
     await waitFor(() => expect(window.location.href).toBe(expectedLogoutInactivityRoute));
   });
-  it('idle user waits for the logout confirmation dialog countdown to finish (no originHref)', async () => {
+  it('idle user waits for the logout confirmation dialog countdown to finish (no originHref and no originAppId)', async () => {
     window.location = { href: '' };
-    render(<IdleLogoutConfirmationModal {...commonProps} onRouteChange={async () => true} />);
+    render(
+      <IdleLogoutConfirmationModal
+        {...commonProps}
+        appId={undefined}
+        onRouteChange={async () => true}
+      />
+    );
     // Simulate a timestamp cookie that is in the past
     Object.defineProperty(window.document, 'cookie', {
       writable: true,

--- a/packages/react/src/components/SuiteHeader/MultiWorkspaceSuiteHeader.story.jsx
+++ b/packages/react/src/components/SuiteHeader/MultiWorkspaceSuiteHeader.story.jsx
@@ -126,6 +126,10 @@ const nonWorkspaceBasedPageWorkspaces = [...adminPageWorkspaces];
 const workspaceBasedPageWorkspaces = adminPageWorkspaces.map((wo) => ({
   ...wo,
   isCurrent: wo.id === 'workspace3',
+  applications: wo.applications?.map((a) => ({
+    ...a,
+    isCurrent: wo.id === 'workspace3' && a.id === 'manage',
+  })),
 }));
 
 const globalApplications = [

--- a/packages/react/src/components/SuiteHeader/MultiWorkspaceSuiteHeader.test.jsx
+++ b/packages/react/src/components/SuiteHeader/MultiWorkspaceSuiteHeader.test.jsx
@@ -100,6 +100,7 @@ const workspaceBasedPageWorkspaces = adminPageWorkspaces.map((wo) => ({
 
 const adminPageCommonProps = {
   suiteName: 'Application Suite',
+  appId: 'someapp',
   appName: 'Application Name',
   userDisplayName: 'Admin User',
   username: 'adminuser',
@@ -148,13 +149,14 @@ const idleTimeoutDataProp = {
 };
 
 describe('SuiteHeader', () => {
+  const appId = 'someapp';
   const originHref = 'https://ibm.com';
   const expectedLogoutRoute = `${
     adminPageCommonProps.routes.logout
-  }?originHref=${encodeURIComponent(originHref)}`;
+  }?originHref=${encodeURIComponent(originHref)}&originAppId=${appId}`;
   const expectedLogoutInactivityRoute = `${
     adminPageCommonProps.routes.logoutInactivity
-  }?originHref=${encodeURIComponent(originHref)}`;
+  }?originHref=${encodeURIComponent(originHref)}&originAppId=${appId}`;
   let originalWindowLocation;
   let originalWindowDocumentCookie;
   beforeEach(() => {
@@ -257,9 +259,9 @@ describe('SuiteHeader', () => {
     await userEvent.click(screen.getAllByRole('button', { name: 'Log out' })[0]);
     expect(window.location.href).toBe(expectedLogoutRoute);
   });
-  it('clicks logout link (no originHref)', async () => {
+  it('clicks logout link (no originHref and no originAppId)', async () => {
     window.location = { href: '' };
-    render(<SuiteHeader {...adminPageCommonProps} />);
+    render(<SuiteHeader {...adminPageCommonProps} appId={undefined} />);
     await userEvent.click(screen.getAllByRole('button', { name: 'Log out' })[0]);
     expect(window.location.href).toBe(adminPageCommonProps.routes.logout);
   });
@@ -463,9 +465,15 @@ describe('SuiteHeader', () => {
     await userEvent.click(modalLogoutButton);
     expect(window.location.href).toBe(expectedLogoutRoute);
   });
-  it('user clicks Log Out on the idle logout confirmation dialog (no originHref)', async () => {
+  it('user clicks Log Out on the idle logout confirmation dialog (no originHref and no originAppId)', async () => {
     window.location = { href: '' };
-    render(<SuiteHeader {...adminPageCommonProps} idleTimeoutData={idleTimeoutDataProp} />);
+    render(
+      <SuiteHeader
+        {...adminPageCommonProps}
+        idleTimeoutData={idleTimeoutDataProp}
+        appId={undefined}
+      />
+    );
     // Simulate a timestamp cookie that is in the past
     Object.defineProperty(window.document, 'cookie', {
       writable: true,
@@ -516,9 +524,15 @@ describe('SuiteHeader', () => {
     });
     await waitFor(() => expect(window.location.href).toBe(expectedLogoutInactivityRoute));
   });
-  it('idle user waits for the logout confirmation dialog countdown to finish (no originHref)', async () => {
+  it('idle user waits for the logout confirmation dialog countdown to finish (no originHref and no originAppId)', async () => {
     window.location = { href: '' };
-    render(<SuiteHeader {...adminPageCommonProps} idleTimeoutData={idleTimeoutDataProp} />);
+    render(
+      <SuiteHeader
+        {...adminPageCommonProps}
+        idleTimeoutData={idleTimeoutDataProp}
+        appId={undefined}
+      />
+    );
     // Simulate a timestamp cookie that is in the past
     Object.defineProperty(window.document, 'cookie', {
       writable: true,

--- a/packages/react/src/components/SuiteHeader/MultiWorkspaceSuiteHeader.test.jsx
+++ b/packages/react/src/components/SuiteHeader/MultiWorkspaceSuiteHeader.test.jsx
@@ -93,14 +93,16 @@ const adminPageWorkspaces = [
 
 const nonWorkspaceBasedPageWorkspaces = [...adminPageWorkspaces];
 
+const appId = 'someapp';
+const selectedWorkspaceId = 'workspace3';
+
 const workspaceBasedPageWorkspaces = adminPageWorkspaces.map((wo) => ({
   ...wo,
-  isCurrent: wo.id === 'workspace3',
+  isCurrent: wo.id === selectedWorkspaceId,
 }));
 
 const adminPageCommonProps = {
   suiteName: 'Application Suite',
-  appId: 'someapp',
   appName: 'Application Name',
   userDisplayName: 'Admin User',
   username: 'adminuser',
@@ -140,6 +142,7 @@ const workspaceBasedPageCommonProps = {
   ...adminPageCommonProps,
   workspaces: workspaceBasedPageWorkspaces,
   isAdminView: false,
+  appId,
 };
 
 const idleTimeoutDataProp = {
@@ -149,14 +152,17 @@ const idleTimeoutDataProp = {
 };
 
 describe('SuiteHeader', () => {
-  const appId = 'someapp';
   const originHref = 'https://ibm.com';
   const expectedLogoutRoute = `${
     adminPageCommonProps.routes.logout
-  }?originHref=${encodeURIComponent(originHref)}&originAppId=${appId}`;
+  }?originHref=${encodeURIComponent(
+    originHref
+  )}&originAppId=${appId}&originWorkspaceId=${selectedWorkspaceId}`;
   const expectedLogoutInactivityRoute = `${
     adminPageCommonProps.routes.logoutInactivity
-  }?originHref=${encodeURIComponent(originHref)}&originAppId=${appId}`;
+  }?originHref=${encodeURIComponent(
+    originHref
+  )}&originAppId=${appId}&originWorkspaceId=${selectedWorkspaceId}`;
   let originalWindowLocation;
   let originalWindowDocumentCookie;
   beforeEach(() => {
@@ -255,13 +261,13 @@ describe('SuiteHeader', () => {
     expect(screen.getByRole('presentation')).not.toHaveClass('is-visible');
   });
   it('clicks logout link', async () => {
-    render(<SuiteHeader {...adminPageCommonProps} />);
+    render(<SuiteHeader {...workspaceBasedPageCommonProps} />);
     await userEvent.click(screen.getAllByRole('button', { name: 'Log out' })[0]);
     expect(window.location.href).toBe(expectedLogoutRoute);
   });
-  it('clicks logout link (no originHref and no originAppId)', async () => {
+  it('clicks logout link (no originHref, no originAppId and no originAppId)', async () => {
     window.location = { href: '' };
-    render(<SuiteHeader {...adminPageCommonProps} appId={undefined} />);
+    render(<SuiteHeader {...adminPageCommonProps} />);
     await userEvent.click(screen.getAllByRole('button', { name: 'Log out' })[0]);
     expect(window.location.href).toBe(adminPageCommonProps.routes.logout);
   });
@@ -450,7 +456,9 @@ describe('SuiteHeader', () => {
     expect(mockOnStayLoggedIn).toHaveBeenCalled();
   });
   it('user clicks Log Out on the idle logout confirmation dialog', async () => {
-    render(<SuiteHeader {...adminPageCommonProps} idleTimeoutData={idleTimeoutDataProp} />);
+    render(
+      <SuiteHeader {...workspaceBasedPageCommonProps} idleTimeoutData={idleTimeoutDataProp} />
+    );
     // Simulate a timestamp cookie that is in the past
     Object.defineProperty(window.document, 'cookie', {
       writable: true,
@@ -465,15 +473,9 @@ describe('SuiteHeader', () => {
     await userEvent.click(modalLogoutButton);
     expect(window.location.href).toBe(expectedLogoutRoute);
   });
-  it('user clicks Log Out on the idle logout confirmation dialog (no originHref and no originAppId)', async () => {
+  it('user clicks Log Out on the idle logout confirmation dialog (no originHref, no originAppId and no originAppId)', async () => {
     window.location = { href: '' };
-    render(
-      <SuiteHeader
-        {...adminPageCommonProps}
-        idleTimeoutData={idleTimeoutDataProp}
-        appId={undefined}
-      />
-    );
+    render(<SuiteHeader {...adminPageCommonProps} idleTimeoutData={idleTimeoutDataProp} />);
     // Simulate a timestamp cookie that is in the past
     Object.defineProperty(window.document, 'cookie', {
       writable: true,
@@ -511,7 +513,9 @@ describe('SuiteHeader', () => {
     expect(window.location.href).not.toBe(expectedLogoutRoute);
   });
   it('idle user waits for the logout confirmation dialog countdown to finish', async () => {
-    render(<SuiteHeader {...adminPageCommonProps} idleTimeoutData={idleTimeoutDataProp} />);
+    render(
+      <SuiteHeader {...workspaceBasedPageCommonProps} idleTimeoutData={idleTimeoutDataProp} />
+    );
     // Simulate a timestamp cookie that is in the past
     Object.defineProperty(window.document, 'cookie', {
       writable: true,
@@ -524,15 +528,9 @@ describe('SuiteHeader', () => {
     });
     await waitFor(() => expect(window.location.href).toBe(expectedLogoutInactivityRoute));
   });
-  it('idle user waits for the logout confirmation dialog countdown to finish (no originHref and no originAppId)', async () => {
+  it('idle user waits for the logout confirmation dialog countdown to finish (no originHref, no originAppId and no originAppId)', async () => {
     window.location = { href: '' };
-    render(
-      <SuiteHeader
-        {...adminPageCommonProps}
-        idleTimeoutData={idleTimeoutDataProp}
-        appId={undefined}
-      />
-    );
+    render(<SuiteHeader {...adminPageCommonProps} idleTimeoutData={idleTimeoutDataProp} />);
     // Simulate a timestamp cookie that is in the past
     Object.defineProperty(window.document, 'cookie', {
       writable: true,

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
@@ -38,6 +38,7 @@ import { SUITE_HEADER_ROUTE_TYPES } from './suiteHeaderConstants';
 
 const defaultProps = {
   className: null,
+  appId: null,
   appName: null,
   extraContent: null,
   userDisplayName: null,
@@ -70,6 +71,8 @@ const propTypes = {
   className: PropTypes.string,
   /** Name of suite (maps to appName in Header) */
   suiteName: PropTypes.string.isRequired,
+  /** Application ID in suite */
+  appId: PropTypes.string,
   /** Application name in suite (maps to subtitle in Header) */
   appName: PropTypes.string,
   /** Extra content (a Tag, for example) */
@@ -126,6 +129,7 @@ const propTypes = {
 const SuiteHeader = ({
   className,
   suiteName,
+  appId,
   appName,
   extraContent,
   userDisplayName,
@@ -192,14 +196,17 @@ const SuiteHeader = ({
 
   const navigatorRoute = currentWorkspace?.href || routes?.navigator || 'javascript:void(0)';
   const adminRoute = routes?.admin || 'javascript:void(0)';
-  // Append originHref query parameter to the logout route
+  // Append originHref query parameter (and, optionally, originAppId) to the logout route
   let logoutRoute = routes?.logout;
   try {
     const url = new URL(routes.logout);
     if (window.location.href) {
       url.searchParams.append('originHref', window.location.href);
-      logoutRoute = url.href;
     }
+    if (appId) {
+      url.searchParams.append('originAppId', appId);
+    }
+    logoutRoute = url.href;
   } catch (e) {
     logoutRoute = routes?.logout;
   }
@@ -280,6 +287,7 @@ const SuiteHeader = ({
       ) : null}
       {idleTimeoutData && routes?.domain !== null && routes?.domain !== undefined ? (
         <IdleLogoutConfirmationModal
+          appId={appId}
           idleTimeoutData={idleTimeoutData}
           routes={routes}
           onRouteChange={onRouteChange}

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
@@ -38,7 +38,6 @@ import { SUITE_HEADER_ROUTE_TYPES } from './suiteHeaderConstants';
 
 const defaultProps = {
   className: null,
-  appId: null,
   appName: null,
   extraContent: null,
   userDisplayName: null,
@@ -71,8 +70,6 @@ const propTypes = {
   className: PropTypes.string,
   /** Name of suite (maps to appName in Header) */
   suiteName: PropTypes.string.isRequired,
-  /** Application ID in suite */
-  appId: PropTypes.string,
   /** Application name in suite (maps to subtitle in Header) */
   appName: PropTypes.string,
   /** Extra content (a Tag, for example) */
@@ -129,7 +126,6 @@ const propTypes = {
 const SuiteHeader = ({
   className,
   suiteName,
-  appId,
   appName,
   extraContent,
   userDisplayName,
@@ -175,6 +171,9 @@ const SuiteHeader = ({
 
   const isMultiWorkspace = workspaces?.length > 0;
   const currentWorkspace = workspaces?.find((wo) => wo.isCurrent);
+  const appId =
+    currentWorkspace?.applications?.find((a) => a.isCurrent)?.id ??
+    applications?.find((a) => a.isCurrent)?.id;
   // Include the current workspace label only if we are not in an admin page and multi workspace is supported and more than one workspace is available
   const currentWorkspaceComponent =
     !isAdminView && isMultiWorkspace && workspaces?.length > 1 && currentWorkspace ? (
@@ -208,6 +207,9 @@ const SuiteHeader = ({
     }
     if (currentWorkspace?.id) {
       url.searchParams.append('originWorkspaceId', currentWorkspace.id);
+    }
+    if (isAdminView) {
+      url.searchParams.append('originIsAdmin', isAdminView);
     }
     logoutRoute = url.href;
   } catch (e) {
@@ -290,6 +292,7 @@ const SuiteHeader = ({
       ) : null}
       {idleTimeoutData && routes?.domain !== null && routes?.domain !== undefined ? (
         <IdleLogoutConfirmationModal
+          isAdminView={isAdminView}
           appId={appId}
           workspaceId={currentWorkspace?.id}
           idleTimeoutData={idleTimeoutData}

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
@@ -195,7 +195,7 @@ const SuiteHeader = ({
 
   const navigatorRoute = currentWorkspace?.href || routes?.navigator || 'javascript:void(0)';
   const adminRoute = routes?.admin || 'javascript:void(0)';
-  // Append originHref query parameter (and, optionally, originAppId) to the logout route
+  // Append originHref query parameter (and, optionally, originIsAdmin, originWorkspaceId and originAppId) to the logout route
   let logoutRoute = routes?.logout;
   try {
     const url = new URL(routes.logout);

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
@@ -206,6 +206,9 @@ const SuiteHeader = ({
     if (appId) {
       url.searchParams.append('originAppId', appId);
     }
+    if (currentWorkspace?.id) {
+      url.searchParams.append('originWorkspaceId', currentWorkspace.id);
+    }
     logoutRoute = url.href;
   } catch (e) {
     logoutRoute = routes?.logout;
@@ -288,6 +291,7 @@ const SuiteHeader = ({
       {idleTimeoutData && routes?.domain !== null && routes?.domain !== undefined ? (
         <IdleLogoutConfirmationModal
           appId={appId}
+          workspaceId={currentWorkspace?.id}
           idleTimeoutData={idleTimeoutData}
           routes={routes}
           onRouteChange={onRouteChange}

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
@@ -14,6 +14,7 @@ const { prefix } = settings;
 
 const commonProps = {
   suiteName: 'Application Suite',
+  appId: 'someapp',
   appName: 'Application Name',
   userDisplayName: 'Admin User',
   username: 'adminuser',
@@ -55,13 +56,14 @@ const idleTimeoutDataProp = {
 };
 
 describe('SuiteHeader', () => {
+  const appId = 'someapp';
   const originHref = 'https://ibm.com';
   const expectedLogoutRoute = `${commonProps.routes.logout}?originHref=${encodeURIComponent(
     originHref
-  )}`;
+  )}&originAppId=${appId}`;
   const expectedLogoutInactivityRoute = `${
     commonProps.routes.logoutInactivity
-  }?originHref=${encodeURIComponent(originHref)}`;
+  }?originHref=${encodeURIComponent(originHref)}&originAppId=${appId}`;
   let originalWindowLocation;
   let originalWindowDocumentCookie;
   beforeEach(() => {
@@ -162,9 +164,9 @@ describe('SuiteHeader', () => {
     await userEvent.click(screen.getAllByRole('button', { name: 'Log out' })[0]);
     expect(window.location.href).toBe(expectedLogoutRoute);
   });
-  it('clicks logout link (no originHref)', async () => {
+  it('clicks logout link (no originHref and no originAppId)', async () => {
     window.location = { href: '' };
-    render(<SuiteHeader {...commonProps} />);
+    render(<SuiteHeader {...commonProps} appId={undefined} />);
     await userEvent.click(screen.getAllByRole('button', { name: 'Log out' })[0]);
     expect(window.location.href).toBe(commonProps.routes.logout);
   });
@@ -386,9 +388,11 @@ describe('SuiteHeader', () => {
     await userEvent.click(modalLogoutButton);
     expect(window.location.href).toBe(expectedLogoutRoute);
   });
-  it('user clicks Log Out on the idle logout confirmation dialog (no originHref)', async () => {
+  it('user clicks Log Out on the idle logout confirmation dialog (no originHref and no originAppId)', async () => {
     window.location = { href: '' };
-    render(<SuiteHeader {...commonProps} idleTimeoutData={idleTimeoutDataProp} />);
+    render(
+      <SuiteHeader {...commonProps} idleTimeoutData={idleTimeoutDataProp} appId={undefined} />
+    );
     // Simulate a timestamp cookie that is in the past
     Object.defineProperty(window.document, 'cookie', {
       writable: true,
@@ -439,9 +443,11 @@ describe('SuiteHeader', () => {
     });
     await waitFor(() => expect(window.location.href).toBe(expectedLogoutInactivityRoute));
   });
-  it('idle user waits for the logout confirmation dialog countdown to finish (no originHref)', async () => {
+  it('idle user waits for the logout confirmation dialog countdown to finish (no originHref and no originAppId)', async () => {
     window.location = { href: '' };
-    render(<SuiteHeader {...commonProps} idleTimeoutData={idleTimeoutDataProp} />);
+    render(
+      <SuiteHeader {...commonProps} idleTimeoutData={idleTimeoutDataProp} appId={undefined} />
+    );
     // Simulate a timestamp cookie that is in the past
     Object.defineProperty(window.document, 'cookie', {
       writable: true,

--- a/packages/react/src/components/SuiteHeader/hooks/useUiResources.js
+++ b/packages/react/src/components/SuiteHeader/hooks/useUiResources.js
@@ -7,6 +7,7 @@ const useUiResources = ({
   baseApiUrl,
   lang = 'en',
   surveyId = null,
+  appId = null,
   workspaceId = null,
   fetchApi = defaultFetchApi,
   isTest = false,
@@ -32,6 +33,7 @@ const useUiResources = ({
         baseApiUrl,
         lang,
         surveyId,
+        appId,
         workspaceId,
         fetchApi,
         isTest,
@@ -42,7 +44,7 @@ const useUiResources = ({
     } finally {
       setIsLoading(false);
     }
-  }, [baseApiUrl, lang, surveyId, workspaceId, isTest, setIsLoading]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [baseApiUrl, lang, surveyId, appId, workspaceId, isTest, setIsLoading]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     // load actual data

--- a/packages/react/src/components/SuiteHeader/util/uiresources.js
+++ b/packages/react/src/components/SuiteHeader/util/uiresources.js
@@ -24,6 +24,7 @@ const getUiResourcesData = async ({
   baseApiUrl,
   lang = 'en',
   surveyId = null,
+  appId = null,
   workspaceId = null,
   fetchApi = defaultFetchApi,
   isTest = false,
@@ -39,8 +40,12 @@ const getUiResourcesData = async ({
 
   const langParam = `&lang=${lang}`;
   const surveyIdParam = surveyId ? `&surveyId=${surveyId}` : '';
+  const appIdParam = appId ? `&appId=${appId}` : '';
   const workspaceIdParam = workspaceId ? `&workspaceId=${workspaceId}` : '';
-  return api('GET', `/uiresources?id=masthead${langParam}${surveyIdParam}${workspaceIdParam}`);
+  return api(
+    'GET',
+    `/uiresources?id=masthead${langParam}${surveyIdParam}${appIdParam}${workspaceIdParam}`
+  );
 };
 
 export default getUiResourcesData;

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -11614,6 +11614,7 @@ Map {
       "SURVEY": "SURVEY",
     },
     "defaultProps": Object {
+      "appId": null,
       "appName": null,
       "applications": null,
       "className": null,
@@ -11680,6 +11681,9 @@ Map {
       "workspaces": null,
     },
     "propTypes": Object {
+      "appId": Object {
+        "type": "string",
+      },
       "appName": Object {
         "type": "string",
       },
@@ -12900,6 +12904,7 @@ Map {
   },
   "IdleLogoutConfirmationModal" => Object {
     "defaultProps": Object {
+      "appId": null,
       "className": null,
       "i18n": Object {
         "closeButtonLabel": "Close",
@@ -12916,8 +12921,12 @@ Map {
       "onRouteChange": [Function],
       "onStayLoggedIn": [Function],
       "routes": null,
+      "workspaceId": null,
     },
     "propTypes": Object {
+      "appId": Object {
+        "type": "string",
+      },
       "className": Object {
         "type": "string",
       },
@@ -12977,6 +12986,9 @@ Map {
           },
         ],
         "type": "shape",
+      },
+      "workspaceId": Object {
+        "type": "string",
       },
     },
   },

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -11614,7 +11614,6 @@ Map {
       "SURVEY": "SURVEY",
     },
     "defaultProps": Object {
-      "appId": null,
       "appName": null,
       "applications": null,
       "className": null,
@@ -11681,9 +11680,6 @@ Map {
       "workspaces": null,
     },
     "propTypes": Object {
-      "appId": Object {
-        "type": "string",
-      },
       "appName": Object {
         "type": "string",
       },
@@ -12918,6 +12914,7 @@ Map {
         "countdown": 30,
         "timeout": 1800,
       },
+      "isAdminView": null,
       "onRouteChange": [Function],
       "onStayLoggedIn": [Function],
       "routes": null,
@@ -12964,6 +12961,9 @@ Map {
           },
         ],
         "type": "shape",
+      },
+      "isAdminView": Object {
+        "type": "bool",
       },
       "onRouteChange": Object {
         "type": "func",


### PR DESCRIPTION
**Summary**

- In `SuiteHeader` component, the following query parameters are now being appended to the logout (and inactivity logout) URL: `originIsAdmin` (when the page that triggered the logout was an admin page), `originWorkspaceId` (when the page that triggered the logout was a workspace-based page) and `originAppId` (when the page that triggered the logout was an application page).
- In `uiresources` API helper and `useUiResources` hook, support has been added for the `appId` parameter so that apps that instantiate `SuiteHeader` can pass the `appId` to the API that will be used by the component when assembling the logout URL (to include the `originAppId` parameter).
- Adjusting unit tests to account for the new query parameters added to the logout URL.

**Acceptance Test (how to verify the PR)**

- Unit tests have been added and existing tests have been adjusted to make sure the new query parameters in the logout URL are taken into account.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- All existing tests are passing.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
