### PR TITLE
fix(table): pagination, toolbar toolips; (card): tooltip

### DIFF
--- a/packages/react/src/components/Card/Card.test.e2e.jsx
+++ b/packages/react/src/components/Card/Card.test.e2e.jsx
@@ -95,7 +95,10 @@ describe('Card', () => {
     cy.findByTestId('Card-title-tooltip').should('exist');
     cy.findByTestId('Card-title-tooltip').should('be.visible');
 
-    cy.scrollTo(0, 500, {
+    cy.scrollTo('bottom', {
+      duration: 500,
+    });
+    cy.scrollTo('top', {
       duration: 500,
     });
 
@@ -126,7 +129,10 @@ describe('Card', () => {
     cy.findByTestId('Card-subtitle').should('exist');
     cy.findByTestId('Card-subtitle').should('be.visible');
 
-    cy.scrollTo(0, 500, {
+    cy.scrollTo('bottom', {
+      duration: 500,
+    });
+    cy.scrollTo('top', {
       duration: 500,
     });
 
@@ -154,7 +160,10 @@ describe('Card', () => {
     cy.findByTestId('Card-tooltip').should('exist');
     cy.findByTestId('Card-tooltip').should('be.visible');
 
-    cy.scrollTo(0, 500, {
+    cy.scrollTo('bottom', {
+      duration: 500,
+    });
+    cy.scrollTo('top', {
       duration: 500,
     });
 

--- a/packages/react/src/components/Card/Card.test.e2e.jsx
+++ b/packages/react/src/components/Card/Card.test.e2e.jsx
@@ -95,7 +95,9 @@ describe('Card', () => {
     cy.findByTestId('Card-title-tooltip').should('exist');
     cy.findByTestId('Card-title-tooltip').should('be.visible');
 
-    cy.scrollTo(0, 50);
+    cy.scrollTo(0, 250, {
+      duration: 300,
+    });
 
     cy.findByTestId('Card-title-tooltip').should('not.exist');
   });
@@ -124,7 +126,9 @@ describe('Card', () => {
     cy.findByTestId('Card-subtitle').should('exist');
     cy.findByTestId('Card-subtitle').should('be.visible');
 
-    cy.scrollTo(0, 50);
+    cy.scrollTo(0, 250, {
+      duration: 300,
+    });
 
     cy.findByTestId('Card-subtitle').should('not.exist');
   });
@@ -150,7 +154,9 @@ describe('Card', () => {
     cy.findByTestId('Card-tooltip').should('exist');
     cy.findByTestId('Card-tooltip').should('be.visible');
 
-    cy.scrollTo(0, 50);
+    cy.scrollTo(0, 250, {
+      duration: 300,
+    });
 
     cy.findByTestId('Card-tooltip').should('not.exist');
   });

--- a/packages/react/src/components/Card/Card.test.e2e.jsx
+++ b/packages/react/src/components/Card/Card.test.e2e.jsx
@@ -3,6 +3,7 @@ import { mount } from '@cypress/react';
 
 import { getCardMinSize } from '../../utils/componentUtilityFunctions';
 import { CARD_SIZES } from '../../constants/LayoutConstants';
+import Button from '../Button';
 
 import Card from './Card';
 
@@ -340,6 +341,147 @@ describe('Card', () => {
         const rect = $el[0].getBoundingClientRect();
         expect(rect.right).not.to.be.greaterThan(windowWidth);
         expect(rect.bottom).not.to.be.greaterThan(windowHeight);
+      });
+    });
+
+    it('should auto adjust tooltip with text and button', () => {
+      const shortTitle =
+        'Card Title that should be truncated and presented in a tooltip while the cards also has an external tooltip.';
+      const titleTextTooltip = (
+        <>
+          <p>This is the external tooltip definition shown when the title is clicked</p>
+          <Button style={{ marginTop: '16px' }}>Take action</Button>
+        </>
+      );
+
+      mount(
+        <>
+          <div
+            style={{
+              height: '1900px',
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'flex-start',
+            }}
+          >
+            <Card
+              testId="top-left"
+              style={{ width: `${getCardMinSize(breakpoint, size).x}px` }}
+              title={shortTitle}
+              subtitle={subtitle}
+              size={size}
+              breakpoint={breakpoint}
+              titleTextTooltip={titleTextTooltip}
+            />
+            <Card
+              testId="top-right"
+              style={{ width: `${getCardMinSize(breakpoint, size).x}px` }}
+              title={shortTitle}
+              subtitle={subtitle}
+              size={size}
+              breakpoint={breakpoint}
+              titleTextTooltip={titleTextTooltip}
+            />
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+            }}
+          >
+            <Card
+              testId="bottom-left"
+              style={{ width: `${getCardMinSize(breakpoint, size).x}px` }}
+              title={shortTitle}
+              subtitle={subtitle}
+              size={size}
+              breakpoint={breakpoint}
+              titleTextTooltip={titleTextTooltip}
+            />
+            <Card
+              testId="bottom-right"
+              style={{ width: `${getCardMinSize(breakpoint, size).x}px` }}
+              title={shortTitle}
+              subtitle={subtitle}
+              size={size}
+              breakpoint={breakpoint}
+              titleTextTooltip={titleTextTooltip}
+            />
+          </div>
+        </>
+      );
+
+      const windowWidth = Cypress.$(cy.state('window')).width();
+      const windowHeight = Cypress.$(cy.state('window')).height();
+
+      // top left card
+      cy.findAllByRole('button', { name: shortTitle }).eq(0).click();
+      cy.findByTestId('top-left-title-tooltip').then(($el) => {
+        const rect = $el[0].getBoundingClientRect();
+        expect(rect.left).to.be.greaterThan(0);
+        expect(rect.top).to.be.greaterThan(0);
+        expect($el).to.be.visible;
+      });
+
+      cy.findAllByRole('button', { name: subtitle }).eq(0).click();
+      cy.findByTestId('top-left-subtitle').then(($el) => {
+        const rect = $el[0].getBoundingClientRect();
+        expect(rect.left).to.be.greaterThan(0);
+        expect(rect.top).to.be.greaterThan(0);
+        expect($el).to.be.visible;
+      });
+
+      // top right card
+      cy.findAllByRole('button', { name: shortTitle }).eq(1).click();
+      cy.findByTestId('top-right-title-tooltip').then(($el) => {
+        const rect = $el[0].getBoundingClientRect();
+        expect(rect.right).not.to.be.greaterThan(windowWidth);
+        expect(rect.top).to.be.greaterThan(0);
+        expect($el).to.be.visible;
+      });
+
+      cy.findAllByRole('button', { name: subtitle }).eq(1).click();
+      cy.findByTestId('top-right-subtitle').then(($el) => {
+        const rect = $el[0].getBoundingClientRect();
+        expect(rect.right).not.to.be.greaterThan(windowWidth);
+        expect(rect.top).to.be.greaterThan(0);
+        expect($el).to.be.visible;
+      });
+
+      cy.scrollTo('bottom');
+
+      // bottom left card
+      cy.findAllByRole('button', { name: shortTitle }).eq(2).click();
+      cy.findByTestId('bottom-left-title-tooltip').then(($el) => {
+        const rect = $el[0].getBoundingClientRect();
+        expect(rect.left).to.be.greaterThan(0);
+        expect(rect.bottom).not.to.be.greaterThan(windowHeight);
+        expect($el).to.be.visible;
+      });
+
+      cy.findAllByRole('button', { name: subtitle }).eq(2).click();
+      cy.findByTestId('bottom-left-subtitle').then(($el) => {
+        const rect = $el[0].getBoundingClientRect();
+        expect(rect.left).to.be.greaterThan(0);
+        expect(rect.bottom).not.to.be.greaterThan(windowHeight);
+        expect($el).to.be.visible;
+      });
+
+      // bottom right card
+      cy.findAllByRole('button', { name: shortTitle }).eq(3).click();
+      cy.findByTestId('bottom-right-title-tooltip').then(($el) => {
+        const rect = $el[0].getBoundingClientRect();
+        expect(rect.right).not.to.be.greaterThan(windowWidth);
+        expect(rect.bottom).not.to.be.greaterThan(windowHeight);
+        expect($el).to.be.visible;
+      });
+
+      cy.findAllByRole('button', { name: subtitle }).eq(3).click();
+      cy.findByTestId('bottom-right-subtitle').then(($el) => {
+        const rect = $el[0].getBoundingClientRect();
+        expect(rect.right).not.to.be.greaterThan(windowWidth);
+        expect(rect.bottom).not.to.be.greaterThan(windowHeight);
+        expect($el).to.be.visible;
       });
     });
   });

--- a/packages/react/src/components/Card/Card.test.e2e.jsx
+++ b/packages/react/src/components/Card/Card.test.e2e.jsx
@@ -95,11 +95,8 @@ describe('Card', () => {
     cy.findByTestId('Card-title-tooltip').should('exist');
     cy.findByTestId('Card-title-tooltip').should('be.visible');
 
-    cy.scrollTo('bottom', {
-      duration: 500,
-    });
-    cy.scrollTo('top', {
-      duration: 500,
+    cy.scrollTo(0, 250, {
+      duration: 300,
     });
 
     cy.findByTestId('Card-title-tooltip').should('not.exist');
@@ -129,11 +126,8 @@ describe('Card', () => {
     cy.findByTestId('Card-subtitle').should('exist');
     cy.findByTestId('Card-subtitle').should('be.visible');
 
-    cy.scrollTo('bottom', {
-      duration: 500,
-    });
-    cy.scrollTo('top', {
-      duration: 500,
+    cy.scrollTo(0, 250, {
+      duration: 300,
     });
 
     cy.findByTestId('Card-subtitle').should('not.exist');
@@ -160,11 +154,8 @@ describe('Card', () => {
     cy.findByTestId('Card-tooltip').should('exist');
     cy.findByTestId('Card-tooltip').should('be.visible');
 
-    cy.scrollTo('bottom', {
-      duration: 500,
-    });
-    cy.scrollTo('top', {
-      duration: 500,
+    cy.scrollTo(0, 250, {
+      duration: 300,
     });
 
     cy.findByTestId('Card-tooltip').should('not.exist');

--- a/packages/react/src/components/Card/Card.test.e2e.jsx
+++ b/packages/react/src/components/Card/Card.test.e2e.jsx
@@ -95,8 +95,8 @@ describe('Card', () => {
     cy.findByTestId('Card-title-tooltip').should('exist');
     cy.findByTestId('Card-title-tooltip').should('be.visible');
 
-    cy.scrollTo(0, 250, {
-      duration: 300,
+    cy.scrollTo(0, 500, {
+      duration: 500,
     });
 
     cy.findByTestId('Card-title-tooltip').should('not.exist');
@@ -126,8 +126,8 @@ describe('Card', () => {
     cy.findByTestId('Card-subtitle').should('exist');
     cy.findByTestId('Card-subtitle').should('be.visible');
 
-    cy.scrollTo(0, 250, {
-      duration: 300,
+    cy.scrollTo(0, 500, {
+      duration: 500,
     });
 
     cy.findByTestId('Card-subtitle').should('not.exist');
@@ -154,8 +154,8 @@ describe('Card', () => {
     cy.findByTestId('Card-tooltip').should('exist');
     cy.findByTestId('Card-tooltip').should('be.visible');
 
-    cy.scrollTo(0, 250, {
-      duration: 300,
+    cy.scrollTo(0, 500, {
+      duration: 500,
     });
 
     cy.findByTestId('Card-tooltip').should('not.exist');

--- a/packages/react/src/components/Card/CardTitle.jsx
+++ b/packages/react/src/components/Card/CardTitle.jsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { Tooltip } from 'carbon-components-react';
+import throttle from 'lodash-es/throttle';
 
 import useHasTextOverflow from '../../hooks/useHasTextOverflow';
 import { usePopoverPositioning } from '../../hooks/usePopoverPositioning';
@@ -10,6 +11,11 @@ import { settings } from '../../constants/Settings';
 
 const { iotPrefix } = settings;
 
+const SCROLL_THROTTLE_TIMEOUT = 10;
+const SCROLL_THROTTLE_OPTIONS = {
+  leading: false,
+  trailing: false,
+};
 const isEngagingEventType = (type) => type === 'click' || type === 'keydown';
 
 const propTypes = {
@@ -101,32 +107,78 @@ export const CardTitle = (
     }
   }, []);
 
+  const handleTitleScroll = useCallback(
+    throttle(
+      () => {
+        setTooltipsState((prevState) => ({
+          ...prevState,
+          title: false,
+        }));
+      },
+      SCROLL_THROTTLE_TIMEOUT,
+      SCROLL_THROTTLE_OPTIONS
+    ),
+    []
+  );
+
+  const handleSubtitleScroll = useCallback(
+    throttle(
+      () => {
+        setTooltipsState((prevState) => ({
+          ...prevState,
+          subtitle: false,
+        }));
+      },
+      SCROLL_THROTTLE_TIMEOUT,
+      SCROLL_THROTTLE_OPTIONS
+    ),
+    []
+  );
+
+  const handleInfoScroll = useCallback(
+    throttle(
+      () => {
+        setTooltipsState((prevState) => ({
+          ...prevState,
+          info: false,
+        }));
+      },
+      SCROLL_THROTTLE_TIMEOUT,
+      SCROLL_THROTTLE_OPTIONS
+    ),
+    []
+  );
+
   // ignore due to window event listeners
   /* istanbul ignore next */
   useEffect(() => {
-    const handleScroll = () => {
-      const isSomeTooltipOpen = Object.values(tooltipsState).some((isOpen) => isOpen);
+    if (tooltipsState.title) {
+      window.addEventListener('scroll', handleTitleScroll);
+    } else {
+      window.removeEventListener('scroll', handleTitleScroll);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tooltipsState.title]);
 
-      /* istanbul ignore else */
-      if (isSomeTooltipOpen) {
-        setTooltipsState((prevState) =>
-          Object.keys(prevState).reduce(
-            (attrs, key) => ({
-              ...attrs,
-              [key]: false,
-            }),
-            {}
-          )
-        );
-      }
-    };
+  /* istanbul ignore next */
+  useEffect(() => {
+    if (tooltipsState.subtitle) {
+      window.addEventListener('scroll', handleSubtitleScroll);
+    } else {
+      window.removeEventListener('scroll', handleSubtitleScroll);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tooltipsState.subtitle]);
 
-    window.addEventListener('scroll', handleScroll);
-
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-    };
-  }, [tooltipsState]);
+  /* istanbul ignore next */
+  useEffect(() => {
+    if (tooltipsState.info) {
+      window.addEventListener('scroll', handleInfoScroll);
+    } else {
+      window.removeEventListener('scroll', handleInfoScroll);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tooltipsState.info]);
 
   const renderMainTitle = () =>
     hasTitleTooltipFromTruncation || hasExternalTitleTextTooltip ? (

--- a/packages/react/src/components/Card/CardTitle.jsx
+++ b/packages/react/src/components/Card/CardTitle.jsx
@@ -107,6 +107,8 @@ export const CardTitle = (
     }
   }, []);
 
+  // below statements are ignored due to window event listeners (tested in cypress)
+  /* istanbul ignore next */
   const handleTitleScroll = useCallback(
     throttle(
       () => {
@@ -121,6 +123,7 @@ export const CardTitle = (
     []
   );
 
+  /* istanbul ignore next */
   const handleSubtitleScroll = useCallback(
     throttle(
       () => {
@@ -135,6 +138,7 @@ export const CardTitle = (
     []
   );
 
+  /* istanbul ignore next */
   const handleInfoScroll = useCallback(
     throttle(
       () => {
@@ -149,7 +153,6 @@ export const CardTitle = (
     []
   );
 
-  // ignore due to window event listeners
   /* istanbul ignore next */
   useEffect(() => {
     if (tooltipsState.title) {

--- a/packages/react/src/components/ComboChartCard/__snapshots__/ComboChartCard.story.storyshot
+++ b/packages/react/src/components/ComboChartCard/__snapshots__/ComboChartCard.story.storyshot
@@ -1938,7 +1938,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                 </div>
               </div>
               <div
-                className="bx--pagination iot--pagination iot--pagination--hide-page bx--pagination--lg"
+                className="bx--pagination iot--pagination bx--pagination--lg"
                 data-testid="BarChartCard-table-table-pagination"
                 style={
                   Object {

--- a/packages/react/src/components/ComboChartCard/__snapshots__/ComboChartCard.story.storyshot
+++ b/packages/react/src/components/ComboChartCard/__snapshots__/ComboChartCard.story.storyshot
@@ -270,7 +270,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                   </div>
                   <button
                     aria-describedby={null}
-                    className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                    className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                     data-testid="download-button"
                     disabled={false}
                     onBlur={[Function]}
@@ -307,7 +307,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                   </button>
                   <button
                     aria-describedby={null}
-                    className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                    className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                     data-testid="filter-button"
                     disabled={false}
                     onBlur={[Function]}

--- a/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -1727,7 +1727,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                       </div>
                       <button
                         aria-describedby={null}
-                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                         data-testid="download-button"
                         disabled={false}
                         onBlur={[Function]}
@@ -1764,7 +1764,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                       </button>
                       <button
                         aria-describedby={null}
-                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                         data-testid="filter-button"
                         disabled={false}
                         onBlur={[Function]}
@@ -4629,7 +4629,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                       </div>
                       <button
                         aria-describedby={null}
-                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                         data-testid="download-button"
                         disabled={false}
                         onBlur={[Function]}
@@ -4666,7 +4666,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                       </button>
                       <button
                         aria-describedby={null}
-                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                         data-testid="filter-button"
                         disabled={false}
                         onBlur={[Function]}
@@ -7566,7 +7566,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                       </div>
                       <button
                         aria-describedby={null}
-                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                         data-testid="download-button"
                         disabled={false}
                         onBlur={[Function]}
@@ -7603,7 +7603,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                       </button>
                       <button
                         aria-describedby={null}
-                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                         data-testid="filter-button"
                         disabled={false}
                         onBlur={[Function]}
@@ -9585,7 +9585,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                       </div>
                       <button
                         aria-describedby={null}
-                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                         data-testid="download-button"
                         disabled={false}
                         onBlur={[Function]}
@@ -9622,7 +9622,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                       </button>
                       <button
                         aria-describedby={null}
-                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                         data-testid="filter-button"
                         disabled={false}
                         onBlur={[Function]}
@@ -12931,7 +12931,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                       </div>
                       <button
                         aria-describedby={null}
-                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                         data-testid="download-button"
                         disabled={false}
                         onBlur={[Function]}
@@ -12968,7 +12968,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                       </button>
                       <button
                         aria-describedby={null}
-                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                         data-testid="filter-button"
                         disabled={false}
                         onBlur={[Function]}
@@ -30573,7 +30573,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                       </div>
                       <button
                         aria-describedby={null}
-                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                         data-testid="download-button"
                         disabled={false}
                         onBlur={[Function]}
@@ -30610,7 +30610,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                       </button>
                       <button
                         aria-describedby={null}
-                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                        className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                         data-testid="filter-button"
                         disabled={false}
                         onBlur={[Function]}

--- a/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
@@ -2238,7 +2238,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                   </div>
                   <button
                     aria-describedby={null}
-                    className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                    className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                     data-testid="download-button"
                     disabled={false}
                     onBlur={[Function]}
@@ -2275,7 +2275,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                   </button>
                   <button
                     aria-describedby={null}
-                    className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                    className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                     data-testid="filter-button"
                     disabled={false}
                     onBlur={[Function]}

--- a/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
+++ b/packages/react/src/components/DashboardEditor/__snapshots__/DashboardEditor.story.storyshot
@@ -692,7 +692,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <button
                               aria-describedby={null}
-                              className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--btn--disabled bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                              className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--btn--disabled bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                               data-testid="download-button"
                               disabled={true}
                               onBlur={[Function]}
@@ -729,7 +729,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                             </button>
                             <button
                               aria-describedby={null}
-                              className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--btn--disabled bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                              className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--btn--disabled bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                               data-testid="filter-button"
                               disabled={true}
                               onBlur={[Function]}
@@ -20095,7 +20095,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                         >
                           <button
                             aria-describedby={null}
-                            className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--btn--disabled bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                            className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--btn--disabled bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                             data-testid="download-button"
                             disabled={true}
                             onBlur={[Function]}
@@ -20132,7 +20132,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           </button>
                           <button
                             aria-describedby={null}
-                            className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--btn--disabled bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                            className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--btn--disabled bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                             data-testid="filter-button"
                             disabled={true}
                             onBlur={[Function]}

--- a/packages/react/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
+++ b/packages/react/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
@@ -2122,7 +2122,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                   </div>
                 </div>
                 <div
-                  className="bx--pagination iot--pagination iot--pagination--hide-page bx--pagination--lg"
+                  className="bx--pagination iot--pagination bx--pagination--lg"
                   data-testid="null-table-pagination"
                   style={
                     Object {
@@ -4368,7 +4368,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                   </div>
                 </div>
                 <div
-                  className="bx--pagination iot--pagination iot--pagination--hide-page bx--pagination--lg"
+                  className="bx--pagination iot--pagination bx--pagination--lg"
                   data-testid="null-table-pagination"
                   style={
                     Object {

--- a/packages/react/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
+++ b/packages/react/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
@@ -278,7 +278,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                     </button>
                     <button
                       aria-describedby={null}
-                      className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                      className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                       data-testid="column-selection-button"
                       disabled={false}
                       onBlur={[Function]}
@@ -315,7 +315,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                     </button>
                     <button
                       aria-describedby={null}
-                      className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--table-toolbar-button-active iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                      className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--table-toolbar-button-active iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                       data-testid="filter-button"
                       disabled={false}
                       onBlur={[Function]}
@@ -352,7 +352,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                     </button>
                     <button
                       aria-describedby={null}
-                      className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                      className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                       data-testid="row-edit-button"
                       disabled={false}
                       onBlur={[Function]}
@@ -2524,7 +2524,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                     </button>
                     <button
                       aria-describedby={null}
-                      className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                      className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                       data-testid="column-selection-button"
                       disabled={false}
                       onBlur={[Function]}
@@ -2561,7 +2561,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                     </button>
                     <button
                       aria-describedby={null}
-                      className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--table-toolbar-button-active iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                      className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--table-toolbar-button-active iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                       data-testid="filter-button"
                       disabled={false}
                       onBlur={[Function]}
@@ -2598,7 +2598,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                     </button>
                     <button
                       aria-describedby={null}
-                      className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                      className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                       data-testid="row-edit-button"
                       disabled={false}
                       onBlur={[Function]}

--- a/packages/react/src/components/PieChartCard/__snapshots__/PieChartCard.story.storyshot
+++ b/packages/react/src/components/PieChartCard/__snapshots__/PieChartCard.story.storyshot
@@ -153,7 +153,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                 >
                   <button
                     aria-describedby={null}
-                    className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                    className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                     data-testid="download-button"
                     disabled={false}
                     onBlur={[Function]}

--- a/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
+++ b/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
@@ -5796,7 +5796,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </div>
           </div>
           <div
-            className="bx--pagination iot--pagination iot--pagination--hide-page bx--pagination--lg"
+            className="bx--pagination iot--pagination bx--pagination--lg"
             data-testid="null-table-pagination"
             style={
               Object {

--- a/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
+++ b/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
@@ -843,7 +843,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               </button>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="column-selection-button"
                 disabled={false}
                 onBlur={[Function]}
@@ -880,7 +880,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               </button>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--table-toolbar-button-active iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--table-toolbar-button-active iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="filter-button"
                 disabled={false}
                 onBlur={[Function]}
@@ -917,7 +917,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               </button>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="row-edit-button"
                 disabled={false}
                 onBlur={[Function]}

--- a/packages/react/src/components/Table/Pagination.jsx
+++ b/packages/react/src/components/Table/Pagination.jsx
@@ -8,11 +8,10 @@ import useSizeObserver from '../../hooks/useSizeObserver';
 
 const { iotPrefix } = settings;
 
-const PAGINATION_MIN_WIDTH_LG_BREAKPOINT = 625;
-
 /**
  * This pagination component hides the items per page selection dropdown if the isItemsPerPageHidden bit is true.
- * It also hides the Items per page and x of x items text if the total width of the pagination bar is less than 500 px
+ * It also hides the Items per page and x of x items text if the total width of the pagination bar is less than 500 px.
+ * In addition, it narrows padding between 608px and 500px due to overflow issue.
  */
 const SizedPagination = ({
   isItemPerPageHidden,
@@ -24,7 +23,6 @@ const SizedPagination = ({
   ...rest
 }) => {
   const [{ width }, paginationRef] = useSizeObserver({ initialWidth: 500 });
-  const isCompact = width < 500;
 
   return (
     <>
@@ -35,13 +33,13 @@ const SizedPagination = ({
         data-testid={testId}
         disabled={preventInteraction || disabled}
         className={classnames(className, `${iotPrefix}--pagination`, {
-          [`${iotPrefix}--pagination--hide-page`]:
-            isItemPerPageHidden || width < PAGINATION_MIN_WIDTH_LG_BREAKPOINT,
+          [`${iotPrefix}--pagination--hide-page`]: isItemPerPageHidden,
           [`${iotPrefix}--pagination--hide-select`]: preventInteraction,
-          [`${iotPrefix}--pagination--compact`]: isCompact,
+          [`${iotPrefix}--pagination--narrow`]: width > 500 && width < 608,
+          [`${iotPrefix}--pagination--compact`]: width < 500,
         })}
         style={{
-          '--pagination-text-display': isCompact ? 'none' : 'flex',
+          '--pagination-text-display': width < 500 ? 'none' : 'flex',
         }}
       />
     </>

--- a/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -364,6 +364,7 @@ const TableToolbar = ({
               size="lg"
               menuOptionsClass={`${iotPrefix}--table-overflow-batch-actions__menu`}
               withCarbonTooltip
+              tooltipPosition="bottom"
             >
               {visibleOverflowBatchActions.map(
                 ({
@@ -610,6 +611,7 @@ const TableToolbar = ({
               onOpen={() => setIsOpen(true)}
               onClose={() => setIsOpen(false)}
               withCarbonTooltip
+              tooltipPosition="bottom"
             >
               {hasAggregations && (
                 <OverflowMenuItem

--- a/packages/react/src/components/Table/TableToolbar/TableToolbarAdvancedFilterFlyout.jsx
+++ b/packages/react/src/components/Table/TableToolbar/TableToolbarAdvancedFilterFlyout.jsx
@@ -288,6 +288,7 @@ const TableToolbarAdvancedFilterFlyout = ({
           }
         ),
         onClick: onToggleAdvancedFilter,
+        tooltipPosition: 'bottom',
       }}
       i18n={{
         applyButtonText,

--- a/packages/react/src/components/Table/TableToolbar/TableToolbarSVGButton.jsx
+++ b/packages/react/src/components/Table/TableToolbar/TableToolbarSVGButton.jsx
@@ -25,7 +25,7 @@ const defaultProps = {
   isActive: false,
   disabled: false,
   tooltipAlignment: 'center',
-  tooltipPosition: 'top',
+  tooltipPosition: 'bottom',
   langDir: 'ltr',
 };
 

--- a/packages/react/src/components/Table/TableToolbar/_table-toolbar.scss
+++ b/packages/react/src/components/Table/TableToolbar/_table-toolbar.scss
@@ -1,4 +1,5 @@
 @import '../../../globals/vars';
+@import '../../../globals/mixins';
 @import './table-toolbar-svg-button';
 @import './advanced-filter-flyout';
 
@@ -34,6 +35,14 @@ div.#{$prefix}--toolbar-action.#{$prefix}--toolbar-search-container-expandable {
 
   .#{$prefix}--toolbar-search-container-active .#{$prefix}--search-input {
     border-bottom: 0;
+  }
+
+  .#{$iot-prefix}--table-overflow-batch-actions.#{$prefix}--overflow-menu--open {
+    @include hide-tooltip();
+  }
+
+  .#{$iot-prefix}--table-toolbar-aggregations__overflow-menu.#{$prefix}--overflow-menu--open {
+    @include hide-tooltip();
   }
 }
 

--- a/packages/react/src/components/Table/__snapshots__/Table.main.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/Table.main.story.storyshot
@@ -142,7 +142,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             aria-describedby={null}
             aria-expanded={false}
             aria-haspopup={true}
-            className="iot--table-overflow-batch-actions bx--overflow-menu bx--overflow-menu--lg bx--btn--icon-only iot--tooltip-svg-wrapper iot--overflow-menu-icon iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+            className="iot--table-overflow-batch-actions bx--overflow-menu bx--overflow-menu--lg bx--btn--icon-only iot--tooltip-svg-wrapper iot--overflow-menu-icon iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             data-testid="table-table-toolbar-batch-actions-overflow-menu"
             disabled={false}
             onBlur={[Function]}
@@ -21873,7 +21873,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           aria-describedby={null}
           aria-expanded={false}
           aria-haspopup={true}
-          className="iot--table-toolbar-aggregations__overflow-menu bx--overflow-menu bx--overflow-menu--md bx--btn--icon-only iot--tooltip-svg-wrapper iot--overflow-menu-icon iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+          className="iot--table-toolbar-aggregations__overflow-menu bx--overflow-menu bx--overflow-menu--md bx--btn--icon-only iot--tooltip-svg-wrapper iot--overflow-menu-icon iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="table-head--overflow"
           disabled={false}
           onBlur={[Function]}
@@ -24669,7 +24669,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
       >
         <button
           aria-describedby={null}
-          className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+          className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="column-selection-button"
           disabled={false}
           onBlur={[Function]}
@@ -24706,7 +24706,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
         </button>
         <button
           aria-describedby={null}
-          className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+          className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="filter-button"
           disabled={false}
           onBlur={[Function]}
@@ -25043,7 +25043,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
         >
           <button
             aria-describedby={null}
-            className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+            className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             data-testid="row-edit-button"
             disabled={false}
             onBlur={[Function]}
@@ -28624,7 +28624,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
         </button>
         <button
           aria-describedby={null}
-          className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--table-toolbar-button-active iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+          className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--table-toolbar-button-active iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="filter-button"
           disabled={false}
           onBlur={[Function]}
@@ -46653,7 +46653,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
             aria-describedby={null}
             aria-expanded={false}
             aria-haspopup={true}
-            className="iot--table-overflow-batch-actions bx--overflow-menu bx--overflow-menu--lg bx--btn--icon-only iot--tooltip-svg-wrapper iot--overflow-menu-icon iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+            className="iot--table-overflow-batch-actions bx--overflow-menu bx--overflow-menu--lg bx--btn--icon-only iot--tooltip-svg-wrapper iot--overflow-menu-icon iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             data-testid="null-table-toolbar-batch-actions-overflow-menu"
             disabled={false}
             onBlur={[Function]}
@@ -62475,7 +62475,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
       >
         <button
           aria-describedby={null}
-          className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+          className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="download-button"
           disabled={false}
           onBlur={[Function]}
@@ -62512,7 +62512,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
         </button>
         <button
           aria-describedby={null}
-          className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--table-toolbar-button-active iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+          className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--table-toolbar-button-active iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="table-31-toolbar-actions-button-toggle"
           disabled={false}
           onBlur={[Function]}
@@ -62551,7 +62551,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           aria-describedby={null}
           aria-expanded={false}
           aria-haspopup={true}
-          className="iot--table-toolbar-aggregations__overflow-menu bx--overflow-menu bx--overflow-menu--md bx--btn--icon-only iot--tooltip-svg-wrapper iot--overflow-menu-icon iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+          className="iot--table-toolbar-aggregations__overflow-menu bx--overflow-menu bx--overflow-menu--md bx--btn--icon-only iot--tooltip-svg-wrapper iot--overflow-menu-icon iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="table-head--overflow"
           disabled={false}
           onBlur={[Function]}

--- a/packages/react/src/components/Table/__snapshots__/Table.main.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/Table.main.story.storyshot
@@ -36443,7 +36443,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
       </div>
     </div>
     <div
-      className="bx--pagination iot--pagination iot--pagination--hide-page bx--pagination--lg"
+      className="bx--pagination iot--pagination bx--pagination--lg"
       data-testid="null-table-pagination"
       style={
         Object {

--- a/packages/react/src/components/Table/__snapshots__/TableColumnCustomization.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/TableColumnCustomization.story.storyshot
@@ -3551,7 +3551,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
       >
         <button
           aria-describedby={null}
-          className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+          className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="column-selection-button"
           disabled={false}
           onBlur={[Function]}

--- a/packages/react/src/components/Table/__snapshots__/TableUserViewManagement.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/TableUserViewManagement.story.storyshot
@@ -612,7 +612,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
           </button>
           <button
             aria-describedby={null}
-            className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--table-toolbar-button-active iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+            className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--table-toolbar-button-active iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             data-testid="filter-button"
             disabled={false}
             onBlur={[Function]}

--- a/packages/react/src/components/Table/_pagination.scss
+++ b/packages/react/src/components/Table/_pagination.scss
@@ -21,6 +21,20 @@
     }
   }
 
+  &--narrow {
+    .#{$prefix}--pagination__left {
+      padding: 0 $spacing-03 0 $spacing-05;
+    }
+
+    .#{$prefix}--pagination__items-count {
+      margin-left: $spacing-03;
+    }
+
+    .#{$prefix}--pagination__right .#{$prefix}--pagination__text {
+      margin-right: $spacing-03;
+    }
+  }
+
   .#{$prefix}--pagination__left {
     margin: auto auto auto 0;
 
@@ -37,10 +51,6 @@
   }
 }
 .#{$iot-prefix}--pagination--hide-page {
-  .#{$prefix}--pagination__left {
-    padding: 0 $spacing-05 0 $spacing-05;
-  }
-
   .#{$prefix}--pagination__left .#{$prefix}--pagination__text:first-child,
   .#{$prefix}--pagination__left span:first-child,
   .#{$prefix}--pagination__left .#{$prefix}--form-item {

--- a/packages/react/src/components/Table/_table.scss
+++ b/packages/react/src/components/Table/_table.scss
@@ -6,6 +6,7 @@
 @import 'TableDetailWizard/table-detail-wizard';
 @import 'TableMultiSortModal/table-multi-sort-modal';
 @import '../../globals/vars';
+@import '../../globals/mixins';
 
 table.#{$prefix}--side-nav--data-table {
   white-space: nowrap;
@@ -105,6 +106,10 @@ button.#{$prefix}--btn.#{$iot-prefix}--tooltip-svg-wrapper.#{$prefix}--btn--ghos
   &.#{$iot-prefix}--table-toolbar-button-active {
     @include box-shadow;
   }
+}
+
+.#{$iot-prefix}--table-toolbar__advanced-filters-button.#{$iot-prefix}--table-toolbar-button-active.#{$iot-prefix}--flyout-menu--trigger-button {
+  @include hide-tooltip();
 }
 
 // regression fix for tiny expand chrevron on some expandable table rows

--- a/packages/react/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/packages/react/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -203,7 +203,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="download-button"
                 disabled={false}
                 onBlur={[Function]}
@@ -240,7 +240,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </button>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="filter-button"
                 disabled={false}
                 onBlur={[Function]}
@@ -2066,7 +2066,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
             >
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--btn--disabled bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--btn--disabled bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="download-button"
                 disabled={true}
                 onBlur={[Function]}
@@ -2103,7 +2103,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </button>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--btn--disabled bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--btn--disabled bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="filter-button"
                 disabled={true}
                 onBlur={[Function]}
@@ -3522,7 +3522,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="download-button"
                 disabled={false}
                 onBlur={[Function]}
@@ -3559,7 +3559,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </button>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="filter-button"
                 disabled={false}
                 onBlur={[Function]}
@@ -4915,7 +4915,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="download-button"
                 disabled={false}
                 onBlur={[Function]}
@@ -4952,7 +4952,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </button>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="filter-button"
                 disabled={false}
                 onBlur={[Function]}
@@ -6483,7 +6483,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </button>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="download-button"
                 disabled={false}
                 onBlur={[Function]}
@@ -6520,7 +6520,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </button>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="filter-button"
                 disabled={false}
                 onBlur={[Function]}
@@ -7442,7 +7442,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="download-button"
                 disabled={false}
                 onBlur={[Function]}
@@ -7479,7 +7479,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </button>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="filter-button"
                 disabled={false}
                 onBlur={[Function]}
@@ -8601,7 +8601,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="download-button"
                 disabled={false}
                 onBlur={[Function]}
@@ -8638,7 +8638,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </button>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="filter-button"
                 disabled={false}
                 onBlur={[Function]}
@@ -10918,7 +10918,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="download-button"
                 disabled={false}
                 onBlur={[Function]}
@@ -10955,7 +10955,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </button>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="filter-button"
                 disabled={false}
                 onBlur={[Function]}
@@ -12969,7 +12969,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="download-button"
                 disabled={false}
                 onBlur={[Function]}
@@ -13006,7 +13006,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </button>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="filter-button"
                 disabled={false}
                 onBlur={[Function]}
@@ -14746,7 +14746,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="download-button"
                 disabled={false}
                 onBlur={[Function]}
@@ -14783,7 +14783,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </button>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="filter-button"
                 disabled={false}
                 onBlur={[Function]}
@@ -16624,7 +16624,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="download-button"
                 disabled={false}
                 onBlur={[Function]}
@@ -16661,7 +16661,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </button>
               <button
                 aria-describedby={null}
-                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="filter-button"
                 disabled={false}
                 onBlur={[Function]}

--- a/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -1061,7 +1061,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                 </div>
                 <button
                   aria-describedby={null}
-                  className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                  className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                   data-testid="download-button"
                   disabled={false}
                   onBlur={[Function]}
@@ -1098,7 +1098,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                 </button>
                 <button
                   aria-describedby={null}
-                  className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--top bx--tooltip--align-center"
+                  className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                   data-testid="filter-button"
                   disabled={false}
                   onBlur={[Function]}

--- a/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -2832,7 +2832,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </div>
             </div>
             <div
-              className="bx--pagination iot--pagination iot--pagination--hide-page bx--pagination--lg"
+              className="bx--pagination iot--pagination bx--pagination--lg"
               data-testid="TimeSeries-table-table-pagination"
               style={
                 Object {

--- a/packages/react/src/globals/_mixins.scss
+++ b/packages/react/src/globals/_mixins.scss
@@ -60,3 +60,13 @@
     }
   }
 }
+
+@mixin hide-tooltip() {
+  .#{$prefix}--assistive-text {
+    display: none;
+  }
+
+  &::before {
+    content: '';
+  }
+}


### PR DESCRIPTION
**Summary**

Changed approach to previous issues:
- #3682 Card tooltip - add throttle to scroll event listener (initial render of a tooltip caused micro-scrolling event, therefore tooltip closed itself, throttle for 10ms prevents this)
- #3278 Pagination in table - decrease padding slightly between `608px` and `500px` instead of hiding items per page block
- Carbon tooltips in table - change direction from `top` to `bottom` in table toolbar (due to `overflow: hidden`)

**Change List (commits, features, bugs, etc)**

- Card tooltip: add `setTimeout` to add scroll event listener
- Table pagination: update css styles
- Tooltips in table toolbar: add props to change direction to `bottom`

**Acceptance Test (how to verify the PR)**

**Card tooltip**
- Go to [this story](https://deploy-preview-3690--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-card-card--with-ellipsed-title-tooltip-external-tooltip)
- Resize the window vertically in order to display vertical scrollbar
- Click on card or subtitle to show tooltip
- Scroll windows vertically
- Verify that tooltip was removed after the scrolling event

**Table pagination**
- Go to [this story](https://deploy-preview-3690--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table--with-pagination)
- Resize the window horizontally till `500px`
- Verify that icon buttons to change pages do not overflow container

**Table toolbar tooltips**
- Go to [this story](https://deploy-preview-3690--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table--playground)
- Set `hasFilter: true`, `hasSearch: true`, `hasAggregations: true` or any other button icons in tooltip
- Hover over icons in toolbar
- Verify that tooltips have direction `bottom`

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
