### PR TITLE
Fix table simple pagination

### DIFF
--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -1275,14 +1275,13 @@ const Table = (props) => {
         </CarbonTable>
       </div>
       {options.hasPagination && !view.table.loadingState.isLoading && visibleData?.length ? ( // don't show pagination row while loading
-        !Number.isNaN(data.length) &&
-        data.length > Math.ceil(maxPages * paginationProps.pageSize) ? (
+        paginationProps.totalItems > Math.ceil(maxPages * paginationProps.pageSize) ? (
           <SimplePagination
             prevPageText={i18n.pageBackwardAria}
             nextPageText={i18n.pageForwardAria}
-            totalItems={data.length}
+            totalItems={paginationProps.totalItems}
             page={paginationProps.page}
-            maxPage={Math.ceil(data.length / paginationProps.pageSize)}
+            maxPage={Math.ceil(paginationProps.totalItems / paginationProps.pageSize)}
             onPage={(page) =>
               actions.pagination.onChangePage({ page, pageSize: paginationProps.pageSize })
             }

--- a/packages/react/src/components/Table/Table.test.jsx
+++ b/packages/react/src/components/Table/Table.test.jsx
@@ -223,6 +223,8 @@ describe('Table', () => {
   });
 
   it('limits the number of pagination select options', () => {
+    const totalItems = 101; // Simulate total items props to be larger then table data
+
     render(
       <Table
         columns={tableColumns}
@@ -230,13 +232,13 @@ describe('Table', () => {
         expandedData={expandedData}
         actions={mockActions}
         options={{ hasPagination: true }}
-        view={{ ...view, pagination: { ...view.pagination, maxPages: 5 } }}
+        view={{ ...view, pagination: { ...view.pagination, totalItems, maxPages: 5 } }}
         testId="table"
       />
     );
     // If number of elements exceeds pagination, then we display simple pagination without dropdowns
     expect(screen.getByTestId('table-table-pagination')).toBeVisible();
-    expect(screen.getByText(`${largeTableData.length} Items`)).toBeVisible();
+    expect(screen.getByText(`${totalItems} Items`)).toBeVisible();
   });
 
   it('Should invoke pagination onChange callback', async () => {
@@ -247,7 +249,7 @@ describe('Table', () => {
         expandedData={expandedData}
         actions={mockActions}
         options={{ hasPagination: true }}
-        view={{ ...view, pagination: { ...view.pagination, maxPages: 5 } }}
+        view={{ ...view, pagination: { ...view.pagination, totalItems: 101, maxPages: 5 } }}
         testId="table"
       />
     );


### PR DESCRIPTION
[GRAPHITE-49742](https://jsw.ibm.com/browse/GRAPHITE-49742)

**Summary**

- If number of items in the table is more then `maxPages * paginationProps.pageSize`, then display SimplePagination without dropdowns

**Change List (commits, features, bugs, etc)**

- Update Table pagination
- Update unit tests

**Acceptance Test (how to verify the PR)**

- Go to [this story](https://deploy-preview-3808--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table--with-pagination)
- In the knob area update `totalItems` to any number higher then 1000
- Verify that simple pagination appear with correct number of items

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
