### PR TITLE
feat(filtertargs): add prop for overflow menu text

### DIFF
--- a/packages/react/src/components/FilterTags/FilterTags.jsx
+++ b/packages/react/src/components/FilterTags/FilterTags.jsx
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 import { settings } from '../../constants/Settings';
 import { useResize } from '../../internal/UseResizeObserver';
 
-const OVERFLOW_REGEXP = /{([^}]+)}/;
+const OVERFLOW_REGEXP = /{(.*)}/;
 const DEFAULT_OVERFLOW_TEXT = 'More: {n}';
 
 const { prefix, iotPrefix } = settings;

--- a/packages/react/src/components/FilterTags/FilterTags.jsx
+++ b/packages/react/src/components/FilterTags/FilterTags.jsx
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 import { settings } from '../../constants/Settings';
 import { useResize } from '../../internal/UseResizeObserver';
 
-const OVERFLOW_REGEXP = /\{(.*?)\}/;
+const OVERFLOW_REGEXP = /{([^}]+)}/;
 const DEFAULT_OVERFLOW_TEXT = 'More: {n}';
 
 const { prefix, iotPrefix } = settings;

--- a/packages/react/src/components/FilterTags/FilterTags.jsx
+++ b/packages/react/src/components/FilterTags/FilterTags.jsx
@@ -7,7 +7,15 @@ import classnames from 'classnames';
 import { settings } from '../../constants/Settings';
 import { useResize } from '../../internal/UseResizeObserver';
 
-const DEFAULT_OVERFLOW_TEXT_CALLBACK = (filterCount) => `More: ${filterCount}`;
+const DEFAULT_OVERFLOW_TEXT = 'More: {n}';
+
+const getFilterTagsOverflowText = (filterCount, i18nProp) => {
+  if (typeof i18nProp === 'function') {
+    return i18nProp(filterCount);
+  }
+
+  return i18nProp.replace('{n}', filterCount);
+};
 
 const { prefix, iotPrefix } = settings;
 /* eslint-disable-next-line react/prop-types */
