### PR TITLE
fix: adding missing z-index imports

### DIFF
--- a/packages/react/src/components/ComboBox/_combo-box.scss
+++ b/packages/react/src/components/ComboBox/_combo-box.scss
@@ -1,6 +1,7 @@
 @use '@carbon/react/scss/components/combo-box';
 @use '../../globals/vars' as *;
 @use '../../globals/mixins' as *;
+@use '@carbon/react/scss/utilities/z-index' as *;
 
 .#{$iot-prefix}--combobox {
   display: flex;

--- a/packages/react/src/components/SideNav/_side-nav.scss
+++ b/packages/react/src/components/SideNav/_side-nav.scss
@@ -8,6 +8,7 @@
 @use '@carbon/react/scss/motion' as *;
 @use '@carbon/react/scss/type' as *;
 @use '@carbon/react/scss/colors' as *;
+@use '@carbon/react/scss/utilities/z-index' as *;
 /////////////////////////////////////////////
 // AI applications dark sidenav theme styles
 ////////////////////////////////////////////

--- a/packages/react/src/components/SuiteHeader/_suite-header.scss
+++ b/packages/react/src/components/SuiteHeader/_suite-header.scss
@@ -7,6 +7,7 @@
 @use '@carbon/react/scss/components/button' as *;
 @use '@carbon/react/scss/utilities/convert';
 @use '@carbon/react/scss/utilities/z-index' as *;
+
 .#{$iot-prefix}--suite-header-profile {
   background-color: $layer-selected-inverse;
   color: $text-inverse; //$inverse-01

--- a/packages/react/src/components/SuiteHeader/_suite-header.scss
+++ b/packages/react/src/components/SuiteHeader/_suite-header.scss
@@ -6,6 +6,7 @@
 @use '@carbon/react/scss/type' as *;
 @use '@carbon/react/scss/components/button' as *;
 @use '@carbon/react/scss/utilities/convert';
+@use '@carbon/react/scss/utilities/z-index' as *;
 .#{$iot-prefix}--suite-header-profile {
   background-color: $layer-selected-inverse;
   color: $text-inverse; //$inverse-01


### PR DESCRIPTION
Closes https://jsw.ibm.com/browse/MAXUIF-3339

**Summary**
Adding missing z-index function import in scss files using it

**Change List (commits, features, bugs, etc)**
Adding missing z-index function in _combo-box.scss, _suite-header.scss, _side-nav.scss

**Acceptance Test (how to verify the PR)**
Check if the z-index prop for the elements updated are applied correctly on the browser

**Regression Test (how to make sure this PR doesn't break old functionality)**
Check if components with the changes are rendered and built correctly

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
