### PR TITLE
fix(suiteheader) Fixing the promise flow in the cached data flow of useUiResources (it was missing an await)

### DIFF
--- a/packages/react/src/components/SuiteHeader/hooks/useUiResources.js
+++ b/packages/react/src/components/SuiteHeader/hooks/useUiResources.js
@@ -42,7 +42,7 @@ const useUiResources = ({
       setIsLoading(true);
       if (useCache) {
         // Set cached and then non-cached data
-        getCachedUiResourcesData(
+        await getCachedUiResourcesData(
           { ...options },
           (cachedData) => {
             setData(cachedData);

--- a/packages/react/src/components/SuiteHeader/hooks/useUiResources.test.js
+++ b/packages/react/src/components/SuiteHeader/hooks/useUiResources.test.js
@@ -34,6 +34,10 @@ describe('useUiResources', () => {
       })
     );
     const { result, waitForNextUpdate } = renderHook(() => useUiResources({}));
+    const [initialData, initialLoading, initialError] = result.current;
+    expect(initialData.username).toEqual(null);
+    expect(initialLoading).toEqual(true);
+    expect(initialError).toEqual(undefined);
     await waitForNextUpdate();
     const [data, loading, error] = result.current;
     // After data has been fetched, make sure that data is populated, loading is false and error is undefined
@@ -60,6 +64,10 @@ describe('useUiResources', () => {
         useCache: false,
       })
     );
+    const [initialData, initialLoading, initialError] = result.current;
+    expect(initialData.username).toEqual(null);
+    expect(initialLoading).toEqual(true);
+    expect(initialError).toEqual(undefined);
     await waitForNextUpdate();
     // After data has been fetched, make sure that data is populated, loading is false and error is undefined
     const [data, loading, error] = result.current;
@@ -70,7 +78,33 @@ describe('useUiResources', () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
     global.fetch = undefined;
   });
-  it('Error state', async () => {
+  it('Error state (cached and non-cached api requests)', async () => {
+    // Mock fetch call
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.reject(new Error('Boom!!!')),
+      })
+    );
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useUiResources({
+        useCache: true,
+      })
+    );
+    const [initialData, initialLoading, initialError] = result.current;
+    expect(initialData.username).toEqual(null);
+    expect(initialLoading).toEqual(true);
+    expect(initialError).toEqual(undefined);
+    await waitForNextUpdate();
+    // After data fetching has errored out, make sure that data still null, loading is false and error is defined
+    const [data, loading, error] = result.current;
+    expect(data.username).toEqual(null);
+    expect(loading).toEqual(false);
+    expect(error.message).toEqual('Boom!!!');
+    // Also, make sure that fetch has been called only once
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    global.fetch = undefined;
+  });
+  it('Error state (non-cached api request only)', async () => {
     // Mock fetch call
     global.fetch = jest.fn(() =>
       Promise.resolve({
@@ -82,6 +116,10 @@ describe('useUiResources', () => {
         useCache: false,
       })
     );
+    const [initialData, initialLoading, initialError] = result.current;
+    expect(initialData.username).toEqual(null);
+    expect(initialLoading).toEqual(true);
+    expect(initialError).toEqual(undefined);
     await waitForNextUpdate();
     // After data fetching has errored out, make sure that data still null, loading is false and error is defined
     const [data, loading, error] = result.current;


### PR DESCRIPTION
**Summary**

- Fixing the promise flow in the cached data flow of useUiResources (it was missing an await) and the `finally` statement was being called right away. It needs to be executed only after both callbacks are fired in `getCachedUiResourcesData()`.

**Acceptance Test (how to verify the PR)**

- Added some tests to make sure that the loading state is true in the initial state of the hook

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Tested in an application with access to the GET /uiresources API and it was possible to notice that the loading state is true until the first callback of getCachedUiResourcesData() is fired.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
