### PR TITLE
feat(sidenav): onFilterItems prop and getTabIndexBasedOnSearch added (4.x.x)

### DIFF
--- a/packages/react/src/components/SideNav/SideNav.jsx
+++ b/packages/react/src/components/SideNav/SideNav.jsx
@@ -8,7 +8,7 @@ import {
   // SideNavSwitcher,
 } from '@carbon/react';
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import classnames from 'classnames';
 import { partition } from 'lodash-es';
 
@@ -172,6 +172,7 @@ export const SideNavPropTypes = {
   }),
 
   testId: PropTypes.string,
+  onFilterItems: PropTypes.func,
 };
 
 const defaultProps = {
@@ -190,6 +191,7 @@ const defaultProps = {
   },
   testId: 'side-nav',
   recentLinks: [],
+  onFilterItems: () => {},
 };
 
 /**
@@ -223,6 +225,7 @@ const SideNav = ({
   i18n,
   testId,
   recentLinks,
+  onFilterItems,
   ...props
 }) => {
   /**
@@ -236,6 +239,10 @@ const SideNav = ({
   const renderLinkMenu = (link, index, level = 0, searchValue) => {
     const isFiltering = searchValue !== undefined;
     let parentActive = false;
+    const tabIndex =
+      searchValue && link.metaData.getTabIndexBasedOnSearch
+        ? link.metaData.getTabIndexBasedOnSearch(link, index)
+        : link.metaData.tabIndex;
     const children = link.childContent.map((childLink, childIndex) => {
       if (isAnyChildActive(childLink)) {
         parentActive = true;
@@ -250,7 +257,6 @@ const SideNav = ({
         ? handleSpecificKeyDown(['Escape'], (evt) => evt.stopPropagation())
         : undefined;
       const content = searchValue ? markText(childLink.content, searchValue) : childLink.content;
-
       return (
         <SideNavMenuItem
           onKeyDown={onKeyDown}
@@ -273,7 +279,12 @@ const SideNav = ({
         title={link.linkContent}
         testId={`${testId}-menu-${index}`}
         className={`${iotPrefix}--side-nav__item--depth-${level}`}
-        {...(link.metaData ?? {})}
+        {...(link.metaData
+          ? {
+              ...link.metaData,
+              tabIndex,
+            }
+          : {})}
       >
         {children}
       </FilterableSideNavMenu>
@@ -293,7 +304,10 @@ const SideNav = ({
 
         const isFiltering = searchValue !== undefined;
         const content = searchValue ? markText(link.linkContent, searchValue) : link.linkContent;
-
+        const tabIndex =
+          searchValue && link.metaData.getTabIndexBasedOnSearch
+            ? link.metaData.getTabIndexBasedOnSearch(link, index)
+            : link.metaData.tabIndex;
         return (
           <SideNavLink
             key={`menu-link-${link.metaData.label.replace(/\s/g, '')}-global`}
@@ -306,7 +320,12 @@ const SideNav = ({
             className={classnames(link.metaData.className, {
               [`${iotPrefix}--side-nav__item--is-filtering`]: isFiltering,
             })}
-            {...link.metaData}
+            {...(link.metaData
+              ? {
+                  ...link.metaData,
+                  tabIndex,
+                }
+              : {})}
           >
             {content}
           </SideNavLink>
@@ -332,6 +351,10 @@ const SideNav = ({
       : filterableLinks;
     setRenderedFilterableLinks(renderLinks(linksToRender, newSearchValue));
   };
+
+  useEffect(() => {
+    onFilterItems(renderedFilterableLinks);
+  }, [onFilterItems, renderedFilterableLinks]);
 
   const search = hasSearch
     ? [

--- a/packages/react/src/components/SideNav/SideNav.jsx
+++ b/packages/react/src/components/SideNav/SideNav.jsx
@@ -240,9 +240,9 @@ const SideNav = ({
     const isFiltering = searchValue !== undefined;
     let parentActive = false;
     const tabIndex =
-      searchValue && link.metaData.getTabIndexBasedOnSearch
+      searchValue && link.metaData?.getTabIndexBasedOnSearch
         ? link.metaData.getTabIndexBasedOnSearch(link, index)
-        : link.metaData.tabIndex;
+        : link.metaData?.tabIndex;
     const children = link.childContent.map((childLink, childIndex) => {
       if (isAnyChildActive(childLink)) {
         parentActive = true;
@@ -305,9 +305,9 @@ const SideNav = ({
         const isFiltering = searchValue !== undefined;
         const content = searchValue ? markText(link.linkContent, searchValue) : link.linkContent;
         const tabIndex =
-          searchValue && link.metaData.getTabIndexBasedOnSearch
+          searchValue && link.metaData?.getTabIndexBasedOnSearch
             ? link.metaData.getTabIndexBasedOnSearch(link, index)
-            : link.metaData.tabIndex;
+            : link.metaData?.tabIndex;
         return (
           <SideNavLink
             key={`menu-link-${link.metaData.label.replace(/\s/g, '')}-global`}


### PR DESCRIPTION
Closes #

**Summary**
This PR enhances the accessibility and filtering capabilities of the SideNav component by:

- Adding a new `onFilterItems` callback function that notifies when filtered items change
- Improving tabIndex handling during search operations for better keyboard navigation
- Adding support for dynamic tabIndex calculation via a new function in link metadata


**Change List (commits, features, bugs, etc)**
- Added `onFilterItems` prop to SideNav component with appropriate PropTypes and default value
- Implemented a useEffect hook to call the onFilterItems callback when filtered links change
- Enhanced tabIndex handling for menu items and links during search/filtering operations
- Added support for dynamic tabIndex calculation via a new `getTabIndexBasedOnSearch` function in link metadata


**Acceptance Test (how to verify the PR)**
- Verify that the `onFilterItems` callback is triggered whenever the filtered links change
- Test that tabIndex is properly updated during search operations for both menu items and links
- Confirm that the `getTabIndexBasedOnSearch` function in metadata properly affects tabIndex when provided

**Regression Test (how to make sure this PR doesn't break old functionality)**
- Ensure existing SideNav functionality works without the new props (default behavior should be maintained)
- Verify that navigation with keyboard still works as expected
- Check that all existing filtering and search functionality still works correctly
- Test with different link configurations to ensure backward compatibility


<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
