### PR TITLE
Table Header font-waight with tooltip and without tooltip should be same

### DIFF
--- a/packages/react/src/components/Table/TableHead/TableHead.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.jsx
@@ -548,6 +548,7 @@ const TableHead = ({
 
   const visibleColumns = ordering.filter((col) => !col.isHidden);
   const lastVisibleColumn = visibleColumns.slice(-1)[0];
+  const firstVisibleColumn = visibleColumns[0];
   const showColumnGroups = columnGroups.some(({ id }) =>
     visibleColumns.find(({ columnGroupId }) => id === columnGroupId)
   );
@@ -659,6 +660,7 @@ const TableHead = ({
 
           const rightmostColumn = langDir === 'ltr' ? lastVisibleColumn : visibleColumns[0];
           const flipTooltipDirection = rightmostColumn === item;
+          const flipFirstColumnTooltipDirection = firstVisibleColumn === item;
 
           return !item.isHidden && matchingColumnMeta ? (
             <TableHeader
@@ -706,7 +708,13 @@ const TableHead = ({
                 truncateCellText={truncateCellText}
                 allowTooltip={false}
                 tooltip={matchingColumnMeta.tooltip}
-                tooltipDirection={flipTooltipDirection ? 'bottom-end' : undefined}
+                tooltipDirection={
+                  flipTooltipDirection
+                    ? 'bottom-end'
+                    : flipFirstColumnTooltipDirection
+                    ? 'bottom-start'
+                    : undefined
+                }
               >
                 {matchingColumnMeta.name}
               </TableCellRenderer>

--- a/packages/react/src/components/Table/TableHead/_table-head.scss
+++ b/packages/react/src/components/Table/TableHead/_table-head.scss
@@ -49,6 +49,10 @@
     padding-left: 1rem;
   }
 
+  th button.#{$prefix}--definition-term {
+    font-weight: 600;
+  }
+
   th[aria-sort].#{$prefix}--table-sort__header--ai-label #{$prefix}--ai-label {
     padding-right: 1rem;
   }


### PR DESCRIPTION

Closes #

**Summary**
- Table Header font-waight should be same with tooltip and without tooltip. its was font-waight:400 with tooltip link so its not consistance so make it same
- First column tooltip was in center so its not visible so check its a first column and tooptip start with bottom-start.

Before title wihout bold
![image](https://github.com/user-attachments/assets/8fc5857a-1306-41e3-9869-74652ffba308)
after
![image](https://github.com/user-attachments/assets/73137027-829b-40be-b1ff-29c8d28fc23b)



Before
![image](https://github.com/user-attachments/assets/9ef62765-b6e9-486c-8841-a077e3f64819)

after
![image](https://github.com/user-attachments/assets/1bb7b0f4-b75d-4ec8-b8d8-a0aac68f2447)

- summary_here

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
