### PR TITLE
fix(appswitcher): firefox focus

### DIFF
--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/MultiWorkspaceSuiteHeaderAppSwitcher.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/MultiWorkspaceSuiteHeaderAppSwitcher.jsx
@@ -192,7 +192,7 @@ const MultiWorkspaceSuiteHeaderAppSwitcher = ({
     selectedWorkspace?.name ?? selectedWorkspace?.id ?? mergedI18n.selectWorkspace;
 
   return (
-    <ul data-testid={testId} className={baseClassName}>
+    <ul data-testid={testId} className={baseClassName} tabIndex={tabIndex}>
       {!isWorkspacesView ? (
         <>
           {workspaces?.length > 1 ? (

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/SuiteHeaderAppSwitcher.jsx
@@ -97,7 +97,7 @@ const SuiteHeaderAppSwitcher = ({
   const tabIndex = isExpanded ? 0 : -1;
 
   return (
-    <ul data-testid={testId} className={baseClassName}>
+    <ul data-testid={testId} className={baseClassName} tabIndex={tabIndex}>
       <li className={`${baseClassName}--nav-link`}>
         {allApplicationsLink ? (
           <>

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/__snapshots__/MultiWorkspaceSuiteHeaderAppSwitcher.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/__snapshots__/MultiWorkspaceSuiteHeaderAppSwitcher.story.storyshot
@@ -15,6 +15,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
     <ul
       className="iot--suite-header-app-switcher-multiworkspace"
       data-testid="multi-workspace-suite-header-app-switcher"
+      tabIndex={-1}
     >
       <p>
         Select a workspace
@@ -189,6 +190,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
     <ul
       className="iot--suite-header-app-switcher-multiworkspace"
       data-testid="multi-workspace-suite-header-app-switcher"
+      tabIndex={-1}
     >
       <li
         className="bx--side-nav__item bx--side-nav__item--large"
@@ -458,6 +460,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
     <ul
       className="iot--suite-header-app-switcher-multiworkspace"
       data-testid="multi-workspace-suite-header-app-switcher"
+      tabIndex={-1}
     >
       <p>
         Select a workspace
@@ -632,6 +635,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
     <ul
       className="iot--suite-header-app-switcher-multiworkspace"
       data-testid="multi-workspace-suite-header-app-switcher"
+      tabIndex={-1}
     >
       <li
         className="bx--side-nav__item bx--side-nav__item--large"
@@ -837,6 +841,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
     <ul
       className="iot--suite-header-app-switcher-multiworkspace"
       data-testid="multi-workspace-suite-header-app-switcher"
+      tabIndex={-1}
     >
       <p>
         Workspace
@@ -1157,6 +1162,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
     <ul
       className="iot--suite-header-app-switcher-multiworkspace"
       data-testid="multi-workspace-suite-header-app-switcher"
+      tabIndex={-1}
     >
       <p>
         Workspace
@@ -1406,6 +1412,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
     <ul
       className="iot--suite-header-app-switcher-multiworkspace"
       data-testid="multi-workspace-suite-header-app-switcher"
+      tabIndex={-1}
     >
       <li
         className="bx--side-nav__item bx--side-nav__item--large"

--- a/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/__snapshots__/SuiteHeaderAppSwitcher.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/SuiteHeaderAppSwitcher/__snapshots__/SuiteHeaderAppSwitcher.story.storyshot
@@ -79,6 +79,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
     <ul
       className="iot--suite-header-app-switcher"
       data-testid="suite-header-app-switcher"
+      tabIndex={-1}
     >
       <li
         className="iot--suite-header-app-switcher--nav-link"
@@ -178,6 +179,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
     <ul
       className="iot--suite-header-app-switcher"
       data-testid="suite-header-app-switcher"
+      tabIndex={-1}
     >
       <li
         className="iot--suite-header-app-switcher--nav-link"

--- a/packages/react/src/components/SuiteHeader/__snapshots__/MultiWorkspaceSuiteHeader.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/__snapshots__/MultiWorkspaceSuiteHeader.story.storyshot
@@ -640,6 +640,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher-multiworkspace"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <p>
                       Select a workspace
@@ -1446,6 +1447,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher-multiworkspace"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <li
                       className="bx--side-nav__item bx--side-nav__item--large"
@@ -2288,6 +2290,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher-multiworkspace"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <p>
                       Workspace
@@ -3159,6 +3162,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher-multiworkspace"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <p>
                       Workspace
@@ -4530,6 +4534,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher-multiworkspace"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <p>
                       Workspace
@@ -5498,6 +5503,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher-multiworkspace"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <p>
                       Workspace
@@ -6489,6 +6495,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher-multiworkspace"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <p>
                       Workspace
@@ -7399,6 +7406,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher-multiworkspace"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <p>
                       Workspace
@@ -8790,6 +8798,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher-multiworkspace"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <p>
                       Workspace
@@ -10280,6 +10289,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher-multiworkspace"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <p>
                       Workspace
@@ -11161,6 +11171,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher-multiworkspace"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <p>
                       Select a workspace
@@ -11967,6 +11978,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher-multiworkspace"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <li
                       className="bx--side-nav__item bx--side-nav__item--large"
@@ -12809,6 +12821,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher-multiworkspace"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <p>
                       Workspace
@@ -13690,6 +13703,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher-multiworkspace"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <li
                       className="bx--side-nav__item bx--side-nav__item--large"

--- a/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
+++ b/packages/react/src/components/SuiteHeader/__snapshots__/SuiteHeader.story.storyshot
@@ -663,6 +663,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <li
                       className="iot--suite-header-app-switcher--nav-link"
@@ -1881,6 +1882,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <li
                       className="iot--suite-header-app-switcher--nav-link"
@@ -2670,6 +2672,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <li
                       className="iot--suite-header-app-switcher--nav-link"
@@ -3508,6 +3511,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <li
                       className="iot--suite-header-app-switcher--nav-link"
@@ -4270,6 +4274,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <li
                       className="iot--suite-header-app-switcher--nav-link"
@@ -5546,6 +5551,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <li
                       className="iot--suite-header-app-switcher--nav-link"
@@ -6888,6 +6894,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <li
                       className="iot--suite-header-app-switcher--nav-link"
@@ -7621,6 +7628,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/U
                   <ul
                     className="iot--suite-header-app-switcher"
                     data-testid="suite-header-app-switcher"
+                    tabIndex={-1}
                   >
                     <li
                       className="iot--suite-header-app-switcher--nav-link"


### PR DESCRIPTION
[GRAPHITE-63825](https://jsw.ibm.com/browse/GRAPHITE-63825)

**Summary**

- Firefox only: disable focus on header panel menu when panel is closed

**Change List (commits, features, bugs, etc)**

- Add dynamic `tabIndex` for header panel menu when panel is closed
- Update snapshots

**Acceptance Test (how to verify the PR)**

- In Firefox
- Go to [this story](https://deploy-preview-3813--carbon-addons-iot-react.netlify.app/iframe.html?id=1-watson-iot-ui-shell-suiteheader-multi-workspace--admin-page&args=&viewMode=story)
- Enable Mac Voice Over or JAWS
- Put focus on App Switcher button
- Press tab one more time
- Verify that Screen Reader announces leaving the page and don't read panel menu items

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
