### PR TITLE
fix: PageTitleBar description 

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -54,7 +54,7 @@
     "test:e2e:update": "cypress-image-diff -u",
     "test:e2e": "cross-env BABEL_ENV='e2e' NODE_ENV='e2e' cypress run-ct --browser=chrome --headed --config video=false,screenshotOnRunFailure=false",
     "test:e2e:interactive": "cross-env BABEL_ENV='e2e' NODE_ENV='e2e' cypress open-ct --browser=chrome --config video=false,screenshotOnRunFailure=false",
-    "test:e2e:ci": "cross-env HEIGHT=1680 WIDTH=1680 BABEL_ENV='e2e' NODE_ENV='e2e' cypress run-ct  --browser=chrome --config watchForFileChanges=false --record video=false,screenshotOnRunFailure=false",
+    "test:e2e:ci": "cross-env HEIGHT=1680 WIDTH=1680 BABEL_ENV='e2e' NODE_ENV='e2e' cypress run-ct  --browser=chrome --config watchForFileChanges=false video=false,screenshotOnRunFailure=false",
     "test:e2e:images": "cd ../.. && docker-compose run --no-deps --rm react-visual-regression-tests bash -c 'cd /@ai-apps/packages/react && pwd && yarn cypress install && yarn test:e2e:ci --record=false --config video=false,screenshotOnRunFailure=false'",
     "test:e2e:docker:build": "cd ../.. && docker-compose up --build",
     "test:e2e:docker:clean": "docker system prune",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -54,7 +54,7 @@
     "test:e2e:update": "cypress-image-diff -u",
     "test:e2e": "cross-env BABEL_ENV='e2e' NODE_ENV='e2e' cypress run-ct --browser=chrome --headed --config video=false,screenshotOnRunFailure=false",
     "test:e2e:interactive": "cross-env BABEL_ENV='e2e' NODE_ENV='e2e' cypress open-ct --browser=chrome --config video=false,screenshotOnRunFailure=false",
-    "test:e2e:ci": "cross-env HEIGHT=1680 WIDTH=1680 BABEL_ENV='e2e' NODE_ENV='e2e' cypress run-ct  --browser=chrome --config watchForFileChanges=false video=false,screenshotOnRunFailure=false",
+    "test:e2e:ci": "cross-env HEIGHT=1680 WIDTH=1680 BABEL_ENV='e2e' NODE_ENV='e2e' cypress run-ct  --browser=chrome --config watchForFileChanges=false --record false video=false,screenshotOnRunFailure=false",
     "test:e2e:images": "cd ../.. && docker-compose run --no-deps --rm react-visual-regression-tests bash -c 'cd /@ai-apps/packages/react && pwd && yarn cypress install && yarn test:e2e:ci --record=false --config video=false,screenshotOnRunFailure=false'",
     "test:e2e:docker:build": "cd ../.. && docker-compose up --build",
     "test:e2e:docker:clean": "docker system prune",

