### PR TITLE
fix(table): scrollbar shows when drag and drop starts

### DIFF
--- a/packages/react/src/components/Table/TableBody/_table-dnd.scss
+++ b/packages/react/src/components/Table/TableBody/_table-dnd.scss
@@ -4,7 +4,6 @@
 // The 6-dots grable handle area on a row that can be dragged. This is really that the parent of
 // that picture so the draggable area is a larger, square.
 .#{$iot-prefix}--table-drag-handle {
-  height: 2rem;
   padding-inline: 1rem;
   display: grid;
   align-items: center;
@@ -28,6 +27,9 @@
 .#{$iot-prefix}--table-drop-row-overlay {
   // Abs positioned, but JavaScript will set its rect
   position: absolute;
+  display: none;
+  top: 0;
+  left: 0;
   border: dashed 2px $carbon--blue-60;
   pointer-events: none;
 }

--- a/packages/react/src/components/Table/TableBody/useTableDnd.jsx
+++ b/packages/react/src/components/Table/TableBody/useTableDnd.jsx
@@ -378,7 +378,7 @@ function useTableDnd(rows, selectedIds, zIndex, onDrag, onDrop) {
       const contentRect = scrollContainer.getBoundingClientRect();
       const rowRect = rowEl.getBoundingClientRect();
       const style = {
-        display: '',
+        display: 'block',
         top: `${rowRect.top + document.documentElement.scrollTop}px`,
         left: `${
           contentRect.left + document.documentElement.scrollLeft - getRtlVerticalScrollbarWidth()


### PR DESCRIPTION
Closes #3775

**Summary**

This fixes bug #3775.

**Change List (commits, features, bugs, etc)**

Updates the CSS for table DnD to position initially show the overlay as display:none and at 0,0 so that it won't cause scrolling or be visible until needed.

**Acceptance Test (how to verify the PR)**

In Storybook, view ?path=/story/1-watson-iot-table--with-drag-and-drop.
Check that there is NO vertical scrollbar (ensure "always show scrollbars" is on for your OS).
Start a drag and check that none appears.

**Regression Test (how to make sure this PR doesn't break old functionality)**

Existing unit tests.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
