### PR TITLE
feat(tearsheet):  add shouldPreventClose prop to control tearSheet closing via promise

### DIFF
--- a/packages/react/src/components/TearSheet/TearSheet.jsx
+++ b/packages/react/src/components/TearSheet/TearSheet.jsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, useMemo } from 'react';
+import React, { cloneElement, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Close } from '@carbon/react/icons';
 import classnames from 'classnames';
@@ -33,6 +33,7 @@ const propTypes = {
   }),
   children: PropTypes.node,
   testId: PropTypes.string,
+  shouldPreventClose: PropTypes.func,
 };
 
 const defaultProps = {
@@ -51,6 +52,7 @@ const defaultProps = {
   children: undefined,
   // TODO: set default testId in v3.
   testId: '',
+  shouldPreventClose: () => new Promise((res) => res(false)),
 };
 
 const TearSheet = ({
@@ -66,15 +68,18 @@ const TearSheet = ({
   i18n,
   children,
   testId,
+  shouldPreventClose,
 }) => {
-  const onCloseButton = () => {
+  const onCloseButton = useCallback(async () => {
+    const preventClose = await shouldPreventClose();
     if (onClose) {
       onClose();
-      goToPreviousSheet();
-    } else {
+    }
+    if (!preventClose) {
       goToPreviousSheet();
     }
-  };
+  }, [shouldPreventClose, onClose, goToPreviousSheet]);
+
   return (
     <div
       // TODO: use only testId in v3.

--- a/packages/react/src/components/TearSheet/TearSheet.jsx
+++ b/packages/react/src/components/TearSheet/TearSheet.jsx
@@ -72,10 +72,10 @@ const TearSheet = ({
 }) => {
   const onCloseButton = useCallback(async () => {
     const preventClose = await shouldPreventClose();
-    if (onClose) {
-      onClose();
-    }
     if (!preventClose) {
+      if (onClose) {
+        onClose();
+      }
       goToPreviousSheet();
     }
   }, [shouldPreventClose, onClose, goToPreviousSheet]);


### PR DESCRIPTION
Closes #

**Summary**

- Introduced a new prop `shouldPreventClose` for `TearSheet`.  
This prop is a promise that resolves to `false` to allow closing or `true` to block closing.  
By default, it resolves to `false`.

**Change List (commits, features, bugs, etc)**

- https://jsw.ibm.com/browse/MAXUIF-2911

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
