### PR TITLE
fix(HeaderActionPanel): remove unnecessary aria-label

### DIFF
--- a/packages/react/src/components/Header/Header.test.e2e.jsx
+++ b/packages/react/src/components/Header/Header.test.e2e.jsx
@@ -125,13 +125,13 @@ describe(
           .find('svg')
           .invoke('attr', 'description')
           .should('eq', 'Help icon');
-        cy.findByLabelText('Header Panel')
+        cy.findByTestId('action-btn__panel')
           .should('be.visible')
           .findByText('JohnDoe@ibm.com')
           .should('be.visible');
         cy.findByRole('button', { name: 'help' })
           .click()
-          .findByLabelText('Header Panel')
+          .findByTestId('action-btn__panel')
           .should('not.exist');
       });
 
@@ -149,13 +149,13 @@ describe(
           .find('svg')
           .invoke('attr', 'description')
           .should('eq', 'Help icon');
-        cy.findByLabelText('Header Panel')
+        cy.findByTestId('action-btn__panel')
           .should('be.visible')
           .findByText('JohnDoe@ibm.com')
           .should('be.visible');
         cy.findByRole('button', { name: 'help' })
           .click()
-          .findByLabelText('Header Panel')
+          .findByTestId('action-btn__panel')
           .should('not.exist');
 
         cy.window().then((win) => {
@@ -227,13 +227,13 @@ describe(
           .find('svg')
           .invoke('attr', 'description')
           .should('eq', 'Close menu');
-        cy.findByLabelText('Header Panel')
+        cy.findByTestId('action-btn__panel')
           .should('be.visible')
           .findByText('JohnDoe@ibm.com')
           .should('be.visible');
         cy.findByRole('button', { name: 'help' })
           .click()
-          .findByLabelText('Header Panel')
+          .findByTestId('action-btn__panel')
           .should('not.exist');
 
         cy.findByRole('button', { name: 'open and close list of options' }).click();

--- a/packages/react/src/components/Header/HeaderAction/HeaderActionPanel.jsx
+++ b/packages/react/src/components/Header/HeaderAction/HeaderActionPanel.jsx
@@ -121,7 +121,6 @@ const HeaderActionPanel = ({
         ref={panelRef}
         tabIndex="-1"
         key={`panel-${index}`}
-        aria-label="Header Panel"
         className={
           item.label !== APP_SWITCHER
             ? classnames('action-btn__headerpanel', {

--- a/packages/react/src/components/Header/__snapshots__/Header.story.storyshot
+++ b/packages/react/src/components/Header/__snapshots__/Header.story.storyshot
@@ -169,7 +169,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               </svg>
             </button>
             <div
-              aria-label="Header Panel"
               className="bx--header-panel action-btn__headerpanel action-btn__headerpanel--closed"
               data-testid="action-btn__panel"
               tabIndex="-1"
@@ -383,7 +382,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               </svg>
             </button>
             <div
-              aria-label="Header Panel"
               className="bx--header-panel action-btn__headerpanel action-btn__headerpanel--closed"
               data-testid="action-btn__panel"
               tabIndex="-1"
@@ -1560,7 +1558,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
               </svg>
             </button>
             <div
-              aria-label="Header Panel"
               className="bx--header-panel action-btn__headerpanel action-btn__headerpanel--closed"
               data-testid="action-btn__panel"
               tabIndex="-1"

--- a/packages/react/src/components/Header/__snapshots__/Header.test.jsx.snap
+++ b/packages/react/src/components/Header/__snapshots__/Header.test.jsx.snap
@@ -107,7 +107,6 @@ exports[`Header should render 1`] = `
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             class="bx--header-panel action-btn__headerpanel action-btn__headerpanel--closed"
             data-testid="action-btn__panel"
             tabindex="-1"

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
@@ -1234,7 +1234,7 @@ describe('SuiteHeader', () => {
 
     it('should close action panel if other action clicked (safari)', () => {
       render(<SuiteHeader {...commonProps} />);
-      const headerPanel = screen.getByLabelText('Header Panel');
+      const headerPanel = screen.getByTestId('action-btn__panel');
       const profileActionButton = screen.getByRole('button', { name: 'user', label: 'user' });
 
       userEvent.click(screen.getByRole('button', { name: APP_SWITCHER }));
@@ -1248,7 +1248,7 @@ describe('SuiteHeader', () => {
 
     it('should close action panel if clicked outside of panel (safari)', () => {
       render(<SuiteHeader {...commonProps} />);
-      const headerPanel = screen.getByLabelText('Header Panel');
+      const headerPanel = screen.getByTestId('action-btn__panel');
 
       userEvent.click(screen.getByRole('button', { name: APP_SWITCHER }));
       expect(headerPanel).toHaveClass(`${prefix}--header-panel--expanded`);
@@ -1259,7 +1259,7 @@ describe('SuiteHeader', () => {
 
     it('should close action dropdown if panel opened (safari)', () => {
       render(<SuiteHeader {...commonProps} />);
-      const headerPanel = screen.getByLabelText('Header Panel');
+      const headerPanel = screen.getByTestId('action-btn__panel');
       const profileActionButton = screen.getByRole('button', { name: 'user', label: 'user' });
 
       userEvent.click(profileActionButton);
@@ -1273,7 +1273,7 @@ describe('SuiteHeader', () => {
 
     it('should NOT close panel if clicked inside panel', () => {
       render(<SuiteHeader {...commonProps} />);
-      const headerPanel = screen.getByLabelText('Header Panel');
+      const headerPanel = screen.getByTestId('action-btn__panel');
 
       userEvent.click(screen.getByRole('button', { name: APP_SWITCHER }));
       expect(headerPanel).toHaveClass(`${prefix}--header-panel--expanded`);
@@ -1284,7 +1284,7 @@ describe('SuiteHeader', () => {
 
     it('should close action menu if clicked outside (safari)', () => {
       render(<SuiteHeader {...commonProps} />);
-      const headerPanel = screen.getByLabelText('Header Panel');
+      const headerPanel = screen.getByTestId('action-btn__panel');
       const profileActionButton = screen.getByRole('button', { name: 'user', label: 'user' });
 
       expect(headerPanel).not.toHaveClass(`${prefix}--header-panel--expanded`);

--- a/packages/react/src/components/SuiteHeader/__snapshots__/MultiWorkspaceSuiteHeader.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/__snapshots__/MultiWorkspaceSuiteHeader.story.storyshot
@@ -622,7 +622,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher-multiworkspace"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -1428,7 +1427,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher-multiworkspace"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -2270,7 +2268,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher-multiworkspace"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -3141,7 +3138,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher-multiworkspace"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -3713,7 +3709,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </span>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel action-btn__headerpanel action-btn__headerpanel--closed"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -4512,7 +4507,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher-multiworkspace"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -5480,7 +5474,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher-multiworkspace"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -6471,7 +6464,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher-multiworkspace"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -7381,7 +7373,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher-multiworkspace"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -8772,7 +8763,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher-multiworkspace"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -9566,7 +9556,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -10262,7 +10251,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher-multiworkspace"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -11143,7 +11131,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher-multiworkspace"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -11949,7 +11936,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher-multiworkspace"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -12791,7 +12777,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher-multiworkspace"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -13672,7 +13657,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher-multiworkspace"
             data-testid="action-btn__panel"
             tabIndex="-1"

--- a/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
@@ -645,7 +645,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -1064,7 +1063,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </span>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel action-btn__headerpanel action-btn__headerpanel--closed"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -1863,7 +1861,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -2652,7 +2649,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -3490,7 +3486,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -4252,7 +4247,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -5528,7 +5522,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -6174,7 +6167,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -6870,7 +6862,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher"
             data-testid="action-btn__panel"
             tabIndex="-1"
@@ -7603,7 +7594,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
             </svg>
           </button>
           <div
-            aria-label="Header Panel"
             className="bx--header-panel bx--app-switcher bx--app-switcher iot--suite-header-app-switcher"
             data-testid="action-btn__panel"
             tabIndex="-1"


### PR DESCRIPTION
[GRAPHITE-65278](https://jsw.ibm.com/browse/GRAPHITE-65278)

**Summary**

- Remove unnecessary aria-label on header panel

**Change List (commits, features, bugs, etc)**

- Delete aria-label from header panel
- Update tests

**Acceptance Test (how to verify the PR)**

- Go to [this story](https://deploy-preview-3812--carbon-addons-iot-react.netlify.app/iframe.html?id=1-watson-iot-ui-shell-suiteheader-multi-workspace--admin-page&args=&viewMode=story)
- Run IBM Accessibility Checker
- Verify no error in `The ARIA attributes 'aria-label' are not valid for the element <div> with implicit ARIA role 'generic'`

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
