### PR TITLE
fix: rollup interop for commonJs module

### DIFF
--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -45,6 +45,7 @@ export default [
         format: 'cjs',
         preserveModulesRoot: 'src',
         exports: 'auto',
+        interop: 'auto'
       },
     ],
     external,


### PR DESCRIPTION
Closes #

**Summary**

- Setting interop to "auto" is the recommended default setting, as it allows Rollup to intelligently determine how to handle each module.
- For more info check (https://rollupjs.org/configuration-options/#output-interop)
- As the testcases were failing for `statefullTable.jsx/Table.jsx` in our project. 
- statefullTable.jsx transformed commonjs file should support default import currently for `useDeepCompareEffect` as it was complaining that `TypeError: useDeepCompareEffect is not a function`. 
- `var useDeepCompareEffect = require('use-deep-compare-effect');` above import contains below object
   `{
        default: [Function: useDeepCompareEffect],
        useDeepCompareEffectNoCheck: [Function: useDeepCompareEffectNoCheck],
        useDeepCompareMemoize: [Function: useDeepCompareMemoize]
      } ` and we should use `useDeepCompareEffect.default` to access the function.
- So proposed solution will solve above issue.

**Change List (commits, features, bugs, etc)**

- rollup interop

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
