### PR TITLE
feat(ValueCard): Allow a "formatter" to be passed

### DIFF
--- a/packages/react/src/components/ValueCard/Attribute.jsx
+++ b/packages/react/src/components/ValueCard/Attribute.jsx
@@ -143,7 +143,9 @@ const Attribute = ({
           precision={precision}
           color={valueColor}
           locale={locale}
-          formatter={formatter ?? customFormatter}
+          // Prefer new formatter. Fall back to legacy customFormatter.
+          formatter={formatter}
+          customFormatter={customFormatter}
           fontSize={fontSize}
           isNumberValueCompact={isNumberValueCompact}
           testId={`${testId}-value`}

--- a/packages/react/src/components/ValueCard/Attribute.jsx
+++ b/packages/react/src/components/ValueCard/Attribute.jsx
@@ -34,6 +34,7 @@ const propTypes = {
     tooltip: PropTypes.string,
   }).isRequired,
   customFormatter: PropTypes.func,
+  formatter: PropTypes.func,
   isEditable: PropTypes.bool,
   layout: PropTypes.oneOf(Object.values(CARD_LAYOUTS)),
   locale: PropTypes.string,
@@ -65,6 +66,7 @@ const defaultProps = {
   secondaryValue: null,
   locale: 'en',
   customFormatter: null,
+  formatter: null,
   isEditable: false,
   testId: 'attribute',
   onValueClick: null,
@@ -80,6 +82,7 @@ const Attribute = ({
   attribute: { label, unit, thresholds, precision, dataSourceId, measurementUnitLabel, tooltip },
   attributeCount,
   customFormatter,
+  formatter,
   isEditable,
   layout,
   locale,
@@ -140,7 +143,7 @@ const Attribute = ({
           precision={precision}
           color={valueColor}
           locale={locale}
-          customFormatter={customFormatter}
+          formatter={formatter ?? customFormatter}
           fontSize={fontSize}
           isNumberValueCompact={isNumberValueCompact}
           testId={`${testId}-value`}

--- a/packages/react/src/components/ValueCard/ValueCard.jsx
+++ b/packages/react/src/components/ValueCard/ValueCard.jsx
@@ -32,6 +32,7 @@ const ValueCard = ({
   id,
   locale,
   customFormatter,
+  formatter,
   children,
   fontSize,
   isNumberValueCompact,
@@ -89,7 +90,7 @@ const ValueCard = ({
         content={content}
         locale={locale}
         title={title}
-        customFormatter={customFormatter}
+        formatter={formatter ?? customFormatter}
         testId={testID || testId}
         onAttributeClick={onAttributeClick}
         size={newSize}
@@ -116,6 +117,7 @@ ValueCard.defaultProps = {
   fontSize: DEFAULT_FONT_SIZE,
   cardVariables: null,
   customFormatter: null,
+  formatter: null,
   isNumberValueCompact: false,
   // TODO: fix this default in V3, so that cards are unique not inherited from the base Card
   testId: 'Card',

--- a/packages/react/src/components/ValueCard/ValueCard.jsx
+++ b/packages/react/src/components/ValueCard/ValueCard.jsx
@@ -90,7 +90,9 @@ const ValueCard = ({
         content={content}
         locale={locale}
         title={title}
-        formatter={formatter ?? customFormatter}
+        // Prefer new formatter. Fall back to legacy customFormatter.
+        formatter={formatter}
+        customFormatter={customFormatter}
         testId={testID || testId}
         onAttributeClick={onAttributeClick}
         size={newSize}

--- a/packages/react/src/components/ValueCard/ValueContent.jsx
+++ b/packages/react/src/components/ValueCard/ValueContent.jsx
@@ -29,6 +29,7 @@ const defaultProps = {
   values: null,
   fontSize: DEFAULT_FONT_SIZE,
   customFormatter: null,
+  formatter: null,
   isNumberValueCompact: false,
   testId: 'ValueContent',
   onAttributeClick: null,
@@ -45,6 +46,7 @@ const ValueContent = ({
   locale,
   isEditable,
   customFormatter,
+  formatter,
   fontSize,
   isNumberValueCompact,
   testId,
@@ -78,7 +80,8 @@ const ValueContent = ({
                 value: determineValue(attribute.secondaryValue.dataSourceId, values),
               }
             }
-            customFormatter={customFormatter}
+            //Prefer new formatter. Fall back to legacy customFormatter.
+            formatter={formatter ?? customFormatter}
             fontSize={fontSize}
             isNumberValueCompact={isNumberValueCompact}
             testId={`${testId}-attribute-${index}`}

--- a/packages/react/src/components/ValueCard/ValueContent.jsx
+++ b/packages/react/src/components/ValueCard/ValueContent.jsx
@@ -80,8 +80,9 @@ const ValueContent = ({
                 value: determineValue(attribute.secondaryValue.dataSourceId, values),
               }
             }
-            //Prefer new formatter. Fall back to legacy customFormatter.
-            formatter={formatter ?? customFormatter}
+            // Prefer new formatter. Fall back to legacy customFormatter.
+            formatter={formatter}
+            customFormatter={customFormatter}
             fontSize={fontSize}
             isNumberValueCompact={isNumberValueCompact}
             testId={`${testId}-attribute-${index}`}

--- a/packages/react/src/components/ValueCard/ValueRenderer.jsx
+++ b/packages/react/src/components/ValueCard/ValueRenderer.jsx
@@ -69,7 +69,8 @@ const ValueRenderer = ({
     dataSourceId,
   };
   let renderValue;
-  let formattedError = false;
+  let formatterNullish = false;
+  let formatterError = false;
   // Feed the value and context into the formatter function, if it exists.
   if (typeof formatter === 'function') {
     try {
@@ -77,10 +78,12 @@ const ValueRenderer = ({
       // Catches null and undefined values from formatter, but allows (0, '', false)
       if (out !== null && out !== undefined) {
         renderValue = out;
+      } else {
+        formatterNullish = true;
       }
     } catch (e) {
       // Turns on the flag, to keep a global reference of the error occuring.
-      formattedError = true;
+      formatterError = true;
     }
   }
   if (renderValue === undefined) {
@@ -102,7 +105,7 @@ const ValueRenderer = ({
   }
 
   // If customFormatter was defined and either... formatter was not passed or there was an error with the formatter function, fall back to customFormatter logic.
-  if (typeof customFormatter === 'function' && (!formatter || formattedError)) {
+  if (typeof customFormatter === 'function' && (!formatter || formatterError || formatterNullish)) {
     renderValue = customFormatter(renderValue, value);
   }
 

--- a/packages/react/src/components/ValueCard/ValueRenderer.jsx
+++ b/packages/react/src/components/ValueCard/ValueRenderer.jsx
@@ -66,15 +66,16 @@ const ValueRenderer = ({
     unit: measurementUnitLabel,
     isNumberValueCompact,
     layout,
-    dataSourceId
-  }
+    dataSourceId,
+  };
   let renderValue;
-  if(typeof formatter === "function"){
+  // Feed the value and context into the formatter function, if it exists.
+  if (typeof formatter === 'function') {
     try {
       const out = formatter(value, ctx);
-      if (out!==null && out !== undefined) {
+      if (out !== null && out !== undefined) {
         renderValue = out;
-      } 
+      }
     } catch (e) {
       // ignore and fall through to defaults
     }
@@ -91,9 +92,9 @@ const ValueRenderer = ({
         </span>
       );
     } else if (typeof value === 'number') {
-        renderValue = formatNumberWithPrecision(value, precision, locale, isNumberValueCompact);
+      renderValue = formatNumberWithPrecision(value, precision, locale, isNumberValueCompact);
     } else if (isNil(value)) {
-        renderValue = PREVIEW_DATA;
+      renderValue = PREVIEW_DATA;
     }
   }
 

--- a/packages/react/src/components/ValueCard/ValueRenderer.jsx
+++ b/packages/react/src/components/ValueCard/ValueRenderer.jsx
@@ -69,15 +69,18 @@ const ValueRenderer = ({
     dataSourceId,
   };
   let renderValue;
+  let formattedError = false;
   // Feed the value and context into the formatter function, if it exists.
   if (typeof formatter === 'function') {
     try {
       const out = formatter(value, ctx);
+      // Catches null and undefined values from formatter, but allows (0, '', false)
       if (out !== null && out !== undefined) {
         renderValue = out;
       }
     } catch (e) {
-      // ignore and fall through to defaults
+      // Turns on the flag, to keep a global reference of the error occuring.
+      formattedError = true;
     }
   }
   if (renderValue === undefined) {
@@ -98,7 +101,10 @@ const ValueRenderer = ({
     }
   }
 
-  renderValue = isNil(customFormatter) ? renderValue : customFormatter(renderValue, value);
+  // If customFormatter was defined and either... formatter was not passed or there was an error with the formatter function, fall back to customFormatter logic.
+  if (typeof customFormatter === 'function' && (!formatter || formattedError)) {
+    renderValue = customFormatter(renderValue, value);
+  }
 
   const commonProps = {
     'data-testid': testId,

--- a/packages/react/src/components/ValueCard/ValueRenderer.jsx
+++ b/packages/react/src/components/ValueCard/ValueRenderer.jsx
@@ -17,6 +17,7 @@ const propTypes = {
   color: PropTypes.string,
   locale: PropTypes.string,
   customFormatter: PropTypes.func,
+  formatter: PropTypes.func,
   fontSize: PropTypes.number.isRequired,
   /** optional option to determine whether the number should be abbreviated (i.e. 10,000 = 10K) */
   isNumberValueCompact: PropTypes.bool.isRequired,
@@ -33,6 +34,7 @@ const defaultProps = {
   color: null,
   locale: 'en',
   customFormatter: null,
+  formatter: null,
   testId: 'value',
   onClick: null,
   measurementUnitLabel: null,
@@ -50,6 +52,7 @@ const ValueRenderer = ({
   color,
   locale,
   customFormatter,
+  formatter,
   fontSize,
   isNumberValueCompact,
   testId,
@@ -57,20 +60,41 @@ const ValueRenderer = ({
   dataSourceId,
   measurementUnitLabel,
 }) => {
-  let renderValue = value;
-  if (typeof value === 'boolean') {
-    renderValue = (
-      <span
-        data-testid={`${testId}-boolean`}
-        className={`${BASE_CLASS_NAME}__value-renderer--boolean`}
-      >
-        {value.toString()}
-      </span>
-    );
-  } else if (typeof value === 'number') {
-    renderValue = formatNumberWithPrecision(value, precision, locale, isNumberValueCompact);
-  } else if (isNil(value)) {
-    renderValue = PREVIEW_DATA;
+  const ctx = {
+    locale,
+    precision,
+    unit: measurementUnitLabel,
+    isNumberValueCompact,
+    layout,
+    dataSourceId
+  }
+  let renderValue;
+  if(typeof formatter === "function"){
+    try {
+      const out = formatter(value, ctx);
+      if (out!==null && out !== undefined) {
+        renderValue = out;
+      } 
+    } catch (e) {
+      // ignore and fall through to defaults
+    }
+  }
+  if (renderValue === undefined) {
+    renderValue = value;
+    if (typeof value === 'boolean') {
+      renderValue = (
+        <span
+          data-testid={`${testId}-boolean`}
+          className={`${BASE_CLASS_NAME}__value-renderer--boolean`}
+        >
+          {value.toString()}
+        </span>
+      );
+    } else if (typeof value === 'number') {
+        renderValue = formatNumberWithPrecision(value, precision, locale, isNumberValueCompact);
+    } else if (isNil(value)) {
+        renderValue = PREVIEW_DATA;
+    }
   }
 
   renderValue = isNil(customFormatter) ? renderValue : customFormatter(renderValue, value);

--- a/packages/react/src/constants/CardPropTypes.js
+++ b/packages/react/src/constants/CardPropTypes.js
@@ -118,7 +118,14 @@ export const ValueContentPropTypes = {
    * the original value and expects a value to be returned that will be rendered on the value card.
    * customerFormatter(defaultFormattedValue, originalValue)
    */
+  /** @deprecated use `formatter` */
   customFormatter: PropTypes.func,
+  /**
+   * formatter(originalValue, ctx) => ReactNode|string
+   * Called before default formatting. If it returns a non-nullish value, that is rendered.
+   * ctx: { locale, attribute, secondary?: boolean, isNumberValueCompact, fontSize }
+   */
+  formatter: PropTypes.func,
   /** optional custom font size for the displayed value */
   fontSize: PropTypes.number,
   /** option to determine whether the number should be abbreviated (i.e. 10,000 = 10K) */


### PR DESCRIPTION
Closes #
MAXUIF-2422

**Summary**
Creates a formatter prop in ValueCard and threads it through ValueContent, Attribute, and ValueRenderer. In ValueRenderer created the logic to handle the new formatter function passed and determine if the function is defined, throws an error, and whether or not we should use the fallback customFormatter instead.

- summary_here

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
