### PR TITLE
3804 suite header and header action fix accessibility scan violations

### DIFF
--- a/packages/react/src/components/Header/Header.test.e2e.jsx
+++ b/packages/react/src/components/Header/Header.test.e2e.jsx
@@ -222,7 +222,7 @@ describe(
           .invoke('attr', 'description')
           .should('eq', 'Open menu');
         cy.findByRole('button', { name: 'open and close list of options' }).click();
-        cy.findByRole('button', { name: 'help', label: 'help' }).should('be.visible').click();
+        cy.findByRole('menuitem', { name: 'help' }).should('be.visible').click();
         cy.findByRole('button', { name: 'help' })
           .find('svg')
           .invoke('attr', 'description')

--- a/packages/react/src/components/Header/Header.test.e2e.jsx
+++ b/packages/react/src/components/Header/Header.test.e2e.jsx
@@ -237,7 +237,7 @@ describe(
           .should('not.exist');
 
         cy.findByRole('button', { name: 'open and close list of options' }).click();
-        cy.findByRole('button', { name: 'user', label: 'user' }).click();
+        cy.findByRole('menuitem', { name: 'user' }).click();
         cy.findByText('JohnDoe@ibm.com').should('be.visible');
         cy.findByRole('button', { name: 'user', label: 'user' })
           .find('svg')

--- a/packages/react/src/components/Header/Header.test.e2e.jsx
+++ b/packages/react/src/components/Header/Header.test.e2e.jsx
@@ -237,13 +237,13 @@ describe(
           .should('not.exist');
 
         cy.findByRole('button', { name: 'open and close list of options' }).click();
-        cy.findByRole('button', { name: 'user' }).click();
+        cy.findByRole('menuitem', { name: 'user' }).click();
         cy.findByText('JohnDoe@ibm.com').should('be.visible');
-        cy.findByRole('button', { name: 'user' })
+        cy.findByRole('menuitem', { name: 'user' })
           .find('svg')
           .invoke('attr', 'description')
           .should('eq', 'Close menu');
-        cy.findByRole('button', { name: 'user' }).click();
+        cy.findByRole('menuitem', { name: 'user' }).click();
         cy.findByRole('button', { name: 'open and close list of options' }).should('be.visible');
 
         // click the left side specifically to _not_ click the svg element right in the center

--- a/packages/react/src/components/Header/Header.test.e2e.jsx
+++ b/packages/react/src/components/Header/Header.test.e2e.jsx
@@ -237,13 +237,13 @@ describe(
           .should('not.exist');
 
         cy.findByRole('button', { name: 'open and close list of options' }).click();
-        cy.findByRole('button', { name: 'user', label: 'user' }).click();
+        cy.findByRole('menuitem', { name: 'user' }).click();
         cy.findByText('JohnDoe@ibm.com').should('be.visible');
-        cy.findByRole('button', { name: 'user', label: 'user' })
+        cy.findByRole('menuitem', { name: 'user' })
           .find('svg')
           .invoke('attr', 'description')
           .should('eq', 'Close menu');
-        cy.findByRole('button', { name: 'user', label: 'user' }).click();
+        cy.findByRole('menuitem', { name: 'user' }).click();
         cy.findByRole('button', { name: 'open and close list of options' }).should('be.visible');
 
         // click the left side specifically to _not_ click the svg element right in the center

--- a/packages/react/src/components/Header/Header.test.e2e.jsx
+++ b/packages/react/src/components/Header/Header.test.e2e.jsx
@@ -237,13 +237,13 @@ describe(
           .should('not.exist');
 
         cy.findByRole('button', { name: 'open and close list of options' }).click();
-        cy.findByRole('menuitem', { name: 'user' }).click();
+        cy.findByRole('button', { name: 'user' }).click();
         cy.findByText('JohnDoe@ibm.com').should('be.visible');
-        cy.findByRole('menuitem', { name: 'user' })
+        cy.findByRole('button', { name: 'user' })
           .find('svg')
           .invoke('attr', 'description')
           .should('eq', 'Close menu');
-        cy.findByRole('menuitem', { name: 'user' }).click();
+        cy.findByRole('button', { name: 'user' }).click();
         cy.findByRole('button', { name: 'open and close list of options' }).should('be.visible');
 
         // click the left side specifically to _not_ click the svg element right in the center

--- a/packages/react/src/components/Header/Header.test.e2e.jsx
+++ b/packages/react/src/components/Header/Header.test.e2e.jsx
@@ -237,13 +237,13 @@ describe(
           .should('not.exist');
 
         cy.findByRole('button', { name: 'open and close list of options' }).click();
-        cy.findByTestId('menuitem', { name: 'user', label: 'user' }).click();
+        cy.findByRole('menuitem', { name: 'user' }).click();
         cy.findByText('JohnDoe@ibm.com').should('be.visible');
-        cy.findByRole('menuitem', { name: 'user' })
+        cy.findByTestId('menuitem', { name: 'user' })
           .find('svg')
           .invoke('attr', 'description')
           .should('eq', 'Close menu');
-        cy.findByRole('menuitem', { name: 'user' }).click();
+        cy.findByTestId('menuitem', { name: 'user' }).click();
         cy.findByRole('button', { name: 'open and close list of options' }).should('be.visible');
 
         // click the left side specifically to _not_ click the svg element right in the center

--- a/packages/react/src/components/Header/Header.test.e2e.jsx
+++ b/packages/react/src/components/Header/Header.test.e2e.jsx
@@ -239,11 +239,11 @@ describe(
         cy.findByRole('button', { name: 'open and close list of options' }).click();
         cy.findByRole('menuitem', { name: 'user' }).click();
         cy.findByText('JohnDoe@ibm.com').should('be.visible');
-        cy.findByRole('button', { name: 'user', label: 'user' })
+        cy.findByRole('menuitem', { name: 'user' })
           .find('svg')
           .invoke('attr', 'description')
           .should('eq', 'Close menu');
-        cy.findByRole('button', { name: 'user', label: 'user' }).click();
+        cy.findByRole('menuitem', { name: 'user' }).click();
         cy.findByRole('button', { name: 'open and close list of options' }).should('be.visible');
 
         // click the left side specifically to _not_ click the svg element right in the center

--- a/packages/react/src/components/Header/Header.test.e2e.jsx
+++ b/packages/react/src/components/Header/Header.test.e2e.jsx
@@ -211,7 +211,7 @@ describe(
         cy.findByLabelText('Announcements').should('not.exist');
         cy.findByRole('button', { name: 'help' }).should('not.exist');
         cy.findByRole('button', { name: 'open and close list of options' }).click();
-        cy.findByRole('button', { name: 'Announcements', label: 'Announcements' })
+        cy.findByRole('menuitem', { name: 'Announcements' })
           .should('be.visible')
           .click()
           .should(() => {
@@ -251,9 +251,7 @@ describe(
         cy.findByRole('button', { name: 'open and close list of options' }).click(5, 5, {
           force: true,
         });
-        cy.findByRole('button', { name: 'Announcements', label: 'Announcements' }).should(
-          'be.visible'
-        );
+        cy.findByRole('menuitem', { name: 'Announcements' }).should('be.visible');
       });
 
       it('should hide header action actions in a small viewport in RTL', () => {
@@ -281,7 +279,7 @@ describe(
         cy.findByLabelText('Announcements').should('not.exist');
         cy.findByRole('button', { name: 'help' }).should('not.exist');
         cy.findByRole('button', { name: 'open and close list of options' }).click();
-        cy.findByRole('button', { name: 'Announcements', label: 'Announcements' })
+        cy.findByRole('menuitem', { name: 'Announcements' })
           .should('be.visible')
           .click()
           .should(() => {
@@ -306,9 +304,7 @@ describe(
         mount(<Header {...commonProps} isActionItemVisible={isActionItemVisible} />);
 
         cy.findByRole('button', { name: 'open and close list of options' }).click();
-        cy.findByRole('button', { name: 'Announcements', label: 'Announcements' }).should(
-          'be.visible'
-        );
+        cy.findByRole('menuitem', { name: 'Announcements' }).should('be.visible');
         cy.findByRole('button', { name: 'Custom icon 1', label: 'Custom icon 1' }).should(
           'not.exist'
         );
@@ -329,9 +325,7 @@ describe(
         mount(<Header {...commonProps} />);
 
         cy.findByRole('button', { name: 'open and close list of options' }).click();
-        cy.findByRole('button', { name: 'Announcements', label: 'Announcements' }).should(
-          'be.visible'
-        );
+        cy.findByRole('menuitem', { name: 'Announcements' }).should('be.visible');
         // I don't know if this is actually necessary in cypress, but just to be safe.
         cy.window().then((win) => {
           Object.defineProperty(win, 'innerWidth', {

--- a/packages/react/src/components/Header/Header.test.e2e.jsx
+++ b/packages/react/src/components/Header/Header.test.e2e.jsx
@@ -186,7 +186,7 @@ describe(
         cy.findByLabelText('Announcements').should('be.visible');
         cy.findByRole('button', { name: 'help' }).should('be.visible');
         cy.findByRole('button', { name: 'open and close list of options' }).should('not.exist');
-        cy.findByRole('menuitem', { name: 'user' }).should('be.visible');
+        cy.findByRole('button', { name: 'user', label: 'user' }).should('be.visible');
       });
 
       it('should hide header action actions in a small viewport', () => {
@@ -211,7 +211,7 @@ describe(
         cy.findByLabelText('Announcements').should('not.exist');
         cy.findByRole('button', { name: 'help' }).should('not.exist');
         cy.findByRole('button', { name: 'open and close list of options' }).click();
-        cy.findByRole('menuitem', { name: 'Announcements' })
+        cy.findByRole('button', { name: 'Announcements', label: 'Announcements' })
           .should('be.visible')
           .click()
           .should(() => {
@@ -222,7 +222,7 @@ describe(
           .invoke('attr', 'description')
           .should('eq', 'Open menu');
         cy.findByRole('button', { name: 'open and close list of options' }).click();
-        cy.findByRole('menuitem', { name: 'help' }).should('be.visible').click();
+        cy.findByRole('button', { name: 'help', label: 'help' }).should('be.visible').click();
         cy.findByRole('button', { name: 'help' })
           .find('svg')
           .invoke('attr', 'description')
@@ -237,13 +237,13 @@ describe(
           .should('not.exist');
 
         cy.findByRole('button', { name: 'open and close list of options' }).click();
-        cy.findByRole('menuitem', { name: 'user' }).click();
+        cy.findByRole('button', { name: 'user', label: 'user' }).click();
         cy.findByText('JohnDoe@ibm.com').should('be.visible');
-        cy.findByRole('menuitem', { name: 'user' })
+        cy.findByRole('button', { name: 'user', label: 'user' })
           .find('svg')
           .invoke('attr', 'description')
           .should('eq', 'Close menu');
-        cy.findByRole('menuitem', { name: 'user' }).click();
+        cy.findByRole('button', { name: 'user', label: 'user' }).click();
         cy.findByRole('button', { name: 'open and close list of options' }).should('be.visible');
 
         // click the left side specifically to _not_ click the svg element right in the center
@@ -251,7 +251,9 @@ describe(
         cy.findByRole('button', { name: 'open and close list of options' }).click(5, 5, {
           force: true,
         });
-        cy.findByRole('menuitem', { name: 'Announcements' }).should('be.visible');
+        cy.findByRole('button', { name: 'Announcements', label: 'Announcements' }).should(
+          'be.visible'
+        );
       });
 
       it('should hide header action actions in a small viewport in RTL', () => {
@@ -279,7 +281,7 @@ describe(
         cy.findByLabelText('Announcements').should('not.exist');
         cy.findByRole('button', { name: 'help' }).should('not.exist');
         cy.findByRole('button', { name: 'open and close list of options' }).click();
-        cy.findByRole('menuitem', { name: 'Announcements' })
+        cy.findByRole('button', { name: 'Announcements', label: 'Announcements' })
           .should('be.visible')
           .click()
           .should(() => {
@@ -304,8 +306,12 @@ describe(
         mount(<Header {...commonProps} isActionItemVisible={isActionItemVisible} />);
 
         cy.findByRole('button', { name: 'open and close list of options' }).click();
-        cy.findByRole('menuitem', { name: 'Announcements' }).should('be.visible');
-        cy.findByRole('menuitem', { name: 'Custom icon 1' }).should('not.exist');
+        cy.findByRole('button', { name: 'Announcements', label: 'Announcements' }).should(
+          'be.visible'
+        );
+        cy.findByRole('button', { name: 'Custom icon 1', label: 'Custom icon 1' }).should(
+          'not.exist'
+        );
       });
 
       it('should get width from documentElement when innerWidth fails', () => {
@@ -323,7 +329,9 @@ describe(
         mount(<Header {...commonProps} />);
 
         cy.findByRole('button', { name: 'open and close list of options' }).click();
-        cy.findByRole('menuitem', { name: 'Announcements' }).should('be.visible');
+        cy.findByRole('button', { name: 'Announcements', label: 'Announcements' }).should(
+          'be.visible'
+        );
         // I don't know if this is actually necessary in cypress, but just to be safe.
         cy.window().then((win) => {
           Object.defineProperty(win, 'innerWidth', {

--- a/packages/react/src/components/Header/Header.test.e2e.jsx
+++ b/packages/react/src/components/Header/Header.test.e2e.jsx
@@ -237,13 +237,13 @@ describe(
           .should('not.exist');
 
         cy.findByRole('button', { name: 'open and close list of options' }).click();
-        cy.findByRole('menuitem', { name: 'user' }).click();
+        cy.findByRole('button', { name: 'user', label: 'user' }).click();
         cy.findByText('JohnDoe@ibm.com').should('be.visible');
-        cy.findByRole('menuitem', { name: 'user' })
+        cy.findByRole('button', { name: 'user', label: 'user' })
           .find('svg')
           .invoke('attr', 'description')
           .should('eq', 'Close menu');
-        cy.findByRole('menuitem', { name: 'user' }).click();
+        cy.findByRole('button', { name: 'user', label: 'user' }).click();
         cy.findByRole('button', { name: 'open and close list of options' }).should('be.visible');
 
         // click the left side specifically to _not_ click the svg element right in the center

--- a/packages/react/src/components/Header/Header.test.e2e.jsx
+++ b/packages/react/src/components/Header/Header.test.e2e.jsx
@@ -237,7 +237,7 @@ describe(
           .should('not.exist');
 
         cy.findByRole('button', { name: 'open and close list of options' }).click();
-        cy.findByRole('menuitem', { name: 'user' }).click();
+        cy.findByTestId('menuitem', { name: 'user', label: 'user' }).click();
         cy.findByText('JohnDoe@ibm.com').should('be.visible');
         cy.findByRole('menuitem', { name: 'user' })
           .find('svg')

--- a/packages/react/src/components/Header/HeaderAction/HeaderActionMenu.jsx
+++ b/packages/react/src/components/Header/HeaderAction/HeaderActionMenu.jsx
@@ -160,7 +160,6 @@ class HeaderActionMenu extends React.Component {
           ref={focusRef}
           testId="menuitem"
           aria-label={ariaLabel}
-          role="menuitem"
           id={id}
         >
           <MenuContent ariaLabel={ariaLabel} />

--- a/packages/react/src/components/Header/HeaderAction/__snapshots__/HeaderActionMenu.test.jsx.snap
+++ b/packages/react/src/components/Header/HeaderAction/__snapshots__/HeaderActionMenu.test.jsx.snap
@@ -11,7 +11,6 @@ exports[`HeaderActionMenu should render 1`] = `
       aria-label="Accessibility label"
       class="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
       data-testid="menuitem"
-      role="menuitem"
       tabindex="0"
       type="button"
     >

--- a/packages/react/src/components/Header/__snapshots__/Header.story.storyshot
+++ b/packages/react/src/components/Header/__snapshots__/Header.story.storyshot
@@ -248,7 +248,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                 onFocus={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
-                role="menuitem"
                 tabIndex={0}
                 type="button"
               >
@@ -633,7 +632,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                 onFocus={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
-                role="menuitem"
                 tabIndex={0}
                 type="button"
               >
@@ -834,7 +832,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                 onFocus={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
-                role="menuitem"
                 tabIndex={0}
                 type="button"
               >
@@ -1057,7 +1054,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                 onFocus={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
-                role="menuitem"
                 tabIndex={0}
                 type="button"
               >
@@ -1643,7 +1639,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                 onFocus={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
-                role="menuitem"
                 tabIndex={0}
                 type="button"
               >

--- a/packages/react/src/components/Header/__snapshots__/Header.test.jsx.snap
+++ b/packages/react/src/components/Header/__snapshots__/Header.test.jsx.snap
@@ -165,7 +165,6 @@ exports[`Header should render 1`] = `
               class="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               id="menu-item-global-action-1"
-              role="menuitem"
               tabindex="0"
               type="button"
             >

--- a/packages/react/src/components/Header/_header.scss
+++ b/packages/react/src/components/Header/_header.scss
@@ -46,7 +46,7 @@ $hoverBgColor: #2c2c2c;
     }
   }
 
-  &__menu-title[role='menuitem'][aria-expanded='true'] + &__menu {
+  &__menu-title[data-testid='menuitem'][aria-expanded='true'] + &__menu {
     left: auto;
     right: 0;
     [dir='rtl'] & {
@@ -166,7 +166,7 @@ $hoverBgColor: #2c2c2c;
   }
 
   .#{$prefix}--header__menu-item {
-    &[role='menuitem'] {
+    &[data-testid='menuitem'] {
       height: 100%;
       justify-content: center;
       padding: 0;
@@ -182,7 +182,7 @@ $hoverBgColor: #2c2c2c;
   }
 }
 
-.#{$prefix}--header__menu .#{$prefix}--header__menu-item[role='menuitem'] {
+.#{$prefix}--header__menu .#{$prefix}--header__menu-item[data-testid='menuitem'] {
   display: flex;
   align-items: center;
   color: $active-ui;

--- a/packages/react/src/components/PageTitleBar/PageTitleBar.test.e2e.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.test.e2e.jsx
@@ -95,7 +95,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset:48px; --negative-header-offset:-48px; --scroll-transition-progress:0;'
+        '--header-offset: 48px; --negative-header-offset: -48px; --scroll-transition-progress: 0;'
       );
 
     cy.scrollTo(0, 118);
@@ -164,7 +164,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset:40px; --negative-header-offset:-40px; --scroll-transition-progress:0;'
+        '--header-offset: 40px; --negative-header-offset: -40px; --scroll-transition-progress: 0;'
       );
 
     cy.scrollTo(0, 100);
@@ -226,7 +226,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset:40px; --negative-header-offset:-40px; --scroll-transition-progress:1;'
+        '--header-offset: 40px; --negative-header-offset: -40px; --scroll-transition-progress: 1;'
       );
 
     breadcrumbsAndTabsAreStickyAndInTheCorrectPosition();
@@ -270,7 +270,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset:0px; --negative-header-offset:0px; --scroll-transition-progress:0;'
+        '--header-offset: 0px; --negative-header-offset: 0px; --scroll-transition-progress: 0;'
       );
 
     cy.scrollTo(0, 250);

--- a/packages/react/src/components/PageTitleBar/PageTitleBar.test.e2e.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.test.e2e.jsx
@@ -281,7 +281,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset: 0px; --negative-header-offset: 0px; --scroll-transition-progress: 1;'
+        '--header-offset: 0px; --negative-header-offset: -0px; --scroll-transition-progress: 1;'
       );
 
     tabsAreStickyAndBreadcrumbsAreHidden();

--- a/packages/react/src/components/PageTitleBar/PageTitleBar.test.e2e.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.test.e2e.jsx
@@ -95,7 +95,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset: 48px; --negative-header-offset: -48px; --scroll-transition-progress: 0;'
+        '--header-offset:48px; --negative-header-offset:-48px; --scroll-transition-progress:0;'
       );
 
     cy.scrollTo(0, 118);
@@ -119,7 +119,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset: 48px; --negative-header-offset: -48px; --scroll-transition-progress: 1;'
+        '--header-offset:48px; --negative-header-offset:-48px; --scroll-transition-progress:1;'
       );
   });
 
@@ -164,7 +164,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset: 40px; --negative-header-offset: -40px; --scroll-transition-progress: 0;'
+        '--header-offset:40px; --negative-header-offset:-40px; --scroll-transition-progress:0;'
       );
 
     cy.scrollTo(0, 100);
@@ -174,7 +174,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset: 40px; --negative-header-offset: -40px; --scroll-transition-progress: 1;'
+        '--header-offset:40px; --negative-header-offset:-40px; --scroll-transition-progress:1;'
       );
 
     breadcrumbsAndTabsAreStickyAndInTheCorrectPosition();
@@ -216,7 +216,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset: 40px; --negative-header-offset: -40px; --scroll-transition-progress: 1;'
+        '--header-offset:40px; --negative-header-offset:-40px; --scroll-transition-progress:1;'
       );
 
     cy.scrollTo(0, 50);
@@ -226,7 +226,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset: 40px; --negative-header-offset: -40px; --scroll-transition-progress: 1;'
+        '--header-offset:40px; --negative-header-offset:-40px; --scroll-transition-progress:1;'
       );
 
     breadcrumbsAndTabsAreStickyAndInTheCorrectPosition();
@@ -270,7 +270,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset: 0px; --negative-header-offset: -0px; --scroll-transition-progress: 0;'
+        '--header-offset:0px; --negative-header-offset:0px; --scroll-transition-progress:0;'
       );
 
     cy.scrollTo(0, 250);
@@ -281,7 +281,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset: 0px; --negative-header-offset: -0px; --scroll-transition-progress: 1;'
+        '--header-offset:0px; --negative-header-offset:0px; --scroll-transition-progress:1;'
       );
 
     tabsAreStickyAndBreadcrumbsAreHidden();

--- a/packages/react/src/components/PageTitleBar/PageTitleBar.test.e2e.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.test.e2e.jsx
@@ -119,7 +119,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset:48px; --negative-header-offset:-48px; --scroll-transition-progress:1;'
+        '--header-offset: 48px; --negative-header-offset: -48px; --scroll-transition-progress: 1;'
       );
   });
 
@@ -174,7 +174,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset:40px; --negative-header-offset:-40px; --scroll-transition-progress:1;'
+        '--header-offset: 40px; --negative-header-offset: -40px; --scroll-transition-progress: 1;'
       );
 
     breadcrumbsAndTabsAreStickyAndInTheCorrectPosition();
@@ -216,7 +216,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset:40px; --negative-header-offset:-40px; --scroll-transition-progress:1;'
+        '--header-offset: 40px; --negative-header-offset: -40px; --scroll-transition-progress: 1;'
       );
 
     cy.scrollTo(0, 50);
@@ -270,7 +270,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset: 0px; --negative-header-offset: 0px; --scroll-transition-progress: 0;'
+        '--header-offset: 0px; --negative-header-offset: -0px; --scroll-transition-progress: 0;'
       );
 
     cy.scrollTo(0, 250);
@@ -281,7 +281,7 @@ describe('PageTitleBar', () => {
       .should(
         'have.attr',
         'style',
-        '--header-offset:0px; --negative-header-offset:0px; --scroll-transition-progress:1;'
+        '--header-offset: 0px; --negative-header-offset: 0px; --scroll-transition-progress: 1;'
       );
 
     tabsAreStickyAndBreadcrumbsAreHidden();

--- a/packages/react/src/components/SuiteHeader/MultiWorkspaceSuiteHeader.test.jsx
+++ b/packages/react/src/components/SuiteHeader/MultiWorkspaceSuiteHeader.test.jsx
@@ -709,13 +709,13 @@ describe('SuiteHeader', () => {
     const originalHref = window.location.href;
     const onRouteChange = jest.fn().mockImplementation(() => false);
     render(<SuiteHeader {...adminPageCommonProps} onRouteChange={onRouteChange} />);
-    userEvent.click(screen.getByRole('menuitem', { name: 'user' }));
+    userEvent.click(screen.getByRole('button', { name: 'user', label: 'user' }));
     await userEvent.click(screen.getByTestId('suite-header-profile--profile'));
     expect(onRouteChange).toHaveBeenCalledWith('PROFILE', adminPageCommonProps.routes.profile);
     expect(window.location.href).toEqual(originalHref);
 
     onRouteChange.mockImplementation(() => true);
-    userEvent.click(screen.getByRole('menuitem', { name: 'user' }));
+    userEvent.click(screen.getByRole('button', { name: 'user', label: 'user' }));
     await userEvent.click(screen.getByTestId('suite-header-profile--profile'));
     expect(onRouteChange).toHaveBeenCalledWith('PROFILE', adminPageCommonProps.routes.profile);
     expect(window.location.href).toBe(adminPageCommonProps.routes.profile);
@@ -936,7 +936,9 @@ describe('SuiteHeader', () => {
       />
     );
 
-    userEvent.type(screen.getByRole('menuitem', { name: 'chip' }), '{enter}', { skipClick: true });
+    userEvent.type(screen.getByRole('button', { name: 'chip', label: 'chip' }), '{enter}', {
+      skipClick: true,
+    });
     expect(screen.getByText('this is my message to you')).toBeVisible();
     jest.spyOn(HTMLAnchorElement.prototype, 'click');
     fireEvent.keyDown(screen.getByTitle('this is my message to you'), { key: 'Enter' });
@@ -975,7 +977,9 @@ describe('SuiteHeader', () => {
       />
     );
 
-    userEvent.type(screen.getByRole('menuitem', { name: 'chip' }), '{enter}', { skipClick: true });
+    userEvent.type(screen.getByRole('button', { name: 'chip', label: 'chip' }), '{enter}', {
+      skipClick: true,
+    });
     expect(screen.getByText('this is my message to you')).toBeVisible();
     jest.spyOn(HTMLButtonElement.prototype, 'click');
     fireEvent.keyDown(screen.getByTitle('this is my message to you'), { key: 'Enter' });
@@ -1013,7 +1017,9 @@ describe('SuiteHeader', () => {
       />
     );
 
-    userEvent.type(screen.getByRole('menuitem', { name: 'chip' }), '{enter}', { skipClick: true });
+    userEvent.type(screen.getByRole('button', { name: 'chip', label: 'chip' }), '{enter}', {
+      skipClick: true,
+    });
     expect(screen.getByText('this is my message to you')).toBeVisible();
     jest.spyOn(HTMLButtonElement.prototype, 'click');
     fireEvent.keyDown(screen.getByTitle('this is my message to you'), { key: 'Enter' });
@@ -1052,7 +1058,9 @@ describe('SuiteHeader', () => {
       />
     );
 
-    userEvent.type(screen.getByRole('menuitem', { name: 'chip' }), '{enter}', { skipClick: true });
+    userEvent.type(screen.getByRole('button', { name: 'chip', label: 'chip' }), '{enter}', {
+      skipClick: true,
+    });
     expect(screen.getByText('this is my message to you')).toBeVisible();
     jest.spyOn(HTMLAnchorElement.prototype, 'click');
     fireEvent.keyDown(screen.getByTitle('this is my message to you'), { key: 'Enter' });
@@ -1094,7 +1102,9 @@ describe('SuiteHeader', () => {
       />
     );
 
-    userEvent.type(screen.getByRole('menuitem', { name: 'chip' }), '{enter}', { skipClick: true });
+    userEvent.type(screen.getByRole('button', { name: 'chip', label: 'chip' }), '{enter}', {
+      skipClick: true,
+    });
     expect(screen.getByText('this is my message to you')).toBeVisible();
     jest.spyOn(HTMLAnchorElement.prototype, 'click');
     fireEvent.keyDown(screen.getByTitle('this is my message to you'), { key: 'Enter' });
@@ -1204,7 +1214,7 @@ describe('SuiteHeader', () => {
         'noopener noreferrer'
       );
       expect(window.open).toHaveBeenCalledTimes(1);
-      userEvent.click(screen.getByRole('menuitem', { name: 'user' }));
+      userEvent.click(screen.getByRole('button', { name: 'user', label: 'user' }));
       await userEvent.click(screen.getByTestId('suite-header-profile--profile'), {
         ctrlKey: true,
       });
@@ -1215,7 +1225,7 @@ describe('SuiteHeader', () => {
       );
       expect(window.open).toHaveBeenCalledTimes(2);
 
-      userEvent.click(screen.getByRole('menuitem', { name: 'Help' }));
+      userEvent.click(screen.getByRole('button', { name: 'Help', label: 'Help' }));
       await userEvent.click(screen.getByTitle('About'), { ctrlKey: true });
       expect(window.open).toHaveBeenLastCalledWith(
         workspaceBasedPageCommonProps.routes.about,

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
@@ -618,13 +618,13 @@ describe('SuiteHeader', () => {
     const originalHref = window.location.href;
     const onRouteChange = jest.fn().mockImplementation(() => false);
     render(<SuiteHeader {...commonProps} onRouteChange={onRouteChange} />);
-    userEvent.click(screen.getByRole('menuitem', { name: 'user' }));
+    userEvent.click(screen.getByRole('button', { name: 'user', label: 'user' }));
     await userEvent.click(screen.getByTestId('suite-header-profile--profile'));
     expect(onRouteChange).toHaveBeenCalledWith('PROFILE', commonProps.routes.profile);
     expect(window.location.href).toEqual(originalHref);
 
     onRouteChange.mockImplementation(() => true);
-    userEvent.click(screen.getByRole('menuitem', { name: 'user' }));
+    userEvent.click(screen.getByRole('button', { name: 'user', label: 'user' }));
     await userEvent.click(screen.getByTestId('suite-header-profile--profile'));
     expect(onRouteChange).toHaveBeenCalledWith('PROFILE', commonProps.routes.profile);
     expect(window.location.href).toBe(commonProps.routes.profile);
@@ -845,7 +845,9 @@ describe('SuiteHeader', () => {
       />
     );
 
-    userEvent.type(screen.getByRole('menuitem', { name: 'chip' }), '{enter}', { skipClick: true });
+    userEvent.type(screen.getByRole('button', { name: 'chip', label: 'chip' }), '{enter}', {
+      skipClick: true,
+    });
     expect(screen.getByText('this is my message to you')).toBeVisible();
     jest.spyOn(HTMLAnchorElement.prototype, 'click');
     fireEvent.keyDown(screen.getByTitle('this is my message to you'), { key: 'Enter' });
@@ -884,7 +886,9 @@ describe('SuiteHeader', () => {
       />
     );
 
-    userEvent.type(screen.getByRole('menuitem', { name: 'chip' }), '{enter}', { skipClick: true });
+    userEvent.type(screen.getByRole('button', { name: 'chip', label: 'chip' }), '{enter}', {
+      skipClick: true,
+    });
     expect(screen.getByText('this is my message to you')).toBeVisible();
     jest.spyOn(HTMLButtonElement.prototype, 'click');
     fireEvent.keyDown(screen.getByTitle('this is my message to you'), { key: 'Enter' });
@@ -922,7 +926,9 @@ describe('SuiteHeader', () => {
       />
     );
 
-    userEvent.type(screen.getByRole('menuitem', { name: 'chip' }), '{enter}', { skipClick: true });
+    userEvent.type(screen.getByRole('button', { name: 'chip', label: 'chip' }), '{enter}', {
+      skipClick: true,
+    });
     expect(screen.getByText('this is my message to you')).toBeVisible();
     jest.spyOn(HTMLButtonElement.prototype, 'click');
     fireEvent.keyDown(screen.getByTitle('this is my message to you'), { key: 'Enter' });
@@ -961,7 +967,9 @@ describe('SuiteHeader', () => {
       />
     );
 
-    userEvent.type(screen.getByRole('menuitem', { name: 'chip' }), '{enter}', { skipClick: true });
+    userEvent.type(screen.getByRole('button', { name: 'chip', label: 'chip' }), '{enter}', {
+      skipClick: true,
+    });
     expect(screen.getByText('this is my message to you')).toBeVisible();
     jest.spyOn(HTMLAnchorElement.prototype, 'click');
     fireEvent.keyDown(screen.getByTitle('this is my message to you'), { key: 'Enter' });
@@ -1003,7 +1011,9 @@ describe('SuiteHeader', () => {
       />
     );
 
-    userEvent.type(screen.getByRole('menuitem', { name: 'chip' }), '{enter}', { skipClick: true });
+    userEvent.type(screen.getByRole('button', { name: 'chip', label: 'chip' }), '{enter}', {
+      skipClick: true,
+    });
     expect(screen.getByText('this is my message to you')).toBeVisible();
     jest.spyOn(HTMLAnchorElement.prototype, 'click');
     fireEvent.keyDown(screen.getByTitle('this is my message to you'), { key: 'Enter' });
@@ -1105,7 +1115,7 @@ describe('SuiteHeader', () => {
         'noopener noreferrer'
       );
       expect(window.open).toHaveBeenCalledTimes(1);
-      userEvent.click(screen.getByRole('menuitem', { name: 'user' }));
+      userEvent.click(screen.getByRole('button', { name: 'user', label: 'user' }));
       await userEvent.click(screen.getByTestId('suite-header-profile--profile'), {
         ctrlKey: true,
       });
@@ -1116,7 +1126,7 @@ describe('SuiteHeader', () => {
       );
       expect(window.open).toHaveBeenCalledTimes(2);
 
-      userEvent.click(screen.getByRole('menuitem', { name: 'Help' }));
+      userEvent.click(screen.getByRole('button', { name: 'Help', label: 'Help' }));
       await userEvent.click(screen.getByTitle('About'), { ctrlKey: true });
       expect(window.open).toHaveBeenLastCalledWith(
         commonProps.routes.about,
@@ -1225,7 +1235,7 @@ describe('SuiteHeader', () => {
     it('should close action panel if other action clicked (safari)', () => {
       render(<SuiteHeader {...commonProps} />);
       const headerPanel = screen.getByLabelText('Header Panel');
-      const profileActionButton = screen.getByRole('menuitem', { name: 'user' });
+      const profileActionButton = screen.getByRole('button', { name: 'user', label: 'user' });
 
       userEvent.click(screen.getByRole('button', { name: APP_SWITCHER }));
       expect(headerPanel).toHaveClass(`${prefix}--header-panel--expanded`);
@@ -1250,7 +1260,7 @@ describe('SuiteHeader', () => {
     it('should close action dropdown if panel opened (safari)', () => {
       render(<SuiteHeader {...commonProps} />);
       const headerPanel = screen.getByLabelText('Header Panel');
-      const profileActionButton = screen.getByRole('menuitem', { name: 'user' });
+      const profileActionButton = screen.getByRole('button', { name: 'user', label: 'user' });
 
       userEvent.click(profileActionButton);
       expect(headerPanel).not.toHaveClass(`${prefix}--header-panel--expanded`);
@@ -1275,7 +1285,7 @@ describe('SuiteHeader', () => {
     it('should close action menu if clicked outside (safari)', () => {
       render(<SuiteHeader {...commonProps} />);
       const headerPanel = screen.getByLabelText('Header Panel');
-      const profileActionButton = screen.getByRole('menuitem', { name: 'user' });
+      const profileActionButton = screen.getByRole('button', { name: 'user', label: 'user' });
 
       expect(headerPanel).not.toHaveClass(`${prefix}--header-panel--expanded`);
       expect(profileActionButton).toHaveAttribute('aria-expanded', 'false');
@@ -1290,8 +1300,10 @@ describe('SuiteHeader', () => {
 
     it('should close action menu if clicked on other action (safari)', () => {
       render(<SuiteHeader {...commonProps} />);
-      const profileActionButton = screen.getByRole('menuitem', { name: 'user' });
-      const helpActionButton = screen.getByRole('menuitem', { name: 'Help' });
+      const profileActionButton = screen.getByRole('button', { name: 'user', label: 'user' });
+      // screen.getByTestId('menuitem', { 'aria-label': 'user' });
+      const helpActionButton = screen.getByRole('button', { name: 'Help', label: 'Help' });
+      // screen.getByTestId('menuitem', { 'aria-label': 'Help' });
 
       expect(helpActionButton).toHaveAttribute('aria-expanded', 'false');
       userEvent.click(helpActionButton);

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
@@ -142,7 +142,7 @@ const SuiteHeaderAppSwitcher = ({
         );
       })}
       {mergedApplications?.length === 0 ? (
-        <div className={`${baseClassName}--no-app`}>
+        <div className={`${baseClassName}--no-app`} role="listitem">
           <div className="bee-icon-container">
             <Bee32 />
             <div className="bee-shadow" />

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/__snapshots__/SuiteHeaderAppSwitcher.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/__snapshots__/SuiteHeaderAppSwitcher.story.storyshot
@@ -122,6 +122,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
       />
       <div
         className="iot--suite-header-app-switcher--no-app"
+        role="listitem"
       >
         <div
           className="bee-icon-container"

--- a/packages/react/src/components/SuiteHeader/__snapshots__/MultiWorkspaceSuiteHeader.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/__snapshots__/MultiWorkspaceSuiteHeader.story.storyshot
@@ -241,7 +241,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -443,7 +442,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -1049,7 +1047,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -1251,7 +1248,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -1830,6 +1826,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
           className="bx--header-action-btn admin-icon bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
           data-testid="menu-item-Administration-global"
           href="https://www.ibm.com"
+          id="admin"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -1886,12 +1883,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="help"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -2087,12 +2084,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               className="bx--header__menu-item bx--header__menu-title iot--btn bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
               data-testid="menuitem"
               disabled={false}
+              id="user"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -2241,6 +2238,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             aria-pressed={null}
             className="bx--header-action-btn action-btn__trigger bx--header__action bx--btn bx--btn--primary bx--tooltip--hidden bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--btn--icon-only--bottom bx--tooltip--align-center"
             disabled={false}
+            id="app-switcher"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -2762,7 +2760,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -2964,7 +2961,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -3818,7 +3814,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -4002,7 +3997,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -4279,7 +4273,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -5106,7 +5099,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -5308,7 +5300,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -6099,7 +6090,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -6301,7 +6291,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -7011,7 +7000,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -7213,7 +7201,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -8404,7 +8391,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -8606,7 +8592,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -9275,7 +9260,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -9413,7 +9397,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -9898,7 +9881,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -10100,7 +10082,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -10781,7 +10762,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -10983,7 +10963,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -11589,7 +11568,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -11791,7 +11769,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -12433,7 +12410,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -12635,7 +12611,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -13316,7 +13291,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -13518,7 +13492,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >

--- a/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
@@ -264,7 +264,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -466,7 +465,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -1167,7 +1165,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -1351,7 +1348,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -1628,7 +1624,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -2276,7 +2271,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -2478,7 +2472,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -3116,7 +3109,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -3318,7 +3310,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -3880,7 +3871,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -4082,7 +4072,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -5158,7 +5147,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -5360,7 +5348,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -5881,7 +5868,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -6019,7 +6005,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -6504,7 +6489,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -6706,7 +6690,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -7239,7 +7222,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >
@@ -7441,7 +7423,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              role="menuitem"
               tabIndex={0}
               type="button"
             >


### PR DESCRIPTION
Closes #GRAPHITE-64846

**Summary**

- While running the a11y scan for `TabListTemplate` component in [Graphite storybook](https://pages.github.ibm.com/maximo-app-framework/graphite/main/react/storybook/?path=/story/templates-%F0%9F%96%A5-tablisttemplate--tablisttemplate) following violations were found and this PR is to fix those accessibility scan violations.
<img width="702" alt="image" src="https://github.com/carbon-design-system/carbon-addons-iot-react/assets/22093326/3b3d9b0e-2af1-469e-bfa0-a0219c04cc49">


**Change List (commits, features, bugs, etc)**

- To fix violations removed `role='menuitem'` from HeaderActions which is used in `<button />` and causing violations in a11y scans.

**Acceptance Test (how to verify the PR)**

- Can be tested in storybook by running scan in Accessibility tab.  Functionally `Header` and `SuitHeader` should work as before.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- No functionality change has been made. 

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
