### PR TITLE
fix(DateTimePickerV2): fix Flyoutmenu open direction

### DIFF
--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
@@ -883,8 +883,10 @@ const DateTimePicker = ({
 
   const windowHeight = window.innerHeight || document.documentElement.clientHeight;
   const inputBottom = containerRef.current?.getBoundingClientRect().bottom;
+  const inputTop = containerRef.current?.getBoundingClientRect().top;
   const flyoutMenuHeight = 482;
   const offBottom = windowHeight - inputBottom < flyoutMenuHeight;
+  const offTop = inputTop < flyoutMenuHeight;
 
   const getPosition = (event) => {
     setLeft(event.target.scrollLeft);
@@ -1010,8 +1012,10 @@ const DateTimePicker = ({
             }}
             testId={`${testId}-datepicker-flyout`}
             direction={
-              useAutoPositioning && offBottom
-                ? FlyoutMenuDirection.TopEnd
+              useAutoPositioning
+                ? offBottom && !offTop
+                  ? FlyoutMenuDirection.TopEnd
+                  : FlyoutMenuDirection.BottomEnd
                 : FlyoutMenuDirection.BottomEnd
             }
             customFooter={CustomFooter}

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithoutTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithoutTimeSpinner.jsx
@@ -730,8 +730,10 @@ const DateTimePicker = ({
 
   const windowHeight = window.innerHeight || document.documentElement.clientHeight;
   const inputBottom = containerRef.current?.getBoundingClientRect().bottom;
+  const inputTop = containerRef.current?.getBoundingClientRect().top;
   const flyoutMenuHeight = 482;
   const offBottom = windowHeight - inputBottom < flyoutMenuHeight;
+  const offTop = inputTop < flyoutMenuHeight;
 
   const getPosition = (event) => {
     setLeft(event.target.scrollLeft);
@@ -856,8 +858,10 @@ const DateTimePicker = ({
             }}
             testId={`${testId}-datepicker-flyout`}
             direction={
-              useAutoPositioning && offBottom
-                ? FlyoutMenuDirection.TopEnd
+              useAutoPositioning
+                ? offBottom && !offTop
+                  ? FlyoutMenuDirection.TopEnd
+                  : FlyoutMenuDirection.BottomEnd
                 : FlyoutMenuDirection.BottomEnd
             }
             customFooter={CustomFooter}


### PR DESCRIPTION
Closes #3703 

**Summary**

- When both top and bottom has not enough height for FlyoutMenu, it should open downwards.

**Change List (commits, features, bugs, etc)**

- DateTimePickerV2WithoutTimeSpinner.jsx
- DateTimePickerV2WithTimeSpinner.jsx

**Acceptance Test (how to verify the PR)**

- go to single select [story](https://deploy-preview-3704--carbon-addons-iot-react.netlify.app/?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-datetimepickerv2--single-select)
- make sure the view is short, not enough for flyout menu from both top and bottom direction
- check flyout menu opens downwards instead of upwards

Before:

https://user-images.githubusercontent.com/24279794/214896543-e55bbecf-bbea-450f-b2fc-93533539e003.mov


After: 

https://user-images.githubusercontent.com/24279794/214896603-590a7e5f-d289-4051-b85a-f311e19ffd6f.mov




**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
