### PR TITLE
fix(pagewizardstep): display extra content to the left

### DIFF
--- a/packages/react/src/components/PageWizard/PageWizard.story.jsx
+++ b/packages/react/src/components/PageWizard/PageWizard.story.jsx
@@ -243,6 +243,32 @@ export const content = [
   </PageWizardStep>,
 ];
 
+const commonProps = {
+  title: 'A cool PageWizard!',
+  description: 'The description from the PageTitleBar',
+  breadcrumb: [
+    <Link to="www.ibm.com">Home</Link>,
+    <Link to="www.ibm.com">Something</Link>,
+    <Link to="www.ibm.com">Something Else</Link>,
+  ],
+};
+
+const customFooterContent = (content) => (
+  <div
+    style={{
+      display: 'flex',
+      alignItems: 'center',
+      fontWeight: 600,
+      fontSize: '1rem',
+      lineHeight: '1.375rem',
+      letterSpacing: 0,
+    }}
+  >
+    <InformationFilled size={20} style={{ marginRight: '0.5rem' }} />
+    {text(content, content)}
+  </div>
+);
+
 export const StepValidationWizard = ({ ...props }) => {
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
@@ -324,211 +350,183 @@ export default {
 };
 
 export const StatefulExample = () => (
-  <div>
-    <StatefulPageWizard
-      currentStepId="step1"
-      onClose={action('closed', () => {})}
-      onSubmit={action('submit', () => {})}
-      onClearError={action('Clear error', () => {})}
-      onNext={action('next', () => {})}
-      onBack={action('back', () => {})}
-      setStep={action('step clicked', () => {})}
-      isClickable
-    >
-      {content}
-    </StatefulPageWizard>
-  </div>
+  <StatefulPageWizard
+    currentStepId="step1"
+    onClose={action('closed', () => {})}
+    onSubmit={action('submit', () => {})}
+    onClearError={action('Clear error', () => {})}
+    onNext={action('next', () => {})}
+    onBack={action('back', () => {})}
+    setStep={action('step clicked', () => {})}
+    isClickable
+  >
+    {content}
+  </StatefulPageWizard>
 );
 
 StatefulExample.storyName = 'stateful example';
 
 export const StatefulExampleWValidationInPageTitleBar = () => (
-  <div>
-    <PageTitleBar
-      title="A cool PageWizard!"
-      description="The description from the PageTitleBar"
-      breadcrumb={[
-        <Link to="www.ibm.com">Home</Link>,
-        <Link to="www.ibm.com">Something</Link>,
-        <Link to="www.ibm.com">Something Else</Link>,
-      ]}
-      content={<StepValidationWizard stepWidth={number('stepWidth', 6)} />}
-    />
-  </div>
+  <PageTitleBar
+    {...commonProps}
+    content={<StepValidationWizard stepWidth={number('stepWidth', 6)} />}
+  />
 );
 
 StatefulExampleWValidationInPageTitleBar.storyName =
   'stateful example w/ validation in PageTitleBar';
 
 export const WrappedInPageTitleBar = () => (
-  <div>
-    <PageTitleBar
-      title="A cool PageWizard!"
-      description="The description from the PageTitleBar"
-      breadcrumb={[
-        <Link to="www.ibm.com">Home</Link>,
-        <Link to="www.ibm.com">Something</Link>,
-        <Link to="www.ibm.com">Something Else</Link>,
-      ]}
-      content={
-        <PageWizard
-          currentStepId="step1"
-          onClose={action('closed', () => {})}
-          onSubmit={action('submit', () => {})}
-          onClearError={action('Clear error', () => {})}
-          onNext={action('next', () => {})}
-          onBack={action('back', () => {})}
-          setStep={action('step clicked', () => {})}
-          isProgressIndicatorVertical={boolean('Toggle Progress Indicator Alignment', true)}
-        >
-          {content}
-        </PageWizard>
-      }
-    />
-  </div>
+  <PageTitleBar
+    {...commonProps}
+    content={
+      <PageWizard
+        currentStepId="step1"
+        onClose={action('closed', () => {})}
+        onSubmit={action('submit', () => {})}
+        onClearError={action('Clear error', () => {})}
+        onNext={action('next', () => {})}
+        onBack={action('back', () => {})}
+        setStep={action('step clicked', () => {})}
+        isProgressIndicatorVertical={boolean('Toggle Progress Indicator Alignment', true)}
+      >
+        {content}
+      </PageWizard>
+    }
+  />
 );
 
 WrappedInPageTitleBar.storyName = 'wrapped in PageTitleBar';
 
 export const WithHorizontalProgressIndicator = () => (
-  <div>
-    <PageWizard
-      currentStepId="step1"
-      onClose={action('closed', () => {})}
-      onSubmit={action('submit', () => {})}
-      onNext={action('next', () => {})}
-      onBack={action('back', () => {})}
-      setStep={action('step clicked', () => {})}
-      onClearError={action('Clear error', () => {})}
-      isProgressIndicatorVertical={boolean('Toggle Progress Indicator Alignment', false)}
-      isClickable
-    >
-      {content}
-    </PageWizard>
-  </div>
+  <PageWizard
+    currentStepId="step1"
+    onClose={action('closed', () => {})}
+    onSubmit={action('submit', () => {})}
+    onNext={action('next', () => {})}
+    onBack={action('back', () => {})}
+    setStep={action('step clicked', () => {})}
+    onClearError={action('Clear error', () => {})}
+    isProgressIndicatorVertical={boolean('Toggle Progress Indicator Alignment', false)}
+    isClickable
+  >
+    {content}
+  </PageWizard>
 );
 
 WithHorizontalProgressIndicator.storyName = 'With Horizontal ProgressIndicator';
 
 export const OnlyOneStepInPageTitleBar = () => (
-  <div>
-    <PageTitleBar
-      title="A cool PageWizard!"
-      description="The description from the PageTitleBar"
-      breadcrumb={[
-        <Link to="www.ibm.com">Home</Link>,
-        <Link to="www.ibm.com">Something</Link>,
-        <Link to="www.ibm.com">Something Else</Link>,
-      ]}
-      content={
-        <PageWizard
-          currentStepId="step1"
-          onClose={action('closed', () => {})}
-          onSubmit={action('submit', () => {})}
-          onNext={action('next', () => {})}
-          onBack={action('back', () => {})}
-          onClearError={() => {}}
-          setStep={action('step clicked', () => {})}
-          sendingData={boolean('sendingData', false)}
-          hasStickyFooter={boolean('hasStickyFooter', false)}
-        >
-          {[content[0]]}
-        </PageWizard>
-      }
-    />
-  </div>
+  <PageTitleBar
+    {...commonProps}
+    content={
+      <PageWizard
+        currentStepId="step1"
+        onClose={action('closed', () => {})}
+        onSubmit={action('submit', () => {})}
+        onNext={action('next', () => {})}
+        onBack={action('back', () => {})}
+        onClearError={() => {}}
+        setStep={action('step clicked', () => {})}
+        sendingData={boolean('sendingData', false)}
+        hasStickyFooter={boolean('hasStickyFooter', false)}
+      >
+        {[content[0]]}
+      </PageWizard>
+    }
+  />
 );
 
 OnlyOneStepInPageTitleBar.storyName = 'only one step, in PageTitleBar';
 
 export const WithStickyFooterStatefulExampleWValidationInPageTitleBar = () => (
-  <div>
-    <PageTitleBar
-      title="A cool PageWizard!"
-      description="The description from the PageTitleBar"
-      breadcrumb={[
-        <Link to="www.ibm.com">Home</Link>,
-        <Link to="www.ibm.com">Something</Link>,
-        <Link to="www.ibm.com">Something Else</Link>,
-      ]}
-      content={
-        <StepValidationWizard
-          hasStickyFooter={boolean('hasStickyFooter', true)}
-          isProgressIndicatorVertical={boolean('Toggle Progress Indicator Alignment', false)}
-          isClickable
-          spaceEqually={boolean('spaceEqually', false)}
-          stepWidth={number('stepWidth', 6)}
-        />
-      }
-    />
-  </div>
+  <PageTitleBar
+    {...commonProps}
+    content={
+      <StepValidationWizard
+        hasStickyFooter={boolean('hasStickyFooter', true)}
+        isProgressIndicatorVertical={boolean('Toggle Progress Indicator Alignment', false)}
+        isClickable
+        spaceEqually={boolean('spaceEqually', false)}
+        stepWidth={number('stepWidth', 6)}
+      />
+    }
+  />
 );
 
 WithStickyFooterStatefulExampleWValidationInPageTitleBar.storyName =
   'With Sticky Footer: stateful example w/ validation in PageTitleBar';
 
 export const WithAdditionalFooterContent = () => (
-  <div>
-    <PageTitleBar
-      title="A cool PageWizard!"
-      description="The description from the PageTitleBar"
-      breadcrumb={[
-        <Link to="www.ibm.com">Home</Link>,
-        <Link to="www.ibm.com">Something</Link>,
-        <Link to="www.ibm.com">Something Else</Link>,
-      ]}
-      content={
-        <StepValidationWizard
-          hasStickyFooter={boolean('hasStickyFooter', true)}
-          isProgressIndicatorVertical={boolean('Toggle Progress Indicator Alignment', true)}
-          beforeFooterContent={<Button kind="tertiary">Save and close</Button>}
-          isClickable
-          afterFooterContent={
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                fontWeight: 600,
-                fontSize: '1rem',
-                lineHeight: '1.375rem',
-                letterSpacing: 0,
-              }}
-            >
-              <InformationFilled size={20} style={{ marginRight: '0.5rem' }} />
-              {text('Additional footer content', 'Additional footer content')}
-            </div>
-          }
-        />
-      }
-    />
-  </div>
+  <PageTitleBar
+    {...commonProps}
+    content={
+      <StepValidationWizard
+        hasStickyFooter={boolean('hasStickyFooter', true)}
+        isProgressIndicatorVertical={boolean('Toggle Progress Indicator Alignment', true)}
+        beforeFooterContent={<Button kind="tertiary">Save and close</Button>}
+        isClickable
+        afterFooterContent={customFooterContent('Additional after footer content')}
+      />
+    }
+  />
 );
 
 WithAdditionalFooterContent.storyName = 'With additional footer content';
 
