### PR TITLE
feat(ValueCard): disable preview in edit mode

### DIFF
--- a/packages/react/src/components/ValueCard/ValueCard.story.jsx
+++ b/packages/react/src/components/ValueCard/ValueCard.story.jsx
@@ -659,6 +659,10 @@ export const Editable = () => {
         locale={select('locale', ['de', 'fr', 'en', 'ja'], 'en')}
         fontSize={number('fontSize', 42)}
         onAttributeClick={action('onAttributeClick')}
+        values={{
+          monthlySummary: number('Monthly summary value (values.monthlySummary)', 1045),
+          yearlySummary: number('Yearly summary value (values.yearlySummary)', 100644),
+        }}
       />
     </div>
   );

--- a/packages/react/src/components/ValueCard/ValueCard.test.jsx
+++ b/packages/react/src/components/ValueCard/ValueCard.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { gray60 } from '@carbon/colors';
 
 import { CARD_DATA_STATE, CARD_SIZES } from '../../constants/LayoutConstants';
 import { settings } from '../../constants/Settings';
@@ -169,7 +168,7 @@ describe('ValueCard', () => {
     expect(onAttributeClick).toHaveBeenCalledWith({ dataSourceId: 'v', value: 10000 });
   });
 
-  it('should show PREVIEW_DATA as secondary value when editable', () => {
+  it('should show PREVIEW_DATA as primary value when editable and no data', () => {
     render(
       <ValueCard
         id="myIdTest"
@@ -189,13 +188,11 @@ describe('ValueCard', () => {
           ],
         }}
         size={CARD_SIZES.SMALL}
-        values={{ v: 10000 }}
         isEditable
       />
     );
     const previewData = screen.getAllByText(PREVIEW_DATA);
-    expect(previewData).toHaveLength(2);
-    expect(previewData[1]).toHaveClass(`${iotPrefix}--value-card__attribute-secondary-value`);
-    expect(previewData[1]).toHaveStyle(`--secondary-value-color:${gray60}`);
+    expect(previewData).toHaveLength(1);
+    expect(previewData[0]).toHaveClass(`${iotPrefix}--value-card__value-renderer--value`);
   });
 });

--- a/packages/react/src/components/ValueCard/ValueContent.jsx
+++ b/packages/react/src/components/ValueCard/ValueContent.jsx
@@ -7,7 +7,7 @@ import { CARD_LAYOUTS, CARD_SIZES } from '../../constants/LayoutConstants';
 import { ValueContentPropTypes } from '../../constants/CardPropTypes';
 import DataStateRenderer from '../Card/DataStateRenderer';
 
-import { BASE_CLASS_NAME, PREVIEW_DATA, DEFAULT_FONT_SIZE, determineValue } from './valueCardUtils';
+import { BASE_CLASS_NAME, DEFAULT_FONT_SIZE, determineValue } from './valueCardUtils';
 import Attribute from './Attribute';
 
 const propTypes = {
@@ -71,19 +71,11 @@ const ValueContent = ({
             isEditable={isEditable}
             title={title}
             renderIconByName={others.renderIconByName}
-            value={
-              // When the card is in the editable state, we will show a preview
-              isEditable
-                ? PREVIEW_DATA
-                : determineValue(attribute.dataSourceId, values, attribute.dataFilter)
-            }
+            value={determineValue(attribute.dataSourceId, values, attribute.dataFilter)}
             secondaryValue={
               attribute.secondaryValue && {
                 ...attribute.secondaryValue,
-                // When the card is in the editable state, we will show a preview
-                value: isEditable
-                  ? PREVIEW_DATA
-                  : determineValue(attribute.secondaryValue.dataSourceId, values),
+                value: determineValue(attribute.secondaryValue.dataSourceId, values),
               }
             }
             customFormatter={customFormatter}

--- a/packages/react/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/packages/react/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -1105,10 +1105,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                     }
                   }
                   tabIndex={0}
-                  title="--"
+                  title="1,045"
                   type="button"
                 >
-                  --
+                  1,045
                 </button>
               </div>
               <span
@@ -1166,10 +1166,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                     }
                   }
                   tabIndex={0}
-                  title="--"
+                  title="100,644"
                   type="button"
                 >
-                  --
+                  100,644
                 </button>
               </div>
               <span


### PR DESCRIPTION
[GRAPHITE-65817](https://jsw.ibm.com/browse/GRAPHITE-65817)

**Summary**

- Disable showing preview stub in edit mode

**Change List (commits, features, bugs, etc)**

- Update ValueCard component to display value (if exists) instead of preview stub in edit mode

**Acceptance Test (how to verify the PR)**

- Go to [this story](https://deploy-preview-3818--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-card-valuecard--editable)
- Verify that data is displayed in card, even though it is in edit mode
- Remove values from the knob
- Verify that preview stub "--" appeared when values do not exist

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
