### PR TITLE
feat(card): set max width to extra actions overflow menu

### DIFF
--- a/packages/react/src/components/Card/Card.story.jsx
+++ b/packages/react/src/components/Card/Card.story.jsx
@@ -142,9 +142,8 @@ export const WithEllipsedTitleTooltipExternalTooltip = () => {
     iconDescription: 'Add',
     callback: action('extra single action icon clicked.'),
   };
-  const multiExtraAction = {
+  const multiExtraAction = object('Multiple extra action', {
     id: 'extramultiaction',
-    icon: Tree16,
     iconDescription: 'Settings',
     children: [
       {
@@ -170,7 +169,7 @@ export const WithEllipsedTitleTooltipExternalTooltip = () => {
         callback: action('extra three dot action item4 clicked.'),
       },
     ],
-  };
+  });
   const demoTitleTextTooltip = boolean('demo title text tooltip (titleTextTooltip)', false);
   const demoIconTooltip = boolean('demo info icon tooltip (tooltip)', true);
   const hasTitleWrap = demoTitleTextTooltip ? false : boolean('wrap title', true);

--- a/packages/react/src/components/Card/Card.test.e2e.jsx
+++ b/packages/react/src/components/Card/Card.test.e2e.jsx
@@ -162,6 +162,55 @@ describe('Card', () => {
     cy.findByTestId('Card-tooltip').should('not.exist');
   });
 
+  it('should expand overflow menu to max width', () => {
+    const overflowMenuCallback = cy.stub();
+    const longOverflowItemText = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+    mount(
+      <Card
+        style={{ width: '600px', height: '360px' }}
+        title="My Title"
+        id="my card"
+        size={CARD_SIZES.MEDIUM}
+        availableActions={{
+          range: false,
+          expand: false,
+          edit: false,
+          clone: false,
+          delete: false,
+          extra: true,
+        }}
+        testId="card_test"
+        extraActions={{
+          id: 'extramultiaction',
+          iconDescription: 'Settings',
+          children: [
+            {
+              id: 'firstItem',
+              itemText: longOverflowItemText,
+              callback: overflowMenuCallback,
+            },
+            {
+              id: 'secondItem',
+              itemText: 'Item2',
+              callback: () => {},
+            },
+          ],
+        }}
+      />
+    );
+
+    cy.findByRole('button', { name: 'open and close list of options' }).click();
+    cy.findByRole('menu').then(($el) => {
+      const menu = $el[0].getBoundingClientRect();
+      expect(menu.width).to.be.greaterThan(160);
+    });
+    cy.findByRole('menuitem', { name: longOverflowItemText })
+      .click()
+      .then(() => {
+        expect(overflowMenuCallback).to.be.calledOnce;
+      });
+  });
+
   describe('Card title tooltips', () => {
     const title =
       'Title Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam vulputate lectus id nulla euismod hendrerit. Integer enim arcu, volutpat non erat vitae, ullamcorper tincidunt enim. Sed porttitor fringilla sapien sit amet finibus.';

--- a/packages/react/src/components/Card/CardToolbar.jsx
+++ b/packages/react/src/components/Card/CardToolbar.jsx
@@ -178,6 +178,7 @@ const CardToolbar = ({
     extraActions && Object.keys(extraActions).length !== 0 ? (
       extraActions.children && extraActions.children.length ? (
         <OverflowMenu
+          menuOptionsClass={`${iotPrefix}--card--toolbar__overflow-menu`}
           flipped={overflowMenuPosition}
           title={extraActions.iconDescription || mergedI18n.overflowMenuDescription}
           iconDescription={extraActions.iconDescription || mergedI18n.overflowMenuDescription}

--- a/packages/react/src/components/Card/_card-toolbar.scss
+++ b/packages/react/src/components/Card/_card-toolbar.scss
@@ -11,6 +11,16 @@
     font-size: 0.875rem;
     font-weight: normal;
   }
+
+  &__overflow-menu {
+    min-width: 10rem;
+    width: unset;
+    max-width: rem(350px); // 350px mobile screen width
+
+    & .#{$prefix}--overflow-menu-options__btn {
+      max-width: unset;
+    }
+  }
 }
 
 .#{$iot-prefix}--card--toolbar-action {


### PR DESCRIPTION
Closes #3733

**Summary**

- Auto-expand overflow menu (in card toolbar) depending on the content

**Change List (commits, features, bugs, etc)**

- Replace width property with min-width
- Add max-width to 350px (min screen on mobile breakpoint)

**Acceptance Test (how to verify the PR)**

- Go to [this story](https://deploy-preview-3759--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-card-card--with-ellipsed-title-tooltip-external-tooltip)
- In the knobs area change extra actions to multiple
- In "Multiple extra action" field add some long text to "itemText" property
- Open overflow menu in card toolbar
- Verify that overflow menu has expanded to fit content (max 350px)

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
