### PR TITLE
fix(pagewizard): add margin padding

### DIFF
--- a/packages/react/src/components/PageWizard/PageWizardStep/PageWizardStep.jsx
+++ b/packages/react/src/components/PageWizard/PageWizardStep/PageWizardStep.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { InlineNotification } from '@carbon/react';
 import classnames from 'classnames';
+import { v4 as uuidv4 } from 'uuid';
 
 import { settings } from '../../../constants/Settings';
 import { childrenPropType } from '../PageWizard';
@@ -93,12 +94,14 @@ const PageWizardStep = ({
   <div className={`${iotPrefix}--page-wizard--step`} id={id}>
     {error ? (
       <InlineNotification
+        key={uuidv4()}
         lowContrast
         title={error}
         subtitle=""
         kind="error"
         onCloseButtonClick={onClearError}
         iconDescription={i18n.close}
+        className={`${iotPrefix}--page-wizard--inline-notificaton`}
       />
     ) : null}
     {children}

--- a/packages/react/src/components/PageWizard/_page-wizard.scss
+++ b/packages/react/src/components/PageWizard/_page-wizard.scss
@@ -81,4 +81,9 @@
       }
     }
   }
+
+  &--inline-notificaton {
+    margin-top: $spacing-05;
+    margin-bottom: $spacing-05;
+  }
 }


### PR DESCRIPTION
Closes #

**Summary**

- add margin padding which was removed in c11
Earlier example: 
![image](https://github.com/user-attachments/assets/c5d0903c-b609-45ba-b9ce-1e0da0627846)

Storybook: 
* Before: https://carbon-design-system.github.io/carbon-addons-iot-react/?path=/story/1-watson-iot-progress-indicator-pagewizard--stateful-example-w-validation-in-page-title-bar
![image](https://github.com/user-attachments/assets/9ce7681c-1806-4371-a36b-b6b15fc62997)

* After: https://deploy-preview-3927--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-progress-indicator-pagewizard--stateful-example-w-validation-in-page-title-bar
![image](https://github.com/user-attachments/assets/65026ae3-80fc-4cac-9e4a-0a27f5699ace)


**Change List (commits, features, bugs, etc)**

- fix(pagewizard): add margin padding

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
