### PR TITLE
8.10 - Fix version issue 

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.152.1-next.2",
+  "version": "2.152.2",
   "npmClient": "yarn"
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -340,7 +340,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "sideEffects": false,
-  "version": "2.152.1-next.2",
+  "version": "2.152.2",
   "resolutions": {
     "chokidar": "3.3.1",
     "react-grid-layout": "1.2.2",


### PR DESCRIPTION
Last merge failed to publish due to duplicate version. This PR bumps up the version to the next patch. 