### PR TITLE
XSMALL depreciation warning removed 

### DIFF
--- a/packages/react/src/utils/cardUtilityFunctions.js
+++ b/packages/react/src/utils/cardUtilityFunctions.js
@@ -92,9 +92,7 @@ export const compareGrains = (grain1, grain2) => {
 
 export const getUpdatedCardSize = (oldSize) => {
   const changedSize =
-    oldSize === 'XSMALL'
-      ? 'SMALL'
-      : oldSize === 'XSMALLWIDE'
+    oldSize === 'XSMALLWIDE'
       ? 'SMALLWIDE'
       : oldSize === 'WIDE'
       ? 'MEDIUMWIDE'


### PR DESCRIPTION
Closes #

**Summary**
in ValueCard component have a CARD_SIZES and in that XSMALL is under LEGACY_CARD_SIZES but in Operation dashboard and other places XSMALL is using so in console unwanted warning displaying so added XSMALL in CARD_SIZES

- summary_here

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
