### PR TITLE
fix(angular-list): fix drag drop issue

### DIFF
--- a/packages/angular/src/list/ai-list.component.ts
+++ b/packages/angular/src/list/ai-list.component.ts
@@ -60,8 +60,11 @@ export enum SelectionType {
           (droppedAbove)="handleDrop(data.parentItem, data.index)"
           (droppedBelow)="handleDrop(data.parentItem, data.index + 1)"
           (droppedNested)="handleDrop(data.item, 0)"
+          (dragEnterBelow)="handleDragOver($event, data.parentItem)"
           (dragOverBelow)="handleDragOver($event, data.parentItem)"
+          (dragEnterAbove)="handleDragOver($event, data.parentItem)"
           (dragOverAbove)="handleDragOver($event, data.parentItem)"
+          (dragEnterNested)="handleDragOver($event, data.item)"
           (dragOverNested)="handleDragOver($event, data.item)"
         >
           <ai-list-item

--- a/packages/angular/src/list/list-item/ai-list-item-wrapper.component.ts
+++ b/packages/angular/src/list/list-item/ai-list-item-wrapper.component.ts
@@ -21,6 +21,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
             aiListTarget
             targetPosition="nested"
             (dropping)="droppedNested.emit($event)"
+            (dragEnter)="dragEnterNested.emit($event)"
             (dragOver)="dragOverNested.emit($event)"
             [targetSize]="100"
           ></div>
@@ -28,12 +29,14 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
             aiListTarget
             targetPosition="above"
             (dropping)="droppedAbove.emit($event)"
+            (dragEnter)="dragEnterAbove.emit($event)"
             (dragOver)="dragOverAbove.emit($event)"
           ></div>
           <div
             aiListTarget
             targetPosition="below"
             (dropping)="droppedBelow.emit($event)"
+            (dragEnter)="dragEnterBelow.emit($event)"
             (dragOver)="dragOverBelow.emit($event)"
           ></div>
         </div>
@@ -67,9 +70,15 @@ export class AIListItemWrapperComponent {
 
   @Output() dragEnd = new EventEmitter<any>();
 
+  @Output() dragEnterAbove = new EventEmitter<any>();
+
+  @Output() dragEnterBelow = new EventEmitter<any>();
+
   @Output() dragOverAbove = new EventEmitter<any>();
 
   @Output() dragOverBelow = new EventEmitter<any>();
+
+  @Output() dragEnterNested = new EventEmitter<any>();
 
   @Output() dragOverNested = new EventEmitter<any>();
 

--- a/packages/angular/src/list/list-item/ai-list-item-wrapper.component.ts
+++ b/packages/angular/src/list/list-item/ai-list-item-wrapper.component.ts
@@ -72,9 +72,9 @@ export class AIListItemWrapperComponent {
 
   @Output() dragEnterAbove = new EventEmitter<any>();
 
-  @Output() dragEnterBelow = new EventEmitter<any>();
-
   @Output() dragOverAbove = new EventEmitter<any>();
+
+  @Output() dragEnterBelow = new EventEmitter<any>();
 
   @Output() dragOverBelow = new EventEmitter<any>();
 


### PR DESCRIPTION
Closes #

**Summary**

Bug: sometimes, when drag and drop an item in the Angular list component, the item may be removed from the list unexpectedly. It is difficult to reproduce on will. Console logging shows that when the problem happens, the list component received a `dragEnd` event but didn't receive a `dropped` event. That explains why the item is removed from the list - the `dropped` event handler adds a duplicate and the `dragEnd` event handler removes the original.

Fix: according to MDN https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations#specifying_drop_targets, we need to prevent the default behavior by cancelling both the `dragenter` and `dragover` events. This PR adds event handler for `dragenter`. With this fix, I could no longer reproduce the problem.

> If you want to allow a drop, you must prevent the default behavior by cancelling both the dragenter and dragover events. 

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
