### PR TITLE
fix(tablehead): group table headers offset

### DIFF
--- a/packages/react/src/components/Table/TableHead/TableHead.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.jsx
@@ -787,7 +787,14 @@ const TableHead = ({
         <ColumnGrouping
           appendedColumns={+showExpanderColumn + !!options.hasRowActions}
           testId={`${testId}-column-grouping`}
-          prependedColumns={+(hasRowSelection === 'multi') + !!(hasRowExpansion || hasRowNesting)}
+          prependedColumns={
+            +!!(
+              hasRowSelection === 'multi' ||
+              (useRadioButtonSingleSelect && hasRowSelection === 'single')
+            ) +
+            !!(hasRowExpansion || hasRowNesting) +
+            !!hasDragAndDrop
+          }
           columnGroups={columnGroups}
           ordering={ordering}
         />

--- a/packages/react/src/components/Table/TableHead/TableHead.test.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.test.jsx
@@ -1914,6 +1914,91 @@ describe('TableHead', () => {
       );
     });
 
+    it('only prepends one extra column header for row nesting and multi row selection and drag and drop enabled', () => {
+      render(
+        <TableHead
+          {...myProps}
+          options={{
+            hasRowNesting: true,
+            hasRowSelection: 'multi',
+            hasDragAndDrop: true,
+          }}
+          testId="my-tablehead"
+        />,
+        {
+          container: document.body.appendChild(document.createElement('table')),
+        }
+      );
+
+      const firstHeaderIndex = 0;
+      const theHeadersInGroupRow = within(
+        screen.getByTestId('my-tablehead-column-grouping')
+      ).getAllByRole('columnheader');
+
+      expect(theHeadersInGroupRow).toHaveLength(1 + 2);
+      expect(theHeadersInGroupRow[firstHeaderIndex]).toHaveAttribute('colspan', '3');
+      expect(theHeadersInGroupRow[firstHeaderIndex]).toHaveClass(
+        `${iotPrefix}--table-header__group-row-spacer`
+      );
+    });
+
+    it('only prepends one extra column header for row nesting and single row radiobutton selection', () => {
+      render(
+        <TableHead
+          {...myProps}
+          options={{
+            hasRowNesting: true,
+            hasRowSelection: 'single',
+            useRadioButtonSingleSelect: true,
+          }}
+          testId="my-tablehead"
+        />,
+        {
+          container: document.body.appendChild(document.createElement('table')),
+        }
+      );
+
+      const firstHeaderIndex = 0;
+      const theHeadersInGroupRow = within(
+        screen.getByTestId('my-tablehead-column-grouping')
+      ).getAllByRole('columnheader');
+
+      expect(theHeadersInGroupRow).toHaveLength(1 + 2);
+      expect(theHeadersInGroupRow[firstHeaderIndex]).toHaveAttribute('colspan', '2');
+      expect(theHeadersInGroupRow[firstHeaderIndex]).toHaveClass(
+        `${iotPrefix}--table-header__group-row-spacer`
+      );
+    });
+
+    it('only prepends one extra column header for row nesting and single row radiobutton selection and drag and drop enabled', () => {
+      render(
+        <TableHead
+          {...myProps}
+          options={{
+            hasRowNesting: true,
+            hasRowSelection: 'single',
+            useRadioButtonSingleSelect: true,
+            hasDragAndDrop: true,
+          }}
+          testId="my-tablehead"
+        />,
+        {
+          container: document.body.appendChild(document.createElement('table')),
+        }
+      );
+
+      const firstHeaderIndex = 0;
+      const theHeadersInGroupRow = within(
+        screen.getByTestId('my-tablehead-column-grouping')
+      ).getAllByRole('columnheader');
+
+      expect(theHeadersInGroupRow).toHaveLength(1 + 2);
+      expect(theHeadersInGroupRow[firstHeaderIndex]).toHaveAttribute('colspan', '3');
+      expect(theHeadersInGroupRow[firstHeaderIndex]).toHaveClass(
+        `${iotPrefix}--table-header__group-row-spacer`
+      );
+    });
+
     it('adds rowspan to "normal column headers" that do not belong to a group while group row is showing', () => {
       render(<TableHead {...myProps} testId="my-tablehead" />, {
         container: document.body.appendChild(document.createElement('table')),


### PR DESCRIPTION
Closes #
GRAPHITE-75026
**Summary**
The colspan is not getting set correctly when the datasource is set as single select, works fine when multi-select. But broken in multi select also when drag and drop is enabled so fixed all these issues together.
- summary_here

**Change List (commits, features, bugs, etc)**
Before:
<img width="1200" alt="image" src="https://github.com/carbon-design-system/carbon-addons-iot-react/assets/136786799/c50fb0f6-6fb0-4463-90a0-936e84c12eee">
After:
<img width="1193" alt="image" src="https://github.com/carbon-design-system/carbon-addons-iot-react/assets/136786799/00398d44-a27c-41fb-9883-3ab8901f8d6c">

- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [x] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [x] PR should link and close out an existing issue
