### PR TITLE
feat(breadcrumb): add option to disable truncation

### DIFF
--- a/packages/react/src/components/Breadcrumb/Breadcrumb.jsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.jsx
@@ -7,6 +7,9 @@ import { Breadcrumb as CarbonBreadcrumb } from 'carbon-components-react';
 import { OverflowMenu } from '../OverflowMenu';
 import { OverflowMenuItem } from '../OverflowMenuItem';
 import { useResize } from '../../internal/UseResizeObserver';
+import { settings } from '../../constants/Settings';
+
+const { iotPrefix } = settings;
 
 const propTypes = {
   /**
@@ -38,7 +41,7 @@ const propTypes = {
   /**
    * Disable truncation on the first or last breadcrumb item.
    */
-  disableTruncation: PropTypes.oneOf(['first', 'last', '']),
+  disableTruncation: PropTypes.oneOf(['first', 'last', 'none']),
 
   testId: PropTypes.string,
 };
@@ -50,25 +53,11 @@ const defaultProps = {
   hasOverflow: false,
   'aria-label': null,
   testId: 'breadcrumb',
-  disableTruncation: '',
+  disableTruncation: 'none',
 };
 
 const Breadcrumb = ({ children, className, hasOverflow, testId, disableTruncation, ...other }) => {
-  const childrenItems = Children.map(children, (child, index) => {
-    if (disableTruncation === 'first' && index === 0) {
-      return React.cloneElement(child, {
-        style: { ...child.props.style, flexShrink: 0 },
-      });
-    }
-
-    if (disableTruncation === 'last' && index === children.length - 1) {
-      return React.cloneElement(child, {
-        style: { ...child.props.style, flexShrink: 0 },
-      });
-    }
-
-    return child;
-  });
+  const childrenItems = Children.map(children, (child) => child);
 
   const breakingWidth = useRef([]);
 
@@ -124,6 +113,7 @@ const Breadcrumb = ({ children, className, hasOverflow, testId, disableTruncatio
     <div
       className={classnames('breadcrumb--container', {
         'breadcrumb--container__overflowfull': afterOverflowItems.length === 1,
+        [`${iotPrefix}--breadcrumb-expand--${disableTruncation}`]: disableTruncation !== 'none',
       })}
       ref={breadcrumbRef}
       // TODO: fix in v3
@@ -155,7 +145,7 @@ const Breadcrumb = ({ children, className, hasOverflow, testId, disableTruncatio
         </CarbonBreadcrumb>
       ) : (
         <CarbonBreadcrumb data-testid={testId} className={className} {...other}>
-          {childrenItems}
+          {children}
         </CarbonBreadcrumb>
       )}
     </div>

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.jsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.jsx
@@ -35,6 +35,11 @@ const propTypes = {
    */
   hasOverflow: PropTypes.bool,
 
+  /**
+   * Disable truncation on the first or last breadcrumb item.
+   */
+  disableTruncation: PropTypes.oneOf(['first', 'last', '']),
+
   testId: PropTypes.string,
 };
 
@@ -45,10 +50,26 @@ const defaultProps = {
   hasOverflow: false,
   'aria-label': null,
   testId: 'breadcrumb',
+  disableTruncation: '',
 };
 
-const Breadcrumb = ({ children, className, hasOverflow, testId, ...other }) => {
-  const childrenItems = Children.map(children, (child) => child);
+const Breadcrumb = ({ children, className, hasOverflow, testId, disableTruncation, ...other }) => {
+  const childrenItems = Children.map(children, (child, index) => {
+    if (disableTruncation === 'first' && index === 0) {
+      return React.cloneElement(child, {
+        style: { ...child.props.style, flexShrink: 0 },
+      });
+    }
+
+    if (disableTruncation === 'last' && index === children.length - 1) {
+      return React.cloneElement(child, {
+        style: { ...child.props.style, flexShrink: 0 },
+      });
+    }
+
+    return child;
+  });
+
   const breakingWidth = useRef([]);
 
   const [overflowItems, setOverflowItems] = useState([]);
@@ -134,7 +155,7 @@ const Breadcrumb = ({ children, className, hasOverflow, testId, ...other }) => {
         </CarbonBreadcrumb>
       ) : (
         <CarbonBreadcrumb data-testid={testId} className={className} {...other}>
-          {children}
+          {childrenItems}
         </CarbonBreadcrumb>
       )}
     </div>

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.story.jsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.story.jsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { withKnobs, boolean, text, select } from '@storybook/addon-knobs';
 import { BreadcrumbSkeleton, BreadcrumbItem } from 'carbon-components-react';
 import { layout05, spacing05 } from '@carbon/layout';
 
@@ -19,7 +19,6 @@ const props = () => ({
   className: 'some-class',
   noTrailingSlash: boolean('No trailing slash (noTrailingSlash)', false),
   onClick: action('onClick'),
-  disableTruncation: text('Disable truncation (first, last)', ''),
 });
 
 const PolyfillWarning = () => (
@@ -148,7 +147,7 @@ export const WithTruncation = () => {
   return (
     <Breadcrumb
       noTrailingSlash
-      disableTruncation={text('Disable truncation (first, last)', 'first')}
+      disableTruncation={select('Disable truncation', ['first', 'last'], 'first')}
     >
       <BreadcrumbItem href="#">{text('Breadcrumb 1 text', 'Breadcrumb 1')}</BreadcrumbItem>
       <BreadcrumbItem href="#">

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.story.jsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.story.jsx
@@ -147,7 +147,7 @@ export const WithTruncation = () => {
   return (
     <Breadcrumb
       noTrailingSlash
-      disableTruncation={select('Disable truncation', ['first', 'last'], 'first')}
+      disableTruncation={select('Disable truncation', ['first', 'last', 'none'], 'first')}
     >
       <BreadcrumbItem href="#">{text('Breadcrumb 1 text', 'Breadcrumb 1')}</BreadcrumbItem>
       <BreadcrumbItem href="#">

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.story.jsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.story.jsx
@@ -19,6 +19,7 @@ const props = () => ({
   className: 'some-class',
   noTrailingSlash: boolean('No trailing slash (noTrailingSlash)', false),
   onClick: action('onClick'),
+  disableTruncation: text('Disable truncation (first, last)', ''),
 });
 
 const PolyfillWarning = () => (
@@ -142,3 +143,22 @@ HasOverflow.parameters = {
     `,
   },
 };
+
+export const WithTruncation = () => {
+  return (
+    <Breadcrumb
+      noTrailingSlash
+      disableTruncation={text('Disable truncation (first, last)', 'first')}
+    >
+      <BreadcrumbItem href="#">{text('Breadcrumb 1 text', 'Breadcrumb 1')}</BreadcrumbItem>
+      <BreadcrumbItem href="#">
+        {text(
+          'Breadcrumb 2 text',
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi finibus tortor vel nisl suscipit, ac commodo lorem lobortis. Aenean at sem porta, rutrum nisi ut, lobortis enim. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi finibus tortor vel nisl suscipit, ac commodo lorem lobortis. Aenean at sem porta, rutrum nisi ut, lobortis enim.'
+        )}
+      </BreadcrumbItem>
+    </Breadcrumb>
+  );
+};
+
+WithTruncation.storyName = 'with truncation';

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.test.e2e.jsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.test.e2e.jsx
@@ -24,7 +24,7 @@ describe('Breadcrumbs', () => {
       .parent()
       .then(($el) => {
         const rect = $el[0].getBoundingClientRect();
-        expect(rect.width).to.be.greaterThan(105);
+        expect(rect.width).to.be.greaterThan(100);
       });
   });
 
@@ -43,7 +43,7 @@ describe('Breadcrumbs', () => {
       .parent()
       .then(($el) => {
         const rect = $el[0].getBoundingClientRect();
-        expect(rect.width).to.be.greaterThan(105);
+        expect(rect.width).to.be.greaterThan(100);
       });
   });
 });

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.test.e2e.jsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.test.e2e.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { mount } from '@cypress/react';
+import { BreadcrumbItem } from 'carbon-components-react';
+
+import Breadcrumb from './Breadcrumb';
+
+describe('Breadcrumbs', () => {
+  beforeEach(() => {
+    cy.viewport(600, 600);
+  });
+
+  it('disable truncation of the first item', () => {
+    mount(
+      <Breadcrumb onClick={cy.stub()} disableTruncation="first" testId="breadcrumb-test">
+        <BreadcrumbItem href="#">Breadcrumb 1</BreadcrumbItem>
+        <BreadcrumbItem href="#">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi finibus tortor vel nisl
+          suscipit, ac commodo lorem lobortis.
+        </BreadcrumbItem>
+      </Breadcrumb>
+    );
+
+    cy.findByText('Breadcrumb 1')
+      .parent()
+      .then(($el) => {
+        const rect = $el[0].getBoundingClientRect();
+        expect(rect.width).to.be.greaterThan(105);
+      });
+  });
+
+  it('disable truncation of the last item', () => {
+    mount(
+      <Breadcrumb onClick={cy.stub()} disableTruncation="last" testId="breadcrumb-test">
+        <BreadcrumbItem href="#">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi finibus tortor vel nisl
+          suscipit, ac commodo lorem lobortis.
+        </BreadcrumbItem>
+        <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
+      </Breadcrumb>
+    );
+
+    cy.findByText('Breadcrumb 2')
+      .parent()
+      .then(($el) => {
+        const rect = $el[0].getBoundingClientRect();
+        expect(rect.width).to.be.greaterThan(105);
+      });
+  });
+});

--- a/packages/react/src/components/Breadcrumb/__snapshots__/Breadcrumb.story.storyshot
+++ b/packages/react/src/components/Breadcrumb/__snapshots__/Breadcrumb.story.storyshot
@@ -273,3 +273,52 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/B
   </div>
 </div>
 `;
+
+exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/Breadcrumb with truncation 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    className="breadcrumb--container breadcrumb--container__overflowfull"
+    data-testid="overflow"
+  >
+    <nav
+      aria-label="Breadcrumb"
+      className={null}
+      data-testid="breadcrumb"
+    >
+      <ol
+        className="bx--breadcrumb bx--breadcrumb--no-trailing-slash"
+      >
+        <li
+          className="bx--breadcrumb-item"
+          style={
+            Object {
+              "flexShrink": 0,
+            }
+          }
+        >
+          <a
+            className="bx--link"
+            href="#"
+            rel={null}
+          >
+            Breadcrumb 1
+          </a>
+        </li>
+        <li
+          className="bx--breadcrumb-item"
+        >
+          <a
+            className="bx--link"
+            href="#"
+            rel={null}
+          >
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi finibus tortor vel nisl suscipit, ac commodo lorem lobortis. Aenean at sem porta, rutrum nisi ut, lobortis enim. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi finibus tortor vel nisl suscipit, ac commodo lorem lobortis. Aenean at sem porta, rutrum nisi ut, lobortis enim.
+          </a>
+        </li>
+      </ol>
+    </nav>
+  </div>
+</div>
+`;

--- a/packages/react/src/components/Breadcrumb/__snapshots__/Breadcrumb.story.storyshot
+++ b/packages/react/src/components/Breadcrumb/__snapshots__/Breadcrumb.story.storyshot
@@ -279,7 +279,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/B
   className="storybook-container"
 >
   <div
-    className="breadcrumb--container breadcrumb--container__overflowfull"
+    className="breadcrumb--container breadcrumb--container__overflowfull iot--breadcrumb-expand--first"
     data-testid="overflow"
   >
     <nav
@@ -292,11 +292,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/B
       >
         <li
           className="bx--breadcrumb-item"
-          style={
-            Object {
-              "flexShrink": 0,
-            }
-          }
         >
           <a
             className="bx--link"

--- a/packages/react/src/components/Breadcrumb/_breadcrumb.scss
+++ b/packages/react/src/components/Breadcrumb/_breadcrumb.scss
@@ -1,4 +1,5 @@
 @import '~carbon-components/scss/components/breadcrumb/breadcrumb';
+@import '../../globals/vars';
 
 .#{$prefix}--breadcrumb {
   display: flex;
@@ -92,5 +93,15 @@ html[dir='rtl'] .breadcrumb--container {
   .#{$prefix}--breadcrumb-item:last-child::after {
     margin-left: auto;
     margin-right: $spacing-03;
+  }
+}
+
+.#{$iot-prefix}--breadcrumb-expand {
+  &--first .#{$prefix}--breadcrumb-item:first-of-type {
+    flex-shrink: 0;
+  }
+
+  &--last .#{$prefix}--breadcrumb-item:last-of-type {
+    flex-shrink: 0;
   }
 }

--- a/packages/react/src/components/Breadcrumb/_breadcrumb.scss
+++ b/packages/react/src/components/Breadcrumb/_breadcrumb.scss
@@ -97,11 +97,23 @@ html[dir='rtl'] .breadcrumb--container {
 }
 
 .#{$iot-prefix}--breadcrumb-expand {
-  &--first .#{$prefix}--breadcrumb-item:first-of-type {
-    flex-shrink: 0;
+  &--first {
+    .#{$prefix}--breadcrumb-item:first-of-type {
+      flex-shrink: 0;
+    }
+
+    .#{$prefix}--breadcrumb-item:last-of-type {
+      min-width: $spacing-09;
+    }
   }
 
-  &--last .#{$prefix}--breadcrumb-item:last-of-type {
-    flex-shrink: 0;
+  &--last {
+    .#{$prefix}--breadcrumb-item:last-of-type {
+      flex-shrink: 0;
+    }
+
+    .#{$prefix}--breadcrumb-item:first-of-type {
+      min-width: $spacing-09;
+    }
   }
 }

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -102,6 +102,7 @@ Map {
       "aria-label": null,
       "children": null,
       "className": null,
+      "disableTruncation": "",
       "hasOverflow": false,
       "noTrailingSlash": false,
       "testId": "breadcrumb",
@@ -115,6 +116,16 @@ Map {
       },
       "className": Object {
         "type": "string",
+      },
+      "disableTruncation": Object {
+        "args": Array [
+          Array [
+            "first",
+            "last",
+            "",
+          ],
+        ],
+        "type": "oneOf",
       },
       "hasOverflow": Object {
         "type": "bool",

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -102,7 +102,7 @@ Map {
       "aria-label": null,
       "children": null,
       "className": null,
-      "disableTruncation": "",
+      "disableTruncation": "none",
       "hasOverflow": false,
       "noTrailingSlash": false,
       "testId": "breadcrumb",
@@ -122,7 +122,7 @@ Map {
           Array [
             "first",
             "last",
-            "",
+            "none",
           ],
         ],
         "type": "oneOf",


### PR DESCRIPTION
Closes #3700 

**Summary**

- Add prop to disable truncation

**Change List (commits, features, bugs, etc)**

- Reset `flex-shrink` property in order to disable truncation

**Acceptance Test (how to verify the PR)**

- Go to [this story](https://deploy-preview-3752--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-breadcrumb--with-truncation)
- Verify that first item is not truncated
- Add long text to "Breadcrumb 1 text" knob and short text to "Breadcrumb 2 text" knob
- Set "Disable truncation knob" to `last`
- Verify that last breadcrumb is not truncated

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
