### PR TITLE
fix: gauge card added padding prop to manage padding

### DIFF
--- a/packages/react/src/components/GaugeCard/GaugeCard.jsx
+++ b/packages/react/src/components/GaugeCard/GaugeCard.jsx
@@ -67,6 +67,7 @@ const GaugeCard = ({
   // TODO: remove deprecated testID in v3.
   testID,
   testId,
+  padding,
   ...others
 }) => {
   const [loadedState, setLoadedState] = useState(false);
@@ -83,9 +84,9 @@ const GaugeCard = ({
     ? {}
     : {
         paddingTop: 0,
-        paddingRight: CARD_CONTENT_PADDING,
-        paddingBottom: CARD_CONTENT_PADDING,
-        paddingLeft: CARD_CONTENT_PADDING,
+        paddingRight: padding ? CARD_CONTENT_PADDING : 0,
+        paddingBottom: padding ? CARD_CONTENT_PADDING : 0,
+        paddingLeft: padding ? CARD_CONTENT_PADDING : 0,
         rowGap: size === CARD_SIZES.SMALL ? 0 : '1rem',
       };
 
@@ -207,6 +208,7 @@ GaugeCard.defaultProps = {
       },
     ],
   },
+  padding: true,
   values: {},
 };
 


### PR DESCRIPTION
Closes #

**Summary**

Added `padding` in gaugeCard to enable/disbale padding based on need.

**Change List (commits, features, bugs, etc)**

-Added `padding` prop

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
