### PR TITLE
fix: select the inner modal body css

### DIFF
--- a/packages/react/src/components/HotspotEditorModal/_hotspot-editor-modal.scss
+++ b/packages/react/src/components/HotspotEditorModal/_hotspot-editor-modal.scss
@@ -2,7 +2,10 @@
 
 .#{$iot-prefix}--hotspot-editor-modal.#{$iot-prefix}--composed-modal {
   // Only apply to the top level modal, in case there is another modal nested inside the modal
-  & > .#{$prefix}--modal-container > .#{$prefix}--modal-content {
+  &
+    > .#{$prefix}--modal-container
+    > .#{$prefix}--modal-container-body
+    > .#{$prefix}--modal-content {
     $right-side-width: 420px;
     padding-right: 0;
     display: flex;


### PR DESCRIPTION
Closes https://jsw.ibm.com/browse/MASMON-1219

**Summary**

- select the inner modal body CSS after carbon 10 upgrade.  Earlier `modal-content` was direct child of `modal-container` now we have one more level.
`modal-container` --> `modal-container-body` --> `modal-content`

**Change List (commits, features, bugs, etc)**

- fix: select the inner modal body css

**Acceptance Test (how to verify the PR)**

- refer  https://jsw.ibm.com/browse/MASMON-1219 

**Regression Test (how to make sure this PR doesn't break old functionality)**

- refer  https://jsw.ibm.com/browse/MASMON-1219 

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
