### PR TITLE
fix: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,27 +17,27 @@
 # These users own any files in the following directory at the root of
 # the repository and any of its subdirectories.
 
-* @davidicus @jessieyan @sls-ca @herleraja @abpaul1993
+* @davidicus @jessieyan @sls-ca @herleraja @abpaul1993 @simson1
 
 #####
 # Core admin team should be notified of changes to build/test/deploy
 
 # Core dependencies
-/package.json  @davidicus @jessieyan @sls-ca @herleraja @abpaul1993
-/yarn.lock     @davidicus @jessieyan @sls-ca @herleraja @abpaul1993
+/package.json  @davidicus @jessieyan @sls-ca @herleraja @abpaul1993 @simson1
+/yarn.lock     @davidicus @jessieyan @sls-ca @herleraja @abpaul1993 @simson1
 
 # Configuration files
-**/*.config.js  @davidicus @jessieyan @sls-ca @herleraja @abpaul1993
-**/config/      @davidicus @jessieyan @sls-ca @herleraja @abpaul1993
-/.nvmrc         @davidicus @jessieyan @sls-ca @herleraja @abpaul1993
+**/*.config.js  @davidicus @jessieyan @sls-ca @herleraja @abpaul1993 @simson1
+**/config/      @davidicus @jessieyan @sls-ca @herleraja @abpaul1993 @simson1
+/.nvmrc         @davidicus @jessieyan @sls-ca @herleraja @abpaul1993 @simson1
 
 # Deploy configuration
-**/.storybook/       @davidicus @jessieyan @sls-ca @herleraja @abpaul1993
-/.github/workflows/  @davidicus @jessieyan @sls-ca @herleraja @abpaul1993
-/netlify.toml        @davidicus @jessieyan @sls-ca @herleraja @abpaul1993
+**/.storybook/       @davidicus @jessieyan @sls-ca @herleraja @abpaul1993 @simson1
+/.github/workflows/  @davidicus @jessieyan @sls-ca @herleraja @abpaul1993 @simson1
+/netlify.toml        @davidicus @jessieyan @sls-ca @herleraja @abpaul1993 @simson1
 
 #####
 # Release team should be notified of Public API changes in the system
 
-**/publicAPI.test.js       @davidicus @jessieyan @sls-ca @herleraja @abpaul1993
-**/publicAPI.test.js.snap  @davidicus @jessieyan @sls-ca @herleraja @abpaul1993
+**/publicAPI.test.js       @davidicus @jessieyan @sls-ca @herleraja @abpaul1993 @simson1
+**/publicAPI.test.js.snap  @davidicus @jessieyan @sls-ca @herleraja @abpaul1993 @simson1


### PR DESCRIPTION
Closes #

**Summary**

- As a part of MAS Monitor team, I need to be as codeowner.