--- a/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
@@ -272,7 +272,7 @@ const PageTitleBar = ({
   const titleActions = useMemo(
     () => (
       <>
-        {description && (collapsed || titleBarContent) ? (
+        {description && collapsed ? (
           <Tooltip
             tabIndex={0}
             triggerText=""
@@ -303,16 +303,7 @@ const PageTitleBar = ({
         ) : null}
       </>
     ),
-    [
-      description,
-      collapsed,
-      titleBarContent,
-      tooltipIconDescription,
-      editable,
-      editIconDescription,
-      onEdit,
-      testId,
-    ]
+    [description, collapsed, tooltipIconDescription, editable, editIconDescription, onEdit, testId]
   );
 
   const headerOffsetCssVar =
@@ -393,7 +384,7 @@ const PageTitleBar = ({
                 {titleActions}
               </div>
             </div>
-            {description && !collapsed && !titleBarContent ? (
+            {description && !collapsed ? (
               <p className="page-title-bar-description">{description}</p>
             ) : null}
             <div className="page-title-bar-header-right">{extraContent || rightContent}</div>

--- a/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
@@ -380,17 +380,19 @@ const PageTitleBar = ({
                     >
                       <>
                         {title}
-                        <Tooltip
-                          tabIndex={0}
-                          triggerText=""
-                          triggerId="tooltip"
-                          tooltipId="tooltip"
-                          renderIcon={Information16}
-                          iconDescription={tooltipIconDescription}
-                          data-testid={`${testId}-tooltip`}
-                        >
-                          {typeof description === 'string' ? <p>{description}</p> : description}
-                        </Tooltip>
+                        {description ? (
+                          <Tooltip
+                            tabIndex={0}
+                            triggerText=""
+                            triggerId="tooltip"
+                            tooltipId="tooltip"
+                            renderIcon={Information16}
+                            iconDescription={tooltipIconDescription}
+                            data-testid={`${testId}-tooltip`}
+                          >
+                            {typeof description === 'string' ? <p>{description}</p> : description}
+                          </Tooltip>
+                        ) : null}
                       </>
                     </BreadcrumbItem>
                   ) : null}

--- a/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
@@ -272,7 +272,7 @@ const PageTitleBar = ({
   const titleActions = useMemo(
     () => (
       <>
-        {description && collapsed ? (
+        {description && (collapsed || condensed) ? (
           <Tooltip
             tabIndex={0}
             triggerText=""
@@ -303,7 +303,16 @@ const PageTitleBar = ({
         ) : null}
       </>
     ),
-    [description, collapsed, tooltipIconDescription, editable, editIconDescription, onEdit, testId]
+    [
+      description,
+      collapsed,
+      condensed,
+      tooltipIconDescription,
+      testId,
+      editable,
+      editIconDescription,
+      onEdit,
+    ]
   );
 
   const headerOffsetCssVar =
@@ -369,7 +378,20 @@ const PageTitleBar = ({
                       isCurrentPage
                       title={title}
                     >
-                      {title}
+                      <>
+                        {title}
+                        <Tooltip
+                          tabIndex={0}
+                          triggerText=""
+                          triggerId="tooltip"
+                          tooltipId="tooltip"
+                          renderIcon={Information16}
+                          iconDescription={tooltipIconDescription}
+                          data-testid={`${testId}-tooltip`}
+                        >
+                          {typeof description === 'string' ? <p>{description}</p> : description}
+                        </Tooltip>
+                      </>
                     </BreadcrumbItem>
                   ) : null}
                 </Breadcrumb>
@@ -384,7 +406,7 @@ const PageTitleBar = ({
                 {titleActions}
               </div>
             </div>
-            {description && !collapsed ? (
+            {description && !collapsed && !condensed ? (
               <p className="page-title-bar-description">{description}</p>
             ) : null}
             <div className="page-title-bar-header-right">{extraContent || rightContent}</div>

--- a/packages/react/src/components/PageTitleBar/PageTitleBar.test.e2e.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.test.e2e.jsx
@@ -95,7 +95,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset:48px; --negative-header-offset:-48px; --scroll-transition-progress:0;'
+        '--header-offset: 48px; --negative-header-offset: -48px; --scroll-transition-progress: 0;'
       );
 
     cy.scrollTo(0, 118);
@@ -119,7 +119,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset:48px; --negative-header-offset:-48px; --scroll-transition-progress:1;'
+        '--header-offset: 48px; --negative-header-offset: -48px; --scroll-transition-progress: 1;'
       );
   });
 
@@ -164,7 +164,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset:40px; --negative-header-offset:-40px; --scroll-transition-progress:0;'
+        '--header-offset: 40px; --negative-header-offset: -40px; --scroll-transition-progress: 0;'
       );
 
     cy.scrollTo(0, 100);
@@ -174,7 +174,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset:40px; --negative-header-offset:-40px; --scroll-transition-progress:1;'
+        '--header-offset: 40px; --negative-header-offset: -40px; --scroll-transition-progress: 1;'
       );
 
     breadcrumbsAndTabsAreStickyAndInTheCorrectPosition();
@@ -216,7 +216,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset:40px; --negative-header-offset:-40px; --scroll-transition-progress:1;'
+        '--header-offset: 40px; --negative-header-offset: -40px; --scroll-transition-progress: 1;'
       );
 
     cy.scrollTo(0, 50);
@@ -226,7 +226,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset:40px; --negative-header-offset:-40px; --scroll-transition-progress:1;'
+        '--header-offset: 40px; --negative-header-offset: -40px; --scroll-transition-progress: 1;'
       );
 
     breadcrumbsAndTabsAreStickyAndInTheCorrectPosition();
@@ -270,7 +270,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset:0px; --negative-header-offset:0px; --scroll-transition-progress:0;'
+        '--header-offset: 0px; --negative-header-offset: -0px; --scroll-transition-progress: 0;'
       );
 
     cy.scrollTo(0, 250);
@@ -281,7 +281,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset:0px; --negative-header-offset:0px; --scroll-transition-progress:1;'
+        '--header-offset: 0px; --negative-header-offset: -0px; --scroll-transition-progress: 1;'
       );
 
     tabsAreStickyAndBreadcrumbsAreHidden();

--- a/packages/react/src/components/PageTitleBar/PageTitleBar.test.e2e.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.test.e2e.jsx
@@ -95,7 +95,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset: 48px; --negative-header-offset: -48px; --scroll-transition-progress: 0;'
+        '--header-offset:48px; --negative-header-offset:-48px; --scroll-transition-progress:0;'
       );
 
     cy.scrollTo(0, 118);
@@ -119,7 +119,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset: 48px; --negative-header-offset: -48px; --scroll-transition-progress: 1;'
+        '--header-offset:48px; --negative-header-offset:-48px; --scroll-transition-progress:1;'
       );
   });
 
@@ -164,7 +164,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset: 40px; --negative-header-offset: -40px; --scroll-transition-progress: 0;'
+        '--header-offset:40px; --negative-header-offset:-40px; --scroll-transition-progress:0;'
       );
 
     cy.scrollTo(0, 100);
@@ -174,7 +174,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset: 40px; --negative-header-offset: -40px; --scroll-transition-progress: 1;'
+        '--header-offset:40px; --negative-header-offset:-40px; --scroll-transition-progress:1;'
       );
 
     breadcrumbsAndTabsAreStickyAndInTheCorrectPosition();
@@ -216,7 +216,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset: 40px; --negative-header-offset: -40px; --scroll-transition-progress: 1;'
+        '--header-offset:40px; --negative-header-offset:-40px; --scroll-transition-progress:1;'
       );
 
     cy.scrollTo(0, 50);
@@ -226,7 +226,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset: 40px; --negative-header-offset: -40px; --scroll-transition-progress: 1;'
+        '--header-offset:40px; --negative-header-offset:-40px; --scroll-transition-progress:1;'
       );
 
     breadcrumbsAndTabsAreStickyAndInTheCorrectPosition();
@@ -270,7 +270,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset: 0px; --negative-header-offset: -0px; --scroll-transition-progress: 0;'
+        '--header-offset:0px; --negative-header-offset:0px; --scroll-transition-progress:0;'
       );
 
     cy.scrollTo(0, 250);
@@ -281,7 +281,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset: 0px; --negative-header-offset: -0px; --scroll-transition-progress: 1;'
+        '--header-offset:0px; --negative-header-offset:0px; --scroll-transition-progress:1;'
       );
 
     tabsAreStickyAndBreadcrumbsAreHidden();

