### PR TITLE
fix: aligned nested Load More Button in Table and List

### DIFF
--- a/packages/react/src/components/List/_list.scss
+++ b/packages/react/src/components/List/_list.scss
@@ -86,6 +86,7 @@
     cursor: pointer;
     min-width: 100%;
     background: $layer-01;
+    justify-content: unset;
     &--content {
       color: $button-primary;
     }

--- a/packages/react/src/components/Table/TableBody/TableBodyLoadMoreRow/TableBodyLoadMoreRow.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyLoadMoreRow/TableBodyLoadMoreRow.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { TableRow, TableCell } from '@carbon/react';
+import classNames from 'classnames';
 
 import { settings } from '../../../../constants/Settings';
 import Button from '../../../Button';
@@ -8,7 +9,7 @@ import SkeletonRow from '../SkeletonRow';
 import { TableColumnsPropTypes } from '../../TablePropTypes';
 import { HtmlElementRefProp } from '../../../../constants/SharedPropTypes';
 
-const { iotPrefix } = settings;
+const { iotPrefix, prefix } = settings;
 
 const propTypes = {
   /** The unique row id */
@@ -38,6 +39,8 @@ const propTypes = {
   hasRowActions: PropTypes.bool,
   /** shows an additional column that can expand/shrink as the table is resized  */
   showExpanderColumn: PropTypes.bool,
+  /** offset level if row is nested */
+  nestingLevel: PropTypes.number,
   rowVisibilityRef: HtmlElementRefProp,
 };
 
@@ -48,6 +51,7 @@ const defaultProps = {
   hasRowNesting: false,
   hasRowSelection: false,
   showExpanderColumn: false,
+  nestingLevel: 0,
   rowVisibilityRef: undefined,
 };
 
@@ -63,10 +67,21 @@ const TableBodyLoadMoreRow = ({
   hasRowNesting,
   hasRowSelection,
   showExpanderColumn,
+  nestingLevel,
   columns,
   totalColumns,
   isLoadingMore,
 }) => {
+  const singleSelectionIndicatorWidth = hasRowSelection === 'single' ? 0 : 5;
+  const nestingLevelPixels = nestingLevel * 32;
+
+  // if this a single hierarchy (i.e. only 1 level of nested children), do NOT show the gray offset
+  const nestingOffset = hasRowNesting?.hasSingleNestedHierarchy
+    ? 0
+    : hasRowSelection === 'single'
+    ? nestingLevelPixels - singleSelectionIndicatorWidth
+    : nestingLevelPixels;
+
   return isLoadingMore ? (
     <SkeletonRow
       id={id}
@@ -81,7 +96,18 @@ const TableBodyLoadMoreRow = ({
       showExpanderColumn={showExpanderColumn}
     />
   ) : (
-    <TableRow isSelected={false}>
+    <TableRow
+      isSelected={false}
+      className={classNames(`${iotPrefix}--expandable-tablerow--expanded`, {
+        [`${iotPrefix}--expandable-tablerow--indented`]: parseInt(nestingOffset, 10) > 0,
+        [`${iotPrefix}--expandable-tablerow--childless`]: hasRowNesting,
+      })}
+      data-nesting-offset={nestingOffset}
+      style={{
+        '--row-nesting-offset': `${nestingOffset}px`,
+      }}
+    >
+      {(hasRowExpansion || hasRowNesting) && <TableCell className={`${prefix}--table-expand`} />}
       <TableCell
         key={`${tableId}-${id}-row-load-more-cell`}
         colSpan={totalColumns}
@@ -89,7 +115,7 @@ const TableBodyLoadMoreRow = ({
         data-testid={`${testId}-${id}-load-more`}
       >
         <Button
-          className={`${iotPrefix}--load-more-cell--content`}
+          className={`${iotPrefix}--load-more-cell--content ${iotPrefix}--table__cell__offset`}
           onClick={() => onRowLoadMore(id)}
           kind="ghost"
           loading={isLoadingMore}

--- a/packages/react/src/components/Table/TableBody/TableBodyRowRenderer.jsx
+++ b/packages/react/src/components/Table/TableBody/TableBodyRowRenderer.jsx
@@ -333,6 +333,7 @@ const TableBodyRowRenderer = (props) => {
       hasRowNesting={hasRowNesting}
       hasRowSelection={hasRowSelection}
       showExpanderColumn={showExpanderColumn}
+      nestingLevel={nestingLevel}
       columns={columns}
       totalColumns={totalColumns}
       isLoadingMore={loadingMoreIds.includes(row.id)}
@@ -365,7 +366,7 @@ const TableBodyRowRenderer = (props) => {
               {...props}
               key={`load-more-row-${row.id}`}
               row={{ id: row.id, isLoadMoreRow: true }}
-              nestingLevel={nestingLevel}
+              nestingLevel={nestingLevel + 1}
               onStartDrag={onStartDrag}
               onDragLeaveRow={onDragLeaveRow}
               onDragEnterRow={onDragEnterRow}


### PR DESCRIPTION
Closes #

**Summary**

- Aligned Load More button with nested children row in Table
- Aligned View More button in List

**Change List (commits, features, bugs, etc)**

- fix: aligned nested Load More Button in Table

**Acceptance Test (how to verify the PR)**
<img width="456" alt="image" src="https://github.com/user-attachments/assets/d8d3d751-82bb-4361-85a2-674491132ea0" />

<img width="1373" alt="image" src="https://github.com/user-attachments/assets/acaa4b8b-5068-4e96-a98f-f2a0a7625f0c" />

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [x] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
