### PR TITLE
fix(table): select all checkbox state on initial render

### DIFF
--- a/packages/react/src/components/Table/StatefulTable.test.jsx
+++ b/packages/react/src/components/Table/StatefulTable.test.jsx
@@ -1552,4 +1552,24 @@ describe('stateful table with real reducer', () => {
       });
     });
   });
+
+  it('should set select all checkbox to indeterminate state', () => {
+    const rows = tableData.slice(0, 5);
+    const selectedIds = rows.map((row) => row.id);
+    const selectionThatWouldCauseAnIndeterminateState = selectedIds.slice(1, 5);
+    render(
+      <StatefulTable
+        id="tableid4"
+        columns={tableColumns}
+        data={rows}
+        options={{ hasRowSelection: 'multi' }}
+        view={{
+          table: {
+            selectedIds: selectionThatWouldCauseAnIndeterminateState,
+          },
+        }}
+      />
+    );
+    expect(screen.getByLabelText('Select all items')).toHaveProperty('indeterminate', true);
+  });
 });

--- a/packages/react/src/components/Table/tableReducer.js
+++ b/packages/react/src/components/Table/tableReducer.js
@@ -605,7 +605,11 @@ export const tableReducer = (state = {}, action) => {
 
       const selectedIds = view ? view.table.selectedIds : [];
       const isSelectingAll = isMultiSelect && selectedIds?.length === allRowsId.length;
-      const isSelectAllSelected = view ? view.table.isSelectAllSelected || isSelectingAll : false;
+      const isSelectAllSelected = isSelectingAll
+        ? true
+        : view
+        ? view.table.isSelectAllSelected
+        : false;
 
       return update(state, {
         data: {


### PR DESCRIPTION
Closes #3790

**Summary**

- Select all checkbox state on initial render if some rows are selected

**Change List (commits, features, bugs, etc)**

- Fix condition for indeterminate checkbox state
- Add unit test

**Acceptance Test (how to verify the PR)**

- Go to [this story](https://deploy-preview-3801--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table--with-selection-and-batch-actions)
- Verify that Select all checkbox is in indeterminate state

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