--- a/packages/react/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
+++ b/packages/react/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
@@ -4713,46 +4713,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
               >
                 Page title
               </h2>
-              <div
-                className="bx--tooltip__label"
-                id="tooltip"
-              >
-                
-                <div
-                  aria-describedby={null}
-                  aria-label="More information"
-                  className="bx--tooltip__trigger"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseOut={[Function]}
-                  onMouseOver={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
-                  <svg
-                    aria-hidden={true}
-                    description={null}
-                    fill="currentColor"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    role={null}
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
-                    />
-                    <path
-                      d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
-                    />
-                  </svg>
-                </div>
-              </div>
               <button
                 aria-describedby={null}
                 className="page-title-bar-title--edit iot--btn bx--btn bx--btn--md bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
@@ -4793,6 +4753,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
               </button>
             </div>
           </div>
+          <p
+            className="page-title-bar-description"
+          >
+            Descriptive text about this page and what the user can or should do on it
+          </p>
           <div
             className="page-title-bar-header-right"
           >
@@ -5239,11 +5204,47 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                   className="bx--breadcrumb-item bx--breadcrumb-item--current page-title-bar-breadcrumb-current"
                   title="Page title"
                 >
-                  <span
-                    className="bx--link"
+                  Page title
+                  <div
+                    className="bx--tooltip__label"
+                    id="tooltip"
                   >
-                    Page title
-                  </span>
+                    
+                    <div
+                      aria-describedby={null}
+                      aria-label="More information"
+                      className="bx--tooltip__trigger"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onContextMenu={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseOut={[Function]}
+                      onMouseOver={[Function]}
+                      role="button"
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-hidden={true}
+                        description={null}
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role={null}
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
+                        />
+                        <path
+                          d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
                 </li>
               </ol>
             </nav>
@@ -5698,11 +5699,47 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                   className="bx--breadcrumb-item bx--breadcrumb-item--current page-title-bar-breadcrumb-current"
                   title="Page title"
                 >
-                  <span
-                    className="bx--link"
+                  Page title
+                  <div
+                    className="bx--tooltip__label"
+                    id="tooltip"
                   >
-                    Page title
-                  </span>
+                    
+                    <div
+                      aria-describedby={null}
+                      aria-label="More information"
+                      className="bx--tooltip__trigger"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onContextMenu={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseOut={[Function]}
+                      onMouseOver={[Function]}
+                      role="button"
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-hidden={true}
+                        description={null}
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role={null}
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
+                        />
+                        <path
+                          d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
                 </li>
               </ol>
             </nav>
@@ -5718,48 +5755,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
               >
                 Page title
               </h2>
-              <div
-                className="bx--tooltip__label"
-                id="tooltip"
-              >
-                
-                <div
-                  aria-describedby={null}
-                  aria-label="More information"
-                  className="bx--tooltip__trigger"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseOut={[Function]}
-                  onMouseOver={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
-                  <svg
-                    aria-hidden={true}
-                    description={null}
-                    fill="currentColor"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    role={null}
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
-                    />
-                    <path
-                      d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
-                    />
-                  </svg>
-                </div>
-              </div>
             </div>
           </div>
+          <p
+            className="page-title-bar-description"
+          >
+            Descriptive text about this page and what the user can or should do on it
+          </p>
           <div
             className="page-title-bar-header-right"
           >
@@ -6049,11 +6051,47 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                   className="bx--breadcrumb-item bx--breadcrumb-item--current page-title-bar-breadcrumb-current"
                   title="Page title"
                 >
-                  <span
-                    className="bx--link"
+                  Page title
+                  <div
+                    className="bx--tooltip__label"
+                    id="tooltip"
                   >
-                    Page title
-                  </span>
+                    
+                    <div
+                      aria-describedby={null}
+                      aria-label="More information"
+                      className="bx--tooltip__trigger"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onContextMenu={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseOut={[Function]}
+                      onMouseOver={[Function]}
+                      role="button"
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-hidden={true}
+                        description={null}
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role={null}
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
+                        />
+                        <path
+                          d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
                 </li>
               </ol>
             </nav>
@@ -6069,46 +6107,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
               >
                 Page title
               </h2>
-              <div
-                className="bx--tooltip__label"
-                id="tooltip"
-              >
-                
-                <div
-                  aria-describedby={null}
-                  aria-label="More information"
-                  className="bx--tooltip__trigger"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseOut={[Function]}
-                  onMouseOver={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
-                  <svg
-                    aria-hidden={true}
-                    description={null}
-                    fill="currentColor"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    role={null}
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
-                    />
-                    <path
-                      d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
-                    />
-                  </svg>
-                </div>
-              </div>
               <button
                 aria-describedby={null}
                 className="page-title-bar-title--edit iot--btn bx--btn bx--btn--md bx--btn--ghost bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
@@ -6149,6 +6147,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
               </button>
             </div>
           </div>
+          <p
+            className="page-title-bar-description"
+          >
+            Descriptive text about this page and what the user can or should do on it
+          </p>
           <div
             className="page-title-bar-header-right"
           >
@@ -7132,11 +7135,47 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                   className="bx--breadcrumb-item bx--breadcrumb-item--current page-title-bar-breadcrumb-current"
                   title="A page title could be really long, you never know"
                 >
-                  <span
-                    className="bx--link"
+                  A page title could be really long, you never know
+                  <div
+                    className="bx--tooltip__label"
+                    id="tooltip"
                   >
-                    A page title could be really long, you never know
-                  </span>
+                    
+                    <div
+                      aria-describedby={null}
+                      aria-label="More information"
+                      className="bx--tooltip__trigger"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onContextMenu={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseOut={[Function]}
+                      onMouseOver={[Function]}
+                      role="button"
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-hidden={true}
+                        description={null}
+                        fill="currentColor"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role={null}
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
+                        />
+                        <path
+                          d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
                 </li>
               </ol>
             </nav>

--- a/packages/react/src/components/PageTitleBar/_page-title-bar.scss
+++ b/packages/react/src/components/PageTitleBar/_page-title-bar.scss
@@ -198,6 +198,11 @@
       transition: opacity $duration--fast-01 linear, transform $duration--fast-01 linear;
       margin-left: 0;
 
+      // Add 1px of padding to prevent tooltip outline from getting cropped
+      .#{$prefix}--tooltip__label {
+        padding-right: 1px;
+      }
+
       // hide the `/` after the breadcrumb for the current item
       &::after {
         display: none;

--- a/packages/react/src/components/PageWizard/__snapshots__/PageWizard.story.storyshot
+++ b/packages/react/src/components/PageWizard/__snapshots__/PageWizard.story.storyshot
@@ -680,48 +680,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
             >
               A cool PageWizard!
             </h2>
-            <div
-              className="bx--tooltip__label"
-              id="tooltip"
-            >
-              
-              <div
-                aria-describedby={null}
-                aria-label="More information"
-                className="bx--tooltip__trigger"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onContextMenu={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                role="button"
-                tabIndex={0}
-              >
-                <svg
-                  aria-hidden={true}
-                  description={null}
-                  fill="currentColor"
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  role={null}
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
-                  />
-                  <path
-                    d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
-                  />
-                </svg>
-              </div>
-            </div>
           </div>
         </div>
+        <p
+          className="page-title-bar-description"
+        >
+          The description from the PageTitleBar
+        </p>
         <div
           className="page-title-bar-header-right"
         />
@@ -1088,48 +1053,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
             >
               A cool PageWizard!
             </h2>
-            <div
-              className="bx--tooltip__label"
-              id="tooltip"
-            >
-              
-              <div
-                aria-describedby={null}
-                aria-label="More information"
-                className="bx--tooltip__trigger"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onContextMenu={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                role="button"
-                tabIndex={0}
-              >
-                <svg
-                  aria-hidden={true}
-                  description={null}
-                  fill="currentColor"
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  role={null}
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
-                  />
-                  <path
-                    d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
-                  />
-                </svg>
-              </div>
-            </div>
           </div>
         </div>
+        <p
+          className="page-title-bar-description"
+        >
+          The description from the PageTitleBar
+        </p>
         <div
           className="page-title-bar-header-right"
         />
@@ -1553,48 +1483,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
             >
               A cool PageWizard!
             </h2>
-            <div
-              className="bx--tooltip__label"
-              id="tooltip"
-            >
-              
-              <div
-                aria-describedby={null}
-                aria-label="More information"
-                className="bx--tooltip__trigger"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onContextMenu={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                role="button"
-                tabIndex={0}
-              >
-                <svg
-                  aria-hidden={true}
-                  description={null}
-                  fill="currentColor"
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  role={null}
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
-                  />
-                  <path
-                    d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
-                  />
-                </svg>
-              </div>
-            </div>
           </div>
         </div>
+        <p
+          className="page-title-bar-description"
+        >
+          The description from the PageTitleBar
+        </p>
         <div
           className="page-title-bar-header-right"
         />
@@ -2379,48 +2274,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
             >
               A cool PageWizard!
             </h2>
-            <div
-              className="bx--tooltip__label"
-              id="tooltip"
-            >
-              
-              <div
-                aria-describedby={null}
-                aria-label="More information"
-                className="bx--tooltip__trigger"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onContextMenu={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                role="button"
-                tabIndex={0}
-              >
-                <svg
-                  aria-hidden={true}
-                  description={null}
-                  fill="currentColor"
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  role={null}
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
-                  />
-                  <path
-                    d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
-                  />
-                </svg>
-              </div>
-            </div>
           </div>
         </div>
+        <p
+          className="page-title-bar-description"
+        >
+          The description from the PageTitleBar
+        </p>
         <div
           className="page-title-bar-header-right"
         />
@@ -3389,48 +3249,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
             >
               A cool PageWizard!
             </h2>
-            <div
-              className="bx--tooltip__label"
-              id="tooltip"
-            >
-              
-              <div
-                aria-describedby={null}
-                aria-label="More information"
-                className="bx--tooltip__trigger"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onContextMenu={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                role="button"
-                tabIndex={0}
-              >
-                <svg
-                  aria-hidden={true}
-                  description={null}
-                  fill="currentColor"
-                  focusable="false"
-                  height={16}
-                  preserveAspectRatio="xMidYMid meet"
-                  role={null}
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
-                  />
-                  <path
-                    d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
-                  />
-                </svg>
-              </div>
-            </div>
           </div>
         </div>
+        <p
+          className="page-title-bar-description"
+        >
+          The description from the PageTitleBar
+        </p>
         <div
           className="page-title-bar-header-right"
         />


### PR DESCRIPTION
Closes #3785 

**Summary**
Fix of incorrect behavior of moving the `PageTitleBar` description to a tooltip when content was provided. It is now displayed below the title and only moved to the tooltip if the `collapsed` prop is passed.
I've also added a feature requested by @JordanWSmith15 where the condensed variation of the title bar (with breadcrumbs) now contains the tooltip as well so the description can be easily accessed.

**Change List (commits, features, bugs, etc)**
- PageTitleBar logic fix to show description when content is provided and only move it to Tooltip if the condensed prop is true
- Tooltip with description added to condensed variation of page title bar to be easily accessed when header is "Dynamic" or "Condensed"
- Unit tests added and updated
- Snapshots updated
- PageTitleBar e2e tests fixed after changes

**Acceptance Test (how to verify the PR)**
- Check PageTitleBar stories and add a description to some of them. Unless `condensed` is set to true the description should be displayed below the title. For the DYNAMIC variation, it should be moved to the tooltip next to the current breadcrumb item when scrolling down. For the CONDENSED variation, it should only be in the tooltip next to the current breadcrumb item.

**Regression Test (how to make sure this PR doesn't break old functionality)**
- Check if description below title is not rendered when it shouldn't like when scrolling down with DYNAMIC headerMode or when using CONDENSED headerMode

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
