### PR TITLE
feat(table): enable percentage-based column width for the table header

### DIFF
--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -609,12 +609,14 @@ export const defaultProps = (baseProps) => ({
   // TODO: set default in v3. Leaving null for backwards compat. to match 'id' which was
   // previously used as testId.
   testId: null,
+  enablePercentageColumnWidth: false,
 });
 
 const Table = (props) => {
   const {
     id,
     columns,
+    enablePercentageColumnWidth,
     columnGroups,
     data,
     expandedData,
@@ -1103,6 +1105,7 @@ const Table = (props) => {
                 truncateCellText: useCellTextTruncate,
               }}
               columns={columns}
+              enablePercentageColumnWidth={enablePercentageColumnWidth}
               columnGroups={columnGroups}
               filters={view.filters}
               actions={{

--- a/packages/react/src/components/Table/TableHead/TableHead.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.jsx
@@ -473,12 +473,49 @@ const TableHead = ({
   );
 
   useEffect(() => {
-    if (enablePercentageColumnWidth && columns.length && percentageMode) {
-      const width = `${parseInt(100 / columns.length, 10)}`;
+    let tableWidth;
+    let columnWidth;
+    const filteredColumns = columns.filter((colOrder) => {
+      const hiddenCol = ordering.find((col) => col.columnId === colOrder.id);
+      return !hiddenCol || !hiddenCol.isHidden;
+    });
 
-      const updatedColumns = columns.map((col) => {
+    const hasOverflowMenu = filteredColumns.some(
+      (column) => column.overflowMenuItems && column.overflowMenuItems.length > 0
+    );
+    const totalColumns = filteredColumns.length;
+    if (
+      enablePercentageColumnWidth &&
+      filteredColumns.length &&
+      percentageMode &&
+      !hasOverflowMenu
+    ) {
+      if (hasRowSelection === 'multi' && !(hasRowExpansion || hasRowNesting)) {
+        tableWidth = `calc(100% - 54px)`;
+        columnWidth = `calc(${tableWidth} / ${totalColumns})`;
+      } else if (
+        (hasRowExpansion || hasRowNesting) &&
+        !(
+          hasRowSelection === 'multi' ||
+          (useRadioButtonSingleSelect && hasRowSelection === 'single')
+        )
+      ) {
+        tableWidth = `calc(100% - 40px)`;
+        columnWidth = `calc(${tableWidth} / ${totalColumns})`;
+      } else if (
+        (hasRowExpansion || hasRowNesting) &&
+        (hasRowSelection === 'multi' ||
+          (useRadioButtonSingleSelect && hasRowSelection === 'single'))
+      ) {
+        tableWidth = `calc(100% - 94px)`;
+        columnWidth = `calc(${tableWidth} / ${totalColumns})`;
+      } else {
+        columnWidth = `${parseInt(100 / filteredColumns.length, 10)}%`;
+      }
+
+      const updatedColumns = filteredColumns.map((col) => {
         const updatedCol = { ...col };
-        updatedCol.width = `${width}%`;
+        updatedCol.width = columnWidth;
         return updatedCol;
       });
 
@@ -492,7 +529,17 @@ const TableHead = ({
         setCurrentColumnWidths(newColumnWidths);
       }
     }
-  }, [columns, ordering, currentColumnWidths, enablePercentageColumnWidth, percentageMode]);
+  }, [
+    columns,
+    ordering,
+    hasRowExpansion,
+    hasRowNesting,
+    hasRowSelection,
+    useRadioButtonSingleSelect,
+    currentColumnWidths,
+    enablePercentageColumnWidth,
+    percentageMode,
+  ]);
 
   const visibleColumns = ordering.filter((col) => !col.isHidden);
   const lastVisibleColumn = visibleColumns.slice(-1)[0];

--- a/packages/react/src/components/Table/TableHead/TableHead.test.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.test.jsx
@@ -188,6 +188,35 @@ describe('TableHead', () => {
     expect(tableHeaders).toHaveLength(0);
   });
 
+  it('check columns % width by enablePercentageColumnWidth props', () => {
+    const myProps = {
+      ...commonTableHeadProps,
+      enablePercentageColumnWidth: true,
+      options: { ...commonTableHeadProps.options, hasResize: true },
+    };
+    const wrapper = mount(<TableHead {...myProps} />, {
+      attachTo: document.createElement('table'),
+    });
+
+    const tableHeader1 = wrapper.find('th[data-testid="-column-col1"]');
+    expect(tableHeader1.prop('style')).toHaveProperty('width', '33%');
+    const tableHeader2 = wrapper.find('th[data-testid="-column-col2"]');
+    expect(tableHeader2.prop('style')).toHaveProperty('width', '33%');
+    const tableHeader3 = wrapper.find('th[data-testid="-column-col3"]');
+    expect(tableHeader3.prop('style')).toHaveProperty('width', '33%');
+
+    const tableHeaderResizeHandles = wrapper.find(`div.${iotPrefix}--column-resize-handle`);
+    tableHeaderResizeHandles.first().simulate('mouseDown');
+    tableHeaderResizeHandles.first().simulate('mouseMove');
+    tableHeaderResizeHandles.first().simulate('mouseUp');
+    const tableResizedHeader1 = wrapper.find('th[data-testid="-column-col1"]');
+    expect(tableResizedHeader1.prop('style')).toHaveProperty('width', 150);
+    const tableResizedHeader2 = wrapper.find('th[data-testid="-column-col2"]');
+    expect(tableResizedHeader2.prop('style')).toHaveProperty('width', 150);
+    const tableResizedHeader3 = wrapper.find('th[data-testid="-column-col3"]');
+    expect(tableResizedHeader3.prop('style')).toHaveProperty('width', 150);
+  });
+
   it('check hidden item is not shown ', () => {
     const myProps = {
       ...commonTableHeadProps,

--- a/packages/react/src/components/Table/TableHead/columnWidthUtilityFunctions.js
+++ b/packages/react/src/components/Table/TableHead/columnWidthUtilityFunctions.js
@@ -27,12 +27,11 @@ function createWidthsMap(ordering, columnWidths, adjustedCols) {
       ? columnWidths.find((col) => col.id === orderedColumn.columnId)
       : columnWidths[orderedColumn.columnId];
     newColumnWidths[orderedColumn.columnId] = {
-      width:
-        current && current.width !== undefined
-          ? current.width.toString().includes('%')
-            ? current.width
-            : parseInt(current.width, 10)
-          : undefined,
+      width: current?.width
+        ? current.width.toString().includes('%')
+          ? current.width
+          : parseInt(current.width, 10)
+        : undefined,
       id: orderedColumn.columnId,
     };
   });

--- a/packages/react/src/components/Table/TableHead/columnWidthUtilityFunctions.js
+++ b/packages/react/src/components/Table/TableHead/columnWidthUtilityFunctions.js
@@ -27,7 +27,12 @@ function createWidthsMap(ordering, columnWidths, adjustedCols) {
       ? columnWidths.find((col) => col.id === orderedColumn.columnId)
       : columnWidths[orderedColumn.columnId];
     newColumnWidths[orderedColumn.columnId] = {
-      width: current && current.width !== undefined ? parseInt(current.width, 10) : undefined,
+      width:
+        current && current.width !== undefined
+          ? current.width.toString().includes('%')
+            ? current.width
+            : parseInt(current.width, 10)
+          : undefined,
       id: orderedColumn.columnId,
     };
   });

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -655,6 +655,7 @@ Map {
         },
       },
       "columnGroups": Array [],
+      "enablePercentageColumnWidth": false,
       "error": null,
       "i18n": Object {
         "actionFailedText": "Action failed",
@@ -2404,6 +2405,7 @@ Map {
       "clearSelectionText": "Clear selection",
       "closeMenuText": "Close menu",
       "columnGroups": Array [],
+      "enablePercentageColumnWidth": false,
       "filterRowIcon": Object {
         "$$typeof": Symbol(react.forward_ref),
         "render": [Function],
@@ -2683,6 +2685,9 @@ Map {
         ],
         "isRequired": true,
         "type": "arrayOf",
+      },
+      "enablePercentageColumnWidth": Object {
+        "type": "bool",
       },
       "filterRowIcon": Object {
         "args": Array [


### PR DESCRIPTION
Closes # https://jsw.ibm.com/browse/GRAPHITE-66562

**Summary**
[PAL][Table] When the enablePercentageColumnWidth property is set to true and column widths are not provided, the system will automatically calculate the column widths based on the total number of columns, distributing them as a percentage of the total width.
And After that if user start Resizing the Column it will get reset to default column width 150px.

- summary_here

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [x] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [x] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [x] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [x] PR should link and close out an existing issue
