### PR TITLE
fix: overflow menu button svg color

### DIFF
--- a/packages/react/src/components/Header/_header.scss
+++ b/packages/react/src/components/Header/_header.scss
@@ -127,9 +127,11 @@ $hoverBgColor: #2c2c2c;
         }
       }
     }
-
-    &__icon {
-      fill: $layer-01;
+    &.#{$prefix}--btn--ghost {
+      // Overflow 3 dots menu button
+      svg.#{$prefix}--overflow-menu__icon {
+        fill: $layer-01;
+      }
     }
 
     .#{$prefix}--header__submenu.#{$prefix}--header-action-btn {


### PR DESCRIPTION
Closes https://jsw.ibm.com/browse/MAXUIF-783

**Summary**
CSS fix to prevent wrong overflow menu button svg fill color

**Change List (commits, features, bugs, etc)**
- CSS fix in `_header.scss`

**Acceptance Test (how to verify the PR)**
- Go to SuiteHeader or Header story and change the browser to mobile view. Check if the 3 dot menu button svg fill color is white instead of black

**Regression Test (how to make sure this PR doesn't break old functionality)**
- Header should render properly without any issues

**Screenshots**
| Before | After |
| -- | -- |
|![image](https://github.com/user-attachments/assets/89c1386d-7930-4b3d-8a0b-c8f2df544a32)|![image](https://github.com/user-attachments/assets/0f628f52-6d02-4d6e-9e2b-6f2f7ad7a391)| 
**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
