### PR TITLE
fix(DateTimePickerv2): update placeholder text to show XM instead of 'a' or 'A'

### DIFF
--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
@@ -607,8 +607,8 @@ describe('DateTimePickerV2', () => {
         }}
       />
     );
-    // default value is YYYY-MM-DD hh:mm A
-    expect(screen.getByText('YYYY-MM-DD hh:mm A')).toBeVisible();
+    // default value is YYYY-MM-DD hh:mm XM
+    expect(screen.getByText('YYYY-MM-DD hh:mm XM')).toBeVisible();
   });
 
   it('should clear date and time fields when click clear button in single select', () => {
@@ -641,7 +641,7 @@ describe('DateTimePickerV2', () => {
 
     userEvent.click(screen.getByText(/clear/i));
 
-    expect(screen.getByText('YYYY-MM-DD hh:mm A')).toBeVisible();
+    expect(screen.getByText('YYYY-MM-DD hh:mm XM')).toBeVisible();
     expect(screen.queryByRole('dialog')).toBeNull();
     expect(mockOnClear).toHaveBeenCalledWith({
       timeRangeKind: 'SINGLE',
@@ -685,7 +685,7 @@ describe('DateTimePickerV2', () => {
     // first open the menu
     userEvent.click(screen.getAllByText(/2020-04-01 12:34 AM/i)[0]);
     userEvent.click(screen.getByText(i18n.resetBtnLabel));
-    expect(screen.getByText('YYYY-MM-DD hh:mm A')).toBeVisible();
+    expect(screen.getByText('YYYY-MM-DD hh:mm XM')).toBeVisible();
 
     // open the calendar again
     userEvent.click(screen.getAllByLabelText('Calendar')[0]);

--- a/packages/react/src/components/DateTimePicker/dateTimePickerUtils.js
+++ b/packages/react/src/components/DateTimePicker/dateTimePickerUtils.js
@@ -148,8 +148,10 @@ export const parseValue = (timeRange, dateTimeMask, toLabel, hasTimeInput) => {
       break;
     }
     case PICKER_KINDS.SINGLE: {
+      // replace 'a' or 'A' in dateTimeMask to be consistent with time picker placeholder text
+      const updatedDateTimeMask = dateTimeMask.replace(/a|A/, 'XM');
       if (!value.start && !value.startDate) {
-        readableValue = dateTimeMask;
+        readableValue = updatedDateTimeMask;
         returnValue.single.start = null;
         break;
       }
@@ -162,7 +164,7 @@ export const parseValue = (timeRange, dateTimeMask, toLabel, hasTimeInput) => {
         startDate = startDate.minutes(formatedStartTime.split(':')[1]);
       } else if (hasTimeInput) {
         returnValue.absolute.startTime = null;
-        readableValue = dateTimeMask;
+        readableValue = updatedDateTimeMask;
         break;
       }
       returnValue.single.start = new Date(startDate.valueOf());


### PR DESCRIPTION
Closes #3762 

**Summary**

- `TimePickerDropDown` follows the carbon guideline to show  placeholder text like `hh:mm XM` if it is 12hours format. To be consistent, we update DateTimePickerV2 single select placeholder text to show `XM` instead of `a` or `A`. 
- It should look like `YYYY-DD-MM hh:mm XM`

**Change List (commits, features, bugs, etc)**

- Update in parseValue() in dateTimePickerUtils.js, specifically to single select. 

**Acceptance Test (how to verify the PR)**

- go to single select [story](https://deploy-preview-3778--carbon-addons-iot-react.netlify.app/?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-datetimepickerv2--single-select)
- update dateTimeMask knob to use 12 hour format like `YYYY-DD-MM hh:mm A`
- open flyout menu
- click on clear button
- check placeholder should use `XM` instead of `A`

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
