### PR TITLE
fix: adding back side-nav style fix that was deleted during merge

### DIFF
--- a/packages/react/src/components/SideNav/_side-nav.scss
+++ b/packages/react/src/components/SideNav/_side-nav.scss
@@ -154,6 +154,15 @@ $hoverBgColor: #2c2c2c;
     // stylelint-disable-next-line declaration-property-unit-blacklist
     transition: width $duration--fast-01 motion(entrance, productive) 300ms;
   }
+
+  // need to override the carbon-components new aria-current page because it's assuming a white theme
+  & a.#{$prefix}--side-nav__link[aria-current='page'] {
+    background-color: $gray-70;
+
+    .#{$prefix}--side-nav__link-text {
+      color: $ui-02;
+    }
+  }
 }
 
 html[dir='rtl'] {


### PR DESCRIPTION
Closes #

**Summary**
Adding back the fix introduced by [this PR](https://github.com/carbon-design-system/carbon-addons-iot-react/pull/1205) to prevent white theme from being applied to current page buttons in side nav.

**Change List (commits, features, bugs, etc)**
Fix added back in `_side-nav.scss`

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
