### PR TITLE
feat(table) AILabel with Table Header column

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -179,7 +179,7 @@
     "@carbon/icons-react": "^11.53.0",
     "@carbon/layout": "^11.28.0",
     "@carbon/pictograms-react": "^11.69.0",
-    "@carbon/react": "^1.72.0",
+    "@carbon/react": "^1.78.0",
     "@carbon/telemetry": "^0.1.0",
     "@carbon/themes": "^11.43.0",
     "@codemirror/lang-css": "^6.3.0",

--- a/packages/react/src/components/Table/Table.main.story.jsx
+++ b/packages/react/src/components/Table/Table.main.story.jsx
@@ -198,8 +198,7 @@ export const Playground = () => {
         'hasEmptyFilterOption',
         'hasMultiSelectFilter',
         'hasFilterRowIcon',
-        'pinHeaderAndFooter',
-        'aiLabelHeader'
+        'pinHeaderAndFooter'
       ].includes(name)
         ? false
         : // For this story always enable the following knobs by default

--- a/packages/react/src/components/Table/Table.main.story.jsx
+++ b/packages/react/src/components/Table/Table.main.story.jsx
@@ -198,7 +198,7 @@ export const Playground = () => {
         'hasEmptyFilterOption',
         'hasMultiSelectFilter',
         'hasFilterRowIcon',
-        'pinHeaderAndFooter'
+        'pinHeaderAndFooter',
       ].includes(name)
         ? false
         : // For this story always enable the following knobs by default
