### PR TITLE
fix(table): reset filter after selecting a row

### DIFF
--- a/packages/react/src/components/Table/baseTableReducer.js
+++ b/packages/react/src/components/Table/baseTableReducer.js
@@ -265,7 +265,8 @@ export const baseTableReducer = (state = {}, action) => {
       const isClearing = isMultiSelect && selectedIds.length === 0;
 
       const allRowsId = [];
-      state.data.forEach((row) => fillArrWithRowIds(row, allRowsId));
+      const iterables = state.view.table.filteredData || state.data;
+      iterables.forEach((row) => fillArrWithRowIds(row, allRowsId));
       const isSelectingAll = isMultiSelect && selectedIds.length === allRowsId.length;
 
       return update(state, {
@@ -289,7 +290,8 @@ export const baseTableReducer = (state = {}, action) => {
 
       const selectedIds = [];
       if (isSelected) {
-        state.data.forEach((row) => fillArrWithRowIds(row, selectedIds));
+        const iterables = state.view.table.filteredData || state.data;
+        iterables.forEach((row) => fillArrWithRowIds(row, selectedIds));
       }
 
       return update(state, {

--- a/packages/react/src/components/Table/tableReducer.js
+++ b/packages/react/src/components/Table/tableReducer.js
@@ -365,6 +365,7 @@ export const tableReducer = (state = {}, action) => {
         action
       );
     case TABLE_SEARCH_APPLY: {
+      // console.log(state.data.length)
       // Quick search should search within the filtered and sorted data
       const data = filterSearchAndSort(
         state.data,
@@ -506,12 +507,10 @@ export const tableReducer = (state = {}, action) => {
     }
 
     case TABLE_ROW_SELECT: {
-      const data = state.view.table.filteredData || state.data;
-      return baseTableReducer({ ...state, data }, action);
+      return baseTableReducer(state, action);
     }
     case TABLE_ROW_SELECT_ALL: {
-      const data = state.view.table.filteredData || state.data;
-      return baseTableReducer({ ...state, data }, action);
+      return baseTableReducer(state, action);
     }
     // By default we need to setup our sorted and filteredData and turn off the loading state
     case TABLE_REGISTER: {

--- a/packages/react/src/components/Table/tableReducer.test.jsx
+++ b/packages/react/src/components/Table/tableReducer.test.jsx
@@ -521,6 +521,34 @@ describe('table reducer', () => {
       expect(tableWithSelectedRow.view.table.isSelectAllIndeterminate).toEqual(false);
     });
 
+    it('TABLE_ROW_SELECT with filtered data', () => {
+      // Init with filtering
+      const filteredTable = tableReducer(initialState, tableRegister({ data: initialState.data }));
+      expect(filteredTable.view.table.filteredData).toHaveLength(14);
+      expect(filteredTable.data).toHaveLength(initialState.data.length);
+
+      // Select a row
+      const tableWithSelectedRow = tableReducer(filteredTable, tableRowSelect(['row-1'], 'multi'));
+      expect(tableWithSelectedRow.view.table.selectedIds).toEqual(['row-1']);
+      expect(tableWithSelectedRow.view.table.isSelectAllSelected).toEqual(false);
+      expect(tableWithSelectedRow.view.table.isSelectAllIndeterminate).toEqual(true);
+
+      // Unselect the row
+      const tableWithUnSelectedRow = tableReducer(
+        tableWithSelectedRow,
+        tableRowSelect([], 'multi')
+      );
+      expect(tableWithUnSelectedRow.view.table.selectedIds).toEqual([]);
+      expect(tableWithUnSelectedRow.view.table.isSelectAllSelected).toEqual(false);
+      expect(tableWithUnSelectedRow.view.table.isSelectAllIndeterminate).toEqual(false);
+
+      // Reset filter
+      const tableFilteredReset = tableReducer(tableWithUnSelectedRow, tableFilterApply({}));
+      expect(tableFilteredReset.view.filters).toEqual([]);
+      expect(tableFilteredReset.view.table.filteredData).toHaveLength(initialState.data.length);
+      expect(tableFilteredReset.data).toHaveLength(initialState.data.length);
+    });
+
     it('TABLE_ROW_SELECT_ALL', () => {
       expect(initialState.view.table.selectedIds).toEqual([]);
       // Select all
@@ -555,6 +583,29 @@ describe('table reducer', () => {
       expect(tableWithUnSelectedAll.view.table.selectedIds.length).toEqual(0);
       expect(tableWithUnSelectedAll.view.table.isSelectAllIndeterminate).toEqual(false);
       expect(tableWithUnSelectedAll.view.table.isSelectAllSelected).toEqual(false);
+    });
+
+    it('TABLE_ROW_SELECT_ALL with filtered data', () => {
+      // Init with filtering
+      const filteredTable = tableReducer(initialState, tableRegister({ data: initialState.data }));
+      expect(filteredTable.view.table.filteredData).toHaveLength(14);
+      expect(filteredTable.data).toHaveLength(initialState.data.length);
+
+      // Select all
+      const tableWithSelectedAll = tableReducer(filteredTable, tableRowSelectAll(true));
+      expect(tableWithSelectedAll.view.table.filteredData).toHaveLength(14);
+      expect(tableWithSelectedAll.view.table.selectedIds).toHaveLength(14);
+
+      // Unselect all
+      const tableWithUnSelectedAll = tableReducer(tableWithSelectedAll, tableRowSelectAll(false));
+      expect(tableWithSelectedAll.view.table.filteredData).toHaveLength(14);
+      expect(tableWithUnSelectedAll.view.table.selectedIds.length).toEqual(0);
+
+      // Reset filter
+      const tableFilteredReset = tableReducer(tableWithUnSelectedAll, tableFilterApply({}));
+      expect(tableFilteredReset.view.filters).toEqual([]);
+      expect(tableFilteredReset.view.table.filteredData).toHaveLength(initialState.data.length);
+      expect(tableFilteredReset.data).toHaveLength(initialState.data.length);
     });
 
     it('TABLE_ROW_SELECT_ALL with nested rows should skip non selectable rows', () => {


### PR DESCRIPTION
Closes #3686 

**Summary**

- Reset table state after filtering and row selection has been cleared.

**Change List (commits, features, bugs, etc)**

- Modify `tableReducer.js`
- Add tests

**Acceptance Test (how to verify the PR)**

- Go to [this story](https://deploy-preview-3687--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table--playground)
- In `Sort & filter` tab enable `hasFilter: true`
- In `Selections & actions` tab enable `useRadioButtonSingleSelect` and `hasRowSelection: multi`
- Apply some filter, for example `Select` column
- Select some row or click select all rows
- Unselect chosen rows
- Reset the filter
- Verify that table data returned to initial state

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
