### PR TITLE
feat(SuiteHeader): add option to hide menu

### DIFF
--- a/packages/react/src/components/SuiteHeader/MultiWorkspaceSuiteHeader.story.jsx
+++ b/packages/react/src/components/SuiteHeader/MultiWorkspaceSuiteHeader.story.jsx
@@ -499,6 +499,7 @@ HeaderWithExtraContent.storyName = 'Header with extra content';
 
 export const HeaderWithSideNav = () => {
   const demoMostRecentLinks = boolean('Demo most recent links', true);
+  const hideMenuButton = boolean('Hide menu button', false);
   const [linksState, setLinksState] = useState([]);
   const [recentLinksState, setRecentLinksState] = useState([]);
 
@@ -728,6 +729,7 @@ export const HeaderWithSideNav = () => {
           links: linksState,
           recentLinks: demoMostRecentLinks ? recentLinksState : [],
         }}
+        hideMenuButton={hideMenuButton}
       />
     </>
   );

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.jsx
@@ -64,6 +64,7 @@ const defaultProps = {
   testId: 'suite-header',
   isActionItemVisible: () => true,
   handleHeaderNameClick: null,
+  hideMenuButton: false,
 };
 
 const propTypes = {
@@ -124,6 +125,9 @@ const propTypes = {
   /** a function that will be passed the actionItem object and returns a boolean to determine if that item should be shown */
   // eslint-disable-next-line react/forbid-foreign-prop-types
   isActionItemVisible: Header.propTypes.isActionItemVisible,
+
+  /** Force menu button to hide regardless of side nav props */
+  hideMenuButton: PropTypes.bool,
 };
 
 const SuiteHeader = ({
@@ -154,6 +158,7 @@ const SuiteHeader = ({
   walkmeLang,
   testId,
   handleHeaderNameClick: handleHeaderNameClickProps,
+  hideMenuButton,
   ...otherHeaderProps
 }) => {
   const mergedI18N = { ...defaultProps.i18n, ...i18n };
@@ -354,7 +359,7 @@ const SuiteHeader = ({
               className={classnames(`${settings.iotPrefix}--suite-header`, className)}
               url={navigatorRoute}
               handleHeaderNameClick={handleHeaderNameClick}
-              hasSideNav={hasSideNav || sideNavProps !== null}
+              hasSideNav={hideMenuButton ? false : hasSideNav || sideNavProps !== null}
               onClickSideNavExpand={(evt) => {
                 onSideNavToggled(evt);
                 onClickSideNavExpand(evt);

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.mdx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.mdx
@@ -519,6 +519,7 @@ Below is a full example of various BUTTON and ANCHOR tags used in both open in n
 | walkmeLang                                           | string   | 'en'                              | Walkme language code                                                                                                                                        |
 | isActionItemVisible                                  | function | () => true                        | Is passed the actionItem object being rendered and returns a boolean if it should be in the DOM. (actionItem) => {}                                         |
 | handleHeaderNameClick                                | function | null                              | On click event callback for application name in SuiteHeader, allows to intercept link redirect                                                              |
+| hideMenuButton                                       | bool     | false                             | Force menu button to hide regardless of side nav props                                                                                                      |
 
 ## Feedback
 

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.story.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.story.jsx
@@ -312,6 +312,7 @@ HeaderWithExtraContent.storyName = 'Header with extra content';
 
 export const HeaderWithSideNav = () => {
   const demoMostRecentLinks = boolean('Demo most recent links', true);
+  const hideMenuButton = boolean('Hide menu button', false);
   const [linksState, setLinksState] = useState([]);
   const [recentLinksState, setRecentLinksState] = useState([]);
 
@@ -540,6 +541,7 @@ export const HeaderWithSideNav = () => {
           links: linksState,
           recentLinks: demoMostRecentLinks ? recentLinksState : [],
         }}
+        hideMenuButton={hideMenuButton}
       />
     </>
   );

--- a/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
+++ b/packages/react/src/components/SuiteHeader/SuiteHeader.test.jsx
@@ -1315,4 +1315,30 @@ describe('SuiteHeader', () => {
       expect(helpActionButton).toHaveAttribute('aria-expanded', 'false');
     });
   });
+
+  it('hides menu button', () => {
+    render(
+      <SuiteHeader
+        {...commonProps}
+        hideMenuButton
+        sideNavProps={{
+          links: [
+            {
+              isEnabled: true,
+              icon: Chip,
+              metaData: {
+                label: 'Devices',
+                href: 'https://google.com',
+                element: 'a',
+                target: '_blank',
+              },
+              linkContent: 'Devices',
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Open Menu' })).toBeNull();
+  });
 });

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -11882,6 +11882,7 @@ Map {
       "globalApplications": Array [],
       "handleHeaderNameClick": null,
       "hasSideNav": false,
+      "hideMenuButton": false,
       "i18n": Object {
         "about": "About",
         "administrationIcon": "Administration",
@@ -12158,6 +12159,9 @@ Map {
         "type": "oneOfType",
       },
       "hasSideNav": Object {
+        "type": "bool",
+      },
+      "hideMenuButton": Object {
         "type": "bool",
       },
       "i18n": Object {


### PR DESCRIPTION
from Graphite

**Summary**

- Add extra prop to hide menu button

**Change List (commits, features, bugs, etc)**

- Add `hideMenuButton` prop that removes menu button regardless of side nav props
- Add UT
- Update docs, storybook

**Acceptance Test (how to verify the PR)**

- Go to [this story](https://deploy-preview-3815--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-ui-shell-suiteheader-multi-workspace--header-with-side-nav)
- Enable `hideMenuButton` knob
- Verify that menu button disappeared

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
