### PR TITLE
fix: ReadOnlyValue component changes

### DIFF
--- a/packages/react/src/components/ReadOnlyValue/ReadOnlyValue.jsx
+++ b/packages/react/src/components/ReadOnlyValue/ReadOnlyValue.jsx
@@ -17,6 +17,7 @@ const ReadOnlyValue = ({
   isLoading,
   skeletonLoadingLabel,
   skeletonLoadingValue,
+  textAreaAttributes = {},
 }) => (
   <div
     data-testid={testId}
@@ -44,6 +45,7 @@ const ReadOnlyValue = ({
               name={value}
               value={value}
               readOnly
+              {...textAreaAttributes}
             />
           ) : (
             <div id={`readonly-${label}`}>{value}</div>

--- a/packages/react/src/components/ReadOnlyValue/ReadOnlyValue.jsx
+++ b/packages/react/src/components/ReadOnlyValue/ReadOnlyValue.jsx
@@ -17,7 +17,7 @@ const ReadOnlyValue = ({
   isLoading,
   skeletonLoadingLabel,
   skeletonLoadingValue,
-  textAreaAttributes = {},
+  textAreaAttributes,
 }) => (
   <div
     data-testid={testId}

--- a/packages/react/src/components/ReadOnlyValue/ReadOnlyValue.jsx
+++ b/packages/react/src/components/ReadOnlyValue/ReadOnlyValue.jsx
@@ -15,7 +15,6 @@ const ReadOnlyValue = ({
   className,
   testId,
   isLoading,
-  skeletonLoadingLabel,
   skeletonLoadingValue,
   textAreaAttributes,
 }) => (
@@ -29,14 +28,13 @@ const ReadOnlyValue = ({
   >
     {/* eslint-disable-next-line jsx-a11y/label-has-for */}
     <label data-testid={`${testId}--label`} htmlFor={`readonly-${label}`}>
+      {label}
       {isLoading ? (
         <>
-          <SkeletonText {...skeletonLoadingLabel} />
           <SkeletonText {...skeletonLoadingValue} />
         </>
       ) : (
         <>
-          {label}
           {typeof value === 'string' ? (
             <textarea
               data-testid={`${testId}--value`}

--- a/packages/react/src/components/ReadOnlyValue/ReadOnlyValue.jsx
+++ b/packages/react/src/components/ReadOnlyValue/ReadOnlyValue.jsx
@@ -37,13 +37,13 @@ const ReadOnlyValue = ({
         <>
           {typeof value === 'string' ? (
             <textarea
+              {...textAreaAttributes}
               data-testid={`${testId}--value`}
               type="text"
               id={`readonly-${label}`}
               name={value}
               value={value}
               readOnly
-              {...textAreaAttributes}
             />
           ) : (
             <div id={`readonly-${label}`}>{value}</div>

--- a/packages/react/src/components/ReadOnlyValue/ReadOnlyValue.story.jsx
+++ b/packages/react/src/components/ReadOnlyValue/ReadOnlyValue.story.jsx
@@ -16,13 +16,6 @@ export default {
   },
 };
 
-const loadingKnobsLabel = () => ({
-  heading: boolean('If content is heading', false, 'Loading (label)'),
-  paragraph: boolean('If content is paragraph', true, 'Loading (label)'),
-  lineCount: text('Line count', 1, 'Loading (label)'),
-  width: text('Width of the loader', '100%', 'Loading (label)'),
-});
-
 const loadingKnobsValue = () => ({
   heading: boolean('If content is heading', false, 'Loading (value)'),
   paragraph: boolean('If content is paragraph', true, 'Loading (value)'),
@@ -36,7 +29,6 @@ export const Basic = () => (
       label="Label"
       value="input value"
       isLoading={boolean('Loading state (isLoading)', false)}
-      skeletonLoadingLabel={loadingKnobsLabel()}
       skeletonLoadingValue={loadingKnobsValue()}
     />
   </div>
@@ -53,7 +45,6 @@ export const MultipleValuesStacked = () => {
         value={text('label text', 'input value 01')}
         isLoading={isLoading}
         type="stacked"
-        skeletonLoadingLabel={loadingKnobsLabel()}
         skeletonLoadingValue={loadingKnobsValue()}
       />
       <ReadOnlyValue
@@ -61,7 +52,6 @@ export const MultipleValuesStacked = () => {
         value={text('label text', 'input value 02')}
         isLoading={isLoading}
         type="stacked"
-        skeletonLoadingLabel={loadingKnobsLabel()}
         skeletonLoadingValue={loadingKnobsValue()}
       />
       <ReadOnlyValue
@@ -69,7 +59,6 @@ export const MultipleValuesStacked = () => {
         value={text('label text', 'input value 03')}
         isLoading={isLoading}
         type="stacked"
-        skeletonLoadingLabel={loadingKnobsLabel()}
         skeletonLoadingValue={loadingKnobsValue()}
       />
       <ReadOnlyValue
@@ -77,7 +66,6 @@ export const MultipleValuesStacked = () => {
         value={text('label text', 'input value 04')}
         isLoading={isLoading}
         type="stacked"
-        skeletonLoadingLabel={loadingKnobsLabel()}
         skeletonLoadingValue={loadingKnobsValue()}
       />
     </div>
@@ -123,7 +111,6 @@ export const BasicInline = () => (
       value="input value"
       type="inline"
       isLoading={boolean('Loading state (isLoading)', false)}
-      skeletonLoadingLabel={loadingKnobsLabel()}
       skeletonLoadingValue={loadingKnobsValue()}
     />
   </div>
@@ -140,7 +127,6 @@ export const MultipleValuesInline = () => {
         value="input value 01"
         type="inline"
         isLoading={isLoading}
-        skeletonLoadingLabel={loadingKnobsLabel()}
         skeletonLoadingValue={loadingKnobsValue()}
       />
       <ReadOnlyValue
@@ -148,7 +134,6 @@ export const MultipleValuesInline = () => {
         value="input value 02"
         type="inline"
         isLoading={isLoading}
-        skeletonLoadingLabel={loadingKnobsLabel()}
         skeletonLoadingValue={loadingKnobsValue()}
       />
       <ReadOnlyValue
@@ -156,7 +141,6 @@ export const MultipleValuesInline = () => {
         value="input value 03"
         type="inline"
         isLoading={isLoading}
-        skeletonLoadingLabel={loadingKnobsLabel()}
         skeletonLoadingValue={loadingKnobsValue()}
       />
       <ReadOnlyValue
@@ -164,7 +148,6 @@ export const MultipleValuesInline = () => {
         value="input value 04"
         type="inline"
         isLoading={isLoading}
-        skeletonLoadingLabel={loadingKnobsLabel()}
         skeletonLoadingValue={loadingKnobsValue()}
       />
     </div>
@@ -215,11 +198,11 @@ export const WithAsyncDataLoad = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [values, setValues] = useState([
     {
-      label: null,
+      label: 'Label 01',
       value: null,
     },
     {
-      label: null,
+      label: 'Label 02',
       value: null,
     },
   ]);

--- a/packages/react/src/components/ReadOnlyValue/ReadOnlyValue.test.jsx
+++ b/packages/react/src/components/ReadOnlyValue/ReadOnlyValue.test.jsx
@@ -56,10 +56,10 @@ describe('ReadOnlyValue', () => {
     const [label, value] = ['label-test01', 'some testing value'];
     const { container } = render(<ReadOnlyValue label={label} value={value} isLoading />);
 
-    expect(screen.queryByText(label)).toBeNull();
+    expect(screen.queryByText(label)).toBeDefined();
     expect(screen.queryByText(value)).toBeNull();
     expect(container.querySelector(`.${prefix}--skeleton__text`)).toBeInTheDocument();
-    expect(container.querySelectorAll(`.${prefix}--skeleton__text`)).toHaveLength(2);
+    expect(container.querySelectorAll(`.${prefix}--skeleton__text`)).toHaveLength(1);
   });
 
   it('should pass prop to skeleton loaders', () => {
@@ -69,12 +69,10 @@ describe('ReadOnlyValue', () => {
         label={label}
         value={value}
         isLoading
-        skeletonLoadingLabel={{ className: 'test-class-1' }}
         skeletonLoadingValue={{ className: 'test-class-2' }}
       />
     );
 
-    expect(container.querySelectorAll(`.${prefix}--skeleton__text`)[0]).toHaveClass('test-class-1');
-    expect(container.querySelectorAll(`.${prefix}--skeleton__text`)[1]).toHaveClass('test-class-2');
+    expect(container.querySelectorAll(`.${prefix}--skeleton__text`)[0]).toHaveClass('test-class-2');
   });
 });

--- a/packages/react/src/components/ReadOnlyValue/ReadOnlyValuePropTypes.js
+++ b/packages/react/src/components/ReadOnlyValue/ReadOnlyValuePropTypes.js
@@ -35,5 +35,5 @@ export const ReadOnlyValueDefaultProps = {
   isLoading: false,
   skeletonLoadingLabel: skeletonLoadingDefaultProps,
   skeletonLoadingValue: skeletonLoadingDefaultProps,
-  textAreaAttr: {},
+  textAreaAttributes: {},
 };

--- a/packages/react/src/components/ReadOnlyValue/ReadOnlyValuePropTypes.js
+++ b/packages/react/src/components/ReadOnlyValue/ReadOnlyValuePropTypes.js
@@ -22,7 +22,6 @@ export const ReadOnlyValuePropTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   testId: PropTypes.string,
   isLoading: PropTypes.bool,
-  skeletonLoadingLabel: skeletonLoadingPropTypes,
   skeletonLoadingValue: skeletonLoadingPropTypes,
   textAreaAttributes: PropTypes.object,
 };
@@ -33,7 +32,6 @@ export const ReadOnlyValueDefaultProps = {
   value: '',
   testId: 'read-only-value',
   isLoading: false,
-  skeletonLoadingLabel: skeletonLoadingDefaultProps,
   skeletonLoadingValue: skeletonLoadingDefaultProps,
   textAreaAttributes: {},
 };

--- a/packages/react/src/components/ReadOnlyValue/ReadOnlyValuePropTypes.js
+++ b/packages/react/src/components/ReadOnlyValue/ReadOnlyValuePropTypes.js
@@ -24,6 +24,7 @@ export const ReadOnlyValuePropTypes = {
   isLoading: PropTypes.bool,
   skeletonLoadingLabel: skeletonLoadingPropTypes,
   skeletonLoadingValue: skeletonLoadingPropTypes,
+  textAreaAttributes: PropTypes.object,
 };
 
 export const ReadOnlyValueDefaultProps = {
@@ -34,4 +35,5 @@ export const ReadOnlyValueDefaultProps = {
   isLoading: false,
   skeletonLoadingLabel: skeletonLoadingDefaultProps,
   skeletonLoadingValue: skeletonLoadingDefaultProps,
+  textAreaAttr: {},
 };

--- a/packages/react/src/components/ReadOnlyValue/__snapshots__/ReadOnlyValue.story.storyshot
+++ b/packages/react/src/components/ReadOnlyValue/__snapshots__/ReadOnlyValue.story.storyshot
@@ -552,16 +552,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/R
     >
       <label
         data-testid="read-only-value--label"
-        htmlFor="readonly-null"
+        htmlFor="readonly-Label 01"
       >
-        <p
-          className="bx--skeleton__text"
-          style={
-            Object {
-              "width": "100%",
-            }
-          }
-        />
+        Label 01
         <p
           className="bx--skeleton__text"
           style={
@@ -578,16 +571,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/R
     >
       <label
         data-testid="read-only-value--label"
-        htmlFor="readonly-null"
+        htmlFor="readonly-Label 02"
       >
-        <p
-          className="bx--skeleton__text"
-          style={
-            Object {
-              "width": "100%",
-            }
-          }
-        />
+        Label 02
         <p
           className="bx--skeleton__text"
           style={

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -13478,6 +13478,7 @@ Map {
         "width": "100%",
       },
       "testId": "read-only-value",
+      "textAreaAttr": Object {},
       "type": "stacked",
       "value": "",
     },
@@ -13534,6 +13535,9 @@ Map {
       },
       "testId": Object {
         "type": "string",
+      },
+      "textAreaAttributes": Object {
+        "type": "object",
       },
       "type": Object {
         "args": Array [

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -13463,13 +13463,6 @@ Map {
     "defaultProps": Object {
       "isLoading": false,
       "label": "",
-      "skeletonLoadingLabel": Object {
-        "className": "",
-        "heading": false,
-        "lineCount": 0,
-        "paragraph": false,
-        "width": "100%",
-      },
       "skeletonLoadingValue": Object {
         "className": "",
         "heading": false,
@@ -13488,28 +13481,6 @@ Map {
       },
       "label": Object {
         "type": "string",
-      },
-      "skeletonLoadingLabel": Object {
-        "args": Array [
-          Object {
-            "className": Object {
-              "type": "string",
-            },
-            "heading": Object {
-              "type": "bool",
-            },
-            "lineCount": Object {
-              "type": "number",
-            },
-            "paragraph": Object {
-              "type": "bool",
-            },
-            "width": Object {
-              "type": "string",
-            },
-          },
-        ],
-        "type": "shape",
       },
       "skeletonLoadingValue": Object {
         "args": Array [

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -13478,7 +13478,7 @@ Map {
         "width": "100%",
       },
       "testId": "read-only-value",
-      "textAreaAttr": Object {},
+      "textAreaAttributes": Object {},
       "type": "stacked",
       "value": "",
     },


### PR DESCRIPTION
Closes #

**Summary**

- Made some changes to ReadOnlyValue Component.

**Change List (commits, features, bugs, etc)**

- Allow attributes to be passed in textarea.
- Removed label loading in the ReadOnlyValue Component as label should be visible.

**Regression Test (how to make sure this PR doesn't break old functionality)**

- There will be no Regression of this.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
