### PR TITLE
fix(table): add column for DnD in the filter/manage columns headers

### DIFF
--- a/packages/react/src/components/Table/Table.main.story.jsx
+++ b/packages/react/src/components/Table/Table.main.story.jsx
@@ -528,10 +528,12 @@ export function WithDragAndDrop() {
     {
       id: 'name',
       name: 'Name (w/ count)',
+      filter: { placeholderText: 'enter a string' },
     },
     {
       id: 'date',
       name: 'Date',
+      filter: { placeholderText: 'enter a string' },
     },
   ];
 
@@ -580,7 +582,13 @@ export function WithDragAndDrop() {
         secondaryTitle="Table"
         columns={columns}
         data={data}
-        options={{ hasDragAndDrop: true, hasResize: true, hasRowSelection: 'multi' }}
+        options={{
+          hasDragAndDrop: true,
+          hasResize: true,
+          hasRowSelection: 'multi',
+          hasFilter: true,
+          hasColumnSelection: true,
+        }}
         actions={{
           table: {
             onDrag: (rows) => {

--- a/packages/react/src/components/Table/TableHead/ColumnHeaderRow/ColumnHeaderRow.jsx
+++ b/packages/react/src/components/Table/TableHead/ColumnHeaderRow/ColumnHeaderRow.jsx
@@ -40,6 +40,9 @@ class ColumnHeaderRow extends Component {
     testId: PropTypes.string,
     /** shows an additional column that can expand/shrink as the table is resized  */
     showExpanderColumn: PropTypes.bool.isRequired,
+    /** Set to true if the table support drag and drop. Inserts a cell in the "darg handle" column
+     * for spacing. */
+    hasDragAndDrop: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -47,6 +50,7 @@ class ColumnHeaderRow extends Component {
     columnSelectionConfigText: defaultI18NPropTypes.columnSelectionConfig,
     isDisabled: false,
     testId: '',
+    hasDragAndDrop: false,
   };
 
   reorderColumn = (srcIndex, destIndex) => {
@@ -78,6 +82,7 @@ class ColumnHeaderRow extends Component {
       isDisabled,
       testId,
       showExpanderColumn,
+      hasDragAndDrop,
     } = this.props;
 
     const visibleColumns = columns.filter(
@@ -86,6 +91,10 @@ class ColumnHeaderRow extends Component {
     return (
       <DragAndDrop>
         <TableRow data-testid={testId} className={`${iotPrefix}--column-header-row--table-row`}>
+          {' '}
+          {hasDragAndDrop && (
+            <TableHeader className={`${iotPrefix}--column-header-row--table-header`} />
+          )}
           {hasRowSelection === 'multi' ? (
             <TableHeader className={`${iotPrefix}--column-header-row--table-header`} />
           ) : null}

--- a/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
+++ b/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
@@ -132,6 +132,9 @@ class FilterHeaderRow extends Component {
     onFilterRowIconClick: PropTypes.func.isRequired,
     /** Freezes table header and footer */
     pinHeaderAndFooter: PropTypes.bool,
+    /** Set to true if the table support drag and drop. Inserts a cell in the "drag handle" column
+     * for spacing. */
+    hasDragAndDrop: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -154,6 +157,7 @@ class FilterHeaderRow extends Component {
     filterRowIcon: null,
     filterRowIconDescription: 'Edit filters',
     pinHeaderAndFooter: false,
+    hasDragAndDrop: true,
   };
 
   state = {
@@ -337,6 +341,7 @@ class FilterHeaderRow extends Component {
       filterRowIcon,
       filterRowIconDescription,
       onFilterRowIconClick,
+      hasDragAndDrop,
     } = this.props;
     const { dropdownMaxHeight, filterValues, filterIconTopOffset } = this.state;
     const visibleColumns = ordering.filter((c) => !c.isHidden);
@@ -347,6 +352,7 @@ class FilterHeaderRow extends Component {
           '--filter-header-dropdown-max-height': dropdownMaxHeight,
         }}
       >
+        {hasDragAndDrop && <TableHeader className={`${iotPrefix}--filter-header-row--header`} />}
         {hasRowSelection === 'multi' ||
         (hasRowSelection === 'single' && useRadioButtonSingleSelect) ? (
           <TableHeader className={`${iotPrefix}--filter-header-row--header`} ref={this.rowRef} />

--- a/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
+++ b/packages/react/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
@@ -157,7 +157,7 @@ class FilterHeaderRow extends Component {
     filterRowIcon: null,
     filterRowIconDescription: 'Edit filters',
     pinHeaderAndFooter: false,
-    hasDragAndDrop: true,
+    hasDragAndDrop: false,
   };
 
   state = {

--- a/packages/react/src/components/Table/TableHead/TableHead.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.jsx
@@ -709,6 +709,7 @@ const TableHead = ({
           filterRowIconDescription={filterRowIconDescription}
           onFilterRowIconClick={onFilterRowIconClick}
           pinHeaderAndFooter={pinHeaderAndFooter}
+          hasDragAndDrop={hasDragAndDrop}
         />
       )}
       {activeBar === 'column' && (
@@ -728,6 +729,7 @@ const TableHead = ({
           columnSelectionConfigText={i18n.columnSelectionConfig}
           isDisabled={isDisabled}
           showExpanderColumn={showExpanderColumn}
+          hasDragAndDrop={hasDragAndDrop}
         />
       )}
     </CarbonTableHead>

--- a/packages/react/src/components/Table/TableSaveViewModal/__snapshots__/TableSaveViewModal.story.storyshot
+++ b/packages/react/src/components/Table/TableSaveViewModal/__snapshots__/TableSaveViewModal.story.storyshot
@@ -333,7 +333,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               onAnimationEnd={[Function]}
             >
               <button
-                aria-controls="accordion-item-1588"
+                aria-controls="accordion-item-1590"
                 aria-expanded={false}
                 className="bx--accordion__heading"
                 onClick={[Function]}
@@ -364,7 +364,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               </button>
               <div
                 className="bx--accordion__content"
-                id="accordion-item-1588"
+                id="accordion-item-1590"
               >
                 <p>
                   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -376,7 +376,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               onAnimationEnd={[Function]}
             >
               <button
-                aria-controls="accordion-item-1589"
+                aria-controls="accordion-item-1591"
                 aria-expanded={false}
                 className="bx--accordion__heading"
                 onClick={[Function]}
@@ -407,7 +407,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
               </button>
               <div
                 className="bx--accordion__content"
-                id="accordion-item-1589"
+                id="accordion-item-1591"
               >
                 <p>
                   Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/packages/react/src/components/Table/__snapshots__/Table.main.story.storyshot
+++ b/packages/react/src/components/Table/__snapshots__/Table.main.story.storyshot
@@ -28624,10 +28624,85 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/T
       <div
         className="bx--toolbar-content iot--table-toolbar-content"
         data-testid="null-table-toolbar-content"
-      />
+      >
+        <button
+          aria-describedby={null}
+          className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
+          data-testid="column-selection-button"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          <div
+            className="bx--assistive-text"
+            onMouseEnter={[Function]}
+          >
+            Column Selection
+          </div>
+          <svg
+            aria-hidden="true"
+            aria-label="Column Selection"
+            className="bx--btn__icon"
+            fill="currentColor"
+            focusable="false"
+            height={20}
+            preserveAspectRatio="xMidYMid meet"
+            role="img"
+            viewBox="0 0 32 32"
+            width={20}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M24 4H26V28H24zM18 6V26H14V6h4m0-2H14a2 2 0 00-2 2V26a2 2 0 002 2h4a2 2 0 002-2V6a2 2 0 00-2-2zM6 4H8V28H6z"
+            />
+          </svg>
+        </button>
+        <button
+          aria-describedby={null}
+          className="bx--btn--icon-only iot--tooltip-svg-wrapper iot--btn iot--btn-icon-selection bx--btn bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
+          data-testid="filter-button"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          <div
+            className="bx--assistive-text"
+            onMouseEnter={[Function]}
+          >
+            Filters
+          </div>
+          <svg
+            aria-hidden="true"
+            aria-label="Filters"
+            className="bx--btn__icon"
+            fill="currentColor"
+            focusable="false"
+            height={20}
+            preserveAspectRatio="xMidYMid meet"
+            role="img"
+            viewBox="0 0 32 32"
+            width={20}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M18,28H14a2,2,0,0,1-2-2V18.41L4.59,11A2,2,0,0,1,4,9.59V6A2,2,0,0,1,6,4H26a2,2,0,0,1,2,2V9.59A2,2,0,0,1,27.41,11L20,18.41V26A2,2,0,0,1,18,28ZM6,6V9.59l8,8V26h4V17.59l8-8V6Z"
+            />
+          </svg>
+        </button>
+      </div>
     </section>
     <div
-      className="addons-iot-table-container"
+      className="addons-iot-table-container iot-table-container--dropdown-height-fix"
     >
       <div
         className="bx--data-table-content"

--- a/packages/react/src/components/TileGallery/__snapshots__/TileGallery.story.storyshot
+++ b/packages/react/src/components/TileGallery/__snapshots__/TileGallery.story.storyshot
@@ -201,7 +201,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   onAnimationEnd={[Function]}
                 >
                   <button
-                    aria-controls="accordion-item-1733"
+                    aria-controls="accordion-item-1735"
                     aria-expanded={true}
                     className="bx--accordion__heading"
                     onClick={[Function]}
@@ -232,7 +232,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   </button>
                   <div
                     className="bx--accordion__content"
-                    id="accordion-item-1733"
+                    id="accordion-item-1735"
                   >
                     <div
                       className="tile-gallery--section--items"
@@ -624,7 +624,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   onAnimationEnd={[Function]}
                 >
                   <button
-                    aria-controls="accordion-item-1734"
+                    aria-controls="accordion-item-1736"
                     aria-expanded={true}
                     className="bx--accordion__heading"
                     onClick={[Function]}
@@ -655,7 +655,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   </button>
                   <div
                     className="bx--accordion__content"
-                    id="accordion-item-1734"
+                    id="accordion-item-1736"
                   >
                     <div
                       className="tile-gallery--section--items"
@@ -1494,7 +1494,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   onAnimationEnd={[Function]}
                 >
                   <button
-                    aria-controls="accordion-item-1740"
+                    aria-controls="accordion-item-1742"
                     aria-expanded={true}
                     className="bx--accordion__heading"
                     onClick={[Function]}
@@ -1525,7 +1525,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                   </button>
                   <div
                     className="bx--accordion__content"
-                    id="accordion-item-1740"
+                    id="accordion-item-1742"
                   >
                     <div
                       className="tile-gallery--section--items"
@@ -1694,7 +1694,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
             onAnimationEnd={[Function]}
           >
             <button
-              aria-controls="accordion-item-1737"
+              aria-controls="accordion-item-1739"
               aria-expanded={true}
               className="bx--accordion__heading"
               onClick={[Function]}
@@ -1725,7 +1725,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
             </button>
             <div
               className="bx--accordion__content"
-              id="accordion-item-1737"
+              id="accordion-item-1739"
             >
               <div
                 className="tile-gallery--section--items"
@@ -2142,7 +2142,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
             onAnimationEnd={[Function]}
           >
             <button
-              aria-controls="accordion-item-1738"
+              aria-controls="accordion-item-1740"
               aria-expanded={true}
               className="bx--accordion__heading"
               onClick={[Function]}
@@ -2173,7 +2173,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
             </button>
             <div
               className="bx--accordion__content"
-              id="accordion-item-1738"
+              id="accordion-item-1740"
             >
               <div
                 className="tile-gallery--section--items"
@@ -2429,7 +2429,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               onAnimationEnd={[Function]}
             >
               <button
-                aria-controls="accordion-item-1735"
+                aria-controls="accordion-item-1737"
                 aria-expanded={true}
                 className="bx--accordion__heading"
                 onClick={[Function]}
@@ -2460,7 +2460,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </button>
               <div
                 className="bx--accordion__content"
-                id="accordion-item-1735"
+                id="accordion-item-1737"
               >
                 <div
                   className="tile-gallery--section--items"
@@ -2877,7 +2877,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               onAnimationEnd={[Function]}
             >
               <button
-                aria-controls="accordion-item-1736"
+                aria-controls="accordion-item-1738"
                 aria-expanded={true}
                 className="bx--accordion__heading"
                 onClick={[Function]}
@@ -2908,7 +2908,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
               </button>
               <div
                 className="bx--accordion__content"
-                id="accordion-item-1736"
+                id="accordion-item-1738"
               >
                 <div
                   className="tile-gallery--section--items"


### PR DESCRIPTION
Closes #3781

**Summary**

When drag and drop is enabled for the table and extra column is injected into the tbody to house the "drag handle". In the normal table header and extra, empty cell/column is added to line up and match the number of columns in the body. This is the same technique used for the "checkbox" select columns.

The issues was that not all headers were updated. There is are "filter" and "select columns" headers that can be added to the table. They were not updated with the extra column, so were not aligned right.

The fix is just to pass the "hasDragAndDrop" prop into those components and add the extra cell there when enabled.

**Change List (commits, features, bugs, etc)**

ColumnHeaderRow.jsx and FilterHeaderRow.jsx were updated with that change.
Other changes are just to the test snapshots that needed updating to account for the new header cell when enabled.

**Acceptance Test (how to verify the PR)**

View a table with DnD enabled and `hasFilter` prop on. Open the filter header row. If all the columns line up right, it's good. It's most obvious in Firefox, where a big white space was left on the right if the table was wide. The storybook `Table > With drag and drop rows` was updated to enable the filter row and test this.

**Regression Test (how to make sure this PR doesn't break old functionality)**

Existing unit tests pass.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
