### PR TITLE
fix: display toogletip

### DIFF
--- a/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
@@ -2,7 +2,13 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState, useMemo, useRef, useCallback } from 'react';
 import classnames from 'classnames';
 import { Information, Edit } from '@carbon/react/icons';
-import { Breadcrumb, BreadcrumbItem, SkeletonText, Tabs } from '@carbon/react';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  SkeletonText,
+  Tabs,
+  unstable_FeatureFlags as FeatureFlags,
+} from '@carbon/react';
 import { throttle } from 'lodash-es';
 
 import { ToggleTip } from '../ToggleTip';
@@ -274,13 +280,15 @@ const PageTitleBar = ({
     () => (
       <>
         {description && (collapsed || condensed) ? (
-          <ToggleTip
-            tabIndex={0}
-            iconDescription={tooltipIconDescription}
-            data-testid={`${testId}-tooltip`}
-            showIcon
-            content={typeof description === 'string' ? <p>{description}</p> : <>{description}</>}
-          />
+          <FeatureFlags enableV12DynamicFloatingStyles>
+            <ToggleTip
+              tabIndex={0}
+              iconDescription={tooltipIconDescription}
+              data-testid={`${testId}-tooltip`}
+              showIcon
+              content={typeof description === 'string' ? <p>{description}</p> : <>{description}</>}
+            />
+          </FeatureFlags>
         ) : null}
         {editable ? (
           <Button
@@ -378,21 +386,23 @@ const PageTitleBar = ({
                       <>
                         {title}
                         {description ? (
-                          <ToggleTip
-                            tabIndex={0}
-                            showIcon
-                            iconDescription={tooltipIconDescription}
-                            data-testid={`${testId}-tooltip`}
-                            content={
-                              typeof description === 'string' ? (
-                                <p>{description}</p>
-                              ) : (
-                                <>{description}</>
-                              )
-                            }
-                          >
-                            <Information />
-                          </ToggleTip>
+                          <FeatureFlags enableV12DynamicFloatingStyles>
+                            <ToggleTip
+                              tabIndex={0}
+                              showIcon
+                              iconDescription={tooltipIconDescription}
+                              data-testid={`${testId}-tooltip`}
+                              content={
+                                typeof description === 'string' ? (
+                                  <p>{description}</p>
+                                ) : (
+                                  <>{description}</>
+                                )
+                              }
+                            >
+                              <Information />
+                            </ToggleTip>
+                          </FeatureFlags>
                         ) : null}
                       </>
                     </BreadcrumbItem>

--- a/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
@@ -2,13 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState, useMemo, useRef, useCallback } from 'react';
 import classnames from 'classnames';
 import { Information, Edit } from '@carbon/react/icons';
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  SkeletonText,
-  Tabs,
-  unstable_FeatureFlags as FeatureFlags,
-} from '@carbon/react';
+import { Breadcrumb, BreadcrumbItem, SkeletonText, Tabs } from '@carbon/react';
 import { throttle } from 'lodash-es';
 
 import { ToggleTip } from '../ToggleTip';
@@ -280,15 +274,14 @@ const PageTitleBar = ({
     () => (
       <>
         {description && (collapsed || condensed) ? (
-          <FeatureFlags enableV12DynamicFloatingStyles>
-            <ToggleTip
-              tabIndex={0}
-              iconDescription={tooltipIconDescription}
-              data-testid={`${testId}-tooltip`}
-              showIcon
-              content={typeof description === 'string' ? <p>{description}</p> : <>{description}</>}
-            />
-          </FeatureFlags>
+          <ToggleTip
+            tabIndex={0}
+            useAutoPositioning
+            iconDescription={tooltipIconDescription}
+            data-testid={`${testId}-tooltip`}
+            showIcon
+            content={typeof description === 'string' ? <p>{description}</p> : <>{description}</>}
+          />
         ) : null}
         {editable ? (
           <Button
@@ -386,23 +379,22 @@ const PageTitleBar = ({
                       <>
                         {title}
                         {description ? (
-                          <FeatureFlags enableV12DynamicFloatingStyles>
-                            <ToggleTip
-                              tabIndex={0}
-                              showIcon
-                              iconDescription={tooltipIconDescription}
-                              data-testid={`${testId}-tooltip`}
-                              content={
-                                typeof description === 'string' ? (
-                                  <p>{description}</p>
-                                ) : (
-                                  <>{description}</>
-                                )
-                              }
-                            >
-                              <Information />
-                            </ToggleTip>
-                          </FeatureFlags>
+                          <ToggleTip
+                            tabIndex={0}
+                            showIcon
+                            useAutoPositioning
+                            iconDescription={tooltipIconDescription}
+                            data-testid={`${testId}-tooltip`}
+                            content={
+                              typeof description === 'string' ? (
+                                <p>{description}</p>
+                              ) : (
+                                <>{description}</>
+                              )
+                            }
+                          >
+                            <Information />
+                          </ToggleTip>
                         ) : null}
                       </>
                     </BreadcrumbItem>


### PR DESCRIPTION
**Summary**

- display toogletip
Earlier: 
<img width="975" alt="image" src="https://github.com/user-attachments/assets/92858d0f-3e1e-45b8-b3d5-7bf4ebb88667" />
Now: 
<img width="975" alt="image" src="https://github.com/user-attachments/assets/1a4eff80-1276-4c8c-aecc-e2c09975e70d" />

**Change List (commits, features, bugs, etc)**

- fix: display toogletip

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