+export const WithAdditionalBeforeFooterContent = () => (
+  <PageTitleBar
+    {...commonProps}
+    content={
+      <StepValidationWizard
+        hasStickyFooter={boolean('hasStickyFooter', true)}
+        isProgressIndicatorVertical={boolean('Toggle Progress Indicator Alignment', true)}
+        beforeFooterContent={customFooterContent('Additional before footer content')}
+        isClickable
+      />
+    }
+  />
+);
+
+WithAdditionalBeforeFooterContent.storyName = 'With additional before footer content';
+
+export const WithAdditionalAfterFooterContent = () => (
+  <PageTitleBar
+    {...commonProps}
+    content={
+      <StepValidationWizard
+        hasStickyFooter={boolean('hasStickyFooter', true)}
+        isProgressIndicatorVertical={boolean('Toggle Progress Indicator Alignment', true)}
+        isClickable
+        afterFooterContent={customFooterContent('Additional after footer content')}
+      />
+    }
+  />
+);
+
+WithAdditionalAfterFooterContent.storyName = 'With additional after footer content';
+
 export const WI18N = () => (
-  <div>
-    <PageWizard
-      currentStepId="step1"
-      onClose={action('closed', () => {})}
-      onSubmit={action('submit', () => {})}
-      onNext={action('next', () => {})}
-      onBack={action('back', () => {})}
-      onClearError={() => {}}
-      setStep={action('step clicked', () => {})}
-      sendingData={boolean('sendingData', false)}
-      hasStickyFooter={boolean('hasStickyFooter', false)}
-      i18={{
-        close: text('Close label', 'Close'),
-        cancel: text('Cancel label', 'Cancel'),
-        back: text('Back label', 'Back'),
-        next: text('Next label', 'Next'),
-        submit: text('Submit label', 'Submit'),
-      }}
-    >
-      {content}
-    </PageWizard>
-  </div>
+  <PageWizard
+    currentStepId="step1"
+    onClose={action('closed', () => {})}
+    onSubmit={action('submit', () => {})}
+    onNext={action('next', () => {})}
+    onBack={action('back', () => {})}
+    onClearError={() => {}}
+    setStep={action('step clicked', () => {})}
+    sendingData={boolean('sendingData', false)}
+    hasStickyFooter={boolean('hasStickyFooter', false)}
+    i18={{
+      close: text('Close label', 'Close'),
+      cancel: text('Cancel label', 'Cancel'),
+      back: text('Back label', 'Back'),
+      next: text('Next label', 'Next'),
+      submit: text('Submit label', 'Submit'),
+    }}
+  >
+    {content}
+  </PageWizard>
 );
 
 WI18N.storyName = 'w/ i18n';

