### PR TITLE
fix(header): handle server-side rendering  #3742

### DIFF
--- a/packages/react/src/components/Header/HeaderActionGroup.jsx
+++ b/packages/react/src/components/Header/HeaderActionGroup.jsx
@@ -103,10 +103,18 @@ const HeaderActionGroup = ({
   }, [actionItems, langDir, overflowItems.length]);
 
   useLayoutEffect(() => {
-    checkForOverflow();
-    window.addEventListener('resize', checkForOverflow);
+    // Check for SSR
+    if (typeof window !== 'undefined') {
+      checkForOverflow();
+      window.addEventListener('resize', checkForOverflow);
+    }
 
-    return () => window.removeEventListener('resize', checkForOverflow);
+    return () => {
+      // Check for SSR
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('resize', checkForOverflow);
+      }
+    };
   }, [checkForOverflow]);
 
   return (


### PR DESCRIPTION
Closes #

**Summary**

Fix issue that happens when you try to use the `<Header ... />` component in a server-side environment.
Partly fixes: #3742 (multiple components of this library contains code that try to use `document` or `window` object, this PR only focuses to fix the Header component.)

**Change List (commits, features, bugs, etc)**

- added checks for SSR and only run the `checkForOverflow()` (which called the window or document object) function when we are on client side so the code can reach the `window` or `document` object.

**Acceptance Test (how to verify the PR)**

- base and e2e tests passed

**Regression Test (how to make sure this PR doesn't break old functionality)**

- good question, that's my first contribution in this repository, think this is such a small change and just an additional check around some overflow checking for the header render that its unlikely will break anything, but i am open for suggestions, improvements.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
