### PR TITLE
fix: set default precision if negative value is set

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/BarChartCardFormItems/BarChartCardFormSettings.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/BarChartCardFormItems/BarChartCardFormSettings.jsx
@@ -8,6 +8,7 @@ import {
   NumberInput,
   Layer,
 } from '@carbon/react';
+import { omit } from 'lodash-es';
 
 import { settings } from '../../../../../constants/Settings';
 
@@ -151,11 +152,17 @@ const BarChartCardFormSettings = ({ cardConfig, onChange, i18n }) => {
             id={`${id}_decimal-precision`}
             label={mergedI18n.decimalPrecisionLabel}
             min={0}
+            max={100}
             onChange={(event, { value }) => {
               const decimalPrecision = Number.parseInt(value, 10);
               onChange({
                 ...cardConfig,
-                content: { ...cardConfig.content, decimalPrecision },
+                content: {
+                  ...omit(cardConfig.content, 'decimalPrecision'),
+                  ...(Number.isNaN(decimalPrecision) || decimalPrecision < 0
+                    ? {}
+                    : { decimalPrecision }),
+                },
               });
             }}
             value={content?.decimalPrecision}

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormSettings.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormSettings.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { TextInput, Toggle, NumberInput, Layer } from '@carbon/react';
+import { omit } from 'lodash-es';
 
 import { settings } from '../../../../../constants/Settings';
 
@@ -118,13 +119,16 @@ const DataSeriesFormSettings = ({ cardConfig, onChange, i18n }) => {
             id={`${id}_decimal-precision`}
             label={mergedI18n.decimalPrecisionLabel}
             min={0}
+            max={100}
             onChange={(event, { value }) => {
               const decimalPrecision = Number.parseInt(value, 10);
               onChange({
                 ...cardConfig,
                 content: {
-                  ...cardConfig.content,
-                  decimalPrecision,
+                  ...omit(cardConfig.content, 'decimalPrecision'),
+                  ...(Number.isNaN(decimalPrecision) || decimalPrecision < 0
+                    ? {}
+                    : { decimalPrecision }),
                 },
               });
             }}


### PR DESCRIPTION
fixes: https://jsw.ibm.com/browse/MASMON-4103

Closes #

**Summary**

- summary_here

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
