### PR TITLE
fix(tablecellrenderer): fix text truncate and tooltip with WrapCellText

### DIFF
--- a/packages/react/src/components/Table/TableCellRenderer/TableCellRenderer.jsx
+++ b/packages/react/src/components/Table/TableCellRenderer/TableCellRenderer.jsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { DefinitionTooltip } from '@carbon/react';
+import { DefinitionTooltip, Tooltip } from '@carbon/react';
 import warning from 'warning';
 
-import { Tooltip } from '../../Tooltip';
 import { settings } from '../../../constants/Settings';
 import { WrapCellTextPropTypes } from '../../../constants/SharedPropTypes';
 
@@ -98,9 +97,10 @@ const TableCellRenderer = ({
     ) : (
       <Tooltip
         showIcon={false}
-        triggerText={element}
+        label={element}
         triggerId="table-cell-tooltip-trigger"
         tooltipId="table-cell-tooltip"
+        autoAlign
       >
         {element}
       </Tooltip>
@@ -113,7 +113,8 @@ const TableCellRenderer = ({
     if (canBeTruncated && truncateCellText && allowTooltip && mySpanRef && mySpanRef.current) {
       setUseTooltip(isElementTruncated(mySpanRef.current));
     }
-  }, [mySpanRef, children, wrapText, truncateCellText, allowTooltip]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mySpanRef.current, children, wrapText, truncateCellText, allowTooltip]);
 
   if (__DEV__) {
     const isObject =

--- a/packages/react/src/components/Table/TableCellRenderer/_table-cell-renderer.scss
+++ b/packages/react/src/components/Table/TableCellRenderer/_table-cell-renderer.scss
@@ -6,19 +6,32 @@
 @use '@carbon/react/scss/utilities' as *;
 @use '@carbon/react/scss/components/data-table' as *;
 
-.#{$iot-prefix}--table__cell--truncate .#{$prefix}--tooltip__label {
-  // Revert the styles added by the tooltip since we want
-  // normal table cell content style even if a tooltip is triggered.
-  font-size: inherit;
-  font-weight: inherit;
-  line-height: inherit;
-  letter-spacing: inherit;
-  display: inherit;
-  align-items: inherit;
-  color: inherit;
+.#{$iot-prefix}--table__cell--truncate {
+  .#{$prefix}--tooltip__label {
+    // Revert the styles added by the tooltip since we want
+    // normal table cell content style even if a tooltip is triggered.
+    font-size: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+    letter-spacing: inherit;
+    display: inherit;
+    align-items: inherit;
+    color: inherit;
 
-  &:focus {
-    outline: none;
+    &:focus {
+      outline: none;
+    }
+  }
+
+  .#{$iot-prefix}--tooltip,
+  .#{$prefix}--tooltip {
+    display: block;
+  }
+
+  .#{$prefix}--tooltip-content {
+    .#{$iot-prefix}--table__cell-text--truncate {
+      white-space: unset;
+    }
   }
 }
 

--- a/packages/react/src/components/Table/TableColumnCustomization.story.jsx
+++ b/packages/react/src/components/Table/TableColumnCustomization.story.jsx
@@ -350,3 +350,52 @@ export const TableLegacyColumnManagement = () => {
 };
 
 TableLegacyColumnManagement.storyName = 'With legacy column management';
+
+export const WithWrapCellText = () => {
+  const selectedTableType = select('Type of Table', ['Table', 'StatefulTable'], 'Table');
+  const tableContainerWidth = select('Table container width', ['none', '300px', '800px'], 'none');
+
+  const wrapCellText = select(
+    'WrapCellText',
+    ['always', 'never', 'auto', 'alwaysTruncate', 'expand'],
+    'auto'
+  );
+
+  const ordering = object('Ordering (view.table.ordering)', [
+    { columnId: 'string' },
+    { columnId: 'date' },
+    { columnId: 'select' },
+    { columnId: 'secretField' },
+  ]);
+
+  const columns = [
+    { id: 'string', name: 'String', width: '100px' },
+    { id: 'date', name: 'Date', width: '250px' },
+    { id: 'select', name: 'Select', width: '100px' },
+    { id: 'secretField', name: 'Secret Information', width: '300px' },
+  ];
+
+  const MyTable = selectedTableType === 'StatefulTable' ? StatefulTable : Table;
+  return (
+    <div style={{ width: tableContainerWidth }}>
+      <MyTable
+        id="table"
+        columns={columns}
+        data={tableData.slice(0, 10)}
+        options={{
+          wrapCellText,
+        }}
+        view={{
+          table: { ordering },
+        }}
+        actions={{
+          table: {
+            onColumnResize: action('onColumnResize'),
+          },
+        }}
+      />
+    </div>
+  );
+};
+
+WithWrapCellText.storyName = 'With Wrap Cell Text';


### PR DESCRIPTION
Closes # [MASMON-4317](https://jsw.ibm.com/browse/MASMON-4317)

**Summary**

- fix(tablecellrenderer): fix text truncate and tooltip with WrapCellText

**Change List (commits, features, bugs, etc)**

- fix(tablecellrenderer): fix text truncate and tooltip with WrapCellText

**Acceptance Test (how to verify the PR)**

- 
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/4e9a6f71-cdf7-46fc-922a-2927063fc734" />


**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