@@ -295,7 +295,7 @@ export const Playground = () => {
       tooltip: demoColumnTooltips ? `A tooltip for ${column.name}` : undefined,
       align: cellTextAlignment,
       editDataFunction: getEditDataFunction(() => {}),
-      overflowMenuItems: demoColumnOverflowMenuItems ? getSelectDataOptions() : undefined
+      overflowMenuItems: demoColumnOverflowMenuItems ? getSelectDataOptions() : undefined,
     }))
     .map((column) => {
       if (demoRenderDataFunction) return column;

--- a/packages/react/src/components/Table/Table.main.story.jsx
+++ b/packages/react/src/components/Table/Table.main.story.jsx
@@ -199,6 +199,7 @@ export const Playground = () => {
         'hasMultiSelectFilter',
         'hasFilterRowIcon',
         'pinHeaderAndFooter',
+        'aiLabelHeader'
       ].includes(name)
         ? false
         : // For this story always enable the following knobs by default
@@ -295,7 +296,7 @@ export const Playground = () => {
       tooltip: demoColumnTooltips ? `A tooltip for ${column.name}` : undefined,
       align: cellTextAlignment,
       editDataFunction: getEditDataFunction(() => {}),
-      overflowMenuItems: demoColumnOverflowMenuItems ? getSelectDataOptions() : undefined,
+      overflowMenuItems: demoColumnOverflowMenuItems ? getSelectDataOptions() : undefined
     }))
     .map((column) => {
       if (demoRenderDataFunction) return column;

--- a/packages/react/src/components/Table/Table.story.helpers.jsx
+++ b/packages/react/src/components/Table/Table.story.helpers.jsx
@@ -222,7 +222,6 @@ export const getTableColumns = () => [
     id: 'string',
     name: 'String',
     filter: { placeholderText: 'enter a string' },
-   
   },
 
   {
@@ -242,33 +241,45 @@ export const getTableColumns = () => [
         }
         return columnValue.includes(filterValue);
       },
-    }
-  },
-  {
-    id: 'select',
-    name: 'Select',
-    filter: { placeholderText: 'pick an option', options: getSelectDataOptions() },
+    },
     decorator: (
-      <AILabel
-        className="ai-label-container"
-        autoAlign={false}
-        size='mini'
-        >
+      <AILabel className="ai-label-container" autoAlign={false} size="mini">
         <AILabelContent>
           <div>
             <p className="secondary">AI Explained</p>
             <h1>84%</h1>
             <p className="secondary bold">Confidence score</p>
             <p className="secondary">
-              Lorem ipsum dolor sit amet, di os consectetur adipiscing elit, sed
-              do eiusmod tempor incididunt ut fsil labore et dolore magna
-              aliqua.
+              Lorem ipsum dolor sit amet, di os consectetur adipiscing elit, sed do eiusmod tempor
+              incididunt ut fsil labore et dolore magna aliqua.
             </p>
             <hr />
             <p className="secondary">Model type</p>
             <p className="bold">Foundation model</p>
           </div>
-     
+        </AILabelContent>
+      </AILabel>
+    ),
+  },
+  {
+    id: 'select',
+    name: 'Select',
+    filter: { placeholderText: 'pick an option', options: getSelectDataOptions() },
+    decorator: (
+      <AILabel className="ai-label-container" autoAlign={false} size="mini">
+        <AILabelContent>
+          <div>
+            <p className="secondary">AI Explained</p>
+            <h1>84%</h1>
+            <p className="secondary bold">Confidence score</p>
+            <p className="secondary">
+              Lorem ipsum dolor sit amet, di os consectetur adipiscing elit, sed do eiusmod tempor
+              incididunt ut fsil labore et dolore magna aliqua.
+            </p>
+            <hr />
+            <p className="secondary">Model type</p>
+            <p className="bold">Foundation model</p>
+          </div>
         </AILabelContent>
       </AILabel>
     ),
@@ -276,25 +287,22 @@ export const getTableColumns = () => [
   {
     id: 'secretField',
     name: 'Secret Information',
-    
   },
   {
     id: 'status',
     name: 'Status',
     renderDataFunction: renderStatusIcon,
-    sortFunction: customColumnSort
+    sortFunction: customColumnSort,
   },
   {
     id: 'number',
     name: 'Number',
     filter: { placeholderText: 'enter a number' },
-
   },
   {
     id: 'boolean',
     name: 'Boolean',
     filter: { placeholderText: 'true or false' },
-  
   },
   {
     id: 'node',
@@ -328,7 +336,6 @@ export const getTableColumns = () => [
     },
   },
 ];
-
 
 export const getTableCustomColumns = () => [
   {

--- a/packages/react/src/components/Table/Table.story.helpers.jsx
+++ b/packages/react/src/components/Table/Table.story.helpers.jsx
@@ -15,7 +15,7 @@ import {
   Add,
   Edit,
 } from '@carbon/react/icons';
-import { ComboBox, DatePickerInput, NumberInput } from '@carbon/react';
+import { AILabel, AILabelContent, ComboBox, DatePickerInput, NumberInput } from '@carbon/react';
 
 import { Checkbox } from '../Checkbox';
 import { TextInput } from '../TextInput';
@@ -222,6 +222,7 @@ export const getTableColumns = () => [
     id: 'string',
     name: 'String',
     filter: { placeholderText: 'enter a string' },
+   
   },
 
   {
@@ -241,7 +242,7 @@ export const getTableColumns = () => [
         }
         return columnValue.includes(filterValue);
       },
-    },
+    }
   },
   {
     id: 'select',
@@ -256,17 +257,42 @@ export const getTableColumns = () => [
     id: 'status',
     name: 'Status',
     renderDataFunction: renderStatusIcon,
-    sortFunction: customColumnSort,
+    sortFunction: customColumnSort
   },
   {
     id: 'number',
     name: 'Number',
     filter: { placeholderText: 'enter a number' },
+    decorator: (
+      <AILabel
+        className="ai-label-container"
+        autoAlign={false}
+        size='mini'
+        >
+        <AILabelContent>
+          <div>
+            <p className="secondary">AI Explained</p>
+            <h1>84%</h1>
+            <p className="secondary bold">Confidence score</p>
+            <p className="secondary">
+              Lorem ipsum dolor sit amet, di os consectetur adipiscing elit, sed
+              do eiusmod tempor incididunt ut fsil labore et dolore magna
+              aliqua.
+            </p>
+            <hr />
+            <p className="secondary">Model type</p>
+            <p className="bold">Foundation model</p>
+          </div>
+     
+        </AILabelContent>
+      </AILabel>
+    ),
   },
   {
     id: 'boolean',
     name: 'Boolean',
     filter: { placeholderText: 'true or false' },
+  
   },
   {
     id: 'node',
@@ -275,6 +301,7 @@ export const getTableColumns = () => [
   {
     id: 'object',
     name: 'Object Id',
+
     renderDataFunction: ({ value }) => {
       return value?.id;
     },
@@ -299,6 +326,7 @@ export const getTableColumns = () => [
     },
   },
 ];
+
 
 export const getTableCustomColumns = () => [
   {

--- a/packages/react/src/components/Table/Table.story.helpers.jsx
+++ b/packages/react/src/components/Table/Table.story.helpers.jsx
@@ -248,21 +248,6 @@ export const getTableColumns = () => [
     id: 'select',
     name: 'Select',
     filter: { placeholderText: 'pick an option', options: getSelectDataOptions() },
-  },
-  {
-    id: 'secretField',
-    name: 'Secret Information',
-  },
-  {
-    id: 'status',
-    name: 'Status',
-    renderDataFunction: renderStatusIcon,
-    sortFunction: customColumnSort
-  },
-  {
-    id: 'number',
-    name: 'Number',
-    filter: { placeholderText: 'enter a number' },
     decorator: (
       <AILabel
         className="ai-label-container"
@@ -287,6 +272,23 @@ export const getTableColumns = () => [
         </AILabelContent>
       </AILabel>
     ),
+  },
+  {
+    id: 'secretField',
+    name: 'Secret Information',
+    
+  },
+  {
+    id: 'status',
+    name: 'Status',
+    renderDataFunction: renderStatusIcon,
+    sortFunction: customColumnSort
+  },
+  {
+    id: 'number',
+    name: 'Number',
+    filter: { placeholderText: 'enter a number' },
+
   },
   {
     id: 'boolean',

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -321,7 +321,7 @@ const TableBodyRow = ({
           matchingColumnMeta && matchingColumnMeta.isSortable && matchingColumnMeta.align === 'end'
             ? matchingColumnMeta.isSortable
             : false;
-           
+
         return !col.isHidden ? (
           <TableCell
             id={`cell-${tableId}-${id}-${col.columnId}`}
@@ -333,8 +333,7 @@ const TableBodyRow = ({
             className={classnames(`data-table-${align}`, {
               [`${iotPrefix}--table__cell--truncate`]: truncateCellText,
               [`${iotPrefix}--table__cell--sortable`]: sortable,
-              [`cds--table-cell--column-slug`]: col.decorator
-              
+              [`cds--table-cell--column-slug`]: col.decorator,
             })}
             width={initialColumnWidth}
           >

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -321,6 +321,7 @@ const TableBodyRow = ({
           matchingColumnMeta && matchingColumnMeta.isSortable && matchingColumnMeta.align === 'end'
             ? matchingColumnMeta.isSortable
             : false;
+           
         return !col.isHidden ? (
           <TableCell
             id={`cell-${tableId}-${id}-${col.columnId}`}
@@ -332,6 +333,8 @@ const TableBodyRow = ({
             className={classnames(`data-table-${align}`, {
               [`${iotPrefix}--table__cell--truncate`]: truncateCellText,
               [`${iotPrefix}--table__cell--sortable`]: sortable,
+              [`cds--table-cell--column-slug`]: col.decorator
+              
             })}
             width={initialColumnWidth}
           >

--- a/packages/react/src/components/Table/TableBody/TableBodyRow/_table-expand-row.scss
+++ b/packages/react/src/components/Table/TableBody/TableBodyRow/_table-expand-row.scss
@@ -2,7 +2,7 @@
 @use '@carbon/react/scss/config' as *;
 @use '@carbon/react/scss/spacing' as *;
 @use '@carbon/react/scss/components/data-table' as *;
-
+@use '@carbon/react/scss/components/ai-label' as *;
 .#{$iot-prefix}--table-expand__button {
   &.#{$prefix}--btn--sm {
     min-height: unset;

--- a/packages/react/src/components/Table/TableHead/TableHead.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.jsx
@@ -687,6 +687,7 @@ const TableHead = ({
               translateWithId={(...args) => tableTranslateWithId(i18n, ...args)}
               sortDirection={sortDirection}
               align={align}
+              decorator={matchingColumnMeta?.decorator}
               className={classnames(`table-header-label-${align}`, {
                 [`${iotPrefix}--table-head--table-header`]: initialColumnWidths !== undefined,
                 'table-header-sortable': matchingColumnMeta.isSortable && !isDisabled,

--- a/packages/react/src/components/Table/TableHead/TableHeader.js
+++ b/packages/react/src/components/Table/TableHead/TableHeader.js
@@ -84,7 +84,7 @@ const TableHeader = React.forwardRef(function TableHeader(
     colHasAILabel = true;
     normalizedDecorator = React.cloneElement(normalizedDecorator, {
       ref: AILableRef,
-      className: 'ai-label-icon',
+      className: '',
       onClick: (event) => {
         event.preventDefault();
         event.stopPropagation();
@@ -114,7 +114,7 @@ const TableHeader = React.forwardRef(function TableHeader(
       >
         <div className={`${prefix}--table-header-label-container`}>
           {!hasTooltip ? (
-              <span className={`${prefix}--table-header-label`}>{children}</span>
+            <span className={`${prefix}--table-header-label`}>{children}</span>
           ) : (
             children
           )}
@@ -272,7 +272,7 @@ TableHeader.propTypes = {
   thStyle: PropTypes.object,
 
   testId: PropTypes.string,
-  decorator: PropTypes.node
+  decorator: PropTypes.node,
 };
 
 /* istanbul ignore next: ignoring the default onClick */
@@ -293,6 +293,7 @@ TableHeader.defaultProps = {
   thStyle: {},
   initialWidth: undefined,
   testId: '',
+  decorator: null,
 };
 
 TableHeader.translationKeys = Object.values(translationKeys);

--- a/packages/react/src/components/Table/TableHead/TableHeader.js
+++ b/packages/react/src/components/Table/TableHead/TableHeader.js
@@ -8,7 +8,7 @@
 
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useRef } from 'react';
 import { ArrowUp, ArrowDown, ArrowsVertical as Arrows } from '@carbon/react/icons';
 
 import { settings } from '../../../constants/Settings';
@@ -71,15 +71,47 @@ const TableHeader = React.forwardRef(function TableHeader(
     testId,
     spanGroupRow,
     rowSpan: rowSpanProp,
+    decorator,
     ...rest
   },
   ref
 ) {
+
+
+  const AILableRef = useRef();
+  let colHasAILabel;
+  let normalizedDecorator = React.isValidElement(decorator)
+    ? decorator
+    : null;
+   
+
+  if (
+    normalizedDecorator &&
+    normalizedDecorator['type']['render']?.name === 'AILabel'
+  ) {
+    colHasAILabel = true;
+    normalizedDecorator = React.cloneElement(
+      normalizedDecorator,
+      {
+        ref: AILableRef,
+        className:'ai-label-icon',
+        onClick:(event) => { 
+          event.preventDefault();
+          event.stopPropagation(); 
+        }
+      }
+    );
+  }
+
+
   const rowSpan = rowSpanProp ?? spanGroupRow ? '2' : undefined;
   const headerClassNames = classnames(headerClassName, {
     [`${iotPrefix}--table-header--span-group-row`]: spanGroupRow,
-  });
-
+    [`${prefix}--table-sort__header--ai-label ${prefix}--table-sort__header--decorator`]:
+    colHasAILabel,
+    });
+  
+  
   if (!isSortable) {
     return (
       // eslint-disable-next-line react/jsx-filename-extension
@@ -93,11 +125,20 @@ const TableHeader = React.forwardRef(function TableHeader(
         ref={ref}
         style={thStyle}
       >
+        <div className={`${prefix}--table-header-label-container`}>
         {!hasTooltip ? (
-          <span className={`${prefix}--table-header-label`}>{children}</span>
+          <>
+           <span className={`${prefix}--table-header-label`}>
+            {children}
+             </span>
+             
+          </>
+         
         ) : (
           children
         )}
+        {colHasAILabel ? normalizedDecorator  : ""}
+        </div>
       </th>
     );
   }
@@ -136,12 +177,15 @@ const TableHeader = React.forwardRef(function TableHeader(
       style={thStyle}
       data-testid={testId}
     >
+      
       <ButtonTag {...buttonProps}>
+      
         {!hasTooltip ? (
-          <span className={`${prefix}--table-header-label`}>{children}</span>
+          <span className={`${prefix}--table-header-label`}>{children} </span>
         ) : (
           children
         )}
+        
         {sortDirection === sortStates.ASC ? (
           <ArrowUp
             className={`${prefix}--table-sort__icon`}
@@ -173,7 +217,11 @@ const TableHeader = React.forwardRef(function TableHeader(
             sortStates,
           })}
         />
+       {colHasAILabel ? normalizedDecorator  : ""}
       </ButtonTag>
+     
+      
+      
     </th>
   );
 });

--- a/packages/react/src/components/Table/TableHead/TableHeader.js
+++ b/packages/react/src/components/Table/TableHead/TableHeader.js
@@ -76,42 +76,29 @@ const TableHeader = React.forwardRef(function TableHeader(
   },
   ref
 ) {
-
-
   const AILableRef = useRef();
   let colHasAILabel;
-  let normalizedDecorator = React.isValidElement(decorator)
-    ? decorator
-    : null;
-   
+  let normalizedDecorator = React.isValidElement(decorator) ? decorator : null;
 
-  if (
-    normalizedDecorator &&
-    normalizedDecorator?.type?.render?.name === 'AILabel'
-  ) {
+  if (normalizedDecorator && normalizedDecorator?.type?.render?.name === 'AILabel') {
     colHasAILabel = true;
-    normalizedDecorator = React.cloneElement(
-      normalizedDecorator,
-      {
-        ref: AILableRef,
-        className:'ai-label-icon',
-        onClick:(event) => { 
-          event.preventDefault();
-          event.stopPropagation(); 
-        }
-      }
-    );
+    normalizedDecorator = React.cloneElement(normalizedDecorator, {
+      ref: AILableRef,
+      className: 'ai-label-icon',
+      onClick: (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+      },
+    });
   }
-
 
   const rowSpan = rowSpanProp ?? spanGroupRow ? '2' : undefined;
   const headerClassNames = classnames(headerClassName, {
     [`${iotPrefix}--table-header--span-group-row`]: spanGroupRow,
     [`${prefix}--table-sort__header--ai-label ${prefix}--table-sort__header--decorator`]:
-    colHasAILabel,
-    });
-  
-  
+      colHasAILabel,
+  });
+
   if (!isSortable) {
     return (
       // eslint-disable-next-line react/jsx-filename-extension
@@ -126,18 +113,12 @@ const TableHeader = React.forwardRef(function TableHeader(
         style={thStyle}
       >
         <div className={`${prefix}--table-header-label-container`}>
-        {!hasTooltip ? (
-          <>
-           <span className={`${prefix}--table-header-label`}>
-            {children}
-             </span>
-             
-          </>
-         
-        ) : (
-          children
-        )}
-        {colHasAILabel ? normalizedDecorator  : ""}
+          {!hasTooltip ? (
+              <span className={`${prefix}--table-header-label`}>{children}</span>
+          ) : (
+            children
+          )}
+          {colHasAILabel ? normalizedDecorator : ''}
         </div>
       </th>
     );
@@ -177,15 +158,12 @@ const TableHeader = React.forwardRef(function TableHeader(
       style={thStyle}
       data-testid={testId}
     >
-      
       <ButtonTag {...buttonProps}>
-      
         {!hasTooltip ? (
           <span className={`${prefix}--table-header-label`}>{children} </span>
         ) : (
           children
         )}
-        
         {sortDirection === sortStates.ASC ? (
           <ArrowUp
             className={`${prefix}--table-sort__icon`}
@@ -217,11 +195,8 @@ const TableHeader = React.forwardRef(function TableHeader(
             sortStates,
           })}
         />
-       {colHasAILabel ? normalizedDecorator  : ""}
+        {colHasAILabel ? normalizedDecorator : ''}
       </ButtonTag>
-     
-      
-      
     </th>
   );
 });
@@ -297,8 +272,7 @@ TableHeader.propTypes = {
   thStyle: PropTypes.object,
 
   testId: PropTypes.string,
-
-  decorator:PropTypes.node
+  decorator: PropTypes.node.n,
 };
 
 /* istanbul ignore next: ignoring the default onClick */

--- a/packages/react/src/components/Table/TableHead/TableHeader.js
+++ b/packages/react/src/components/Table/TableHead/TableHeader.js
@@ -87,7 +87,7 @@ const TableHeader = React.forwardRef(function TableHeader(
 
   if (
     normalizedDecorator &&
-    normalizedDecorator['type']['render']?.name === 'AILabel'
+    normalizedDecorator?.type?.render?.name === 'AILabel'
   ) {
     colHasAILabel = true;
     normalizedDecorator = React.cloneElement(
@@ -297,6 +297,8 @@ TableHeader.propTypes = {
   thStyle: PropTypes.object,
 
   testId: PropTypes.string,
+
+  decorator:PropTypes.node
 };
 
 /* istanbul ignore next: ignoring the default onClick */

--- a/packages/react/src/components/Table/TableHead/TableHeader.js
+++ b/packages/react/src/components/Table/TableHead/TableHeader.js
@@ -272,7 +272,7 @@ TableHeader.propTypes = {
   thStyle: PropTypes.object,
 
   testId: PropTypes.string,
-  decorator: PropTypes.node.n,
+  decorator: PropTypes.node
 };
 
 /* istanbul ignore next: ignoring the default onClick */

--- a/packages/react/src/components/Table/TableHead/_table-head.scss
+++ b/packages/react/src/components/Table/TableHead/_table-head.scss
@@ -14,7 +14,7 @@
 @use 'FilterHeaderRow/filter-header-row' as *;
 @use '@carbon/react/scss/components/data-table/sort' as *;
 @use '@carbon/react/scss/components/ai-label' as *;
-@use '@carbon/react/scss/utilities/ai-gradient' as *;
+@use '@carbon/react/scss/utilities' as *;
 .#{$prefix}--data-table {
   th {
     height: $spacing-09;

--- a/packages/react/src/components/Table/TableHead/_table-head.scss
+++ b/packages/react/src/components/Table/TableHead/_table-head.scss
@@ -13,7 +13,8 @@
 @use 'ColumnHeaderRow/column-header-row' as *;
 @use 'FilterHeaderRow/filter-header-row' as *;
 @use '@carbon/react/scss/components/data-table/sort' as *;
-
+@use '@carbon/react/scss/components/ai-label' as *;
+@use '@carbon/react/scss/utilities/ai-gradient' as *;
 .#{$prefix}--data-table {
   th {
     height: $spacing-09;
@@ -27,8 +28,29 @@
     }
   }
 
-  th[aria-sort] {
+  th[aria-sort]:not(.cds--table-sort__header--ai-label) {
     padding-left: 1rem;
+  }
+
+  th.#{$prefix}--table-sort__header--ai-label{
+    @include ai-table-gradient();
+  }
+
+  th.#{$prefix}--table-sort__header--ai-label:not(.table-header-sortable){
+    .#{$prefix}--table-header-label-container {
+    display: flex;
+    align-items: center;
+    .cds--table-header-label{
+      margin-right: 1rem;;
+      width: 100%;
+    }
+    }
+    
+  }
+
+  
+  th[aria-sort].#{$prefix}--table-sort__header--ai-label span.#{$prefix}--popover-container {
+    padding-left:  1rem;
   }
 
   // override sort icons, so they stay in the middle, at xl size, too.

--- a/packages/react/src/components/Table/TableHead/_table-head.scss
+++ b/packages/react/src/components/Table/TableHead/_table-head.scss
@@ -32,25 +32,29 @@
     padding-left: $spacing-05;
   }
 
-  th.#{$prefix}--table-sort__header--ai-label{
+  th.#{$prefix}--table-sort__header--ai-label,
+  th.#{$prefix}--table-sort__header--ai-label .cds--table-sort {
     @include ai-table-gradient();
   }
 
-  th.#{$prefix}--table-sort__header--ai-label:not(.table-header-sortable){
+  th.#{$prefix}--table-sort__header--ai-label:not(.table-header-sortable) {
     .#{$prefix}--table-header-label-container {
-    display: flex;
-    align-items: center;
-    .cds--table-header-label{
-      margin-right: $spacing-05;
-      width: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      .cds--table-header-label {
+        margin-right: $spacing-05;
+        width: 100%;
+      }
     }
-    }
-    
   }
 
-  
   th[aria-sort].#{$prefix}--table-sort__header--ai-label span.#{$prefix}--popover-container {
-    padding-left:  1rem;
+    padding-left: 1rem;
+  }
+
+  th[aria-sort].#{$prefix}--table-sort__header--ai-label .cds--ai-label {
+    padding-right: 1rem;
   }
 
   // override sort icons, so they stay in the middle, at xl size, too.

--- a/packages/react/src/components/Table/TableHead/_table-head.scss
+++ b/packages/react/src/components/Table/TableHead/_table-head.scss
@@ -29,7 +29,7 @@
   }
 
   th[aria-sort]:not(.cds--table-sort__header--ai-label) {
-    padding-left: 1rem;
+    padding-left: $spacing-05;
   }
 
   th.#{$prefix}--table-sort__header--ai-label{
@@ -41,7 +41,7 @@
     display: flex;
     align-items: center;
     .cds--table-header-label{
-      margin-right: 1rem;;
+      margin-right: $spacing-05;
       width: 100%;
     }
     }

--- a/packages/react/src/components/Table/_table.scss
+++ b/packages/react/src/components/Table/_table.scss
@@ -168,7 +168,6 @@ button.#{$prefix}--btn.#{$iot-prefix}--tooltip-svg-wrapper.#{$prefix}--btn--ghos
   padding-left: 1rem;
   border-top: 1px solid $icon-on-color;
   border-bottom: 1px solid $layer-selected-01;
-  background: $icon-on-color;
   color: $text-secondary;
 }
 

--- a/packages/react/src/components/Table/_table.scss
+++ b/packages/react/src/components/Table/_table.scss
@@ -19,6 +19,7 @@
 @use '@carbon/react/scss/components/data-table' as *;
 @use '@carbon/react/scss/components/data-table/action' as *;
 @use '@carbon/react/scss/components/ai-label' as *;
+
 table.#{$prefix}--side-nav--data-table {
   white-space: nowrap;
 }
@@ -167,7 +168,7 @@ button.#{$prefix}--btn.#{$iot-prefix}--tooltip-svg-wrapper.#{$prefix}--btn--ghos
   padding-left: 1rem;
   border-top: 1px solid $icon-on-color;
   border-bottom: 1px solid $layer-selected-01;
- // background: $icon-on-color;
+  background: $icon-on-color;
   color: $text-secondary;
 }
 

--- a/packages/react/src/components/Table/_table.scss
+++ b/packages/react/src/components/Table/_table.scss
@@ -18,7 +18,7 @@
 @use '@carbon/react/scss/components/data-table/sort/data-table-sort' as *;
 @use '@carbon/react/scss/components/data-table' as *;
 @use '@carbon/react/scss/components/data-table/action' as *;
-
+@use '@carbon/react/scss/components/ai-label' as *;
 table.#{$prefix}--side-nav--data-table {
   white-space: nowrap;
 }
@@ -167,7 +167,7 @@ button.#{$prefix}--btn.#{$iot-prefix}--tooltip-svg-wrapper.#{$prefix}--btn--ghos
   padding-left: 1rem;
   border-top: 1px solid $icon-on-color;
   border-bottom: 1px solid $layer-selected-01;
-  background: $icon-on-color;
+ // background: $icon-on-color;
   color: $text-secondary;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2002,6 +2002,13 @@
   dependencies:
     "@ibm/telemetry-js" "^1.5.0"
 
+"@carbon/colors@^11.30.0":
+  version "11.30.0"
+  resolved "https://registry.yarnpkg.com/@carbon/colors/-/colors-11.30.0.tgz#a4dfd1372558338618fd04f2b36318d5b1d9e95e"
+  integrity sha512-DvTOv6yLpSnPVFJdNeW6dqo4KlpbmFBQvEM0HI/PP7WVcox8QEJKyw5SkEo/lK23pVg6xzBOQKIMLrouNAkWoQ==
+  dependencies:
+    "@ibm/telemetry-js" "^1.5.0"
+
 "@carbon/feature-flags@^0.24.0":
   version "0.24.0"
   resolved "https://registry.yarnpkg.com/@carbon/feature-flags/-/feature-flags-0.24.0.tgz#4a1f01d4a09c0489edfb062702fdfe04cc5f1f8e"
@@ -2017,10 +2024,25 @@
     "@carbon/layout" "^11.28.0"
     "@ibm/telemetry-js" "^1.5.0"
 
+"@carbon/grid@^11.32.0":
+  version "11.32.0"
+  resolved "https://registry.yarnpkg.com/@carbon/grid/-/grid-11.32.0.tgz#68e16df9dd19afda157331ec3d1411f0d8f7d86c"
+  integrity sha512-O8QkUoOglhmOgZ7cvxUSy9I+G+eY/k9t1BnqunHGs7xIswkXeFxOwvUPbcUbrVoNu4rMP8eXv91Eq/f3QpV/Jg==
+  dependencies:
+    "@carbon/layout" "^11.30.0"
+    "@ibm/telemetry-js" "^1.5.0"
+
 "@carbon/icon-helpers@^10.54.0":
   version "10.54.0"
   resolved "https://registry.yarnpkg.com/@carbon/icon-helpers/-/icon-helpers-10.54.0.tgz#ff8171c66628f3436e3598e5bf20ce7f75194fe1"
   integrity sha512-IJ6uzwRA/6yvSG6tTCQoKIcGehwZYYqjvLHylILmEwyfB8kWV9VmJu957hfrfbS2rmuCXwmN6kCAnb4WS8FnFw==
+  dependencies:
+    "@ibm/telemetry-js" "^1.5.0"
+
+"@carbon/icon-helpers@^10.56.0":
+  version "10.56.0"
+  resolved "https://registry.yarnpkg.com/@carbon/icon-helpers/-/icon-helpers-10.56.0.tgz#a4fceaf33c48f3246273bf0be75ff29adda794e0"
+  integrity sha512-D7xiWI0V5yUPrmycBaP/M7W/TTKbLl0lFvdC8GftcUS/QB+WTpwJCQxARIGW0b+X7hpgins1urDDHYAUDqWHXQ==
   dependencies:
     "@ibm/telemetry-js" "^1.5.0"
 
@@ -2033,6 +2055,15 @@
     "@ibm/telemetry-js" "^1.5.0"
     prop-types "^15.7.2"
 
+"@carbon/icons-react@^11.57.0":
+  version "11.57.0"
+  resolved "https://registry.yarnpkg.com/@carbon/icons-react/-/icons-react-11.57.0.tgz#6c2ac21d789654e84d0a5c57266bf77a6ae99e41"
+  integrity sha512-N578SANLJfu5kKYF0jXSa9cFccd8nkg4GMZltoxN5/U6lmCjP2kPRq/zOuH3GXbzXwUlMztdx9A+m3KeaqLi2g==
+  dependencies:
+    "@carbon/icon-helpers" "^10.56.0"
+    "@ibm/telemetry-js" "^1.5.0"
+    prop-types "^15.7.2"
+
 "@carbon/layout@^11.28.0":
   version "11.28.0"
   resolved "https://registry.yarnpkg.com/@carbon/layout/-/layout-11.28.0.tgz#7bcff327518c05e6a9e9e5f54bb11f2c3d7c4685"
@@ -2040,10 +2071,17 @@
   dependencies:
     "@ibm/telemetry-js" "^1.5.0"
 
-"@carbon/motion@^11.24.0":
-  version "11.24.0"
-  resolved "https://registry.yarnpkg.com/@carbon/motion/-/motion-11.24.0.tgz#0ec14cba5e7974d2b08f63d1216d566c54d7deed"
-  integrity sha512-JtsSQ3DgVqZXpOdKthetUi5Tp94jkWffgxgrEylbNYErITNt7PeSF6YTXnqtSldk/dUCBkfD1kXkfH1NAxrr1w==
+"@carbon/layout@^11.30.0":
+  version "11.30.0"
+  resolved "https://registry.yarnpkg.com/@carbon/layout/-/layout-11.30.0.tgz#a394658a717cab89e1517794869405156ac1145c"
+  integrity sha512-r/z1tvTkBfZu0Mk6r0QDYVvi67TT8NSIA4cJHTng4F+GiBu1VBpiHHYYMvdFzqYGhqKMVtER4hp9mldRBn00dQ==
+  dependencies:
+    "@ibm/telemetry-js" "^1.5.0"
+
+"@carbon/motion@^11.25.0":
+  version "11.25.0"
+  resolved "https://registry.yarnpkg.com/@carbon/motion/-/motion-11.25.0.tgz#854c1e906c7b35333786ebf8c8f1c83701ef09e4"
+  integrity sha512-oqrXmWmlVuXmKhHG1dUm4zy2TR8CGYqcentDcMEAJqcvlF1qhDuF/1j0JQ0X7mOl3/suGBtBsxCoC5CN8KO1IQ==
   dependencies:
     "@ibm/telemetry-js" "^1.5.0"
 
@@ -2056,45 +2094,42 @@
     "@ibm/telemetry-js" "^1.5.0"
     prop-types "^15.7.2"
 
-"@carbon/react@^1.72.0":
-  version "1.72.0"
-  resolved "https://registry.yarnpkg.com/@carbon/react/-/react-1.72.0.tgz#ce4fee6e6ba45c6fde4fea4a6b9c382a267adf63"
-  integrity sha512-cQdf7EDeu7E4fTjP/vqfni4buc8V7XHw2YIlGVeRlLXVSc3WdoJgimLYaKUV4o0vvoqQvmiDEKDu0XdT7USJiw==
+"@carbon/react@^1.78.0":
+  version "1.78.0"
+  resolved "https://registry.yarnpkg.com/@carbon/react/-/react-1.78.0.tgz#dfe562a465afd5e4c8338c6907e711347a526d4d"
+  integrity sha512-fOg8H2uAMQVwN3Rd1YaZ07jOOhi99F3zEQ71xpTGRHw2dWbN+g18wuZFV9dEYqzg10CxZ6wuNGD3DFodRdLjiQ==
   dependencies:
     "@babel/runtime" "^7.24.7"
     "@carbon/feature-flags" "^0.24.0"
-    "@carbon/icons-react" "^11.53.0"
-    "@carbon/layout" "^11.28.0"
-    "@carbon/styles" "^1.71.0"
-    "@floating-ui/react" "^0.26.0"
+    "@carbon/icons-react" "^11.57.0"
+    "@carbon/layout" "^11.30.0"
+    "@carbon/styles" "^1.77.0"
+    "@floating-ui/react" "^0.27.4"
     "@ibm/telemetry-js" "^1.5.0"
     classnames "2.5.1"
     copy-to-clipboard "^3.3.1"
     downshift "9.0.8"
+    es-toolkit "^1.27.0"
     flatpickr "4.6.13"
     invariant "^2.2.3"
-    lodash.debounce "^4.0.8"
-    lodash.omit "^4.5.0"
-    lodash.throttle "^4.1.1"
     prop-types "^15.7.2"
     react-fast-compare "^3.2.2"
-    react-is "^18.2.0"
     tabbable "^6.2.0"
     use-resize-observer "^6.0.0"
     window-or-global "^1.0.1"
 
-"@carbon/styles@^1.71.0":
-  version "1.71.0"
-  resolved "https://registry.yarnpkg.com/@carbon/styles/-/styles-1.71.0.tgz#de67fc603f290d0e22450f3ff2d8adb08831ebb4"
-  integrity sha512-tkQ/Ub7QYHCyFqXJMCe7+Dbpypx7pCefJCeEEluEqpeVSfLu1qtRMZUftfndvzChIZUXtm+ImpHtRknRnyS3+g==
+"@carbon/styles@^1.77.0":
+  version "1.77.0"
+  resolved "https://registry.yarnpkg.com/@carbon/styles/-/styles-1.77.0.tgz#ab951a38ad4944155357b6d77335245b4d7b6eb4"
+  integrity sha512-PkiU35E6s7fUhFp6RgwEbA/BvipQ9EbMfu5kKjCoI0BH+LNyqnkNU69sEqZJ+pSXFhl7y+eGjVgByARvULXgwA==
   dependencies:
-    "@carbon/colors" "^11.28.0"
+    "@carbon/colors" "^11.30.0"
     "@carbon/feature-flags" "^0.24.0"
-    "@carbon/grid" "^11.29.0"
-    "@carbon/layout" "^11.28.0"
-    "@carbon/motion" "^11.24.0"
-    "@carbon/themes" "^11.43.0"
-    "@carbon/type" "^11.33.0"
+    "@carbon/grid" "^11.32.0"
+    "@carbon/layout" "^11.30.0"
+    "@carbon/motion" "^11.25.0"
+    "@carbon/themes" "^11.48.0"
+    "@carbon/type" "^11.36.0"
     "@ibm/plex" "6.0.0-next.6"
     "@ibm/plex-mono" "0.0.3-alpha.0"
     "@ibm/plex-sans" "0.0.3-alpha.0"
@@ -2122,6 +2157,17 @@
     "@ibm/telemetry-js" "^1.5.0"
     color "^4.0.0"
 
+"@carbon/themes@^11.48.0":
+  version "11.48.0"
+  resolved "https://registry.yarnpkg.com/@carbon/themes/-/themes-11.48.0.tgz#1d41c5e39f80cee416a7913e8bc62339e2c8ddc6"
+  integrity sha512-MrDUdaY/VjsDzmeII94wcKKlamZpEfcsU7JO6Jz2Ums7TT+zhglH0JSUEJclwzeMwnKNgEhKUiBZjQYNmz3nLQ==
+  dependencies:
+    "@carbon/colors" "^11.30.0"
+    "@carbon/layout" "^11.30.0"
+    "@carbon/type" "^11.36.0"
+    "@ibm/telemetry-js" "^1.5.0"
+    color "^4.0.0"
+
 "@carbon/type@^11.33.0":
   version "11.33.0"
   resolved "https://registry.yarnpkg.com/@carbon/type/-/type-11.33.0.tgz#c09de4da5e0ccee69f683aa66067ee35730d188e"
@@ -2129,6 +2175,15 @@
   dependencies:
     "@carbon/grid" "^11.29.0"
     "@carbon/layout" "^11.28.0"
+    "@ibm/telemetry-js" "^1.5.0"
+
+"@carbon/type@^11.36.0":
+  version "11.36.0"
+  resolved "https://registry.yarnpkg.com/@carbon/type/-/type-11.36.0.tgz#e6fdbd8de90ba8a051de080d6ec83d0e2fda9ca8"
+  integrity sha512-SL0LQTyRoPeifHZy9KFMNheas4qa6BvdvADkd0E4L2tG6JOijpqkicRQ/OnCe5Z/DfIdqe7Qj+0Qm5uGz6G69Q==
+  dependencies:
+    "@carbon/grid" "^11.32.0"
+    "@carbon/layout" "^11.30.0"
     "@ibm/telemetry-js" "^1.5.0"
 
 "@carbon/utils-position@^1.3.0":
@@ -2858,26 +2913,31 @@
     "@floating-ui/core" "^1.0.0"
     "@floating-ui/utils" "^0.2.0"
 
-"@floating-ui/react-dom@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.0.tgz#4f0e5e9920137874b2405f7d6c862873baf4beff"
-  integrity sha512-lNzj5EQmEKn5FFKc04+zasr09h/uX8RtJRNj5gUXsSQIXHVWTVh+hVAg1vOMCexkX8EgvemMvIFpQfkosnVNyA==
+"@floating-ui/react-dom@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.2.tgz#a1349bbf6a0e5cb5ded55d023766f20a4d439a31"
+  integrity sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==
   dependencies:
     "@floating-ui/dom" "^1.0.0"
 
-"@floating-ui/react@^0.26.0":
-  version "0.26.17"
-  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.26.17.tgz#efa2e1a0dea3d9d308965c5ccd49756bb64a883d"
-  integrity sha512-ESD+jYWwqwVzaIgIhExrArdsCL1rOAzryG/Sjlu8yaD3Mtqi3uVyhbE2V7jD58Mo52qbzKz2eUY/Xgh5I86FCQ==
+"@floating-ui/react@^0.27.4":
+  version "0.27.5"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.27.5.tgz#27a6e63a8ef35eb8712ef304a154ea706da26814"
+  integrity sha512-BX3jKxo39Ba05pflcQmqPPwc0qdNsdNi/eweAFtoIdrJWNen2sVEWMEac3i6jU55Qfx+lOcdMNKYn2CtWmlnOQ==
   dependencies:
-    "@floating-ui/react-dom" "^2.1.0"
-    "@floating-ui/utils" "^0.2.0"
+    "@floating-ui/react-dom" "^2.1.2"
+    "@floating-ui/utils" "^0.2.9"
     tabbable "^6.0.0"
 
 "@floating-ui/utils@^0.2.0":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.2.tgz#d8bae93ac8b815b2bd7a98078cf91e2724ef11e5"
   integrity sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw==
+
+"@floating-ui/utils@^0.2.9":
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.9.tgz#50dea3616bc8191fb8e112283b49eaff03e78429"
+  integrity sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==
 
 "@gar/promisify@^1.0.1", "@gar/promisify@^1.1.3":
   version "1.1.3"
@@ -10098,6 +10158,11 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+es-toolkit@^1.27.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/es-toolkit/-/es-toolkit-1.33.0.tgz#bcc9d92ef2e1ed4618c00dd30dfda9faddf4a0b7"
+  integrity sha512-X13Q/ZSc+vsO1q600bvNK4bxgXMkHcf//RxCmYDaRY5DAcT+eoXjY5hoAPGMdRnWQjvyLEcyauG3b6hz76LNqg==
+
 es6-error@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
@@ -14548,11 +14613,6 @@ lodash.memoize@~3.0.3:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"
   integrity sha512-eDn9kqrAmVUC1wmZvlQ6Uhde44n+tXpqPrN8olQJbttgh0oKclk+SF54P47VEGE9CEiMeRwAP8BaM7UHvBkz2A==
 
-lodash.omit@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
-  integrity sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==
-
 lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
@@ -14577,11 +14637,6 @@ lodash.templatesettings@^4.0.0:
   integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
   dependencies:
     lodash._reinterpolate "^3.0.0"
-
-lodash.throttle@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
-  integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
 
 lodash.truncate@^4.4.2:
   version "4.4.2"
@@ -17818,7 +17873,7 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-is@^18.0.0, react-is@^18.2.0:
+react-is@^18.0.0:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==


### PR DESCRIPTION
Closes #

**Summary**
I upgraded Carbon 1.72.0 to 1.78.0 because I need to use AILabel component introduced in Carbon lib. after that I create a props for table column and name is decorator. we can pass decorator with column information and check root element is AILabel then only it will render in column header.

- summary_here

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
