### PR TITLE
Masmon 1701 - Data table "destination": "groupBy" added to non dimension data item

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -10,6 +10,7 @@ import {
   handleDataSeriesChange,
   DataItemsPropTypes,
   DashboardEditorActionsPropTypes,
+  dimensionFilterFun,
 } from '../../../../DashboardEditor/editorUtils';
 import Button from '../../../../Button';
 import List from '../../../../List/List';
@@ -152,7 +153,6 @@ const TableCardFormContent = ({
   const [showEditor, setShowEditor] = useState(false);
   // Need to keep track of the data item that's currently being edited so the detailed modal knows which one to show
   const [editDataItem, setEditDataItem] = useState({});
-  const [removedDataItems, setRemovedDataItems] = useState([]);
 
   // Initialize the selected columns if its not currently set
   const dataSection = useMemo(() => {
@@ -186,7 +186,7 @@ const TableCardFormContent = ({
       cardConfig?.dataSource?.groupBy?.map((dataSourceId) => ({
         id: dataSourceId,
         text: dataSourceId,
-      })),
+      })) ?? [],
     [cardConfig]
   );
 
@@ -284,7 +284,6 @@ const TableCardFormContent = ({
       );
 
       setSelectedDataItems(filteredColumns.map((item) => item.dataSourceId));
-      setRemovedDataItems([...removedDataItems, dataItem]);
 
       // if we no longer have a groupBy, then we can exclude the dataSource from the response
       let updatedDataSource = {};
@@ -311,7 +310,7 @@ const TableCardFormContent = ({
         ...updatedDataSource,
       });
     },
-    [cardConfig, dataSection, onChange, removedDataItems, setSelectedDataItems]
+    [cardConfig, dataSection, onChange, setSelectedDataItems]
   );
 
   const handleEditButton = useCallback(
@@ -439,31 +438,41 @@ const TableCardFormContent = ({
         >
           <MultiSelect
             // need to re-gen if selected card changes or if a dataItem is removed from the list
-            key={`data-item-select-${removedDataItems.length}-selected_card-id-${cardConfig.id}`}
+            key={`data-item-select-selected_card-id-${cardConfig.id}`}
             id={`${cardConfig.id}_dataSourceIds`}
             label={mergedI18n.selectGroupByDimensions}
             translateWithId={translateWithId}
             direction="bottom"
             itemToString={(item) => item.id}
-            initialSelectedItems={initialSelectedDimensions}
+            selectedItems={initialSelectedDimensions}
             items={validDimensions}
             light
             onChange={({ selectedItems }) => {
               // Add the new dimensions as dimension columns at the beginning of the table
-              const newCard = handleDataSeriesChange(
-                selectedItems.map((i) => ({
-                  dataItemId: i.id,
-                  dataSourceId: i.id,
-                  label: i.text,
-                  dataItemType: 'DIMENSION',
-                  destination: 'groupBy',
-                })),
-                cardConfig,
-                null,
-                null
-              );
-              // setSelectedDataItems(selectedItems.map(({ id }) => id));
-              onChange(newCard);
+              const existingDimensionColumns = dataSection.filter(dimensionFilterFun);
+              if (existingDimensionColumns.length > selectedItems.length) {
+                const selectedDimensions = selectedItems.map((dimension) => dimension.text);
+                existingDimensionColumns.forEach((dimension) => {
+                  if (!selectedDimensions.includes(dimension.dataSourceId)) {
+                    handleRemoveButton(dimension);
+                  }
+                });
+              } else {
+                const newCard = handleDataSeriesChange(
+                  selectedItems.map((i) => ({
+                    dataItemId: i.id,
+                    dataSourceId: i.id,
+                    label: i.text,
+                    dataItemType: 'DIMENSION',
+                    destination: 'groupBy',
+                  })),
+                  cardConfig,
+                  null,
+                  null
+                );
+                // setSelectedDataItems(selectedItems.map(({ id }) => id));
+                onChange(newCard);
+              }
             }}
             titleText={mergedI18n.dataItemEditorDimensionTitle}
           />

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -10,7 +10,7 @@ import {
   handleDataSeriesChange,
   DataItemsPropTypes,
   DashboardEditorActionsPropTypes,
-  dimensionFilterFun,
+  dimensionFilterFunction,
 } from '../../../../DashboardEditor/editorUtils';
 import Button from '../../../../Button';
 import List from '../../../../List/List';
@@ -448,16 +448,16 @@ const TableCardFormContent = ({
             items={validDimensions}
             light
             onChange={({ selectedItems }) => {
-              // Add the new dimensions as dimension columns at the beginning of the table
-              const existingDimensionColumns = dataSection.filter(dimensionFilterFun);
+              const existingDimensionColumns = dataSection.filter(dimensionFilterFunction);
               if (existingDimensionColumns.length > selectedItems.length) {
                 const selectedDimensions = selectedItems.map((dimension) => dimension.text);
-                existingDimensionColumns.forEach((dimension) => {
-                  if (!selectedDimensions.includes(dimension.dataSourceId)) {
-                    handleRemoveButton(dimension);
-                  }
-                });
+                handleRemoveButton(
+                  existingDimensionColumns.find(
+                    (dimension) => !selectedDimensions.includes(dimension.dataSourceId)
+                  ) ?? {}
+                );
               } else {
+                // Add the new dimensions as dimension columns at the beginning of the table
                 const newCard = handleDataSeriesChange(
                   selectedItems.map((i) => ({
                     dataItemId: i.id,
@@ -470,7 +470,6 @@ const TableCardFormContent = ({
                   null,
                   null
                 );
-                // setSelectedDataItems(selectedItems.map(({ id }) => id));
                 onChange(newCard);
               }
             }}

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
@@ -159,7 +159,7 @@ describe('TableCardFormContent', () => {
     expect(screen.queryByText('validDataItem')).toBeDefined();
     expect(screen.queryByText('inValidDataItem')).toBeNull();
   });
-  it('selecting dimensions shows clear button', () => {
+  it('selecting dimensions should call onChange', () => {
     const mockOnChange = jest.fn();
     render(<TableCardFormContent {...commonProps} onChange={mockOnChange} />);
     expect(mockOnChange).not.toHaveBeenCalled();
@@ -167,8 +167,6 @@ describe('TableCardFormContent', () => {
     fireEvent.click(screen.getByLabelText(/Select dim/));
     expect(screen.queryByText('manufacturer')).toBeDefined();
     fireEvent.click(screen.queryByText('manufacturer'));
-    // the selection state of the box should be updated
-    expect(screen.getByLabelText('Clear selection')).toBeTruthy();
     // the callback for onChange should be called
     expect(mockOnChange).toHaveBeenCalledWith({
       ...commonCardConfig,

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.test.jsx
@@ -192,6 +192,55 @@ describe('TableCardFormContent', () => {
       dataSource: { groupBy: ['manufacturer'] },
     });
   });
+  it('un-selecting dimension should call onChange with removed dimension', () => {
+    const mockOnChange = jest.fn();
+    render(
+      <TableCardFormContent
+        {...commonProps}
+        cardConfig={{
+          ...commonCardConfig,
+          content: {
+            columns: [
+              {
+                label: 'Timestamp',
+                dataSourceId: 'timestamp',
+                type: 'TIMESTAMP',
+              },
+              {
+                label: 'Manufacturer',
+                dataSourceId: 'manufacturer',
+                dataItemType: 'DIMENSION',
+                destination: 'groupBy',
+              },
+              { label: 'Temperature', dataSourceId: 'temperature' },
+            ],
+          },
+          dataSource: { groupBy: ['manufacturer'] },
+        }}
+        onChange={mockOnChange}
+      />
+    );
+    expect(mockOnChange).not.toHaveBeenCalled();
+    // check for the temperature and pressure to be shown under data items
+    fireEvent.click(screen.getByRole('button', { name: /Select dim/ }));
+    expect(screen.queryByText('manufacturer')).toBeDefined();
+    fireEvent.click(screen.queryByText('manufacturer'));
+    // the callback for onChange should be called
+    expect(mockOnChange).toHaveBeenCalledWith({
+      ...commonCardConfig,
+      content: {
+        columns: [
+          {
+            label: 'Timestamp',
+            dataSourceId: 'timestamp',
+            type: 'TIMESTAMP',
+          },
+          { label: 'Temperature', dataSourceId: 'temperature' },
+        ],
+      },
+      dataSource: {},
+    });
+  });
   it('edit mode with dataitems and dimension columns show work correctly', () => {
     render(
       <TableCardFormContent

--- a/packages/react/src/components/DashboardEditor/editorUtils.jsx
+++ b/packages/react/src/components/DashboardEditor/editorUtils.jsx
@@ -492,6 +492,10 @@ export const formatAttributes = (selectedItems, cardConfig) => {
   return attributes;
 };
 
+export const dimensionFilterFun = (col) =>
+  col.dataItemType === 'DIMENSION' ||
+  (col.destination === 'groupBy' && col.dataSourceId === 'deviceid'); // For manually added deviceId dimension
+
 /**
  * determines how to format the dataSection based on card type
  * @param {array} selectedItems
@@ -527,25 +531,7 @@ export const handleDataSeriesChange = (
         content: { ...cardConfig.content, series },
       };
     case CARD_TYPES.TABLE: {
-      const columns = Array.isArray(content?.columns)
-        ? content.columns.map((column) => {
-            // find if the column is grouped by
-            const groupByColumn = selectedItems.find(
-              (el) => el.dataSourceId === column.dataSourceId
-            );
-            // if data item is already added to table but no destination: groupby, add it
-            if (groupByColumn && column.destination !== 'groupBy') {
-              return { ...column, destination: 'groupBy' };
-            }
-            // if data item is not selected but has destination: groupBy, remove it
-            if (!groupByColumn && column.destination === 'groupBy') {
-              const { destination: _, ...rest } = column;
-              return { ...rest };
-            }
-            // else, nothing to change
-            return column;
-          })
-        : [];
+      const columns = Array.isArray(content?.columns) ? content.columns : [];
 
       // in certain cases (for groupBy updates) the full set of attribute columns isn't passed
       const existingAttributeColumns = columns.filter(
@@ -567,10 +553,10 @@ export const handleDataSeriesChange = (
         sort: 'DESC',
       };
 
-      const existingDimensionColumns = columns.filter((col) => col.dataItemType === 'DIMENSION');
+      const existingDimensionColumns = columns.filter(dimensionFilterFun);
 
       // new dimension columns should go right after the timestamp column
-      const dimensionColumns = selectedItems.filter((col) => col.dataItemType === 'DIMENSION');
+      const dimensionColumns = selectedItems.filter(dimensionFilterFun);
       const allDimensionColumns = existingDimensionColumns.concat(dimensionColumns);
 
       // for raw table cards, the dimensions columns go in the attributes section

--- a/packages/react/src/components/DashboardEditor/editorUtils.jsx
+++ b/packages/react/src/components/DashboardEditor/editorUtils.jsx
@@ -492,7 +492,7 @@ export const formatAttributes = (selectedItems, cardConfig) => {
   return attributes;
 };
 
-export const dimensionFilterFun = (col) =>
+export const dimensionFilterFunction = (col) =>
   col.dataItemType === 'DIMENSION' ||
   (col.destination === 'groupBy' && col.dataSourceId === 'deviceid'); // For manually added deviceId dimension
 
@@ -553,10 +553,10 @@ export const handleDataSeriesChange = (
         sort: 'DESC',
       };
 
-      const existingDimensionColumns = columns.filter(dimensionFilterFun);
+      const existingDimensionColumns = columns.filter(dimensionFilterFunction);
 
       // new dimension columns should go right after the timestamp column
-      const dimensionColumns = selectedItems.filter(dimensionFilterFun);
+      const dimensionColumns = selectedItems.filter(dimensionFilterFunction);
       const allDimensionColumns = existingDimensionColumns.concat(dimensionColumns);
 
       // for raw table cards, the dimensions columns go in the attributes section

--- a/packages/react/src/components/DashboardEditor/editorUtils.test.jsx
+++ b/packages/react/src/components/DashboardEditor/editorUtils.test.jsx
@@ -540,6 +540,7 @@ describe('editorUtils', () => {
           dataSourceId: 'manufacturer',
           label: 'Manufacturer',
           dataItemType: 'DIMENSION',
+          destination: 'groupBy',
         },
       ];
       const mockedGroupedbyTableCard = {
@@ -553,12 +554,6 @@ describe('editorUtils', () => {
               label: 'Timestamp',
               type: 'TIMESTAMP',
               sort: 'DESC',
-            },
-            {
-              dataItemId: 'manufacturer',
-              dataSourceId: 'manufacturer',
-              label: 'Manufacturer',
-              dataItemType: 'DIMENSION',
             },
             {
               dataItemId: 'firmware',
@@ -590,22 +585,23 @@ describe('editorUtils', () => {
               sort: 'DESC',
             },
             {
-              dataItemId: 'manufacturer',
-              dataSourceId: 'manufacturer',
-              label: 'Manufacturer',
-              dataItemType: 'DIMENSION',
-              destination: 'groupBy',
-            },
-            {
               dataItemId: 'firmware',
               dataSourceId: 'firmware',
               label: 'Firmware',
               dataItemType: 'DIMENSION',
+              destination: 'groupBy',
+            },
+            {
+              dataItemId: 'manufacturer',
+              dataItemType: 'DIMENSION',
+              dataSourceId: 'manufacturer',
+              destination: 'groupBy',
+              label: 'Manufacturer',
             },
           ],
         },
         dataSource: {
-          groupBy: ['manufacturer'],
+          groupBy: ['firmware', 'manufacturer'],
         },
       });
     });

--- a/packages/react/src/components/ReadOnlyValue/ReadOnlyValuePropTypes.js
+++ b/packages/react/src/components/ReadOnlyValue/ReadOnlyValuePropTypes.js
@@ -24,6 +24,7 @@ export const ReadOnlyValuePropTypes = {
   isLoading: PropTypes.bool,
   skeletonLoadingValue: skeletonLoadingPropTypes,
   textAreaAttributes: PropTypes.object,
+  className: PropTypes.string,
 };
 
 export const ReadOnlyValueDefaultProps = {

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -13476,6 +13476,9 @@ Map {
       "value": "",
     },
     "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
       "isLoading": Object {
         "type": "bool",
       },


### PR DESCRIPTION
Closes #

**Summary**

- Data table "destination": "groupBy" added to non dimension data item

**Change List (commits, features, bugs, etc)**

- Removed the un-necessory logic for 'destination: groupBy' property as it requires for only dimension dataitem.
- Fixed some bugs related to multiselect like if you unselect any item from multiselect then it should get removed from the list.


<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
