### PR TITLE
Adding support for useCache in uiresources API helper and useUiResources hook

### DIFF
--- a/packages/react/src/components/SuiteHeader/SuiteHeader.mdx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.mdx
@@ -95,6 +95,7 @@ const SuiteHeaderWithDataFetchingUtilExample = () => {
       lang: 'en',
       surveyId: 'test',
       workspaceId: 'workspace1',
+      appId: 'monitor',
     }).then(setData);
   }, []);
 
@@ -126,6 +127,7 @@ const SuiteHeaderWithDataFetchingHookExample = () => {
     lang: 'en',
     surveyId: 'test',
     workspaceId: 'workspace1',
+    appId: 'monitor',
   });
 
   return (

--- a/packages/react/src/components/SuiteHeader/hooks/useUiResources.js
+++ b/packages/react/src/components/SuiteHeader/hooks/useUiResources.js
@@ -49,7 +49,6 @@ const useUiResources = ({
             setIsLoading(false);
           },
           (err) => {
-            console.log('ERRORRRR');
             setError(err);
           }
         );

--- a/packages/react/src/components/SuiteHeader/hooks/useUiResources.js
+++ b/packages/react/src/components/SuiteHeader/hooks/useUiResources.js
@@ -11,6 +11,7 @@ const useUiResources = ({
   workspaceId = null,
   fetchApi = defaultFetchApi,
   isTest = false,
+  useCache = true,
 }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState();
@@ -27,24 +28,32 @@ const useUiResources = ({
   });
 
   const refreshData = useCallback(async () => {
+    const options = {
+      baseApiUrl,
+      lang,
+      surveyId,
+      appId,
+      workspaceId,
+      fetchApi,
+      isTest,
+    };
     try {
       setIsLoading(true);
-      const uiResourcesData = await getUiResourcesData({
-        baseApiUrl,
-        lang,
-        surveyId,
-        appId,
-        workspaceId,
-        fetchApi,
-        isTest,
-      });
+      if (useCache) {
+        // Set cached data
+        const cachedUIResourcesData = await getUiResourcesData({ ...options, useCache });
+        setData(cachedUIResourcesData);
+        setIsLoading(false);
+      }
+      // Refresh data
+      const uiResourcesData = await getUiResourcesData({ ...options });
       setData(uiResourcesData);
     } catch (err) {
       setError(err);
     } finally {
       setIsLoading(false);
     }
-  }, [baseApiUrl, lang, surveyId, appId, workspaceId, isTest, setIsLoading]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [baseApiUrl, lang, surveyId, appId, workspaceId, isTest, setIsLoading, useCache]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     // load actual data

--- a/packages/react/src/components/SuiteHeader/hooks/useUiResources.js
+++ b/packages/react/src/components/SuiteHeader/hooks/useUiResources.js
@@ -41,7 +41,7 @@ const useUiResources = ({
     try {
       setIsLoading(true);
       if (useCache) {
-        // Set cached data
+        // Set cached and then non-cached data
         getCachedUiResourcesData(
           { ...options },
           (cachedData) => {
@@ -53,7 +53,7 @@ const useUiResources = ({
           }
         );
       } else {
-        // Refresh data
+        // Set non-cached data only
         const uiResourcesData = await getUiResourcesData({ ...options });
         setData(uiResourcesData);
       }

--- a/packages/react/src/components/SuiteHeader/hooks/useUiResources.js
+++ b/packages/react/src/components/SuiteHeader/hooks/useUiResources.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 
 // eslint-disable-next-line import/extensions
 import getUiResourcesData, { defaultFetchApi } from '../util/uiresources';
+import getCachedUiResourcesData from '../util/cacheduiresources';
 
 const useUiResources = ({
   baseApiUrl,
@@ -41,13 +42,15 @@ const useUiResources = ({
       setIsLoading(true);
       if (useCache) {
         // Set cached data
-        const cachedUIResourcesData = await getUiResourcesData({ ...options, useCache });
-        setData(cachedUIResourcesData);
-        setIsLoading(false);
+        getCachedUiResourcesData({ ...options }, (cachedData) => {
+          setData(cachedData);
+          setIsLoading(false);
+        });
+      } else {
+        // Refresh data
+        const uiResourcesData = await getUiResourcesData({ ...options });
+        setData(uiResourcesData);
       }
-      // Refresh data
-      const uiResourcesData = await getUiResourcesData({ ...options });
-      setData(uiResourcesData);
     } catch (err) {
       setError(err);
     } finally {

--- a/packages/react/src/components/SuiteHeader/hooks/useUiResources.js
+++ b/packages/react/src/components/SuiteHeader/hooks/useUiResources.js
@@ -42,10 +42,17 @@ const useUiResources = ({
       setIsLoading(true);
       if (useCache) {
         // Set cached data
-        getCachedUiResourcesData({ ...options }, (cachedData) => {
-          setData(cachedData);
-          setIsLoading(false);
-        });
+        getCachedUiResourcesData(
+          { ...options },
+          (cachedData) => {
+            setData(cachedData);
+            setIsLoading(false);
+          },
+          (err) => {
+            console.log('ERRORRRR');
+            setError(err);
+          }
+        );
       } else {
         // Refresh data
         const uiResourcesData = await getUiResourcesData({ ...options });

--- a/packages/react/src/components/SuiteHeader/hooks/useUiResources.test.js
+++ b/packages/react/src/components/SuiteHeader/hooks/useUiResources.test.js
@@ -5,7 +5,28 @@ import testApiData from '../util/uiresources.fixture';
 import useUiResources from './useUiResources';
 
 describe('useUiResources', () => {
-  it('initial and success state (default)', async () => {
+  it('initial state', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve(testApiData['/uiresources']),
+      })
+    );
+    const { result } = renderHook(() =>
+      useUiResources({
+        lang: 'en',
+        surveyId: 'test',
+        workspaceId: 'mockedworkspace',
+        useCache: false,
+      })
+    );
+    // Make sure that initial data is null, loading is true and error is undefined
+    const [initialData, initialLoading, initialError] = result.current;
+    expect(initialData.username).toEqual(null);
+    expect(initialLoading).toEqual(true);
+    expect(initialError).toEqual(undefined);
+    global.fetch = undefined;
+  });
+  it('success state (cached and non-cached api requests)', async () => {
     global.fetch = jest.fn(() =>
       Promise.resolve({
         json: () => Promise.resolve(testApiData['/uiresources']),
@@ -18,11 +39,6 @@ describe('useUiResources', () => {
         workspaceId: 'mockedworkspace',
       })
     );
-    // Make sure that initial data is null, loading is true and error is undefined
-    const [initialData, initialLoading, initialError] = result.current;
-    expect(initialData.username).toEqual(null);
-    expect(initialLoading).toEqual(true);
-    expect(initialError).toEqual(undefined);
     await waitForNextUpdate();
     const [data, loading, error] = result.current;
     // After data has been fetched, make sure that data is populated, loading is false and error is undefined
@@ -33,7 +49,7 @@ describe('useUiResources', () => {
     expect(global.fetch).toHaveBeenCalledTimes(2);
     global.fetch = undefined;
   });
-  it('Success state (non-cached only)', async () => {
+  it('Success state (non-cached api request only)', async () => {
     global.fetch = jest.fn(() =>
       Promise.resolve({
         json: () => Promise.resolve(testApiData['/uiresources']),
@@ -68,6 +84,7 @@ describe('useUiResources', () => {
         lang: 'en',
         surveyId: 'test',
         workspaceId: 'mockedworkspace',
+        useCache: false,
       })
     );
     await waitForNextUpdate();

--- a/packages/react/src/components/SuiteHeader/hooks/useUiResources.test.js
+++ b/packages/react/src/components/SuiteHeader/hooks/useUiResources.test.js
@@ -1,0 +1,83 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import testApiData from '../util/uiresources.fixture';
+
+import useUiResources from './useUiResources';
+
+describe('useUiResources', () => {
+  it('initial and success state (default)', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve(testApiData['/uiresources']),
+      })
+    );
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useUiResources({
+        lang: 'en',
+        surveyId: 'test',
+        workspaceId: 'mockedworkspace',
+      })
+    );
+    // Make sure that initial data is null, loading is true and error is undefined
+    const [initialData, initialLoading, initialError] = result.current;
+    expect(initialData.username).toEqual(null);
+    expect(initialLoading).toEqual(true);
+    expect(initialError).toEqual(undefined);
+    await waitForNextUpdate();
+    const [data, loading, error] = result.current;
+    // After data has been fetched, make sure that data is populated, loading is false and error is undefined
+    expect(data).toEqual(testApiData['/uiresources']);
+    expect(loading).toEqual(false);
+    expect(error).toEqual(undefined);
+    // Also, make sure that fetch has been called twice (one for the cached uiresources data and another for the non-cached data)
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    global.fetch = undefined;
+  });
+  it('Success state (non-cached only)', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve(testApiData['/uiresources']),
+      })
+    );
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useUiResources({
+        lang: 'en',
+        surveyId: 'test',
+        workspaceId: 'mockedworkspace',
+        useCache: false,
+      })
+    );
+    await waitForNextUpdate();
+    // After data has been fetched, make sure that data is populated, loading is false and error is undefined
+    const [data, loading, error] = result.current;
+    expect(data).toEqual(testApiData['/uiresources']);
+    expect(loading).toEqual(false);
+    expect(error).toEqual(undefined);
+    // Also, make sure that fetch has been called only once
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    global.fetch = undefined;
+  });
+  it('Error state', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.reject(new Error('Boom!!!')),
+      })
+    );
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useUiResources({
+        lang: 'en',
+        surveyId: 'test',
+        workspaceId: 'mockedworkspace',
+      })
+    );
+    await waitForNextUpdate();
+    // After data fetching has errored out, make sure that data still null, loading is false and error is defined
+    const [data, loading, error] = result.current;
+    expect(data.username).toEqual(null);
+    expect(loading).toEqual(false);
+    expect(error.message).toEqual('Boom!!!');
+    // Also, make sure that fetch has been called only once
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    global.fetch = undefined;
+  });
+});

--- a/packages/react/src/components/SuiteHeader/hooks/useUiResources.test.js
+++ b/packages/react/src/components/SuiteHeader/hooks/useUiResources.test.js
@@ -27,6 +27,7 @@ describe('useUiResources', () => {
     global.fetch = undefined;
   });
   it('success state (cached and non-cached api requests)', async () => {
+    // Mock fetch calls
     global.fetch = jest.fn(() =>
       Promise.resolve({
         json: () => Promise.resolve(testApiData['/uiresources']),
@@ -50,6 +51,7 @@ describe('useUiResources', () => {
     global.fetch = undefined;
   });
   it('Success state (non-cached api request only)', async () => {
+    // Mock fetch call
     global.fetch = jest.fn(() =>
       Promise.resolve({
         json: () => Promise.resolve(testApiData['/uiresources']),
@@ -74,6 +76,7 @@ describe('useUiResources', () => {
     global.fetch = undefined;
   });
   it('Error state', async () => {
+    // Mock fetch call
     global.fetch = jest.fn(() =>
       Promise.resolve({
         json: () => Promise.reject(new Error('Boom!!!')),

--- a/packages/react/src/components/SuiteHeader/util/cacheduiresources.js
+++ b/packages/react/src/components/SuiteHeader/util/cacheduiresources.js
@@ -1,0 +1,11 @@
+// eslint-disable-next-line import/extensions
+import getUiResourcesData from './uiresources';
+
+const getCachedUiResourcesData = async (options, cb) => {
+  const cachedUIResourcesData = await getUiResourcesData({ ...options, useCache: true });
+  cb(cachedUIResourcesData);
+  const nonCachedUIResourcesData = await getUiResourcesData({ ...options });
+  cb(nonCachedUIResourcesData);
+};
+
+export default getCachedUiResourcesData;

--- a/packages/react/src/components/SuiteHeader/util/cacheduiresources.js
+++ b/packages/react/src/components/SuiteHeader/util/cacheduiresources.js
@@ -1,11 +1,16 @@
 // eslint-disable-next-line import/extensions
 import getUiResourcesData from './uiresources';
 
-const getCachedUiResourcesData = async (options, cb) => {
-  const cachedUIResourcesData = await getUiResourcesData({ ...options, useCache: true });
-  cb(cachedUIResourcesData);
-  const nonCachedUIResourcesData = await getUiResourcesData({ ...options });
-  cb(nonCachedUIResourcesData);
+const getCachedUiResourcesData = async (options, cb, errCb) => {
+  try {
+    const cachedUIResourcesData = await getUiResourcesData({ ...options, useCache: true });
+    cb(cachedUIResourcesData);
+    const nonCachedUIResourcesData = await getUiResourcesData({ ...options });
+    cb(nonCachedUIResourcesData);
+    const x = y;
+  } catch (err) {
+    errCb(err);
+  }
 };
 
 export default getCachedUiResourcesData;

--- a/packages/react/src/components/SuiteHeader/util/cacheduiresources.js
+++ b/packages/react/src/components/SuiteHeader/util/cacheduiresources.js
@@ -7,7 +7,6 @@ const getCachedUiResourcesData = async (options, cb, errCb) => {
     cb(cachedUIResourcesData);
     const nonCachedUIResourcesData = await getUiResourcesData({ ...options });
     cb(nonCachedUIResourcesData);
-    const x = y;
   } catch (err) {
     errCb(err);
   }

--- a/packages/react/src/components/SuiteHeader/util/uiresources.fixture.js
+++ b/packages/react/src/components/SuiteHeader/util/uiresources.fixture.js
@@ -26,9 +26,33 @@ const fixture = {
       },
       {
         id: 'Health',
-        name: 'Manage',
+        name: 'Health',
         href: 'https://mockedworkspace.health.mydomain.com/',
         isExternal: false,
+      },
+    ],
+    workspaces: [
+      {
+        id: 'mockedworkspace',
+        name: 'Mocked Workspace',
+        href: 'https://mockedworkspace.home.my-domain',
+        isCurrent: true,
+        applications: [
+          {
+            id: 'manage',
+            name: 'Manage',
+            href: 'https://mockedworkspace.manage.mydomain.com/',
+            isExternal: false,
+            isCurrent: false,
+          },
+          {
+            id: 'Health',
+            name: 'Health',
+            href: 'https://mockedworkspace.health.mydomain.com/',
+            isExternal: false,
+            isCurrent: false,
+          },
+        ],
       },
     ],
     i18n: {

--- a/packages/react/src/components/SuiteHeader/util/uiresources.js
+++ b/packages/react/src/components/SuiteHeader/util/uiresources.js
@@ -26,6 +26,7 @@ const getUiResourcesData = async ({
   surveyId = null,
   appId = null,
   workspaceId = null,
+  useCache = false,
   fetchApi = defaultFetchApi,
   isTest = false,
 }) => {
@@ -42,9 +43,10 @@ const getUiResourcesData = async ({
   const surveyIdParam = surveyId ? `&surveyId=${surveyId}` : '';
   const appIdParam = appId ? `&appId=${appId}` : '';
   const workspaceIdParam = workspaceId ? `&workspaceId=${workspaceId}` : '';
+  const cacheParam = useCache ? `&cache=${true}` : '';
   return api(
     'GET',
-    `/uiresources?id=masthead${langParam}${surveyIdParam}${appIdParam}${workspaceIdParam}`
+    `/uiresources?id=masthead${langParam}${surveyIdParam}${appIdParam}${workspaceIdParam}${cacheParam}`
   );
 };
 


### PR DESCRIPTION
**Summary**

In order to reduce the loading time of the `GET /uiresources` API, the `useUiResources` hook has been updated to include support for the `useCache` flag, which triggers `GET /uiresources` API twice, the first time with the `&cache=true` query parameter and the second time without it. The idea is to populate the result with data as fast as possible and only then refresh the result with the most up-to-date data. This is ok because the API response does not change very often and it is a slow API (when requesting the non-cached version of it).

**Change List (commits, features, bugs, etc)**

- Adding support for `useCache` flag in `GET /uiresources` API helper
- Adding a `cacheduiresources.js` that runs 2 consecutive `GET /resources` API requests (one cached and the other non-cached)
- Adding support for `useCache` flag in the `useUiResources` hook, which triggers  the use of `getCachedUiResourcesData` from `cacheduiresources.js` to make the API requests.
- Added unit tests for the `useUiResources` hook.

**Acceptance Test (how to verify the PR)**

- Run `jest src/components/SuiteHeader/hooks/useUiResources.test.js` and notice the that all tests pass.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- The `useUiResources` hook code has been copied as is (with the changes in this PR) to an application that uses `SuiteHeader` component and has access to the `GET /uiresources` API and it has been confirmed that the hook is working as expected.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
