### PR TITLE
fix: locale format for cards

### DIFF
--- a/packages/react/src/components/BarChartCard/BarChartCard.jsx
+++ b/packages/react/src/components/BarChartCard/BarChartCard.jsx
@@ -20,7 +20,7 @@ import {
 } from '../../utils/cardUtilityFunctions';
 import StatefulTable from '../Table/StatefulTable';
 import { csvDownloadHandler } from '../../utils/componentUtilityFunctions';
-import dayjs from '../../utils/dayjs';
+import dayjs, { DAYJS_INPUT_FORMATS } from '../../utils/dayjs';
 import { formatGraphTick } from '../TimeSeriesCard/timeSeriesUtils';
 
 import {
@@ -59,9 +59,9 @@ const defaultProps = {
   },
   locale: 'en',
   showTimeInGMT: false,
-  tooltipDateFormatPattern: 'L HH:mm:ss',
+  tooltipDateFormatPattern: DAYJS_INPUT_FORMATS.SECONDS,
   values: null,
-  defaultDateFormatPattern: 'L HH:mm',
+  defaultDateFormatPattern: DAYJS_INPUT_FORMATS.SECONDS,
 };
 
 const BarChartCard = ({

--- a/packages/react/src/components/BarChartCard/barChartUtils.js
+++ b/packages/react/src/components/BarChartCard/barChartUtils.js
@@ -1,6 +1,6 @@
 import { isNil, isEmpty, capitalize, omit } from 'lodash-es';
 
-import dayjs from '../../utils/dayjs';
+import dayjs, { DAYJS_INPUT_FORMATS } from '../../utils/dayjs';
 import { BAR_CHART_TYPES, BAR_CHART_LAYOUTS, CARD_SIZES } from '../../constants/LayoutConstants';
 import { CHART_COLORS } from '../../constants/CardPropTypes';
 import { convertStringsToDOMElement } from '../../utils/componentUtilityFunctions';
@@ -425,7 +425,7 @@ export const handleTooltip = (
   defaultTooltip,
   timeDataSourceId,
   showTimeInGMT,
-  tooltipDateFormatPattern = 'L HH:mm:ss',
+  tooltipDateFormatPattern = DAYJS_INPUT_FORMATS.SECONDS,
   locale
 ) => {
   dayjs.locale(locale);
@@ -527,7 +527,7 @@ export const formatTableData = (
   type,
   values,
   chartData,
-  defaultDateFormatPattern = 'L HH:mm'
+  defaultDateFormatPattern = DAYJS_INPUT_FORMATS.SECONDS
 ) => {
   const tableData = [];
   if (!isNil(values) && !isNil(chartData)) {

--- a/packages/react/src/components/BarChartCard/barChartUtils.test.js
+++ b/packages/react/src/components/BarChartCard/barChartUtils.test.js
@@ -585,7 +585,7 @@ describe('barChartUtils', () => {
         values: {
           Emissions: 120,
           Particles: 447,
-          timestamp: '02/09/2020 10:23',
+          timestamp: '02/09/2020 10:23:45',
         },
       },
       {
@@ -594,7 +594,7 @@ describe('barChartUtils', () => {
         values: {
           Emissions: 150,
           Particles: 450,
-          timestamp: '02/10/2020 10:23',
+          timestamp: '02/10/2020 10:23:45',
         },
       },
       {
@@ -603,7 +603,7 @@ describe('barChartUtils', () => {
         values: {
           Emissions: 170,
           Particles: 512,
-          timestamp: '02/11/2020 10:23',
+          timestamp: '02/11/2020 10:23:45',
         },
       },
       {
@@ -612,7 +612,7 @@ describe('barChartUtils', () => {
         values: {
           Emissions: 200,
           Particles: 565,
-          timestamp: '02/12/2020 10:23',
+          timestamp: '02/12/2020 10:23:45',
         },
       },
     ]);

--- a/packages/react/src/components/Card/Card.jsx
+++ b/packages/react/src/components/Card/Card.jsx
@@ -25,6 +25,7 @@ import { getUpdatedCardSize, useCardResizing } from '../../utils/cardUtilityFunc
 import { parseValue } from '../DateTimePicker/dateTimePickerUtils';
 import useSizeObserver from '../../hooks/useSizeObserver';
 import EmptyState from '../EmptyState/EmptyState';
+import { DAYJS_INPUT_FORMATS } from '../../utils/dayjs';
 
 import CardTypeContent from './CardTypeContent';
 import CardToolbar from './CardToolbar';
@@ -266,7 +267,7 @@ export const defaultProps = {
   tooltip: undefined,
   titleTextTooltip: undefined,
   footerContent: undefined,
-  dateTimeMask: 'YYYY-MM-DD HH:mm',
+  dateTimeMask: DAYJS_INPUT_FORMATS.RANGE,
   padding: 'default',
   overrides: undefined,
   type: null,

--- a/packages/react/src/components/Card/Card.test.jsx
+++ b/packages/react/src/components/Card/Card.test.jsx
@@ -18,6 +18,7 @@ const tooltipElement = <div>This is some other text</div>;
 const cardProps = {
   title: 'My Title',
   id: 'my card',
+  dateTimeMask: 'YYYY-MM-DD HH:mm',
 };
 
 describe('Card', () => {

--- a/packages/react/src/components/Card/CardToolbar.jsx
+++ b/packages/react/src/components/Card/CardToolbar.jsx
@@ -14,6 +14,7 @@ import DateTimePicker, {
 } from '../DateTimePicker/DateTimePickerV2WithoutTimeSpinner';
 import Button from '../Button';
 import { PRESET_VALUES } from '../../constants/DateConstants';
+import { DAYJS_INPUT_FORMATS } from '../../utils/dayjs';
 
 import CardRangePicker, { CardRangePickerPropTypes } from './CardRangePicker';
 
@@ -109,7 +110,7 @@ const defaultProps = {
     extraActionLabel: 'Action Label',
   },
   testId: 'card-toolbar',
-  dateTimeMask: 'YYYY-MM-DD HH:mm',
+  dateTimeMask: DAYJS_INPUT_FORMATS.RANGE,
   renderDateDropdownInPortal: true,
 };
 

--- a/packages/react/src/components/Card/__snapshots__/Card.story.storyshot
+++ b/packages/react/src/components/Card/__snapshots__/Card.story.storyshot
@@ -5515,7 +5515,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
             className="iot--card--subtitle--text"
             data-testid="Card-subtitle"
           >
-            2018-10-28 13:10 to 2018-10-28 13:30
+            10/28/2018 13:10 to 10/28/2018 13:30
           </div>
         </span>
         <div

--- a/packages/react/src/components/ComboChartCard/ComboChartCard.jsx
+++ b/packages/react/src/components/ComboChartCard/ComboChartCard.jsx
@@ -14,6 +14,7 @@ import { CardPropTypes, ComboChartPropTypes } from '../../constants/CardPropType
 import { settings } from '../../constants/Settings';
 import StatefulTable from '../Table/StatefulTable';
 import { csvDownloadHandler } from '../../utils/componentUtilityFunctions';
+import { DAYJS_INPUT_FORMATS } from '../../utils/dayjs';
 
 import { useTableData, useTableColumns, useChartData, useChartOptions } from './comboChartHelpers';
 
@@ -42,8 +43,8 @@ const defaultProps = {
   },
   showTimeInGMT: false,
   domainRange: null,
-  tooltipDateFormatPattern: 'L HH:mm:ss',
-  defaultDateFormatPattern: 'L HH:mm',
+  tooltipDateFormatPattern: DAYJS_INPUT_FORMATS.SECONDS,
+  defaultDateFormatPattern: DAYJS_INPUT_FORMATS.SECONDS,
 };
 
 const ComboChartCard = ({

--- a/packages/react/src/components/ComboChartCard/ComboChartCard.test.jsx
+++ b/packages/react/src/components/ComboChartCard/ComboChartCard.test.jsx
@@ -170,7 +170,7 @@ describe('ComboChartCard', () => {
     expect(container.querySelector('#mock-combo-chart')).toBeInTheDocument();
     userEvent.click(screen.getByLabelText('Download table content'));
     expect(fileDownload).toHaveBeenCalledWith(
-      `health,age,condition,rul,date\n83,77,95,92,12/15/2018 00:00\n85,78,97,93,12/01/2018 00:00\n`,
+      `health,age,condition,rul,date\n83,77,95,92,12/15/2018 00:00:00\n85,78,97,93,12/01/2018 00:00:00\n`,
       `Health.csv`
     );
   });

--- a/packages/react/src/components/ComboChartCard/__snapshots__/ComboChartCard.story.storyshot
+++ b/packages/react/src/components/ComboChartCard/__snapshots__/ComboChartCard.story.storyshot
@@ -717,9 +717,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <span
                               className=""
-                              title="12/15/2018 00:00"
+                              title="12/15/2018 00:00:00"
                             >
-                              12/15/2018 00:00
+                              12/15/2018 00:00:00
                             </span>
                           </span>
                         </td>
@@ -842,9 +842,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <span
                               className=""
-                              title="12/01/2018 00:00"
+                              title="12/01/2018 00:00:00"
                             >
-                              12/01/2018 00:00
+                              12/01/2018 00:00:00
                             </span>
                           </span>
                         </td>
@@ -967,9 +967,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <span
                               className=""
-                              title="10/15/2019 00:00"
+                              title="10/15/2019 00:00:00"
                             >
-                              10/15/2019 00:00
+                              10/15/2019 00:00:00
                             </span>
                           </span>
                         </td>
@@ -1092,9 +1092,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <span
                               className=""
-                              title="10/15/2019 00:00"
+                              title="10/15/2019 00:00:00"
                             >
-                              10/15/2019 00:00
+                              10/15/2019 00:00:00
                             </span>
                           </span>
                         </td>
@@ -1217,9 +1217,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <span
                               className=""
-                              title="10/01/2019 00:00"
+                              title="10/01/2019 00:00:00"
                             >
-                              10/01/2019 00:00
+                              10/01/2019 00:00:00
                             </span>
                           </span>
                         </td>
@@ -1342,9 +1342,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <span
                               className=""
-                              title="09/16/2019 00:00"
+                              title="09/16/2019 00:00:00"
                             >
-                              09/16/2019 00:00
+                              09/16/2019 00:00:00
                             </span>
                           </span>
                         </td>
@@ -1467,9 +1467,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <span
                               className=""
-                              title="09/01/2019 00:00"
+                              title="09/01/2019 00:00:00"
                             >
-                              09/01/2019 00:00
+                              09/01/2019 00:00:00
                             </span>
                           </span>
                         </td>
@@ -1592,9 +1592,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <span
                               className=""
-                              title="08/15/2019 00:00"
+                              title="08/15/2019 00:00:00"
                             >
-                              08/15/2019 00:00
+                              08/15/2019 00:00:00
                             </span>
                           </span>
                         </td>
@@ -1717,9 +1717,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <span
                               className=""
-                              title="08/01/2019 00:00"
+                              title="08/01/2019 00:00:00"
                             >
-                              08/01/2019 00:00
+                              08/01/2019 00:00:00
                             </span>
                           </span>
                         </td>
@@ -1842,9 +1842,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
                           >
                             <span
                               className=""
-                              title="07/15/2019 00:00"
+                              title="07/15/2019 00:00:00"
                             >
-                              07/15/2019 00:00
+                              07/15/2019 00:00:00
                             </span>
                           </span>
                         </td>

--- a/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -10086,9 +10086,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                               >
                                 <span
                                   className=""
-                                  title="09/30/2019 00:00"
+                                  title="09/30/2019 00:00:00"
                                 >
-                                  09/30/2019 00:00
+                                  09/30/2019 00:00:00
                                 </span>
                               </span>
                             </td>
@@ -10216,9 +10216,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                               >
                                 <span
                                   className=""
-                                  title="09/30/2019 00:00"
+                                  title="09/30/2019 00:00:00"
                                 >
-                                  09/30/2019 00:00
+                                  09/30/2019 00:00:00
                                 </span>
                               </span>
                             </td>
@@ -10346,9 +10346,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                               >
                                 <span
                                   className=""
-                                  title="09/30/2019 00:00"
+                                  title="09/30/2019 00:00:00"
                                 >
-                                  09/30/2019 00:00
+                                  09/30/2019 00:00:00
                                 </span>
                               </span>
                             </td>
@@ -10476,9 +10476,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                               >
                                 <span
                                   className=""
-                                  title="09/30/2019 00:00"
+                                  title="09/30/2019 00:00:00"
                                 >
-                                  09/30/2019 00:00
+                                  09/30/2019 00:00:00
                                 </span>
                               </span>
                             </td>
@@ -10606,9 +10606,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                               >
                                 <span
                                   className=""
-                                  title="09/30/2019 00:00"
+                                  title="09/30/2019 00:00:00"
                                 >
-                                  09/30/2019 00:00
+                                  09/30/2019 00:00:00
                                 </span>
                               </span>
                             </td>
@@ -10736,9 +10736,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                               >
                                 <span
                                   className=""
-                                  title="09/30/2019 00:00"
+                                  title="09/30/2019 00:00:00"
                                 >
-                                  09/30/2019 00:00
+                                  09/30/2019 00:00:00
                                 </span>
                               </span>
                             </td>
@@ -10866,9 +10866,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                               >
                                 <span
                                   className=""
-                                  title="09/30/2019 00:00"
+                                  title="09/30/2019 00:00:00"
                                 >
-                                  09/30/2019 00:00
+                                  09/30/2019 00:00:00
                                 </span>
                               </span>
                             </td>

--- a/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
+++ b/packages/react/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
@@ -2682,9 +2682,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                           >
                             <span
                               className=""
-                              title="07/23/2019 04:26"
+                              title="07/23/2019 04:26:10"
                             >
-                              07/23/2019 04:26
+                              07/23/2019 04:26:10
                             </span>
                           </span>
                         </td>
@@ -2762,9 +2762,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                           >
                             <span
                               className=""
-                              title="07/23/2019 05:26"
+                              title="07/23/2019 05:26:10"
                             >
-                              07/23/2019 05:26
+                              07/23/2019 05:26:10
                             </span>
                           </span>
                         </td>
@@ -2842,9 +2842,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                           >
                             <span
                               className=""
-                              title="07/23/2019 05:26"
+                              title="07/23/2019 05:26:10"
                             >
-                              07/23/2019 05:26
+                              07/23/2019 05:26:10
                             </span>
                           </span>
                         </td>
@@ -2922,9 +2922,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                           >
                             <span
                               className=""
-                              title="07/23/2019 04:26"
+                              title="07/23/2019 04:26:10"
                             >
-                              07/23/2019 04:26
+                              07/23/2019 04:26:10
                             </span>
                           </span>
                         </td>
@@ -3002,9 +3002,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                           >
                             <span
                               className=""
-                              title="07/23/2019 04:30"
+                              title="07/23/2019 04:30:10"
                             >
-                              07/23/2019 04:30
+                              07/23/2019 04:30:10
                             </span>
                           </span>
                         </td>
@@ -3082,9 +3082,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                           >
                             <span
                               className=""
-                              title="08/02/2019 09:42"
+                              title="08/02/2019 09:42:26"
                             >
-                              08/02/2019 09:42
+                              08/02/2019 09:42:26
                             </span>
                           </span>
                         </td>
@@ -3162,9 +3162,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                           >
                             <span
                               className=""
-                              title="07/23/2019 05:26"
+                              title="07/23/2019 05:26:10"
                             >
-                              07/23/2019 05:26
+                              07/23/2019 05:26:10
                             </span>
                           </span>
                         </td>

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.jsx
@@ -20,7 +20,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import TimePickerSpinner from '../TimePickerSpinner/TimePickerSpinner';
 import { settings } from '../../constants/Settings';
-import dayjs from '../../utils/dayjs';
+import dayjs, { DAYJS_INPUT_FORMATS } from '../../utils/dayjs';
 import { handleSpecificKeyDown, useOnClickOutside } from '../../utils/componentUtilityFunctions';
 import { Tooltip } from '../Tooltip';
 
@@ -210,7 +210,7 @@ const propTypes = {
 const defaultProps = {
   testId: 'date-time-picker',
   defaultValue: null,
-  dateTimeMask: 'YYYY-MM-DD HH:mm',
+  dateTimeMask: DAYJS_INPUT_FORMATS.RANGE,
   presets: PRESET_VALUES,
   intervals: [
     {
@@ -326,12 +326,7 @@ const DateTimePicker = ({
     ...i18n,
   };
 
-  // make sure locale is 2 letters
-  const newLocale = locale?.length === 2 ? locale : locale.slice(0, 2);
-  // initialize the dayjs locale
-  useEffect(() => {
-    dayjs.locale(newLocale);
-  }, [newLocale]);
+  dayjs.locale(locale);
 
   // State
   const [customRangeKind, setCustomRangeKind, onCustomRangeChange] =
@@ -959,7 +954,7 @@ const DateTimePicker = ({
                         value={
                           absoluteValue ? [absoluteValue.startDate, absoluteValue.endDate] : ''
                         }
-                        locale={newLocale}
+                        locale={locale.split('-')[0]}
                       >
                         <DatePickerInput
                           labelText=""

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.story.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.story.jsx
@@ -62,6 +62,7 @@ export const Default = () => {
             value: RELATIVE_VALUES.YESTERDAY,
           },
         ]}
+        dateTimeMask={text('dateTimeMask', 'YYYY-MM-DD HH:mm')}
         hasTimeInput={boolean('hasTimeInput', true)}
         invalid={boolean('invalid', false)}
         disabled={boolean('disabled', false)}

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.story.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.story.jsx
@@ -56,7 +56,6 @@ export const Default = () => {
     >
       <DateTimePicker
         id="datetimepicker"
-        dateTimeMask={text('dateTimeMask', 'YYYY-MM-DD HH:mm')}
         relatives={[
           {
             label: 'Yesterday',

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.test.jsx
@@ -30,6 +30,7 @@ const dateTimePickerProps = {
   testId: 'date-time-picker',
   onCancel: jest.fn(),
   onApply: jest.fn(),
+  dateTimeMask: 'YYYY-MM-DD HH:mm',
 };
 
 const i18n = {
@@ -1184,6 +1185,7 @@ describe('DateTimePicker', () => {
       const onApply = jest.fn();
       render(
         <DateTimePicker
+          dateTimeMask="YYYY-MM-DD HH:mm"
           onApply={onApply}
           hasTimeInput
           defaultValue={{

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.test.jsx
@@ -31,6 +31,7 @@ const dateTimePickerProps = {
   testId: 'date-time-picker',
   onCancel: jest.fn(),
   onApply: jest.fn(),
+  dateTimeMask: 'YYYY-MM-DD HH:mm',
 };
 
 const i18n = {
@@ -403,8 +404,8 @@ describe('DateTimePickerV2', () => {
     render(
       <DateTimePicker
         useNewTimeSpinner
-        dateTimeMask="YYYY-MM-DD hh:mm A"
         {...dateTimePickerProps}
+        dateTimeMask="YYYY-MM-DD hh:mm A"
         defaultValue={defaultAbsoluteValue}
       />
     );

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
@@ -22,7 +22,7 @@ import { useLangDirection } from 'use-lang-direction';
 import TimePickerSpinner from '../TimePickerSpinner/TimePickerSpinner';
 import TimePickerDropdown from '../TimePicker/TimePickerDropdown';
 import { settings } from '../../constants/Settings';
-import dayjs from '../../utils/dayjs';
+import dayjs, { DAYJS_INPUT_FORMATS } from '../../utils/dayjs';
 import {
   PICKER_KINDS,
   PRESET_VALUES,
@@ -210,7 +210,7 @@ const dateTimePickerId = uuidv4();
 export const defaultProps = {
   testId: 'date-time-picker',
   defaultValue: null,
-  dateTimeMask: 'YYYY-MM-DD HH:mm',
+  dateTimeMask: DAYJS_INPUT_FORMATS.RANGE,
   presets: PRESET_VALUES,
   intervals: [
     {

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithoutTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithoutTimeSpinner.jsx
@@ -21,7 +21,7 @@ import { useLangDirection } from 'use-lang-direction';
 
 import TimePickerSpinner from '../TimePickerSpinner/TimePickerSpinner';
 import { settings } from '../../constants/Settings';
-import dayjs from '../../utils/dayjs';
+import dayjs, { DAYJS_INPUT_FORMATS } from '../../utils/dayjs';
 import {
   PICKER_KINDS,
   PRESET_VALUES,
@@ -183,7 +183,7 @@ const propTypes = {
 const defaultProps = {
   testId: 'date-time-picker',
   defaultValue: null,
-  dateTimeMask: 'YYYY-MM-DD HH:mm',
+  dateTimeMask: DAYJS_INPUT_FORMATS.RANGE,
   presets: PRESET_VALUES,
   intervals: [
     {

--- a/packages/react/src/components/DateTimePicker/__snapshots__/DateTimePicker.story.storyshot
+++ b/packages/react/src/components/DateTimePicker/__snapshots__/DateTimePicker.story.storyshot
@@ -52,7 +52,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
               id="definition-tooltip-2"
               role="tooltip"
             >
-              2018-10-28 07:04 to Now
+              10/28/2018 07:04 to Now
             </span>
           </span>
           <svg
@@ -94,7 +94,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                 <li
                   className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--current"
                 >
-                  2018-10-28 07:04 to Now
+                  10/28/2018 07:04 to Now
                 </li>
                 <li
                   className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--custom"
@@ -911,9 +911,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
         >
           <span
             className=""
-            title="2020-04-01 12:34 to 2020-04-06 10:49"
+            title="04/01/2020 12:34 to 04/06/2020 10:49"
           >
-            2020-04-01 12:34 to 2020-04-06 10:49
+            04/01/2020 12:34 to 04/06/2020 10:49
           </span>
           <svg
             aria-label="Calendar"
@@ -1425,7 +1425,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
               id="definition-tooltip-4"
               role="tooltip"
             >
-              2018-10-27 19:34 to Now
+              10/27/2018 19:34 to Now
             </span>
           </span>
           <svg
@@ -1466,7 +1466,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                 <li
                   className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--current"
                 >
-                  2018-10-27 19:34 to Now
+                  10/27/2018 19:34 to Now
                 </li>
                 <li
                   className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--custom"
@@ -1597,9 +1597,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
         >
           <span
             className=""
-            title="2018-10-28 13:10 to 2018-10-28 13:30"
+            title="10/28/2018 13:10 to 10/28/2018 13:30"
           >
-            2018-10-28 13:10 to 2018-10-28 13:30
+            10/28/2018 13:10 to 10/28/2018 13:30
           </span>
           <svg
             aria-label="Calendar"
@@ -2160,7 +2160,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
               id="definition-tooltip-8"
               role="tooltip"
             >
-              2018-10-27 19:34 to Now
+              10/27/2018 19:34 to Now
             </span>
           </span>
           <svg
@@ -2201,7 +2201,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                 <li
                   className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--current"
                 >
-                  2018-10-27 19:34 to Now
+                  10/27/2018 19:34 to Now
                 </li>
                 <li
                   className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--preset"
@@ -2341,7 +2341,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
               id="definition-tooltip-6"
               role="tooltip"
             >
-              2018-10-27 19:34 to Now
+              10/27/2018 19:34 to Now
             </span>
           </span>
           <svg
@@ -2382,7 +2382,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/D
                 <li
                   className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--current"
                 >
-                  2018-10-27 19:34 to Now
+                  10/27/2018 19:34 to Now
                 </li>
                 <li
                   className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--custom"

--- a/packages/react/src/components/DateTimePicker/__snapshots__/DateTimePickerV2.story.storyshot
+++ b/packages/react/src/components/DateTimePicker/__snapshots__/DateTimePickerV2.story.storyshot
@@ -779,7 +779,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
               id="definition-tooltip-14"
               role="tooltip"
             >
-              2018-10-27 19:34 to Now
+              10/27/2018 19:34 to Now
             </span>
           </span>
         </div>
@@ -891,9 +891,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
         >
           <span
             className=""
-            title="2018-10-28 13:10 to 2018-10-28 13:30"
+            title="10/28/2018 13:10 to 10/28/2018 13:30"
           >
-            2018-10-28 13:10 to 2018-10-28 13:30
+            10/28/2018 13:10 to 10/28/2018 13:30
           </span>
         </div>
         <div
@@ -1153,7 +1153,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
               id="definition-tooltip-18"
               role="tooltip"
             >
-              2018-10-27 19:34 to Now
+              10/27/2018 19:34 to Now
             </span>
           </span>
         </div>
@@ -1282,7 +1282,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 2 - Watson IoT E
               id="definition-tooltip-16"
               role="tooltip"
             >
-              2018-10-27 19:34 to Now
+              10/27/2018 19:34 to Now
             </span>
           </span>
         </div>

--- a/packages/react/src/components/TableCard/TableCard.jsx
+++ b/packages/react/src/components/TableCard/TableCard.jsx
@@ -1,11 +1,11 @@
 import React, { useMemo, useCallback } from 'react';
 import { OverflowMenu, OverflowMenuItem, Link } from 'carbon-components-react';
-import { isNil, uniqBy, cloneDeep, capitalize, isFinite } from 'lodash-es';
+import { isNil, uniqBy, cloneDeep, capitalize } from 'lodash-es';
 import { OverflowMenuVertical16 } from '@carbon/icons-react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 
-import dayjs from '../../utils/dayjs';
+import dayjs, { DAYJS_INPUT_FORMATS } from '../../utils/dayjs';
 import { CardPropTypes, TableCardPropTypes } from '../../constants/CardPropTypes';
 import Card, { defaultProps as CardDefaultProps } from '../Card/Card';
 import { CARD_SIZES } from '../../constants/LayoutConstants';
@@ -70,7 +70,7 @@ const defaultProps = {
   },
   renderDateDropdownInPortal: true,
   withToolbarTooltips: false,
-  defaultDateFormatPattern: 'L HH:mm',
+  defaultDateFormatPattern: DAYJS_INPUT_FORMATS.SECONDS,
 };
 
 const TableCard = ({
@@ -305,7 +305,7 @@ const TableCard = ({
     return tableData.map((row) => {
       const values = { ...row.values };
       Object.keys(values).forEach((column) => {
-        if (!isEditable && isFinite(values[column]) && filteredTimestampColumns.includes(column)) {
+        if (!isEditable && filteredTimestampColumns.includes(column)) {
           values[column] = values[column]
             ? dayjs(values[column]).format(defaultDateFormatPattern)
             : '';

--- a/packages/react/src/components/TableCard/TableCard.test.jsx
+++ b/packages/react/src/components/TableCard/TableCard.test.jsx
@@ -247,7 +247,7 @@ describe('TableCard', () => {
       row: {
         alert: 'AHI005 Asset failure',
         count: 1.2039201932,
-        hour: '07/23/2019 05:26',
+        hour: '07/23/2019 05:26:10',
         long_description: 'long description for a given event payload',
         pressure: 0,
       },
@@ -1014,7 +1014,7 @@ describe('TableCard', () => {
 
     userEvent.click(screen.getByRole('button', { name: /download/i }));
     expect(fileDownload).toHaveBeenCalledWith(
-      `alert,count,hour,long_description,pressure\nAHI005 Asset failure,1.2039201932,07/23/2019 05:26,long description for a given event payload,0\nAHI003 process need to optimize adjust X variables,1.10329291,07/23/2019 04:26,long description for a given event payload,2\n`,
+      `alert,count,hour,long_description,pressure\nAHI005 Asset failure,1.2039201932,07/23/2019 05:26:10,long description for a given event payload,0\nAHI003 process need to optimize adjust X variables,1.10329291,07/23/2019 04:26:10,long description for a given event payload,2\n`,
       'Open Alerts.csv'
     );
   });

--- a/packages/react/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/packages/react/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -710,9 +710,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:26"
+                          title="07/23/2019 04:26:10"
                         >
-                          07/23/2019 04:26
+                          07/23/2019 04:26:10
                         </span>
                       </span>
                     </td>
@@ -869,9 +869,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -1028,9 +1028,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -1187,9 +1187,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:26"
+                          title="07/23/2019 04:26:10"
                         >
-                          07/23/2019 04:26
+                          07/23/2019 04:26:10
                         </span>
                       </span>
                     </td>
@@ -1346,9 +1346,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:30"
+                          title="07/23/2019 04:30:10"
                         >
-                          07/23/2019 04:30
+                          07/23/2019 04:30:10
                         </span>
                       </span>
                     </td>
@@ -1505,9 +1505,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="08/02/2019 09:42"
+                          title="08/02/2019 09:42:26"
                         >
-                          08/02/2019 09:42
+                          08/02/2019 09:42:26
                         </span>
                       </span>
                     </td>
@@ -1664,9 +1664,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -3978,9 +3978,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:26"
+                          title="07/23/2019 04:26:10"
                         >
-                          07/23/2019 04:26
+                          07/23/2019 04:26:10
                         </span>
                       </span>
                     </td>
@@ -4058,9 +4058,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -4138,9 +4138,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -4218,9 +4218,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:26"
+                          title="07/23/2019 04:26:10"
                         >
-                          07/23/2019 04:26
+                          07/23/2019 04:26:10
                         </span>
                       </span>
                     </td>
@@ -4298,9 +4298,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:30"
+                          title="07/23/2019 04:30:10"
                         >
-                          07/23/2019 04:30
+                          07/23/2019 04:30:10
                         </span>
                       </span>
                     </td>
@@ -4378,9 +4378,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="08/02/2019 09:42"
+                          title="08/02/2019 09:42:26"
                         >
-                          08/02/2019 09:42
+                          08/02/2019 09:42:26
                         </span>
                       </span>
                     </td>
@@ -4458,9 +4458,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -5437,9 +5437,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:30"
+                          title="07/23/2019 04:30:10"
                         >
-                          07/23/2019 04:30
+                          07/23/2019 04:30:10
                         </span>
                       </span>
                     </td>
@@ -5542,9 +5542,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:30"
+                          title="07/23/2019 04:30:10"
                         >
-                          07/23/2019 04:30
+                          07/23/2019 04:30:10
                         </span>
                       </span>
                     </td>
@@ -5647,9 +5647,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 03:30"
+                          title="07/23/2019 03:30:10"
                         >
-                          07/23/2019 03:30
+                          07/23/2019 03:30:10
                         </span>
                       </span>
                     </td>
@@ -5752,9 +5752,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 03:30"
+                          title="07/23/2019 03:30:10"
                         >
-                          07/23/2019 03:30
+                          07/23/2019 03:30:10
                         </span>
                       </span>
                     </td>
@@ -5857,9 +5857,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -5962,9 +5962,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -6067,9 +6067,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="08/02/2019 09:42"
+                          title="08/02/2019 09:42:26"
                         >
-                          08/02/2019 09:42
+                          08/02/2019 09:42:26
                         </span>
                       </span>
                     </td>
@@ -7017,9 +7017,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -9288,9 +9288,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:26"
+                          title="07/23/2019 04:26:10"
                         >
-                          07/23/2019 04:26
+                          07/23/2019 04:26:10
                         </span>
                       </span>
                     </td>
@@ -9480,9 +9480,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -9672,9 +9672,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -9864,9 +9864,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:26"
+                          title="07/23/2019 04:26:10"
                         >
-                          07/23/2019 04:26
+                          07/23/2019 04:26:10
                         </span>
                       </span>
                     </td>
@@ -10056,9 +10056,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:30"
+                          title="07/23/2019 04:30:10"
                         >
-                          07/23/2019 04:30
+                          07/23/2019 04:30:10
                         </span>
                       </span>
                     </td>
@@ -10248,9 +10248,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="08/02/2019 09:42"
+                          title="08/02/2019 09:42:26"
                         >
-                          08/02/2019 09:42
+                          08/02/2019 09:42:26
                         </span>
                       </span>
                     </td>
@@ -10440,9 +10440,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -11446,9 +11446,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:26"
+                          title="07/23/2019 04:26:10"
                         >
-                          07/23/2019 04:26
+                          07/23/2019 04:26:10
                         </span>
                       </span>
                     </td>
@@ -11613,9 +11613,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -11780,9 +11780,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -11947,9 +11947,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:26"
+                          title="07/23/2019 04:26:10"
                         >
-                          07/23/2019 04:26
+                          07/23/2019 04:26:10
                         </span>
                       </span>
                     </td>
@@ -12114,9 +12114,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:30"
+                          title="07/23/2019 04:30:10"
                         >
-                          07/23/2019 04:30
+                          07/23/2019 04:30:10
                         </span>
                       </span>
                     </td>
@@ -12281,9 +12281,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="08/02/2019 09:42"
+                          title="08/02/2019 09:42:26"
                         >
-                          08/02/2019 09:42
+                          08/02/2019 09:42:26
                         </span>
                       </span>
                     </td>
@@ -12448,9 +12448,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -13495,9 +13495,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:26"
+                          title="07/23/2019 04:26:10"
                         >
-                          07/23/2019 04:26
+                          07/23/2019 04:26:10
                         </span>
                       </span>
                     </td>
@@ -13629,9 +13629,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -13763,9 +13763,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -13897,9 +13897,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:26"
+                          title="07/23/2019 04:26:10"
                         >
-                          07/23/2019 04:26
+                          07/23/2019 04:26:10
                         </span>
                       </span>
                     </td>
@@ -14031,9 +14031,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:30"
+                          title="07/23/2019 04:30:10"
                         >
-                          07/23/2019 04:30
+                          07/23/2019 04:30:10
                         </span>
                       </span>
                     </td>
@@ -14165,9 +14165,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="08/02/2019 09:42"
+                          title="08/02/2019 09:42:26"
                         >
-                          08/02/2019 09:42
+                          08/02/2019 09:42:26
                         </span>
                       </span>
                     </td>
@@ -14299,9 +14299,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -15253,9 +15253,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:26"
+                          title="07/23/2019 04:26:10"
                         >
-                          07/23/2019 04:26
+                          07/23/2019 04:26:10
                         </span>
                       </span>
                     </td>
@@ -15388,9 +15388,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -15487,9 +15487,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -15622,9 +15622,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:26"
+                          title="07/23/2019 04:26:10"
                         >
-                          07/23/2019 04:26
+                          07/23/2019 04:26:10
                         </span>
                       </span>
                     </td>
@@ -15757,9 +15757,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:30"
+                          title="07/23/2019 04:30:10"
                         >
-                          07/23/2019 04:30
+                          07/23/2019 04:30:10
                         </span>
                       </span>
                     </td>
@@ -15928,9 +15928,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="08/02/2019 09:42"
+                          title="08/02/2019 09:42:26"
                         >
-                          08/02/2019 09:42
+                          08/02/2019 09:42:26
                         </span>
                       </span>
                     </td>
@@ -16099,9 +16099,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -17309,9 +17309,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:26"
+                          title="07/23/2019 04:26:10"
                         >
-                          07/23/2019 04:26
+                          07/23/2019 04:26:10
                         </span>
                       </span>
                     </td>
@@ -17512,9 +17512,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -17715,9 +17715,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>
@@ -17918,9 +17918,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:26"
+                          title="07/23/2019 04:26:10"
                         >
-                          07/23/2019 04:26
+                          07/23/2019 04:26:10
                         </span>
                       </span>
                     </td>
@@ -18135,9 +18135,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 04:30"
+                          title="07/23/2019 04:30:10"
                         >
-                          07/23/2019 04:30
+                          07/23/2019 04:30:10
                         </span>
                       </span>
                     </td>
@@ -18369,9 +18369,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="08/02/2019 09:42"
+                          title="08/02/2019 09:42:26"
                         >
-                          08/02/2019 09:42
+                          08/02/2019 09:42:26
                         </span>
                       </span>
                     </td>
@@ -18603,9 +18603,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                       >
                         <span
                           className=""
-                          title="07/23/2019 05:26"
+                          title="07/23/2019 05:26:10"
                         >
-                          07/23/2019 05:26
+                          07/23/2019 05:26:10
                         </span>
                       </span>
                     </td>

--- a/packages/react/src/components/TableCard/tableCardUtils.jsx
+++ b/packages/react/src/components/TableCard/tableCardUtils.jsx
@@ -3,7 +3,7 @@ import { isNil } from 'lodash-es';
 import { Link } from 'carbon-components-react';
 
 import { formatNumberWithPrecision, getVariables } from '../../utils/cardUtilityFunctions';
-import dayjs from '../../utils/dayjs';
+import dayjs, { DAYJS_INPUT_FORMATS } from '../../utils/dayjs';
 
 export const determinePrecisionAndValue = (precision = 0, value, locale) => {
   const precisionDefined = Number.isInteger(value) ? 0 : precision;
@@ -23,7 +23,10 @@ export const determinePrecisionAndValue = (precision = 0, value, locale) => {
  * @param {Array<Object>} columns - Array of TableCard columns
  * @return {array} array of columns with formatted links and updated variable values
  */
-export const createColumnsWithFormattedLinks = (columns, defaultDateFormatPattern = 'L HH:mm') => {
+export const createColumnsWithFormattedLinks = (
+  columns,
+  defaultDateFormatPattern = DAYJS_INPUT_FORMATS.SECONDS
+) => {
   return columns.map((column) => {
     const { linkTemplate } = column;
     if (linkTemplate) {
@@ -124,7 +127,7 @@ export const handleExpandedItemLinks = (row, expandedRow, cardVariables) => {
 export const determineFilterFunction = (
   column,
   defaultFilterStringPlaceholdText,
-  defaultDateFormatPattern = 'L HH:mm'
+  defaultDateFormatPattern = DAYJS_INPUT_FORMATS.SECONDS
 ) => {
   return {
     ...(column.type === 'TIMESTAMP'

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -26,7 +26,7 @@ import {
   handleTooltip,
 } from '../../utils/cardUtilityFunctions';
 import deprecate from '../../internal/deprecate';
-import dayjs from '../../utils/dayjs';
+import dayjs, { DAYJS_INPUT_FORMATS } from '../../utils/dayjs';
 import { usePrevious } from '../../hooks/usePrevious';
 
 import {
@@ -201,9 +201,9 @@ const defaultProps = {
   interval: 'hour',
   showTimeInGMT: false,
   domainRange: null,
-  tooltipDateFormatPattern: 'L HH:mm:ss',
+  tooltipDateFormatPattern: DAYJS_INPUT_FORMATS.SECONDS,
   tooltipShowTotals: true,
-  defaultDateFormatPattern: 'L HH:mm',
+  defaultDateFormatPattern: DAYJS_INPUT_FORMATS.SECONDS,
 };
 
 const TimeSeriesCard = ({

--- a/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.test.jsx
+++ b/packages/react/src/components/TimeSeriesCard/TimeSeriesCard.test.jsx
@@ -244,7 +244,7 @@ describe('TimeSeriesCard', () => {
     expect(container.querySelector('#mock-line-chart')).toBeInTheDocument();
     userEvent.click(screen.getByLabelText('Download table content'));
     expect(fileDownload).toHaveBeenCalledWith(
-      `temperature,timestamp\n100,03/05/2021 15:30\n`,
+      `temperature,timestamp\n100,03/05/2021 15:30:00\n`,
       'Temperature.csv'
     );
   });

--- a/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/packages/react/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -1702,9 +1702,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                         >
                           <span
                             className=""
-                            title="10/01/2019 10:54"
+                            title="10/01/2019 10:54:12"
                           >
-                            10/01/2019 10:54
+                            10/01/2019 10:54:12
                           </span>
                         </span>
                       </td>
@@ -1896,9 +1896,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                         >
                           <span
                             className=""
-                            title="09/01/2019 10:54"
+                            title="09/01/2019 10:54:12"
                           >
-                            09/01/2019 10:54
+                            09/01/2019 10:54:12
                           </span>
                         </span>
                       </td>
@@ -2090,9 +2090,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                         >
                           <span
                             className=""
-                            title="08/01/2019 10:54"
+                            title="08/01/2019 10:54:12"
                           >
-                            08/01/2019 10:54
+                            08/01/2019 10:54:12
                           </span>
                         </span>
                       </td>
@@ -2284,9 +2284,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                         >
                           <span
                             className=""
-                            title="07/01/2019 10:54"
+                            title="07/01/2019 10:54:12"
                           >
-                            07/01/2019 10:54
+                            07/01/2019 10:54:12
                           </span>
                         </span>
                       </td>
@@ -2478,9 +2478,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                         >
                           <span
                             className=""
-                            title="06/01/2019 10:54"
+                            title="06/01/2019 10:54:12"
                           >
-                            06/01/2019 10:54
+                            06/01/2019 10:54:12
                           </span>
                         </span>
                       </td>
@@ -2672,9 +2672,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots 1 - Watson IoT/C
                         >
                           <span
                             className=""
-                            title="05/01/2019 10:54"
+                            title="05/01/2019 10:54:12"
                           >
-                            05/01/2019 10:54
+                            05/01/2019 10:54:12
                           </span>
                         </span>
                       </td>

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -7837,7 +7837,7 @@ Map {
         },
         "type": "SIMPLE",
       },
-      "defaultDateFormatPattern": "L HH:mm",
+      "defaultDateFormatPattern": "L HH:mm:ss",
       "domainRange": null,
       "i18n": Object {
         "defaultFilterStringPlaceholdText": "Filter",
@@ -9359,7 +9359,7 @@ Map {
   },
   "DateTimePicker" => Object {
     "defaultProps": Object {
-      "dateTimeMask": "YYYY-MM-DD HH:mm",
+      "dateTimeMask": "L HH:mm",
       "defaultValue": null,
       "disabled": false,
       "expanded": false,
@@ -9849,7 +9849,7 @@ Map {
   "DateTimePickerV2" => Object {
     "defaultProps": Object {
       "datePickerType": "range",
-      "dateTimeMask": "YYYY-MM-DD HH:mm",
+      "dateTimeMask": "L HH:mm",
       "defaultValue": null,
       "disabled": false,
       "expanded": false,
@@ -16134,7 +16134,7 @@ Map {
         "xs": 4,
       },
       "data": null,
-      "dateTimeMask": "YYYY-MM-DD HH:mm",
+      "dateTimeMask": "L HH:mm",
       "footerContent": undefined,
       "hasTitleWrap": false,
       "hideHeader": false,
@@ -19732,7 +19732,7 @@ Map {
           "type": "end_line",
         },
       },
-      "defaultDateFormatPattern": "L HH:mm",
+      "defaultDateFormatPattern": "L HH:mm:ss",
       "domainRange": null,
       "i18n": Object {
         "alertDetected": "Alert detected:",
@@ -22246,7 +22246,7 @@ Map {
   },
   "TableCard" => Object {
     "defaultProps": Object {
-      "defaultDateFormatPattern": "L HH:mm",
+      "defaultDateFormatPattern": "L HH:mm:ss",
       "filters": Array [],
       "i18n": Object {
         "cloneCardLabel": "Clone card",
@@ -32227,7 +32227,7 @@ Map {
         "includeZeroOnYaxis": false,
         "showLegend": true,
       },
-      "defaultDateFormatPattern": "L HH:mm",
+      "defaultDateFormatPattern": "L HH:mm:ss",
       "domainRange": null,
       "i18n": Object {
         "defaultFilterStringPlaceholdText": "type and hit enter to apply",

--- a/packages/react/src/utils/cardUtilityFunctions.js
+++ b/packages/react/src/utils/cardUtilityFunctions.js
@@ -4,7 +4,7 @@ import { isNil, mapValues } from 'lodash-es';
 
 import { CARD_SIZES } from '../constants/LayoutConstants';
 
-import dayjs from './dayjs';
+import dayjs, { DAYJS_INPUT_FORMATS } from './dayjs';
 import { convertStringsToDOMElement } from './componentUtilityFunctions';
 
 /**
@@ -497,7 +497,7 @@ export const handleTooltip = (
   alertRanges,
   alertDetected,
   showTimeInGMT,
-  tooltipDateFormatPattern = 'L HH:mm:ss',
+  tooltipDateFormatPattern = DAYJS_INPUT_FORMATS.SECONDS,
   locale
 ) => {
   dayjs.locale(locale);

--- a/packages/react/src/utils/dayjs.js
+++ b/packages/react/src/utils/dayjs.js
@@ -165,4 +165,9 @@ const loadLocales = () => {
 
 loadLocales();
 
+export const DAYJS_INPUT_FORMATS = {
+  SECONDS: 'L HH:mm:ss',
+  RANGE: 'L HH:mm',
+};
+
 export default dayjs;


### PR DESCRIPTION
Closes #

**Summary**

- Fix locale format

**Change List (commits, features, bugs, etc)**

- For all cards default date and tooltip format changed to 'L HH:mm:ss'.
- <DatePicker of the carbon library need locale in 2 digits for that we don't need to set locale of 2 digit in carbon-addons code.
- Ex. For locale 'en-gb' and 'en' date format is diffrent. so we should not set locale in 2 digits.

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
