### PR TITLE
fix: display numeric data for x and y coordinates

### DIFF
--- a/packages/react/src/components/HotspotEditorModal/DynamicHotspotSourcePicker/DynamicHotspotSourcePicker.jsx
+++ b/packages/react/src/components/HotspotEditorModal/DynamicHotspotSourcePicker/DynamicHotspotSourcePicker.jsx
@@ -6,7 +6,6 @@ import { IconButton } from '@carbon/react';
 
 import { settings } from '../../../constants/Settings';
 import { Dropdown } from '../../Dropdown';
-import deprecate from '../../../internal/deprecate';
 
 const { iotPrefix } = settings;
 
@@ -25,11 +24,6 @@ const propTypes = {
   onYValueChange: PropTypes.func.isRequired,
   selectedSourceIdX: PropTypes.string,
   selectedSourceIdY: PropTypes.string,
-  // eslint-disable-next-line react/require-default-props
-  testID: deprecate(
-    PropTypes.string,
-    `The 'testID' prop has been deprecated. Please use 'testId' instead.`
-  ),
   testId: PropTypes.string,
   i18n: PropTypes.shape({
     clearIconDescription: PropTypes.string,
@@ -67,8 +61,6 @@ const DynamicHotspotSourcePicker = ({
   onYValueChange,
   selectedSourceIdX,
   selectedSourceIdY,
-  // TODO: remove deprecated testID prop in v3.
-  testID,
   testId,
   i18n,
   translateWithId,
@@ -83,10 +75,10 @@ const DynamicHotspotSourcePicker = ({
     yCoordinateDropdownLabelText,
   } = mergedI18n;
   return (
-    <div data-testid={testID || testId} className={classname}>
+    <div data-testid={testId} className={classname}>
       <Dropdown
         key={`${id}-x-coordinate-dropdown-${selectedSourceIdX}`}
-        data-testid={`${testID || testId}-x-coordinate-dropdown`}
+        data-testid={`${testId}-x-coordinate-dropdown`}
         selectedItem={dataSourceItems.find((item) => item.dataSourceId === selectedSourceIdX)}
         id={`${id}-x-coordinate-dropdown`}
         titleText={xCoordinateDropdownTitleText}
@@ -100,7 +92,7 @@ const DynamicHotspotSourcePicker = ({
       />
       <Dropdown
         key={`${id}-y-coordinate-dropdown-${selectedSourceIdY}`}
-        data-testid={`${testID || testId}-y-coordinate-dropdown`}
+        data-testid={`${testId}-y-coordinate-dropdown`}
         selectedItem={dataSourceItems.find((item) => item.dataSourceId === selectedSourceIdY)}
         id={`${id}-y-coordinate-dropdown`}
         titleText={yCoordinateDropdownTitleText}
@@ -113,7 +105,7 @@ const DynamicHotspotSourcePicker = ({
         }}
       />
       <IconButton
-        data-testid={`${testID || testId}-clear-dropdown`}
+        data-testid={`${testId}-clear-dropdown`}
         className={classnames(`${classname}__clear-button`, {
           [`${classname}__clear-button--invisible`]: !selectedSourceIdX || !selectedSourceIdY,
         })}

--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.jsx
@@ -110,6 +110,7 @@ const propTypes = {
       dataSourceId: PropTypes.string,
       label: PropTypes.string,
       unit: PropTypes.string,
+      columnType: PropTypes.oneOf(['LITERAL', 'BOOLEAN', 'TIMESTAMP', 'NUMBER']),
     })
   ),
   /** Default border width in px for new text hotspots */
@@ -305,6 +306,7 @@ const HotspotEditorModal = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [getValidDataItems, dataItems] // watching the card config for changes will simply load this too many times
   );
+
   const {
     currentType,
     hotspots,
@@ -484,7 +486,7 @@ const HotspotEditorModal = ({
       <>
         <DynamicHotspotSourcePicker
           i18n={mergedI18n}
-          dataSourceItems={myDataItems}
+          dataSourceItems={myDataItems.filter((dataItem) => dataItem.columnType === 'NUMBER')}
           onXValueChange={(newXSource) => {
             updateDynamicHotspotSourceX(newXSource);
             loadDemoHotspots(newXSource, dynamicHotspotSourceY);
@@ -497,8 +499,6 @@ const HotspotEditorModal = ({
           selectedSourceIdY={dynamicHotspotSourceY}
           onClear={clearDynamicHotspotsSource}
           translateWithId={translateWithId}
-          // TODO: pass testId in v3 to override defaults
-          // testId={`${testId}-hotspot-source-picker`}
         />
         {showTooManyHotspotsInfo ? (
           <InlineNotification

--- a/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.story.jsx
+++ b/packages/react/src/components/HotspotEditorModal/HotspotEditorModal.story.jsx
@@ -62,18 +62,21 @@ const dataItems = [
     dataSourceId: 'temp_last',
     label: '{high} temp',
     unit: '{unitVar}',
+    columnType: 'NUMBER',
   },
   {
     dataItemId: 'temperature',
     dataSourceId: 'temperature',
     label: 'Temperature',
     unit: '°',
+    columnType: 'NUMBER',
   },
   {
     dataItemId: 'pressure',
     dataSourceId: 'pressure',
     label: 'Pressure',
     unit: 'psi',
+    columnType: 'NUMBER',
   },
 ];
 


### PR DESCRIPTION
Closes #https://jsw.ibm.com/browse/MASMON-4179

**Summary**

- display numeric data for x and y coordinates
Before:
![image](https://github.com/user-attachments/assets/ef19551f-88fe-44b2-9ef0-c7f5c83ab0e4)

Now:
![image](https://github.com/user-attachments/assets/f7334272-e362-43f3-b2aa-9c69de739c01)

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