@@ -42,7 +50,7 @@ const FilterTags = ({
   const [overflowItems, setOverflowItems] = useState([]);
   const [visibleItems, setVisibleItems] = useState(childrenItems);
 
-  const { filterTagsOverflowMenuText = DEFAULT_OVERFLOW_TEXT_CALLBACK, ...i18n } = i18nProps;
+  const { filterTagsOverflowMenuText = DEFAULT_OVERFLOW_TEXT, ...i18n } = i18nProps;
 
   useEffect(
     () => {
@@ -110,7 +118,7 @@ const FilterTags = ({
           className={`${iotPrefix}--filtertags-overflow-menu`}
           renderIcon={() => (
             <div className={`${prefix}--tag`}>
-              {filterTagsOverflowMenuText(overflowItems.length)}
+              {getFilterTagsOverflowText(overflowItems.length, filterTagsOverflowMenuText)}
             </div>
           )}
           menuOptionsClass={`${iotPrefix}--filtertags-overflow-items`}
@@ -174,7 +182,7 @@ const defaultProps = {
   tagContainer: null,
   onChange: null,
   i18n: {
-    filterTagsOverflowMenuText: DEFAULT_OVERFLOW_TEXT_CALLBACK,
+    filterTagsOverflowMenuText: DEFAULT_OVERFLOW_TEXT,
   },
   testId: 'filter-tags',
 };

--- a/packages/react/src/components/FilterTags/FilterTags.jsx
+++ b/packages/react/src/components/FilterTags/FilterTags.jsx
@@ -7,7 +7,6 @@ import classnames from 'classnames';
 import { settings } from '../../constants/Settings';
 import { useResize } from '../../internal/UseResizeObserver';
 
-const OVERFLOW_REGEXP = /{(.*)}/;
 const DEFAULT_OVERFLOW_TEXT = 'More: {n}';
 
 const { prefix, iotPrefix } = settings;
@@ -92,7 +91,7 @@ const FilterTags = ({
   );
 
   const filterTagsOverflowMenuTextText = filterTagsOverflowMenuText.replace(
-    OVERFLOW_REGEXP,
+    '{n}',
     overflowItems.length
   );
 

--- a/packages/react/src/components/FilterTags/FilterTags.jsx
+++ b/packages/react/src/components/FilterTags/FilterTags.jsx
@@ -7,6 +7,9 @@ import classnames from 'classnames';
 import { settings } from '../../constants/Settings';
 import { useResize } from '../../internal/UseResizeObserver';
 
+const OVERFLOW_REGEXP = /\{(.*?)\}/;
+const DEFAULT_OVERFLOW_TEXT = 'More: {n}';
+
 const { prefix, iotPrefix } = settings;
 /* eslint-disable-next-line react/prop-types */
 const DefaultWrapper = React.forwardRef(({ children, i18n, ...props }, ref) => {
@@ -23,7 +26,15 @@ const OverflowTag = ({ children }) => (
   </span>
 );
 
-const FilterTags = ({ children, hasOverflow, id, tagContainer, onChange, i18n, testId }) => {
+const FilterTags = ({
+  children,
+  hasOverflow,
+  id,
+  tagContainer,
+  onChange,
+  i18n: i18nProps,
+  testId,
+}) => {
   const TagContainer = tagContainer || DefaultWrapper;
   const overFlowContainerRef = useRef(null);
   useResize(overFlowContainerRef);
@@ -31,6 +42,8 @@ const FilterTags = ({ children, hasOverflow, id, tagContainer, onChange, i18n, t
   const breakingWidth = useRef([]);
   const [overflowItems, setOverflowItems] = useState([]);
   const [visibleItems, setVisibleItems] = useState(childrenItems);
+
+  const { filterTagsOverflowMenuText = DEFAULT_OVERFLOW_TEXT, ...i18n } = i18nProps;
 
   useEffect(
     () => {
@@ -78,6 +91,11 @@ const FilterTags = ({ children, hasOverflow, id, tagContainer, onChange, i18n, t
     /* eslint-enable react-hooks/exhaustive-deps */
   );
 
+  const filterTagsOverflowMenuTextText = filterTagsOverflowMenuText.replace(
+    OVERFLOW_REGEXP,
+    overflowItems.length
+  );
+
   return (
     <TagContainer
       key={`${hasOverflow}-Tag-Container`}
@@ -97,7 +115,7 @@ const FilterTags = ({ children, hasOverflow, id, tagContainer, onChange, i18n, t
           data-floating-menu-container
           className={`${iotPrefix}--filtertags-overflow-menu`}
           renderIcon={() => (
-            <div className={`${prefix}--tag`}>{`More: ${overflowItems.length}`}</div>
+            <div className={`${prefix}--tag`}>{filterTagsOverflowMenuTextText}</div>
           )}
           menuOptionsClass={`${iotPrefix}--filtertags-overflow-items`}
           menuOffset={{
@@ -159,7 +177,9 @@ const defaultProps = {
   hasOverflow: true,
   tagContainer: null,
   onChange: null,
-  i18n: {},
+  i18n: {
+    filterTagsOverflowMenuText: DEFAULT_OVERFLOW_TEXT,
+  },
   testId: 'filter-tags',
 };
 

--- a/packages/react/src/components/FilterTags/FilterTags.jsx
+++ b/packages/react/src/components/FilterTags/FilterTags.jsx
@@ -28,9 +28,10 @@ const DefaultWrapper = React.forwardRef(({ children, i18n, ...props }, ref) => {
 });
 /* eslint-disable-next-line react/prop-types */
 const OverflowTag = ({ children }) => (
-  <span>
-    {children} <Close16 />
-  </span>
+  <div className={`${iotPrefix}--filtertags-overflow-item__wrapper`}>
+    <span>{children}</span>
+    <Close16 />
+  </div>
 );
 
 const FilterTags = ({

--- a/packages/react/src/components/FilterTags/FilterTags.jsx
+++ b/packages/react/src/components/FilterTags/FilterTags.jsx
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 import { settings } from '../../constants/Settings';
 import { useResize } from '../../internal/UseResizeObserver';
 
-const DEFAULT_OVERFLOW_TEXT = 'More: {n}';
+const DEFAULT_OVERFLOW_TEXT_CALLBACK = (filterCount) => `More: ${filterCount}`;
 
 const { prefix, iotPrefix } = settings;
 /* eslint-disable-next-line react/prop-types */
@@ -42,7 +42,7 @@ const FilterTags = ({
   const [overflowItems, setOverflowItems] = useState([]);
   const [visibleItems, setVisibleItems] = useState(childrenItems);
 
-  const { filterTagsOverflowMenuText = DEFAULT_OVERFLOW_TEXT, ...i18n } = i18nProps;
+  const { filterTagsOverflowMenuText = DEFAULT_OVERFLOW_TEXT_CALLBACK, ...i18n } = i18nProps;
 
   useEffect(
     () => {
@@ -90,11 +90,6 @@ const FilterTags = ({
     /* eslint-enable react-hooks/exhaustive-deps */
   );
 
-  const filterTagsOverflowMenuTextText = filterTagsOverflowMenuText.replace(
-    '{n}',
-    overflowItems.length
-  );
-
   return (
     <TagContainer
       key={`${hasOverflow}-Tag-Container`}
@@ -114,7 +109,9 @@ const FilterTags = ({
           data-floating-menu-container
           className={`${iotPrefix}--filtertags-overflow-menu`}
           renderIcon={() => (
-            <div className={`${prefix}--tag`}>{filterTagsOverflowMenuTextText}</div>
+            <div className={`${prefix}--tag`}>
+              {filterTagsOverflowMenuText(overflowItems.length)}
+            </div>
           )}
           menuOptionsClass={`${iotPrefix}--filtertags-overflow-items`}
           menuOffset={{
@@ -177,7 +174,7 @@ const defaultProps = {
   tagContainer: null,
   onChange: null,
   i18n: {
-    filterTagsOverflowMenuText: DEFAULT_OVERFLOW_TEXT,
+    filterTagsOverflowMenuText: DEFAULT_OVERFLOW_TEXT_CALLBACK,
   },
   testId: 'filter-tags',
 };

--- a/packages/react/src/components/FilterTags/FilterTags.test.jsx
+++ b/packages/react/src/components/FilterTags/FilterTags.test.jsx
@@ -210,4 +210,58 @@ describe('Filtertags', () => {
     userEvent.click(screen.getByText('Hello Daughter'));
     expect(mockOnClose).toHaveBeenCalledWith('tag-four');
   });
+
+  it('will render custom overflow menu text from i18n prop', () => {
+    const mockOnClose = jest.fn();
+    render(
+      <FilterTags
+        i18n={{
+          filterTagsOverflowMenuText: 'Hidden items: {anyPlaceholder}',
+        }}
+      >
+        {tagData.map((tag) => (
+          <Tag
+            key={`tag-${tag.id}`}
+            filter
+            type={tag.type}
+            title="Clear Filter"
+            style={{ marginRight: '1rem' }}
+            onClose={() => mockOnClose(tag.id)}
+          >
+            {tag.text}
+          </Tag>
+        ))}
+      </FilterTags>
+    );
+    const moreButton = screen.queryByText(/Hidden items:*/);
+    userEvent.click(moreButton);
+    expect(screen.getByText('Hello Daughter')).toBeTruthy();
+    userEvent.click(screen.getByText('Hello Daughter'));
+    expect(mockOnClose).toHaveBeenCalledWith('tag-four');
+  });
+
+  it('will render text without count substitution if {} is not provided', () => {
+    const mockOnClose = jest.fn();
+    render(
+      <FilterTags
+        i18n={{
+          filterTagsOverflowMenuText: 'Hidden items',
+        }}
+      >
+        {tagData.map((tag) => (
+          <Tag
+            key={`tag-${tag.id}`}
+            filter
+            type={tag.type}
+            title="Clear Filter"
+            style={{ marginRight: '1rem' }}
+            onClose={() => mockOnClose(tag.id)}
+          >
+            {tag.text}
+          </Tag>
+        ))}
+      </FilterTags>
+    );
+    expect(screen.getByText('Hidden items')).toBeVisible();
+  });
 });

--- a/packages/react/src/components/FilterTags/FilterTags.test.jsx
+++ b/packages/react/src/components/FilterTags/FilterTags.test.jsx
@@ -216,7 +216,7 @@ describe('Filtertags', () => {
     render(
       <FilterTags
         i18n={{
-          filterTagsOverflowMenuText: 'Hidden items: {n}',
+          filterTagsOverflowMenuText: (itemCount) => `Hidden items: ${itemCount}`,
         }}
       >
         {tagData.map((tag) => (
@@ -240,12 +240,12 @@ describe('Filtertags', () => {
     expect(mockOnClose).toHaveBeenCalledWith('tag-four');
   });
 
-  it('will render text without count substitution if {} is not provided', () => {
+  it('will render text without count substitution if callback parameter is not provided', () => {
     const mockOnClose = jest.fn();
     render(
       <FilterTags
         i18n={{
-          filterTagsOverflowMenuText: 'Hidden items',
+          filterTagsOverflowMenuText: () => 'Hidden items',
         }}
       >
         {tagData.map((tag) => (

--- a/packages/react/src/components/FilterTags/FilterTags.test.jsx
+++ b/packages/react/src/components/FilterTags/FilterTags.test.jsx
@@ -216,7 +216,7 @@ describe('Filtertags', () => {
     render(
       <FilterTags
         i18n={{
-          filterTagsOverflowMenuText: 'Hidden items: {anyPlaceholder}',
+          filterTagsOverflowMenuText: 'Hidden items: {n}',
         }}
       >
         {tagData.map((tag) => (

--- a/packages/react/src/components/FilterTags/_filter-tags.scss
+++ b/packages/react/src/components/FilterTags/_filter-tags.scss
@@ -36,9 +36,15 @@
   }
 }
 
-.#{$iot-prefix}--filtertags-overflow-item span {
+.#{$iot-prefix}--filtertags-overflow-item__wrapper {
   display: flex;
   align-items: center;
   justify-content: space-between;
   width: 100%;
+
+  span {
+    width: 90%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }

--- a/packages/react/src/components/FilterTags/_filter-tags.scss
+++ b/packages/react/src/components/FilterTags/_filter-tags.scss
@@ -6,7 +6,7 @@
 
     .#{$prefix}--overflow-menu {
       width: auto;
-      min-width: 4.5rem;
+      height: unset;
     }
   }
 

--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -561,7 +561,7 @@ export const defaultProps = (baseProps) => ({
     actionFailedText: 'Action failed',
     toolbarTooltipLabel: 'Toolbar tooltip',
     filterRowIconDescription: 'Edit filters',
-    filterTagsOverflowMenuText: '+{n}',
+    filterTagsOverflowMenuText: (filterCount) => `+${filterCount}`,
   },
   error: null,
   // TODO: set default in v3. Leaving null for backwards compat. to match 'id' which was

--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -561,7 +561,7 @@ export const defaultProps = (baseProps) => ({
     actionFailedText: 'Action failed',
     toolbarTooltipLabel: 'Toolbar tooltip',
     filterRowIconDescription: 'Edit filters',
-    filterTagsOverflowMenuText: (filterCount) => `+${filterCount}`,
+    filterTagsOverflowMenuText: '+{n}',
   },
   error: null,
   // TODO: set default in v3. Leaving null for backwards compat. to match 'id' which was

--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -561,6 +561,7 @@ export const defaultProps = (baseProps) => ({
     actionFailedText: 'Action failed',
     toolbarTooltipLabel: 'Toolbar tooltip',
     filterRowIconDescription: 'Edit filters',
+    filterTagsOverflowMenuText: '+{n}',
   },
   error: null,
   // TODO: set default in v3. Leaving null for backwards compat. to match 'id' which was
@@ -954,6 +955,9 @@ const Table = (props) => {
           <FilterTags
             // TODO: remove id in V3.
             testId={`${id || testId}-filter-tags`}
+            i18n={{
+              filterTagsOverflowMenuText: i18n.filterTagsOverflowMenuText,
+            }}
           >
             {view.advancedFilters
               .filter((advFilter) => view.selectedAdvancedFilterIds.includes(advFilter.filterId))

--- a/packages/react/src/components/Table/Table.main.story.jsx
+++ b/packages/react/src/components/Table/Table.main.story.jsx
@@ -42,6 +42,7 @@ import {
   getEditDataFunction,
   getRowActionStates,
   getAdvancedFilters,
+  getMoreAdvancedFilters,
   getTableKnobs,
   getI18nKnobs,
   getBatchActions,
@@ -800,12 +801,18 @@ export const WithFiltering = () => {
   }
 
   // Advanced filter settings
+  let displayOverflowFilterTags;
   const [showBuilder, setShowBuilder] = useStoryState(false);
   const [advancedFilters, setAdvancedFilters] = useStoryState(
     hasAdvancedFilter ? getAdvancedFilters() : undefined
   );
   const selectedAdvancedFilterIds = hasAdvancedFilter
-    ? object('Active advanced filters (view.selectedAdvancedFilterIds) ☢️', ['story-filter'])
+    ? object(
+        'Active advanced filters (view.selectedAdvancedFilterIds) ☢️',
+        displayOverflowFilterTags
+          ? ['story-filter']
+          : ['story-filter', 'story-filter1', 'story-filter2']
+      )
     : undefined;
   const advancedFilterFlyoutOpen = hasAdvancedFilter
     ? boolean('Show advanced filter flyout (view.toolbar.advancedFilterFlyoutOpen) ☢️', true)
@@ -816,6 +823,14 @@ export const WithFiltering = () => {
   const storyNotice = hasAdvancedFilter ? (
     <StoryNotice experimental componentName="StatefulTable with advancedFilters" />
   ) : null;
+
+  if (hasAdvancedFilter) {
+    displayOverflowFilterTags = boolean(
+      'Enable overflow menu in filter tags for advanced filters  ☢️',
+      false
+    );
+  }
+
   const operands = {
     CONTAINS: (a, b) => a.includes(b),
     NEQ: (a, b) => a !== b,
@@ -843,6 +858,10 @@ export const WithFiltering = () => {
           );
         })
       : data;
+
+  if (displayOverflowFilterTags) {
+    setAdvancedFilters((prevFilters) => [...prevFilters, ...getMoreAdvancedFilters()]);
+  }
 
   const knobRegeneratedKey = `${JSON.stringify(activeFilters)}`;
   return (

--- a/packages/react/src/components/Table/Table.story.helpers.jsx
+++ b/packages/react/src/components/Table/Table.story.helpers.jsx
@@ -915,6 +915,54 @@ export const getAdvancedFilters = () => [
   },
 ];
 
+export const getMoreAdvancedFilters = () => [
+  {
+    filterId: 'story-filter1',
+    /** Text for main tilte of page */
+    filterTitleText:
+      'string CONTAINS toyota Some really long text to enable overflow menu to display Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas ac leo augue. Vivamus id orci arcu.',
+    /**
+     * the rules passed into the component. The RuleBuilder is a controlled component, so
+     * this works the same as passing defaultValue to a controlled input component.
+     */
+    filterRules: {
+      id: 'kmnhf092gub',
+      groupLogic: 'ALL',
+      rules: [
+        {
+          id: 'asdadguen87',
+          columnId: 'string',
+          operand: 'CONTAINS',
+          value: 'toyota',
+        },
+      ],
+    },
+    filterColumns: getTableColumns(),
+  },
+  {
+    filterId: 'story-filter2',
+    /** Text for main tilte of page */
+    filterTitleText: 'select=option-A',
+    /**
+     * the rules passed into the component. The RuleBuilder is a controlled component, so
+     * this works the same as passing defaultValue to a controlled input component.
+     */
+    filterRules: {
+      id: '9jf87klobuf',
+      groupLogic: 'ALL',
+      rules: [
+        {
+          id: 'iijn109fmwhd',
+          columnId: 'select',
+          operand: 'CONTAINS',
+          value: 'option-A',
+        },
+      ],
+    },
+    filterColumns: getTableColumns(),
+  },
+];
+
 const getParsedIntOrUndefined = (value) => {
   const parsedValue = Number.parseInt(value, 10);
   return Number.isNaN(parsedValue) ? undefined : parsedValue;

--- a/packages/react/src/components/Table/TablePropTypes.js
+++ b/packages/react/src/components/Table/TablePropTypes.js
@@ -225,6 +225,8 @@ export const I18NPropTypes = PropTypes.shape({
   toolbarTooltipLabel: PropTypes.string,
   /** tooltip text for filter row icon button */
   filterRowIconDescription: PropTypes.string,
+  /** overflow menu text for truncated filter tags */
+  filterTagsOverflowMenuText: PropTypes.string,
 });
 
 export const defaultI18NPropTypes = {

--- a/packages/react/src/components/Table/TablePropTypes.js
+++ b/packages/react/src/components/Table/TablePropTypes.js
@@ -226,7 +226,7 @@ export const I18NPropTypes = PropTypes.shape({
   /** tooltip text for filter row icon button */
   filterRowIconDescription: PropTypes.string,
   /** overflow menu text callback for truncated filter tags */
-  filterTagsOverflowMenuText: PropTypes.func,
+  filterTagsOverflowMenuText: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
 });
 
 export const defaultI18NPropTypes = {

--- a/packages/react/src/components/Table/TablePropTypes.js
+++ b/packages/react/src/components/Table/TablePropTypes.js
@@ -225,8 +225,8 @@ export const I18NPropTypes = PropTypes.shape({
   toolbarTooltipLabel: PropTypes.string,
   /** tooltip text for filter row icon button */
   filterRowIconDescription: PropTypes.string,
-  /** overflow menu text for truncated filter tags */
-  filterTagsOverflowMenuText: PropTypes.string,
+  /** overflow menu text callback for truncated filter tags */
+  filterTagsOverflowMenuText: PropTypes.func,
 });
 
 export const defaultI18NPropTypes = {

--- a/packages/react/src/components/Table/mdx/Table.mdx
+++ b/packages/react/src/components/Table/mdx/Table.mdx
@@ -745,7 +745,7 @@ import TableViewDropdownContent from '../TableViewDropdown/TableViewDropdownCont
 | multiSortDescending              | string       | 'Descending'             |                                                        |
 | loadMoreText                     | string       | 'Load more...'           |                                                        |
 | filterRowIconDescription         | string       | 'Edit filters'           |                                                        |
-| filterTagsOverflowMenuText       | string       | '+{n}'                   | Text in curly brackets will be replaced                |
+| filterTagsOverflowMenuText       | string       | '+{n}'                   | {n} will be replaced by filter count                   |
 
 ## Source Code
 

--- a/packages/react/src/components/Table/mdx/Table.mdx
+++ b/packages/react/src/components/Table/mdx/Table.mdx
@@ -745,6 +745,7 @@ import TableViewDropdownContent from '../TableViewDropdown/TableViewDropdownCont
 | multiSortDescending              | string       | 'Descending'             |                                                        |
 | loadMoreText                     | string       | 'Load more...'           |                                                        |
 | filterRowIconDescription         | string       | 'Edit filters'           |                                                        |
+| filterTagsOverflowMenuText       | string       | '+{n}'                   | Text in curly brackets will be replaced                |
 
 ## Source Code
 

--- a/packages/react/src/components/Table/mdx/Table.mdx
+++ b/packages/react/src/components/Table/mdx/Table.mdx
@@ -745,7 +745,7 @@ import TableViewDropdownContent from '../TableViewDropdown/TableViewDropdownCont
 | multiSortDescending              | string       | 'Descending'             |                                                        |
 | loadMoreText                     | string       | 'Load more...'           |                                                        |
 | filterRowIconDescription         | string       | 'Edit filters'           |                                                        |
-| filterTagsOverflowMenuText       | string       | '+{n}'                   | {n} will be replaced by filter count                   |
+| filterTagsOverflowMenuText       | func         | '+{filterCount}'         | {filterCount} is number of hidden filters              |
 
 ## Source Code
 

--- a/packages/react/src/components/Table/mdx/Table.mdx
+++ b/packages/react/src/components/Table/mdx/Table.mdx
@@ -745,7 +745,7 @@ import TableViewDropdownContent from '../TableViewDropdown/TableViewDropdownCont
 | multiSortDescending              | string       | 'Descending'             |                                                        |
 | loadMoreText                     | string       | 'Load more...'           |                                                        |
 | filterRowIconDescription         | string       | 'Edit filters'           |                                                        |
-| filterTagsOverflowMenuText       | func         | '+{filterCount}'         | {filterCount} is number of hidden filters              |
+| filterTagsOverflowMenuText       | string, func | '+{n}'                   | {n} is number of hidden filters              |
 
 ## Source Code
 

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -671,6 +671,7 @@ Map {
         "filterDescending": "Sort rows by this header in descending order",
         "filterNone": "Unsort rows by this header",
         "filterRowIconDescription": "Edit filters",
+        "filterTagsOverflowMenuText": "+{n}",
         "inProgressText": "In progress",
         "itemSelected": [Function],
         "itemsPerPage": "Items per page:",
@@ -1330,6 +1331,9 @@ Map {
               "type": "string",
             },
             "filterRowIconDescription": Object {
+              "type": "string",
+            },
+            "filterTagsOverflowMenuText": Object {
               "type": "string",
             },
             "inProgressText": Object {
@@ -2699,6 +2703,9 @@ Map {
               "type": "string",
             },
             "filterRowIconDescription": Object {
+              "type": "string",
+            },
+            "filterTagsOverflowMenuText": Object {
               "type": "string",
             },
             "inProgressText": Object {
@@ -31193,7 +31200,9 @@ Map {
   "FilterTags" => Object {
     "defaultProps": Object {
       "hasOverflow": true,
-      "i18n": Object {},
+      "i18n": Object {
+        "filterTagsOverflowMenuText": "More: {n}",
+      },
       "id": "filter-tag-container",
       "onChange": null,
       "tagContainer": null,

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -671,7 +671,7 @@ Map {
         "filterDescending": "Sort rows by this header in descending order",
         "filterNone": "Unsort rows by this header",
         "filterRowIconDescription": "Edit filters",
-        "filterTagsOverflowMenuText": "+{n}",
+        "filterTagsOverflowMenuText": [Function],
         "inProgressText": "In progress",
         "itemSelected": [Function],
         "itemsPerPage": "Items per page:",
@@ -1334,7 +1334,7 @@ Map {
               "type": "string",
             },
             "filterTagsOverflowMenuText": Object {
-              "type": "string",
+              "type": "func",
             },
             "inProgressText": Object {
               "type": "string",
@@ -2706,7 +2706,7 @@ Map {
               "type": "string",
             },
             "filterTagsOverflowMenuText": Object {
-              "type": "string",
+              "type": "func",
             },
             "inProgressText": Object {
               "type": "string",
@@ -31201,7 +31201,7 @@ Map {
     "defaultProps": Object {
       "hasOverflow": true,
       "i18n": Object {
-        "filterTagsOverflowMenuText": "More: {n}",
+        "filterTagsOverflowMenuText": [Function],
       },
       "id": "filter-tag-container",
       "onChange": null,

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -671,7 +671,7 @@ Map {
         "filterDescending": "Sort rows by this header in descending order",
         "filterNone": "Unsort rows by this header",
         "filterRowIconDescription": "Edit filters",
-        "filterTagsOverflowMenuText": [Function],
+        "filterTagsOverflowMenuText": "+{n}",
         "inProgressText": "In progress",
         "itemSelected": [Function],
         "itemsPerPage": "Items per page:",
@@ -1334,7 +1334,17 @@ Map {
               "type": "string",
             },
             "filterTagsOverflowMenuText": Object {
-              "type": "func",
+              "args": Array [
+                Array [
+                  Object {
+                    "type": "func",
+                  },
+                  Object {
+                    "type": "string",
+                  },
+                ],
+              ],
+              "type": "oneOfType",
             },
             "inProgressText": Object {
               "type": "string",
@@ -2706,7 +2716,17 @@ Map {
               "type": "string",
             },
             "filterTagsOverflowMenuText": Object {
-              "type": "func",
+              "args": Array [
+                Array [
+                  Object {
+                    "type": "func",
+                  },
+                  Object {
+                    "type": "string",
+                  },
+                ],
+              ],
+              "type": "oneOfType",
             },
             "inProgressText": Object {
               "type": "string",
@@ -31201,7 +31221,7 @@ Map {
     "defaultProps": Object {
       "hasOverflow": true,
       "i18n": Object {
-        "filterTagsOverflowMenuText": [Function],
+        "filterTagsOverflowMenuText": "More: {n}",
       },
       "id": "filter-tag-container",
       "onChange": null,


### PR DESCRIPTION
Closes #3710

**Summary**

- Add i18n prop for text in OverflowMenu displayed for truncated FilterTags

**Change List (commits, features, bugs, etc)**

- Add i18n prop to FilterTags component
- Add default i18n prop for FilterTags inside Table component
- Update tests and docs

**Acceptance Test (how to verify the PR)**

- Go to [this story](https://deploy-preview-3713--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table--with-filtering)
- Enable: `hasAdvancedFilters`
- Click on `Enable overflow menu in filter tags for advanced filters`
- Re-enable `hasAdvancedFilters` in order to reset memoized filters
- See OverflowMenu for truncated filters displayed as `+1` (resize screen horizontally if it's not displayed)

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
