### PR TITLE
chore(codeowners): add amritha as codeowners for this piece

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,3 +44,6 @@
 
 # Angular team should be required for Angular changes
 /packages/angular/ @carbon-design-system/angular-maintainers
+
+# Monitor still has use for this component
+/packages/react/src/components/DashboardEditor/ @davidicus @jessieyan @sls-ca @herleraja


### PR DESCRIPTION
Monitor still heavily relies on this component. Amritha has asked to be added as code owner to help with their development. This component is still in experimental. 

