### PR TITLE
fix(PageTitleBar): add option for breadcrumb overflow in PageTitleBar

### DIFF
--- a/packages/react/src/components/Breadcrumb/_breadcrumb.scss
+++ b/packages/react/src/components/Breadcrumb/_breadcrumb.scss
@@ -68,10 +68,11 @@
       outline: none;
     }
   }
+
   .#{$prefix}--overflow-menu-options__option {
     min-height: $spacing-08;
-    overflow-y: scroll;
   }
+
   &.#{$prefix}--overflow-menu-options::after,
   &.#{$prefix}--overflow-menu-options[data-floating-menu-direction='bottom']::after {
     transform: translate(-50%, -8px);

--- a/packages/react/src/components/Breadcrumb/_breadcrumb.scss
+++ b/packages/react/src/components/Breadcrumb/_breadcrumb.scss
@@ -58,12 +58,19 @@
 }
 
 .breadcrumb--overflow-items {
+  max-height: 75%;
+  overflow-y: scroll;
+
   &.#{$prefix}--overflow-menu-options--open {
     transform: translate(-45%, 1rem);
 
     &:focus {
       outline: none;
     }
+  }
+  .#{$prefix}--overflow-menu-options__option {
+    min-height: $spacing-08;
+    overflow-y: scroll;
   }
   &.#{$prefix}--overflow-menu-options::after,
   &.#{$prefix}--overflow-menu-options[data-floating-menu-direction='bottom']::after {

--- a/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.jsx
@@ -2,13 +2,14 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState, useMemo, useRef, useCallback } from 'react';
 import classnames from 'classnames';
 import { Information, Edit } from '@carbon/react/icons';
-import { Breadcrumb, BreadcrumbItem, SkeletonText, Tabs } from '@carbon/react';
+import { BreadcrumbItem, SkeletonText, Tabs } from '@carbon/react';
 import { throttle } from 'lodash-es';
 
 import { ToggleTip } from '../ToggleTip';
 import { settings } from '../../constants/Settings';
 import deprecate from '../../internal/deprecate';
 import Button from '../Button';
+import Breadcrumb from '../Breadcrumb/Breadcrumb';
 
 const { iotPrefix } = settings;
 const HEADER_MODES = {
@@ -43,6 +44,7 @@ const PageTitleBarPropTypes = {
   upperActions: PropTypes.node,
   /** Breadcrumbs to show */
   breadcrumb: PropTypes.arrayOf(PropTypes.node),
+  hasBreadcrumbOverflow: PropTypes.bool,
   /** Should page description be collapsed into tooltip. Should be `true` when using in conjunction with tabs. */
   collapsed: PropTypes.bool,
   /** Is the title editable, will display edit icon with callback */
@@ -93,6 +95,7 @@ const defaultProps = {
   extraContent: undefined,
   upperActions: undefined,
   breadcrumb: null,
+  hasBreadcrumbOverflow: false,
   collapsed: undefined,
   editable: false,
   forceContentOutside: false,
@@ -121,6 +124,7 @@ const PageTitleBar = ({
   extraContent,
   upperActions,
   breadcrumb,
+  hasBreadcrumbOverflow,
   collapsed,
   forceContentOutside,
   headerMode,
@@ -362,8 +366,13 @@ const PageTitleBar = ({
             upperActions ||
             headerMode === HEADER_MODES.DYNAMIC ||
             headerMode === HEADER_MODES.CONDENSED ? (
-              <div className="page-title-bar-breadcrumb breadcrumb--container" ref={breadcrumbRef}>
-                <Breadcrumb>
+              <div
+                className={classnames('page-title-bar-breadcrumb', {
+                  'page-title-bar-breadcrumb--overflow': hasBreadcrumbOverflow,
+                })}
+                ref={breadcrumbRef}
+              >
+                <Breadcrumb hasOverflow={hasBreadcrumbOverflow}>
                   {breadcrumb
                     ? breadcrumb.map((crumb, index) => (
                         <BreadcrumbItem key={`breadcrumb-${index}`}>{crumb}</BreadcrumbItem>

--- a/packages/react/src/components/PageTitleBar/PageTitleBar.story.jsx
+++ b/packages/react/src/components/PageTitleBar/PageTitleBar.story.jsx
@@ -79,6 +79,29 @@ const breadcrumbKnobOptions = {
 };
 const breadcrumbDefaultValue = pageTitleBarBreadcrumb;
 
+const pageTitleBarBreadcrumbOverflow = [
+  <a href="/">item 1</a>,
+  <a href="/">item 2</a>,
+  <a href="/">item 3</a>,
+  <a href="/">item 4</a>,
+  <a href="/">item 5</a>,
+  <a href="/">item 6</a>,
+  <a href="/">item 7</a>,
+  <a href="/">item 8</a>,
+  <a href="/">item 9</a>,
+  <a href="/">item 10</a>,
+  <a href="/">item 11</a>,
+  <a href="/">item 12</a>,
+  <a href="/">item 13</a>,
+  <a href="/">item 14</a>,
+  <a href="/">item 15</a>,
+  <a href="/">item 16</a>,
+  <a href="/">item 17</a>,
+  <a href="/">item 18</a>,
+  <a href="/">item 19</a>,
+  <a href="/">item 20</a>,
+];
+
 export default {
   title: '1 - Watson IoT/Page header/PageTitleBar',
   decorators: [withKnobs, (storyFn) => <FullWidthWrapper>{storyFn()}</FullWidthWrapper>],
@@ -189,6 +212,19 @@ export const WithEditableTitleBar = () => (
 );
 
 WithEditableTitleBar.storyName = 'with editable title bar and subtitle';
+
+export const WithBreadcrumbOverflow = () => (
+  <div style={{ height: '150vh' }}>
+    <PageTitleBar
+      title={text('title', commonPageTitleBarProps.title)}
+      breadcrumb={pageTitleBarBreadcrumbOverflow}
+      hasBreadcrumbOverflow={boolean('hasBreadcrumbOverflow', true)}
+      description={commonPageTitleBarProps.description}
+    />
+  </div>
+);
+
+WithBreadcrumbOverflow.storyName = 'with breadcrumb overflow';
 
 export const WithSelect = () => (
   <div style={{ height: '150vh' }}>

--- a/packages/react/src/components/PageTitleBar/_page-title-bar.scss
+++ b/packages/react/src/components/PageTitleBar/_page-title-bar.scss
@@ -195,6 +195,19 @@
       }
     }
 
+    &--overflow {
+      display: block;
+      overflow-x: hidden; // Hide horizontal overflow to support scrollWidth-based breadcrumb truncation
+
+      .#{$prefix}--popover-container {
+        position: absolute; // Add absolute position to prevent tooltip clipping
+      }
+
+      .breadcrumb--overflow:after {
+        margin-left: $spacing-06; // Add margin to avoid overlap with next breadcrumb item
+      }
+    }
+
     .page-title-bar-breadcrumb-current {
       --breadcrumb-scroll-distance: 20px;
       white-space: nowrap;


### PR DESCRIPTION
Closes # [MASMON-1428](https://jsw.ibm.com/browse/MASMON-1428)

**Summary**

- Add option for overflow breadcrumb in PageTitleBar

**Change List (commits, features, bugs, etc)**

- fix(PageTitleBar): add option for breadcrumb overflow in PageTitleBar

**Acceptance Test (how to verify the PR)**

- 
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/930905d2-23d5-479b-8722-6658895affe7" />


**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
