### PR TITLE
fix(datetimepickerv2withtimespinner): added null undefined check

### DIFF
--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
@@ -1042,7 +1042,7 @@ const DateTimePicker = ({
                     [`${iotPrefix}--date-time-picker__disabled`]:
                       disabled ||
                       (isSingleSelect &&
-                        (!singleDateValue.startDate || (hasTimeInput ? !singleTimeValue : false))),
+                        (!singleDateValue?.startDate || (hasTimeInput ? !singleTimeValue : false))), // singleDateValue might be null or undefined
                   })}
                   title={humanValue}
                 >
@@ -1314,7 +1314,7 @@ const DateTimePicker = ({
                             absoluteValue && datePickerType === 'range'
                               ? [absoluteValue.startDate, absoluteValue.endDate]
                               : singleDateValue && datePickerType === 'single'
-                              ? [singleDateValue.startDate]
+                              ? [singleDateValue?.startDate]
                               : null
                           }
                           locale={locale}


### PR DESCRIPTION
Closes #
GRAPHITE-73143
**Summary**
In DateTimePickerV2WithTimeSpinner component there was an issue !singleDateValue.startDate  in this logic because if the singleDateValue is null or undefined it was giving exception that cannot read properties of null.  
- summary_here

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
