### PR TITLE
fix(datetimepickerv2): make sure locale is 2 letters

### DIFF
--- a/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
@@ -323,10 +323,13 @@ const DateTimePicker = ({
     ...defaultProps.i18n,
     ...i18n,
   };
+
+  // make sure locale is 2 letters
+  const newLocale = locale?.length === 2 ? locale : locale.slice(0, 2);
   // initialize the dayjs locale
   useEffect(() => {
-    dayjs.locale(locale);
-  }, [locale]);
+    dayjs.locale(newLocale);
+  }, [newLocale]);
 
   // State
   const [customRangeKind, setCustomRangeKind, onCustomRangeChange] = useDateTimePickerRangeKind(
@@ -954,7 +957,7 @@ const DateTimePicker = ({
                         value={
                           absoluteValue ? [absoluteValue.startDate, absoluteValue.endDate] : ''
                         }
-                        locale={locale}
+                        locale={newLocale}
                       >
                         <DatePickerInput
                           labelText=""

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
@@ -1211,5 +1211,43 @@ describe('DateTimePicker', () => {
       expect(dropdownTrigger).toHaveTextContent('2021-08-01 13:30 to 2021-08-06 10:49');
       expect(onApply).toHaveBeenCalledTimes(1);
     });
+
+    it('should render with locale that is 2 letters', () => {
+      render(
+        <DateTimePicker
+          {...dateTimePickerProps}
+          locale="en"
+          hasTimeInput
+          defaultValue={{
+            timeRangeKind: PICKER_KINDS.ABSOLUTE,
+            timeRangeValue: {
+              start: '2021-08-01 12:34',
+              end: '2021-08-06 10:49',
+            },
+          }}
+        />
+      );
+
+      expect(screen.getByText('2021-08-01 12:34 to 2021-08-06 10:49')).toBeVisible();
+    });
+
+    it('should render with locale that is not 2 letters', () => {
+      render(
+        <DateTimePicker
+          {...dateTimePickerProps}
+          locale="en-us"
+          hasTimeInput
+          defaultValue={{
+            timeRangeKind: PICKER_KINDS.ABSOLUTE,
+            timeRangeValue: {
+              start: '2021-08-01 12:34',
+              end: '2021-08-06 10:49',
+            },
+          }}
+        />
+      );
+
+      expect(screen.getByText('2021-08-01 12:34 to 2021-08-06 10:49')).toBeVisible();
+    });
   });
 });

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
@@ -34,6 +34,8 @@ const DateTimePicker = ({
   style,
   ...others
 }) => {
+  // make sure locale is 2 letters
+  const newLocale = locale?.length === 2 ? locale : locale.slice(0, 2);
   return useNewTimeSpinner ? (
     <DateTimePickerNew
       testId={testId}
@@ -54,7 +56,7 @@ const DateTimePicker = ({
       onClear={onClear}
       i18n={i18n}
       light={light}
-      locale={locale}
+      locale={newLocale}
       id={id}
       hasIconOnly={hasIconOnly}
       menuOffset={menuOffset}
@@ -83,7 +85,7 @@ const DateTimePicker = ({
       onApply={onApply}
       i18n={i18n}
       light={light}
-      locale={locale}
+      locale={newLocale}
       id={id}
       hasIconOnly={hasIconOnly}
       menuOffset={menuOffset}

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
@@ -2843,4 +2843,54 @@ describe('DateTimePickerV2', () => {
     );
     expect(screen.getByText(PRESET_VALUES[0].label)).toBeVisible();
   });
+
+  it('should render with locale that is 2 letters', () => {
+    render(
+      <DateTimePicker
+        {...dateTimePickerProps}
+        locale="en"
+        useNewTimeSpinner
+        onApply={jest.fn()}
+        datePickerType="single"
+        dateTimeMask="YYYY-MM-DD hh:mm A"
+        hasTimeInput
+        showRelativeOption={false}
+        defaultValue={{
+          timeRangeKind: PICKER_KINDS.SINGLE,
+          timeSingleValue: {
+            startDate: '2020-04-01',
+            startTime: '12:34 AM',
+          },
+        }}
+      />
+    );
+
+    // default value is 2020-04-01 12:34 AM
+    expect(screen.getByText('2020-04-01 12:34 AM')).toBeVisible();
+  });
+
+  it('should render with locale that is not 2 letters', () => {
+    render(
+      <DateTimePicker
+        {...dateTimePickerProps}
+        locale="en-us"
+        useNewTimeSpinner
+        onApply={jest.fn()}
+        datePickerType="single"
+        dateTimeMask="YYYY-MM-DD hh:mm A"
+        hasTimeInput
+        showRelativeOption={false}
+        defaultValue={{
+          timeRangeKind: PICKER_KINDS.SINGLE,
+          timeSingleValue: {
+            startDate: '2020-04-01',
+            startTime: '12:34 AM',
+          },
+        }}
+      />
+    );
+
+    // default value is 2020-04-01 12:34 AM
+    expect(screen.getByText('2020-04-01 12:34 AM')).toBeVisible();
+  });
 });


### PR DESCRIPTION
Closes #3757 

**Summary**

- We need to make sure locale is 2 letters. If use passes in locale like "en-us", we make sure we use `en` instead of `en-us`

**Change List (commits, features, bugs, etc)**

- Add locale checks for `DateTimePicker` and `DateTimePickerv2`

**Acceptance Test (how to verify the PR)**

- go to single select story
- change locale to 'en-us'
- make sure no errors show up in the console

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