--- a/packages/react/src/components/PageWizard/PageWizardStep/PageWizardStep.jsx
+++ b/packages/react/src/components/PageWizard/PageWizardStep/PageWizardStep.jsx
@@ -112,17 +112,21 @@ const PageWizardStep = ({
         [`${iotPrefix}--page-wizard--content--after-footer`]: !!afterFooterContent,
       })}
     >
-      {beforeFooterContent}
+      <div
+        className={`${iotPrefix}--page-wizard--content--footer ${iotPrefix}--page-wizard--content--footer--before--content`}
+      >
+        {beforeFooterContent}
+      </div>
+
       {!hasPrev ? (
         <Button onClick={onClose} kind="secondary">
           {i18n.cancel}
         </Button>
-      ) : null}
-      {hasPrev ? (
+      ) : (
         <Button onClick={onBack} kind="secondary">
           {i18n.back}
         </Button>
-      ) : null}
+      )}
       {hasNext ? (
         <Button
           onClick={() => {
@@ -144,7 +148,9 @@ const PageWizardStep = ({
         </Button>
       )}
       {afterFooterContent && (
-        <div className={`${iotPrefix}--page-wizard--content--after-footer--content`}>
+        <div
+          className={`${iotPrefix}--page-wizard--content--footer ${iotPrefix}--page-wizard--content--footer--after--content`}
+        >
           {afterFooterContent}
         </div>
       )}

--- a/packages/react/src/components/PageWizard/_page-wizard.scss
+++ b/packages/react/src/components/PageWizard/_page-wizard.scss
@@ -58,6 +58,7 @@
     }
 
     &--actions--sticky {
+      display: flex;
       position: fixed;
       bottom: 0;
       left: 0;
@@ -70,13 +71,15 @@
       }
     }
 
-    &--after-footer {
+    &--footer {
       display: flex;
+      align-items: center;
+      &--before--content {
+        flex: 1;
+        justify-content: flex-start;
+      }
 
-      &--content {
-        display: flex;
-        width: 100%;
-        align-items: center;
+      &--after--content {
         justify-content: flex-end;
       }
     }


### PR DESCRIPTION
**Summary**

- Partially updating the sticky footer as per desgin
https://carbondesignsystem.com/components/progress-indicator/usage/

Before 
![image](https://github.com/user-attachments/assets/5ad10d8c-7591-427d-9f30-6defc400ffb4)
Now
https://deploy-preview-3962--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-progress-indicator-pagewizard--with-additional-footer-content
![image](https://github.com/user-attachments/assets/004fd784-dec3-4b3c-910e-062f97b28289)
https://deploy-preview-3962--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-progress-indicator-pagewizard--with-additional-before-footer-content 
![image](https://github.com/user-attachments/assets/2c3983da-0d46-4067-a9f7-eb26d666b002)
https://deploy-preview-3962--carbon-addons-iot-react.netlify.app/?path=/story/1-watson-iot-progress-indicator-pagewizard--with-additional-after-footer-content
![image](https://github.com/user-attachments/assets/46f6725f-f37c-4ee0-8fa9-546b60c5c124)


**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
