### PR TITLE
fix: re render card editor on card change

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditor.jsx
+++ b/packages/react/src/components/CardEditor/CardEditor.jsx
@@ -379,6 +379,7 @@ const CardEditor = ({
               />
             ) : null}
             <CardEditForm
+              key={cardConfig.id}
               cardConfig={finalCardToEdit}
               isSummaryDashboard={isSummaryDashboard}
               onChange={onChange}


### PR DESCRIPTION
Closes Issue 1 in https://jsw.ibm.com/browse/MASMON-3460

**Summary**

- re-render card editor on card change

**Change List (commits, features, bugs, etc)**

- fix: re render card editor on card change

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
