### PR TITLE
fix(walkme): Defining the required Walkme global variable and function in a useEffect hook because they were not being set inside the script tag for some reason.

### DIFF
--- a/packages/react/src/components/Walkme/Walkme.jsx
+++ b/packages/react/src/components/Walkme/Walkme.jsx
@@ -25,7 +25,7 @@ const Walkme = ({ path, lang }) => {
   useEffect(() => {
     window.walkme_get_language = function () {
       return lang === 'en' ? '' : lang;
-    }
+    };
   }, [lang]);
 
   return (

--- a/packages/react/src/components/Walkme/Walkme.jsx
+++ b/packages/react/src/components/Walkme/Walkme.jsx
@@ -1,7 +1,9 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable no-script-url */
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable func-names */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Helmet, HelmetProvider } from 'react-helmet-async';
 
@@ -17,16 +19,18 @@ const propTypes = {
 };
 
 const Walkme = ({ path, lang }) => {
+  useEffect(() => {
+    window._walkmeConfig = { smartLoad: true };
+  }, []);
+  useEffect(() => {
+    window.walkme_get_language = function () {
+      return lang === 'en' ? '' : lang;
+    }
+  }, [lang]);
+
   return (
     <HelmetProvider>
       <Helmet>
-        <script>
-          {`window._walkmeConfig = {smartLoad:true};
-            window.walkme_get_language = function () {
-              return '${lang === 'en' ? '' : lang}';
-            }
-          `}
-        </script>
         <script type="text/javascript" src={path} />
       </Helmet>
     </HelmetProvider>

--- a/packages/react/src/components/Walkme/Walkme.test.jsx
+++ b/packages/react/src/components/Walkme/Walkme.test.jsx
@@ -9,10 +9,12 @@ describe('Walkme', () => {
     render(<Walkme path="/some/path" />);
     // Make sure the scripts in Walkme component were executed
     await waitFor(() => expect(window._walkmeConfig).toEqual({ smartLoad: true }));
+    await waitFor(() => expect(window.walkme_get_language()).toEqual(''));
   });
   it('renders walkme with specified language', async () => {
     render(<Walkme path="/some/path" lang="pt-BR" />);
     // Make sure the scripts in Walkme component were executed
     await waitFor(() => expect(window._walkmeConfig).toEqual({ smartLoad: true }));
+    await waitFor(() => expect(window.walkme_get_language()).toEqual('pt-BR'));
   });
 });


### PR DESCRIPTION
The `_walkmeConfig` object and `walkme_get_language()` function, which are required for Walkme to work properly, were being left undefined for some reason when the Walkme component rendered more than once. This happens more frequently when the `lang` property availability in the component is delayed, which triggers more re-renders. This has always worked in the past but, for some reason, it is not working anymore. The solution was to move the assignments of the variable and function outside of the script tag and put them inside `useEffect` hooks. 
Here is an article that warns about the issues of using `<script>` tags in React: https://codingshower.com/adding-and-executing-script-tags-in-react-render/ 

**Change List (commits, features, bugs, etc)**

- Moved the definition of `_walkmeConfig` and `walkme_get_language()` functions to `useEffect` hooks to make sure they are defined and can be used by Walkme script when needed.

**Acceptance Test (how to verify the PR)**

- I've used the component in an web app that integrates a Walkme script that supports multiple languages and I was able to see translated content `when` property lang is set to a language different than `en`. 

**Regression Test (how to make sure this PR doesn't break old functionality)**

- There was no noticeable side effect after this change.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
