### PR TITLE
fix(datetimepicker): add check for mask value

### DIFF
--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
@@ -2818,7 +2818,7 @@ describe('DateTimePickerV2', () => {
     });
   });
 
-  it('should render without a time picker', () => {
+  it('should render without a time picker and a mask that does not include time', () => {
     render(
       <DateTimePicker
         {...dateTimePickerProps}

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
@@ -2817,4 +2817,16 @@ describe('DateTimePickerV2', () => {
       expect(onApply).toHaveBeenCalledTimes(1);
     });
   });
+
+  it('should render without a time picker', () => {
+    render(
+      <DateTimePicker
+        {...dateTimePickerProps}
+        i18n={i18n}
+        dateTimeMask="MM/DD/YYYY"
+        hasTimeInput={false}
+      />
+    );
+    expect(screen.getByText(PRESET_VALUES[0].label)).toBeVisible();
+  });
 });

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
@@ -341,7 +341,7 @@ const DateTimePicker = ({
   const is24hours = useMemo(() => {
     const [, time] = dateTimeMask.split(' ');
     const hoursMask = time?.split(':')[0];
-    return hoursMask.includes('H');
+    return hoursMask ? hoursMask.includes('H') : false;
   }, [dateTimeMask]);
   const isSingleSelect = useMemo(() => datePickerType === 'single', [datePickerType]);
 

--- a/packages/react/src/components/DateTimePicker/dateTimePickerUtils.js
+++ b/packages/react/src/components/DateTimePicker/dateTimePickerUtils.js
@@ -16,7 +16,7 @@ const { iotPrefix } = settings;
 const is24hours = (dateTimeMask) => {
   const [, time] = dateTimeMask.split(' ');
   const hoursMask = time?.split(':')[0];
-  return hoursMask.includes('H');
+  return hoursMask ? hoursMask.includes('H') : false;
 };
 
 /** convert time from 12 hours to 24 hours, if time12hour is 24 hours format, return immediately

--- a/packages/react/src/components/Header/_header.scss
+++ b/packages/react/src/components/Header/_header.scss
@@ -49,6 +49,10 @@ $hoverBgColor: #2c2c2c;
   &__menu-title[role='menuitem'][aria-expanded='true'] + &__menu {
     left: auto;
     right: 0;
+    [dir='rtl'] & {
+      left: 0;
+      right: auto;
+    }
   }
 
   &__menu {


### PR DESCRIPTION
Closes #3741

**Summary**

New check for date time mask is throwing error when `hasTimeInput` is used and  mask is provided that does not include time. This PR puts in an additional check to ensure that there is a value before running check.  

**Change List (commits, features, bugs, etc)**

- Add check in our utilities file in `dateTimePickerUtils.js`
- Add check in our DateTimePicker file in `DateTimePickerV2WithTimeSpinner.jsx`
- Add test to ensure this functionality is covered in `DateTimePickerV2.test.jsx`

