### PR TITLE
feat(datetimepickerv2): datetimepickerV2 hide back button props

### DIFF
--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
@@ -18,6 +18,7 @@ const DateTimePicker = ({
   showRelativeOption,
   showCustomRangeLink,
   hasTimeInput,
+  hideBackButton,
   renderPresetTooltipText,
   onCancel,
   onApply,
@@ -47,6 +48,7 @@ const DateTimePicker = ({
       expanded={expanded}
       disabled={disabled}
       invalid={invalid}
+      hideBackButton={hideBackButton}
       showRelativeOption={showRelativeOption}
       showCustomRangeLink={showCustomRangeLink}
       hasTimeInput={hasTimeInput}

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.story.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.story.jsx
@@ -223,6 +223,9 @@ export const SelectedAbsoluteWithNewTimeSpinner = () => {
       hasTimeInput={boolean('hasTimeInput', true)}
       onApply={action('onApply')}
       onCancel={action('onCancel')}
+      showCustomRangeLink={boolean('show custom range link', true)}
+      hideBackButton={boolean('hide back button', false)}
+      showRelativeOption={boolean('show the relative option', true)}
       style={{ zIndex: number('zIndex', 0) }}
       i18n={object('i18n', {
         startTimeLabel: 'Start',

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
@@ -127,6 +127,8 @@ export const propTypes = {
   ),
   /** show the picker in the expanded state */
   expanded: PropTypes.bool,
+  /** hide the back button and display cancel button while only using absolute range selector */
+  hideBackButton: PropTypes.bool,
   /** disable the input */
   disabled: PropTypes.bool,
   /** specify the input in invalid state */
@@ -248,6 +250,7 @@ export const defaultProps = {
   disabled: false,
   invalid: false,
   showRelativeOption: true,
+  hideBackButton: false,
   showCustomRangeLink: true,
   hasTimeInput: true,
   renderPresetTooltipText: null,
@@ -312,6 +315,7 @@ const DateTimePicker = ({
   showCustomRangeLink,
   hasTimeInput,
   renderPresetTooltipText,
+  hideBackButton,
   onCancel,
   onApply,
   onClear,
@@ -749,7 +753,6 @@ const DateTimePicker = ({
 
   const onApplyClick = () => {
     const value = renderValue();
-    setLastAppliedValue(value);
     const returnValue = {
       timeRangeKind: value.kind,
       timeRangeValue: null,
@@ -802,6 +805,7 @@ const DateTimePicker = ({
         };
         break;
     }
+    setLastAppliedValue(returnValue);
 
     if (onApply && isValid) {
       setIsExpanded(false);
@@ -872,7 +876,7 @@ const DateTimePicker = ({
   const CustomFooter = () => {
     return (
       <div className={`${iotPrefix}--date-time-picker__menu-btn-set`}>
-        {isCustomRange && !isSingleSelect ? (
+        {isCustomRange && !isSingleSelect && !hideBackButton ? (
           <Button
             kind="secondary"
             className={`${iotPrefix}--date-time-picker__menu-btn ${iotPrefix}--date-time-picker__menu-btn-back`}

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -9797,6 +9797,7 @@ Map {
       "expanded": false,
       "hasIconOnly": false,
       "hasTimeInput": true,
+      "hideBackButton": false,
       "i18n": Object {
         "absoluteLabel": "Absolute",
         "amString": "AM",
@@ -10133,6 +10134,9 @@ Map {
         "type": "bool",
       },
       "hasTimeInput": Object {
+        "type": "bool",
+      },
+      "hideBackButton": Object {
         "type": "bool",
       },
       "i18n": Object {


### PR DESCRIPTION
Closes #
https://jsw.ibm.com/browse/GRAPHITE-62796
**Summary**
When using only the absolute date range selector, a back button appears in the footer to return to the default preset list. However, according to the design, we should not display a back button. Instead, I have replaced it with a cancel button, which will reset the date range to the previously selected one and close the flyout.
- summary_here

**Change List (commits, features, bugs, etc)**
DateTimePickerV2(useNewTimeSpinner)
- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [x] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [x] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [x] PR should link and close out an existing issue
