### PR TITLE
fix(table): add min width for pinned last column

### DIFF
--- a/packages/react/src/components/Table/_table.scss
+++ b/packages/react/src/components/Table/_table.scss
@@ -435,6 +435,9 @@ button.#{$prefix}--btn.#{$iot-prefix}--tooltip-svg-wrapper.#{$prefix}--btn--ghos
     right: 0;
     filter: drop-shadow(-1px 0 0 $active-ui);
 
+    min-width: rem(56px);
+    width: rem(56px); // Needed for fixed/resizable columns that don't respect min-width
+
     [dir='rtl'] & {
       right: unset;
       left: 0;


### PR DESCRIPTION
Closes #3814

**Summary**

- Add min width for last pinned column

**Change List (commits, features, bugs, etc)**

- Add min width css property to the last table cells

**Acceptance Test (how to verify the PR)**

- Go to [this story](https://deploy-preview-3816--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-table--playground)
- In "Selections & actions" enable `hasRowActions`
- In "Column configuration" set `hasResize` and `pinColumn` last
- Verify that last column is pinned and visible

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
