### PR TITLE
feat(SuiteHeader): add unique id to action items

### DIFF
--- a/packages/react/src/components/Header/HeaderAction/HeaderAction.jsx
+++ b/packages/react/src/components/Header/HeaderAction/HeaderAction.jsx
@@ -51,6 +51,8 @@ const HeaderAction = ({
   const parentContainerRef = useRef(null);
   const menuButtonRef = useRef(null);
 
+  const actionId = item.id || `menu-item-global-action-${index}`;
+
   const mergedI18n = useMemo(
     () => ({
       ...defaultProps.i18n,
@@ -124,6 +126,7 @@ const HeaderAction = ({
             i18n={mergedI18n}
             inOverflow={inOverflow}
             showCloseIconWhenPanelExpanded={showCloseIconWhenPanelExpanded}
+            id={actionId}
           />
         ) : (
           // otherwise render a submenu type dropdown
@@ -146,6 +149,7 @@ const HeaderAction = ({
             data-testid={testID || testId}
             title={item.label}
             childContent={item.childContent}
+            id={actionId}
           />
         )}
       </div>
@@ -166,6 +170,7 @@ const HeaderAction = ({
       href={item.href}
       rel={item.rel}
       target={item.target}
+      id={actionId}
     >
       {renderLabel ? item.label : item.btnContent}
     </HeaderGlobalAction>

--- a/packages/react/src/components/Header/HeaderAction/HeaderActionMenu.jsx
+++ b/packages/react/src/components/Header/HeaderAction/HeaderActionMenu.jsx
@@ -49,6 +49,8 @@ class HeaderActionMenu extends React.Component {
     label: PropTypes.string.isRequired,
     /** MenuItem's to be rendered as children */
     childContent: PropTypes.arrayOf(PropTypes.shape(ChildContentPropTypes)).isRequired,
+    /** Unique id for action menu */
+    id: PropTypes.string.isRequired,
   };
 
   static defaultProps = {
@@ -127,6 +129,7 @@ class HeaderActionMenu extends React.Component {
       label,
       focusRef,
       isExpanded,
+      id,
     } = this.props;
 
     const accessibilityLabel = {
@@ -158,6 +161,7 @@ class HeaderActionMenu extends React.Component {
           testId="menuitem"
           aria-label={ariaLabel}
           role="menuitem"
+          id={id}
         >
           <MenuContent ariaLabel={ariaLabel} />
         </Button>

--- a/packages/react/src/components/Header/HeaderAction/HeaderActionPanel.jsx
+++ b/packages/react/src/components/Header/HeaderAction/HeaderActionPanel.jsx
@@ -53,6 +53,7 @@ const HeaderActionPanel = ({
   i18n,
   inOverflow,
   showCloseIconWhenPanelExpanded,
+  id,
 }) => {
   const panelRef = useRef();
 
@@ -103,6 +104,7 @@ const HeaderActionPanel = ({
         aria-expanded={isExpanded}
         onClick={() => onToggleExpansion()}
         ref={focusRef}
+        id={id}
       >
         {renderLabel ? (
           item.label

--- a/packages/react/src/components/Header/HeaderPropTypes.js
+++ b/packages/react/src/components/Header/HeaderPropTypes.js
@@ -40,6 +40,8 @@ export const HeaderActionPropTypes = {
   item: PropTypes.shape(HeaderActionItemPropTypes).isRequired,
   /** unique index for the menu item */
   index: PropTypes.number.isRequired,
+  /** unique id for the menu item */
+  id: PropTypes.number.isRequired,
   // eslint-disable-next-line react/require-default-props
   testID: deprecate(
     PropTypes.string,

--- a/packages/react/src/components/Header/__snapshots__/Header.story.storyshot
+++ b/packages/react/src/components/Header/__snapshots__/Header.story.storyshot
@@ -81,6 +81,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             className="bx--header-action-btn bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             data-testid="menu-item-alerts-global"
             disabled={false}
+            id="menu-item-global-action-0"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -126,6 +127,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               aria-pressed={null}
               className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               disabled={false}
+              id="menu-item-global-action-1"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -239,6 +241,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                 className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="menuitem"
                 disabled={false}
+                id="menu-item-global-action-2"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
@@ -348,6 +351,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               aria-pressed={null}
               className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               disabled={false}
+              id="app-switcher"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -487,6 +491,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-user-global"
           disabled={false}
+          id="menu-item-global-action-0"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -619,6 +624,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                 className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="menuitem"
                 disabled={false}
+                id="menu-item-global-action-0"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
@@ -818,6 +824,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                 className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="menuitem"
                 disabled={false}
+                id="menu-item-global-action-0"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
@@ -1039,6 +1046,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                 className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="menuitem"
                 disabled={false}
+                id="menu-item-global-action-0"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
@@ -1232,6 +1240,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             className="bx--header-action-btn isReallyHidden bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             data-testid="menu-item-HiddenByClass-global"
             disabled={false}
+            id="menu-item-global-action-0"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -1270,6 +1279,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             className="bx--header-action-btn bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             data-testid="menu-item-Announcements-global"
             disabled={false}
+            id="menu-item-global-action-1"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -1308,6 +1318,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             className="bx--header-action-btn bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             data-testid="menu-item-Custom icon 1-global"
             disabled={false}
+            id="menu-item-global-action-2"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -1346,6 +1357,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             className="bx--header-action-btn bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             data-testid="menu-item-Custom icon 2-global"
             disabled={false}
+            id="menu-item-global-action-3"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -1384,6 +1396,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             className="bx--header-action-btn bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             data-testid="menu-item-Custom icon 3-global"
             disabled={false}
+            id="menu-item-global-action-4"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -1420,6 +1433,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             className="bx--header-action-btn bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             data-testid="menu-item-Header action with href-global"
             href="https://www.ibm.com"
+            id="menu-item-global-action-5"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -1457,6 +1471,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             className="bx--header-action-btn bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             data-testid="menu-item-alerts-global"
             disabled={false}
+            id="menu-item-global-action-6"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -1502,6 +1517,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               aria-pressed={null}
               className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               disabled={false}
+              id="menu-item-global-action-7"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -1615,6 +1631,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                 className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
                 data-testid="menuitem"
                 disabled={false}
+                id="menu-item-global-action-8"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}

--- a/packages/react/src/components/Header/__snapshots__/Header.test.jsx.snap
+++ b/packages/react/src/components/Header/__snapshots__/Header.test.jsx.snap
@@ -72,6 +72,7 @@ exports[`Header should render 1`] = `
             aria-haspopup="menu"
             aria-label="help"
             class="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
+            id="menu-item-global-action-0"
             tabindex="0"
             type="button"
           >
@@ -163,6 +164,7 @@ exports[`Header should render 1`] = `
               aria-label="user"
               class="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
+              id="menu-item-global-action-1"
               role="menuitem"
               tabindex="0"
               type="button"

--- a/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
+++ b/packages/react/src/components/SideNav/__snapshots__/SideNav.story.storyshot
@@ -85,6 +85,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             className="bx--header-action-btn bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             data-testid="menu-item-user-global"
             disabled={false}
+            id="menu-item-global-action-0"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -6133,6 +6134,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             className="bx--header-action-btn bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             data-testid="menu-item-user-global"
             disabled={false}
+            id="menu-item-global-action-0"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}

--- a/packages/react/src/components/SuiteHeader/MultiWorkspaceSuiteHeader.test.jsx
+++ b/packages/react/src/components/SuiteHeader/MultiWorkspaceSuiteHeader.test.jsx
@@ -2,6 +2,8 @@ import { act, render, screen, waitFor, within, fireEvent } from '@testing-librar
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 import React from 'react';
+import NotificationOn from '@carbon/icons-react/es/notification/24';
+import { ScreenOff16 } from '@carbon/icons-react';
 import Chip from '@carbon/icons-react/es/chip/24';
 import MockDate from 'mockdate';
 
@@ -1328,5 +1330,40 @@ describe('SuiteHeader', () => {
   it('should not show current workspace in the main header bar for admin page with more than one workspace available', async () => {
     render(<SuiteHeader {...adminPageCommonProps} />);
     expect(screen.queryByTestId('suite-header--current-workspace')).not.toBeInTheDocument();
+  });
+
+  it('should assign unique id to action items', () => {
+    const firstActionLabel = 'Label one';
+    const secondActionLabel = 'Label two';
+    const { container } = render(
+      <SuiteHeader
+        {...adminPageCommonProps}
+        customActionItems={[
+          {
+            label: firstActionLabel,
+            btnContent: (
+              <ScreenOff16 id="hidden-button" fill="white" description="hidden-button-icon" />
+            ),
+          },
+          {
+            label: secondActionLabel,
+            btnContent: (
+              <span id="bell-icon">
+                <NotificationOn id="notification-button" fill="white" description="Icon" />
+              </span>
+            ),
+          },
+        ]}
+      />
+    );
+
+    expect(container.querySelectorAll('#menu-item-global-action-0')).toHaveLength(1);
+    expect(container.querySelectorAll('#menu-item-global-action-1')).toHaveLength(1);
+    expect(container.querySelector('#menu-item-global-action-0')).toHaveTextContent(
+      firstActionLabel
+    );
+    expect(container.querySelector('#menu-item-global-action-1')).toHaveTextContent(
+      secondActionLabel
+    );
   });
 });

--- a/packages/react/src/components/SuiteHeader/__snapshots__/MultiWorkspaceSuiteHeader.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/__snapshots__/MultiWorkspaceSuiteHeader.story.storyshot
@@ -177,6 +177,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon admin-icon__selected bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -233,6 +234,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -434,6 +436,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -588,6 +591,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -980,6 +984,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon admin-icon__selected bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -1036,6 +1041,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -1237,6 +1243,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -1391,6 +1398,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -1842,6 +1850,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -1898,6 +1907,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -2099,6 +2109,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -2253,6 +2264,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -2727,6 +2739,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-aHiddenIcon-global"
           disabled={false}
+          id="menu-item-global-action-0"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -2766,6 +2779,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-bell-global"
           disabled={false}
+          id="menu-item-global-action-1"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -2816,6 +2830,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="menu-item-global-action-2"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -2947,6 +2962,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="menu-item-global-action-3"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -3073,6 +3089,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -3129,6 +3146,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -3405,6 +3423,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -3618,6 +3637,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -4172,6 +4192,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon admin-icon__selected bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com/3"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -4228,6 +4249,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -4429,6 +4451,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -4583,6 +4606,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -5160,6 +5184,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -5216,6 +5241,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -5417,6 +5443,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -5571,6 +5598,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -6067,6 +6095,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon admin-icon__selected bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com/3"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -6123,6 +6152,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -6324,6 +6354,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -6478,6 +6509,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -7455,6 +7487,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -7511,6 +7544,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -7712,6 +7746,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -7866,6 +7901,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -8321,6 +8357,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon admin-icon__hidden bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="javascript:void(0)"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -8377,6 +8414,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -8514,6 +8552,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -8657,6 +8696,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -8939,6 +8979,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon admin-icon__selected bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com/3"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -8995,6 +9036,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -9196,6 +9238,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -9350,6 +9393,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -9817,6 +9861,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -9873,6 +9918,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -10074,6 +10120,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -10228,6 +10275,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -10620,6 +10668,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -10676,6 +10725,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -10877,6 +10927,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -11031,6 +11082,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -11459,6 +11511,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -11515,6 +11568,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -11716,6 +11770,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -11870,6 +11925,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -12337,6 +12393,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -12393,6 +12450,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -12594,6 +12652,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -12748,6 +12807,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}

--- a/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
@@ -200,6 +200,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -256,6 +257,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -457,6 +459,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -611,6 +614,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -932,6 +936,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-aHiddenIcon-global"
           disabled={false}
+          id="menu-item-global-action-0"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -971,6 +976,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-bell-global"
           disabled={false}
+          id="menu-item-global-action-1"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -1021,6 +1027,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="menu-item-global-action-2"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -1152,6 +1159,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="menu-item-global-action-3"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -1278,6 +1286,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -1334,6 +1343,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -1610,6 +1620,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -1823,6 +1834,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -2198,6 +2210,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -2254,6 +2267,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -2455,6 +2469,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -2609,6 +2624,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -3033,6 +3049,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -3089,6 +3106,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -3290,6 +3308,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -3444,6 +3463,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -3792,6 +3812,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -3848,6 +3869,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -4049,6 +4071,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -4203,6 +4226,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -5065,6 +5089,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -5121,6 +5146,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -5322,6 +5348,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -5476,6 +5503,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -5783,6 +5811,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon admin-icon__hidden bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="javascript:void(0)"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -5839,6 +5868,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -5976,6 +6006,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -6119,6 +6150,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -6401,6 +6433,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -6457,6 +6490,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -6658,6 +6692,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -6812,6 +6847,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -7131,6 +7167,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -7187,6 +7224,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -7388,6 +7426,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -7542,6 +7581,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}


### PR DESCRIPTION
Closes #3793

**Summary**

- Add `id` provided via props or generated based on index to header action items

**Change List (commits, features, bugs, etc)**

- Add id prop Header component
- Update prop types / tests

**Acceptance Test (how to verify the PR)**

- Go to [this story](https://deploy-preview-3796--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-ui-shell-suiteheader-multi-workspace--admin-page)
- Using dev tools verify that header action items has unique id

<img width="906" alt="image" src="https://github.com/carbon-design-system/carbon-addons-iot-react/assets/112560065/aaf941c9-6c72-47b3-b2db-ccaef1febc3e">


**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here


<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
