### PR TITLE
feat: removed additional condition for current node

### DIFF
--- a/packages/react/src/components/Table/TableBody/useTableDnd.jsx
+++ b/packages/react/src/components/Table/TableBody/useTableDnd.jsx
@@ -331,7 +331,7 @@ function useTableDnd(rows, selectedIds, zIndex, onDrag, onDrop, hasBreadcrumbDro
           // There is another way to have breadcrumb leaf node as disabled by not setting the href,
           // in any case it should be a enabled hyperlink to consider as drop target
           // istanbul ignore else
-          if (link.nodeType === Node.ELEMENT_NODE && link.tagName.toLowerCase() === 'a') {
+          if (link.nodeType === Node.ELEMENT_NODE) {
             const verticalPadding = 5;
             const horizontalPadding = 4;
             const style = {


### PR DESCRIPTION
Class validation is enough as Graphite have custom implementation of breadcrumb which style span element as hyperlink hence this change is needed to allow that kind of drop targets as well.

Closes #3840 

**Summary**

Graphite shows even active breadcrumb nodes as span elements instead of hyperlink hence removing the extra check.

**Change List (commits, features, bugs, etc)**

- Minor change removed the extra if condition of drop node must be of type "a" i.e. hyperlink.

**Acceptance Test (how to verify the PR)**

- Storybook: Table > with drag and drop rows. hasBradcrumbDrop checked in knobs. Should work as it is and drop over leaf node or disabled node shouldn't be allowed.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- Existing table tests.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [x] PR should link and close out an existing issue
