### PR TITLE
fix: use contentswitcher css instead of default child css alone

### DIFF
--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.jsx
@@ -13,7 +13,18 @@ import {
 } from '@carbon/react';
 import { pick, sortBy } from 'lodash-es';
 import update from 'immutability-helper';
-import { gray50, red50, green50, blue50 } from '@carbon/colors';
+import {
+  gray50,
+  red50,
+  green50,
+  blue50,
+  cyan50,
+  magenta50,
+  purple50,
+  teal50,
+  yellow50,
+  orange50,
+} from '@carbon/colors';
 import warning from 'warning';
 
 import { HotspotIconPropType, ColorPropType } from '../../constants/SharedPropTypes';
@@ -37,11 +48,17 @@ import DynamicHotspotSourcePicker from './DynamicHotspotSourcePicker/DynamicHots
 
 const { iotPrefix, prefix } = settings;
 
-const selectableColors = [
+export const selectableColors = [
   { carbonColor: gray50, name: 'gray' },
   { carbonColor: red50, name: 'red' },
   { carbonColor: green50, name: 'green' },
   { carbonColor: blue50, name: 'blue' },
+  { carbonColor: cyan50, name: 'cyan' },
+  { carbonColor: magenta50, name: 'magenta' },
+  { carbonColor: purple50, name: 'purple' },
+  { carbonColor: teal50, name: 'teal' },
+  { carbonColor: yellow50, name: 'yellow' },
+  { carbonColor: orange50, name: 'orange' },
 ];
 
 const propTypes = {

--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.story.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.story.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { boolean, select, withKnobs } from '@storybook/addon-knobs';
-import { gray50, red50, green50, blue50 } from '@carbon/colors';
+import { gray50, red50, green50 } from '@carbon/colors';
 import { InformationSquareFilled, InformationFilled } from '@carbon/react/icons';
 
 import { CARD_SIZES, CARD_TYPES } from '../../constants/LayoutConstants';
 import StoryNotice, { experimentalStoryTitle } from '../../internal/StoryNotice';
 
 import landscape from './landscape.jpg';
-import HotspotEditorModal from './HotspotEditorModal';
+import HotspotEditorModal, { selectableColors } from './HotspotEditorModal';
 // import HotspotEditorModalREADME from './HotspotEditorModalREADME.mdx'; //carbon 11
 
 export const Experimental = () => <StoryNotice componentName="ColorDropdown" experimental />;
@@ -39,13 +39,6 @@ const selectableIcons = [
     icon: InformationFilled,
     text: 'Information filled',
   },
-];
-
-const selectableColors = [
-  { carbonColor: gray50, name: 'gray' },
-  { carbonColor: red50, name: 'red' },
-  { carbonColor: green50, name: 'green' },
-  { carbonColor: blue50, name: 'blue' },
 ];
 
 const cardConfig = {

--- a/packages/react/src/components/HotspotEditorModal/HotspotTextStyleTab/HotspotTextStyleTab.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotTextStyleTab/HotspotTextStyleTab.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { merge } from 'lodash-es';
-import { NumberInput, IconSwitch } from '@carbon/react';
+import { NumberInput, IconSwitch, unstable_FeatureFlags as FeatureFlags } from '@carbon/react';
 import {
   TrashCan,
   InformationFilled,
@@ -15,7 +15,7 @@ import ColorDropdown from '../../ColorDropdown/ColorDropdown';
 import Button from '../../Button/Button';
 import { isNumberValidForMinMax } from '../../../utils/componentUtilityFunctions';
 
-const { iotPrefix } = settings;
+const { iotPrefix, prefix } = settings;
 
 const colorPropType = PropTypes.shape({
   carbonColor: PropTypes.string,
@@ -225,42 +225,45 @@ const HotspotTextStyleTab = ({
             onSubmit={preventFormSubmission}
             className={`${iotPrefix}--hotspot-text-style-tab__form`}
           >
-            <div className={`${iotPrefix}--hotspot-text-style-tab__text-style`}>
-              <IconSwitch
-                disabled={hasNonEditableContent}
-                onClick={() => onChange({ bold: !bold })}
-                data-testid="hotspot-bold"
-                selected={bold}
-                text={boldLabelText}
-                renderIcon={TextBold}
-                index={0}
-                light={light}
-              />
+            <div className={`${iotPrefix}--hotspot-text-style-tab__row`}>
+              <div className={`${prefix}--content-switcher ${prefix}--content-switcher--icon-only`}>
+                <FeatureFlags enableV12DynamicFloatingStyles>
+                  <IconSwitch
+                    disabled={hasNonEditableContent}
+                    onClick={() => onChange({ bold: !bold })}
+                    data-testid="hotspot-bold"
+                    selected={bold}
+                    text={boldLabelText}
+                    renderIcon={TextBold}
+                    index={0}
+                    light={light}
+                  />
 
-              <IconSwitch
-                disabled={hasNonEditableContent}
-                name="italic"
-                onClick={() => onChange({ italic: !italic })}
-                data-testid="hotspot-italic"
-                selected={italic}
-                text={italicLabelText}
-                renderIcon={TextItalic}
-                index={1}
-                light={light}
-              />
-              <IconSwitch
-                disabled={hasNonEditableContent}
-                name="underline"
-                onClick={() => onChange({ underline: !underline })}
-                data-testid="hotspot-underline"
-                selected={underline}
-                text={underlineLabelText}
-                renderIcon={TextUnderline}
-                index={2}
-                light={light}
-              />
+                  <IconSwitch
+                    disabled={hasNonEditableContent}
+                    name="italic"
+                    onClick={() => onChange({ italic: !italic })}
+                    data-testid="hotspot-italic"
+                    selected={italic}
+                    text={italicLabelText}
+                    renderIcon={TextItalic}
+                    index={1}
+                    light={light}
+                  />
+                  <IconSwitch
+                    disabled={hasNonEditableContent}
+                    name="underline"
+                    onClick={() => onChange({ underline: !underline })}
+                    data-testid="hotspot-underline"
+                    selected={underline}
+                    text={underlineLabelText}
+                    renderIcon={TextUnderline}
+                    index={2}
+                    light={light}
+                  />
+                </FeatureFlags>
+              </div>
             </div>
-
             <div className={`${iotPrefix}--hotspot-text-style-tab__row`}>
               <ColorDropdown
                 disabled={hasNonEditableContent}

--- a/packages/react/src/components/HotspotEditorModal/HotspotTextStyleTab/HotspotTextStyleTab.story.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotTextStyleTab/HotspotTextStyleTab.story.jsx
@@ -2,22 +2,9 @@ import React, { useState } from 'react';
 import { merge } from 'lodash-es';
 import { action } from '@storybook/addon-actions';
 import { boolean, withKnobs } from '@storybook/addon-knobs';
-import {
-  purple70,
-  cyan50,
-  teal70,
-  magenta70,
-  red50,
-  red90,
-  green60,
-  blue80,
-  magenta50,
-  purple50,
-  teal50,
-  cyan90,
-} from '@carbon/colors';
 
 import { hotspotTypes, useHotspotEditorState } from '../hooks/hotspotStateHook';
+import { selectableColors } from '../HotspotEditorModal';
 
 import HotspotTextStyleTab from './HotspotTextStyleTab';
 import HotspotTextStyleTabREADME from './HotspotTextStyleTabREADME.mdx';
@@ -49,21 +36,6 @@ export default {
   },
 };
 
-const colors = [
-  { carbonColor: purple70, name: 'purple70' },
-  { carbonColor: cyan50, name: 'cyan50' },
-  { carbonColor: teal70, name: 'teal70' },
-  { carbonColor: magenta70, name: 'magenta70' },
-  { carbonColor: red50, name: 'red50' },
-  { carbonColor: red90, name: 'red90' },
-  { carbonColor: green60, name: 'green60' },
-  { carbonColor: blue80, name: 'blue80' },
-  { carbonColor: magenta50, name: 'magenta50' },
-  { carbonColor: purple50, name: 'purple50' },
-  { carbonColor: teal50, name: 'teal50' },
-  { carbonColor: cyan90, name: 'cyan90' },
-];
-
 export const Default = () => {
   const isLight = boolean('light', true);
   const WithState = () => {
@@ -77,9 +49,9 @@ export const Default = () => {
         maxOpacity={100}
         minBorderWidth={0}
         maxBorderWidth={50}
-        fontColors={colors}
-        backgroundColors={colors}
-        borderColors={colors}
+        fontColors={selectableColors}
+        backgroundColors={selectableColors}
+        borderColors={selectableColors}
         formValues={formValues}
         onChange={(change) => {
           setFormValues(merge({}, formValues, change));
@@ -119,9 +91,9 @@ export const UsingHotspotStateHook = () => {
         maxOpacity={100}
         minBorderWidth={0}
         maxBorderWidth={50}
-        fontColors={colors}
-        backgroundColors={colors}
-        borderColors={colors}
+        fontColors={selectableColors}
+        backgroundColors={selectableColors}
+        borderColors={selectableColors}
         formValues={selectedHotspot}
         onChange={updateTextHotspotStyle}
         onDelete={deleteSelectedHotspot}

--- a/packages/react/src/components/HotspotEditorModal/HotspotTextStyleTab/_hotspot-text-style-tab.scss
+++ b/packages/react/src/components/HotspotEditorModal/HotspotTextStyleTab/_hotspot-text-style-tab.scss
@@ -18,14 +18,6 @@ $border-radius: 5px;
     }
   }
 
-  &__text-style {
-    @include content-switcher-border-radius($border-radius, left, right);
-  }
-
-  html[dir='rtl'] &__text-style {
-    @include content-switcher-border-radius($border-radius, right, left);
-  }
-
   &__dropdown {
     width: 100%;
   }


### PR DESCRIPTION
Closes https://jsw.ibm.com/browse/MASMON-4147

**Summary**

- Before:  https://carbon-design-system.github.io/carbon-addons-iot-react/?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-dashboardeditor-%E2%98%A2%EF%B8%8F-hotspoteditormodal-hotspottextstyletab--default
![image](https://github.com/user-attachments/assets/38720b5c-f2bc-4910-9d97-70165d4707cf)


- Now: https://deploy-preview-3966--carbon-addons-iot-react.netlify.app/?path=/story/2-watson-iot-experimental-%E2%98%A2%EF%B8%8F-dashboardeditor-%E2%98%A2%EF%B8%8F-hotspoteditormodal-hotspottextstyletab--default
![image](https://github.com/user-attachments/assets/41ccfdf0-7f6f-4452-9ca6-ebec096e3686)


**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
