### PR TITLE
expose close on select date props to use outside carbon iot

### DIFF
--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
@@ -33,6 +33,7 @@ const DateTimePicker = ({
   renderInPortal,
   useAutoPositioning,
   style,
+  closeOnSelect,
   ...others
 }) => {
   return useNewTimeSpinner ? (
@@ -64,6 +65,7 @@ const DateTimePicker = ({
       renderInPortal={renderInPortal}
       useAutoPositioning={useAutoPositioning}
       style={style}
+      closeOnSelect={closeOnSelect}
       others={others}
     />
   ) : (
@@ -93,6 +95,7 @@ const DateTimePicker = ({
       renderInPortal={renderInPortal}
       useAutoPositioning={useAutoPositioning}
       style={style}
+      closeOnSelect={closeOnSelect}
       others={others}
     />
   );

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.jsx
@@ -95,7 +95,6 @@ const DateTimePicker = ({
       renderInPortal={renderInPortal}
       useAutoPositioning={useAutoPositioning}
       style={style}
-      closeOnSelect={closeOnSelect}
       others={others}
     />
   );

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2.story.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2.story.jsx
@@ -202,6 +202,7 @@ export const SingleSelect = () => {
         style={{ zIndex: number('zIndex', 0) }}
         renderInPortal={boolean('renderInPortal', true)}
         locale={text('locale', 'en')}
+        closeOnSelect={boolean('Close On Select', true)}
       />
       <div style={{ height: '10rem' }} />
     </div>

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
@@ -200,6 +200,8 @@ export const propTypes = {
   /** Auto reposition if flyout menu offscreen */
   useAutoPositioning: PropTypes.bool,
   style: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+  /** If is set to true Datepicker will close after date select */
+  closeOnSelect: PropTypes.bool,
 };
 
 export const defaultProps = {
@@ -298,6 +300,7 @@ export const defaultProps = {
   renderInPortal: true,
   useAutoPositioning: false,
   style: {},
+  closeOnSelect: true,
 };
 
 const DateTimePicker = ({
@@ -327,6 +330,7 @@ const DateTimePicker = ({
   renderInPortal,
   useAutoPositioning,
   style,
+  closeOnSelect,
   ...others
 }) => {
   const id = useRef(others.id || uuidv4()).current;
@@ -1220,7 +1224,7 @@ const DateTimePicker = ({
                             : null
                         }
                         locale={locale?.split('-')[0]}
-                        closeOnSelect={false}
+                        closeOnSelect={closeOnSelect}
                       >
                         <DatePickerInput
                           labelText={mergedI18n.startDateLabel}


### PR DESCRIPTION
Closes #

**Summary**

In DateTimePicker previously date picker is not closed after select date, default is false, so I enable with props and expose that props so we can set true/false as required.

**Change List (commits, features, bugs, etc)**

- Created a default props for closeOnSelect and default value is False

**Acceptance Test (how to verify the PR)**

- Go to Storybook -> 2. Watson IOT experimental -> Single select with new time spinner. added knobs at last **Close On Select**

**Regression Test (how to make sure this PR doesn't break old functionality)**



<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
