### PR TITLE
feat: add support for large DataItem Edit modal

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
@@ -341,6 +341,7 @@ const DataSeriesFormItemModal = ({
                       )
                     );
                   }}
+                  autoAlign
                 />
               </div>
             ) : (
@@ -383,6 +384,7 @@ const DataSeriesFormItemModal = ({
                       grain: selectedItem.id,
                     });
                   }}
+                  autoAlign
                 />
               </div>
             ) : (
@@ -493,6 +495,7 @@ const DataSeriesFormItemModal = ({
                       setEditDataItem(omit(editDataItem, 'precision'));
                     }
                   }}
+                  autoAlign
                 />
               )}
             </div>
@@ -527,6 +530,7 @@ const DataSeriesFormItemModal = ({
                     }
                   }}
                   titleText={mergedI18n.dataItemEditorDataItemFilter}
+                  autoAlign
                 />
               </div>
 
@@ -554,6 +558,7 @@ const DataSeriesFormItemModal = ({
                           dataFilter,
                         });
                       }}
+                      autoAlign
                     />
                   )}
               </div>

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
@@ -466,6 +466,7 @@ const DataSeriesFormItem = ({
           hasThresholds: type === CARD_TYPES.VALUE,
           hasTooltip: type === CARD_TYPES.VALUE,
         }}
+        isLarge
       />
       <ContentFormItemTitle
         title={mergedI18n.dataItemEditorSectionTitle}

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/TableCardFormItems/TableCardFormContent.jsx
@@ -375,6 +375,7 @@ const TableCardFormContent = ({
           hasThresholds: true,
           hasTooltip: true,
         }}
+        isLarge
       />
       <ContentFormItemTitle
         title={mergedI18n.tableColumnEditorSectionTitle}

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ThresholdsFormItem.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ThresholdsFormItem.jsx
@@ -221,6 +221,7 @@ const ThresholdsFormItem = ({
                     onChange(updatedThresholds.map((item) => omit(item, 'id')));
                     setThresholds(updatedThresholds);
                   }}
+                  autoAlign
                 />
               </div>
               <div className={`${baseClassName}--threshold-input-group--item-end`}>

--- a/packages/react/src/components/ColorDropdown/ColorDropdown.jsx
+++ b/packages/react/src/components/ColorDropdown/ColorDropdown.jsx
@@ -146,6 +146,7 @@ const ColorDropdown = ({
       type="default"
       data-testid={testID || testId}
       disabled={disabled}
+      autoAlign
     />
   );
 };

--- a/packages/react/src/components/SimpleIconDropdown/SimpleIconDropdown.jsx
+++ b/packages/react/src/components/SimpleIconDropdown/SimpleIconDropdown.jsx
@@ -92,6 +92,7 @@ const SimpleIconDropdown = ({
       type="default"
       // TODO: remove deprecated 'testID' in v3
       data-testid={testID || testId}
+      autoAlign
     />
   );
 };


### PR DESCRIPTION
Closes # [MASMON-3199](https://jsw.ibm.com/browse/MASMON-3199)

**Summary**

- feat: add support for large DataItem Edit modal

**Change List (commits, features, bugs, etc)**

- feat: add support for large DataItem Edit modal

**Acceptance Test (how to verify the PR)**

![image](https://github.com/user-attachments/assets/e1c66502-673f-4c1f-b232-ea3bee1df8cd)



**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
