### PR TITLE
fix(headeraction): close panel on other action click

### DIFF
--- a/packages/react/src/components/Header/HeaderAction/HeaderActionPanel.jsx
+++ b/packages/react/src/components/Header/HeaderAction/HeaderActionPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { settings } from 'carbon-components';
 import classnames from 'classnames';
@@ -9,6 +9,7 @@ import { white } from '@carbon/colors';
 import { APP_SWITCHER } from '../headerConstants';
 import { handleSpecificKeyDown } from '../../../utils/componentUtilityFunctions';
 import { HeaderActionPropTypes } from '../HeaderPropTypes';
+import { isSafari } from '../../SuiteHeader/suiteHeaderUtils';
 
 const { prefix: carbonPrefix } = settings;
 
@@ -53,6 +54,8 @@ const HeaderActionPanel = ({
   inOverflow,
   showCloseIconWhenPanelExpanded,
 }) => {
+  const panelRef = useRef();
+
   const mergedI18n = useMemo(
     () => ({
       ...defaultProps.i18n,
@@ -60,6 +63,37 @@ const HeaderActionPanel = ({
     }),
     [i18n]
   );
+
+  /**
+   * This workaround is needed because blur event is not triggered
+   * on button in Safari. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#clicking_and_focus
+   */
+  useEffect(() => {
+    if (!isSafari()) {
+      return;
+    }
+
+    const handleActionClick = (event) => {
+      if (panelRef.current && panelRef.current.contains(event.target)) {
+        return;
+      }
+
+      /* istanbul ignore next */
+      if (isExpanded && !focusRef.current.contains(event.target)) {
+        onToggleExpansion();
+      }
+    };
+
+    const panelTriggerRef = focusRef?.current;
+    if (panelTriggerRef) {
+      panelTriggerRef.parentNode.parentNode.addEventListener('click', handleActionClick);
+    }
+
+    // eslint-disable-next-line consistent-return
+    return () =>
+      panelTriggerRef.parentNode.parentNode.removeEventListener('click', handleActionClick);
+  }, [isExpanded]); // eslint-disable-line react-hooks/exhaustive-deps
+
   return (
     <>
       <HeaderGlobalAction
@@ -82,6 +116,7 @@ const HeaderActionPanel = ({
       </HeaderGlobalAction>
       <HeaderPanel
         data-testid="action-btn__panel"
+        ref={panelRef}
         tabIndex="-1"
         key={`panel-${index}`}
         aria-label="Header Panel"

--- a/packages/react/src/components/Header/HeaderAction/HeaderActionPanel.jsx
+++ b/packages/react/src/components/Header/HeaderAction/HeaderActionPanel.jsx
@@ -73,26 +73,25 @@ const HeaderActionPanel = ({
       return;
     }
 
-    const handleActionClick = (event) => {
-      if (panelRef.current && panelRef.current.contains(event.target)) {
+    const handleOutsidePanelClick = (event) => {
+      if (
+        (panelRef.current && panelRef.current.contains(event.target)) ||
+        (focusRef.current && focusRef.current.contains(event.target))
+      ) {
         return;
       }
 
-      /* istanbul ignore next */
-      if (isExpanded && !focusRef.current.contains(event.target)) {
+      if (isExpanded) {
         onToggleExpansion();
       }
     };
 
-    const panelTriggerRef = focusRef?.current;
-    if (panelTriggerRef) {
-      panelTriggerRef.parentNode.parentNode.addEventListener('click', handleActionClick);
-    }
+    document.addEventListener('click', handleOutsidePanelClick, { capture: true });
 
     // eslint-disable-next-line consistent-return
-    return () =>
-      panelTriggerRef.parentNode.parentNode.removeEventListener('click', handleActionClick);
-  }, [isExpanded]); // eslint-disable-line react-hooks/exhaustive-deps
+    return () => document.removeEventListener('click', handleOutsidePanelClick, { capture: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isExpanded, onToggleExpansion]);
 
   return (
     <>

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
@@ -1224,6 +1224,17 @@ describe('SuiteHeader', () => {
       expect(profileActionButton).toHaveAttribute('aria-expanded', 'true');
     });
 
+    it('should close action panel if clicked outside of panel (safari)', () => {
+      render(<SuiteHeader {...commonProps} />);
+      const headerPanel = screen.getByLabelText('Header Panel');
+
+      userEvent.click(screen.getByRole('button', { name: 'AppSwitcher' }));
+      expect(headerPanel).toHaveClass(`${prefix}--header-panel--expanded`);
+
+      userEvent.click(document.body);
+      expect(headerPanel).not.toHaveClass(`${prefix}--header-panel--expanded`);
+    });
+
     it('should close action dropdown if panel opened (safari)', () => {
       render(<SuiteHeader {...commonProps} />);
       const headerPanel = screen.getByLabelText('Header Panel');

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
@@ -1190,4 +1190,58 @@ describe('SuiteHeader', () => {
     // Expect skeletons
     expect(screen.getByTestId('suite-header-app-switcher--loading')).toBeVisible();
   });
+
+  describe('header action and panel (safari)', () => {
+    beforeAll(() => {
+      const userAgentGetter = jest.spyOn(window, 'navigator', 'get');
+      userAgentGetter.mockReturnValue({
+        userAgent:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 00_00_0) AppleWebKit/000.0.00 (KHTML, like Gecko) Version/00.0 Safari/000.0.00',
+      });
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+      jest.restoreAllMocks();
+    });
+
+    it('should close action panel if other action clicked (safari)', () => {
+      render(<SuiteHeader {...commonProps} />);
+      const headerPanel = screen.getByLabelText('Header Panel');
+      const profileActionButton = screen.getByRole('menuitem', { name: 'user' });
+
+      userEvent.click(screen.getByRole('button', { name: 'AppSwitcher' }));
+      expect(headerPanel).toHaveClass(`${prefix}--header-panel--expanded`);
+      expect(profileActionButton).toHaveAttribute('aria-expanded', 'false');
+
+      userEvent.click(profileActionButton);
+      expect(headerPanel).not.toHaveClass(`${prefix}--header-panel--expanded`);
+      expect(profileActionButton).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('should close action dropdown if panel opened (safari)', () => {
+      render(<SuiteHeader {...commonProps} />);
+      const headerPanel = screen.getByLabelText('Header Panel');
+      const profileActionButton = screen.getByRole('menuitem', { name: 'user' });
+
+      userEvent.click(profileActionButton);
+      expect(headerPanel).not.toHaveClass(`${prefix}--header-panel--expanded`);
+      expect(profileActionButton).toHaveAttribute('aria-expanded', 'true');
+
+      userEvent.click(screen.getByRole('button', { name: 'AppSwitcher' }));
+      expect(headerPanel).toHaveClass(`${prefix}--header-panel--expanded`);
+      expect(profileActionButton).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('should NOT close panel if clicked inside panel', () => {
+      render(<SuiteHeader {...commonProps} />);
+      const headerPanel = screen.getByLabelText('Header Panel');
+
+      userEvent.click(screen.getByRole('button', { name: 'AppSwitcher' }));
+      expect(headerPanel).toHaveClass(`${prefix}--header-panel--expanded`);
+
+      userEvent.click(screen.getByText('My applications'));
+      expect(headerPanel).toHaveClass(`${prefix}--header-panel--expanded`);
+    });
+  });
 });

--- a/packages/react/src/components/SuiteHeader/suiteHeaderUtils.js
+++ b/packages/react/src/components/SuiteHeader/suiteHeaderUtils.js
@@ -1,2 +1,13 @@
 export const shouldOpenInNewWindow = (e) =>
   navigator.userAgent.indexOf('Mac') !== -1 ? e.metaKey : e.ctrlKey;
+
+export const isSafari = () => {
+  // Check for SSR
+  /* istanbul ignore else */
+  if (typeof window !== 'undefined') {
+    return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+  }
+
+  /* istanbul ignore next */
+  return false;
+};


### PR DESCRIPTION
Closes #3755 

**Summary**

- __on Safari__
- Close header panel if clicked outside of the panel

**Change List (commits, features, bugs, etc)**

- Add event listener to `document` to toggle panel state
- Add tests

**Acceptance Test (how to verify the PR)**

- __on Safari__
- Go to [this story](https://deploy-preview-3758--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-ui-shell-suiteheader-multi-workspace--admin-page)
- Click on app switcher to open panel
- EDIT: <s>Click on any other header action</s> Click anywhere outside panel
- Verify that panel closed
- Click again on app switcher
- Navigate to some workspace
- Verify that panel is not closing on internal click events

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
