### PR TITLE
fix(PageWizard): add stepWidth prop support

### DIFF
--- a/packages/react/src/components/PageWizard/PageWizard.jsx
+++ b/packages/react/src/components/PageWizard/PageWizard.jsx
@@ -60,6 +60,7 @@ export const PageWizardPropTypes = {
   testId: PropTypes.string,
   /** Specify whether the progress steps should be split equally in size in the div */
   spaceEqually: PropTypes.bool,
+  stepWidth: PropTypes.number,
 };
 
 export const defaultProps = {
@@ -85,6 +86,7 @@ export const defaultProps = {
   isClickable: false,
   testId: 'page-wizard',
   spaceEqually: false,
+  stepWidth: null,
 };
 
 const PageWizard = ({
@@ -108,6 +110,7 @@ const PageWizard = ({
   isClickable,
   testId,
   spaceEqually,
+  stepWidth,
 }) => {
   const children = ch.length ? ch : [ch];
   const steps = React.Children.map(children, (step) => step.props);
@@ -195,6 +198,7 @@ const PageWizard = ({
             isVerticalMode={isProgressIndicatorVertical}
             isClickable={isClickable}
             spaceEqually={spaceEqually}
+            stepWidth={stepWidth}
             // TODO: pass down the testId in v3 instead of falling back to the
             // default.
             // testId={`${testId}-progress-indicator`}

--- a/packages/react/src/components/PageWizard/PageWizard.story.jsx
+++ b/packages/react/src/components/PageWizard/PageWizard.story.jsx
@@ -1,7 +1,7 @@
 /* Used dependencies */
 import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
-import { boolean, text } from '@storybook/addon-knobs';
+import { boolean, number, text } from '@storybook/addon-knobs';
 import { Button, Form, FormGroup, FormItem, Link, TextInput } from 'carbon-components-react';
 import { InformationFilled20 } from '@carbon/icons-react';
 
@@ -352,7 +352,7 @@ export const StatefulExampleWValidationInPageTitleBar = () => (
         <Link to="www.ibm.com">Something</Link>,
         <Link to="www.ibm.com">Something Else</Link>,
       ]}
-      content={<StepValidationWizard />}
+      content={<StepValidationWizard stepWidth={number('stepWidth', 6)} />}
     />
   </div>
 );
@@ -457,6 +457,7 @@ export const WithStickyFooterStatefulExampleWValidationInPageTitleBar = () => (
           isProgressIndicatorVertical={boolean('Toggle Progress Indicator Alignment', false)}
           isClickable
           spaceEqually={boolean('spaceEqually', false)}
+          stepWidth={number('stepWidth', 6)}
         />
       }
     />

--- a/packages/react/src/components/PageWizard/__snapshots__/PageWizard.story.storyshot
+++ b/packages/react/src/components/PageWizard/__snapshots__/PageWizard.story.storyshot
@@ -706,6 +706,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
               >
                 <li
                   className="iot--progress-step iot--progress-step--current"
+                  style={
+                    Object {
+                      "minWidth": "6rem",
+                      "width": "6rem",
+                    }
+                  }
                 >
                   <button
                     aria-disabled={false}
@@ -773,6 +779,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                 </li>
                 <li
                   className="iot--progress-step iot--progress-step--incomplete"
+                  style={
+                    Object {
+                      "minWidth": "6rem",
+                      "width": "6rem",
+                    }
+                  }
                 >
                   <button
                     aria-disabled={false}
@@ -2300,6 +2312,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
               >
                 <li
                   className="iot--progress-step iot--progress-step--current"
+                  style={
+                    Object {
+                      "height": "6rem",
+                      "minHeight": "6rem",
+                    }
+                  }
                 >
                   <button
                     aria-disabled={false}
@@ -2367,6 +2385,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/P
                 </li>
                 <li
                   className="iot--progress-step iot--progress-step--incomplete"
+                  style={
+                    Object {
+                      "height": "6rem",
+                      "minHeight": "6rem",
+                    }
+                  }
                 >
                   <button
                     aria-disabled={false}

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -29510,6 +29510,7 @@ Map {
       "sendingData": false,
       "setStep": null,
       "spaceEqually": false,
+      "stepWidth": null,
       "testId": "page-wizard",
     },
     "propTypes": Object {
@@ -29603,6 +29604,9 @@ Map {
       },
       "spaceEqually": Object {
         "type": "bool",
+      },
+      "stepWidth": Object {
+        "type": "number",
       },
       "testId": Object {
         "type": "string",


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-addons-iot-react/issues/3836

**Summary**

- add step width prop support for PageWizard and StatefulPageWizard components

**Change List (commits, features, bugs, etc)**

- fix(PageWizard): add stepWidth prop support

**Acceptance Test (how to verify the PR)**

- set the stepWidth to 4 in https://deploy-preview-3837--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-progress-indicator-pagewizard--stateful-example-w-validation-in-page-title-bar
<img width="1298" alt="image" src="https://github.com/carbon-design-system/carbon-addons-iot-react/assets/18572477/3b78942c-70aa-4530-8b16-18adac65ce17">
- set the stepWidth to 10 in to view the step width change
<img width="1113" alt="image" src="https://github.com/carbon-design-system/carbon-addons-iot-react/assets/18572477/026fd6a3-c240-4140-8bc0-c43db6b8be71">

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
