### PR TITLE
fix(datetime-input): landmark issue fix for accessibility MAXUIF-3057

### DIFF
--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
@@ -291,6 +291,9 @@ export const defaultProps = {
     invalidDateText: 'Date is required',
     amString: 'AM',
     pmString: 'PM',
+    buttonActions: 'Button actions',
+    datePickerContent: 'Date picker content',
+    datePickerReference: 'Date picker reference',
   },
   light: false,
   locale: 'en',
@@ -988,58 +991,60 @@ const DateTimePicker = ({
   // eslint-disable-next-line react/prop-types
   const CustomFooter = () => {
     return (
-      <div className={`${iotPrefix}--date-time-picker__menu-btn-set`}>
-        {isCustomRange && !isSingleSelect && !hideBackButton ? (
+      <div role="region" aria-label={mergedI18n.buttonActions}>
+        <div className={`${iotPrefix}--date-time-picker__menu-btn-set`}>
+          {isCustomRange && !isSingleSelect && !hideBackButton ? (
+            <Button
+              kind="secondary"
+              className={`${iotPrefix}--date-time-picker__menu-btn ${iotPrefix}--date-time-picker__menu-btn-back`}
+              size="md"
+              {...others}
+              onClick={toggleIsCustomRange}
+              onKeyUp={handleSpecificKeyDown(['Enter', ' '], toggleIsCustomRange)}
+            >
+              {mergedI18n.backBtnLabel}
+              id={`back-${others.id}`}
+            </Button>
+          ) : isSingleSelect ? (
+            <Button
+              kind="secondary"
+              className={`${iotPrefix}--date-time-picker__menu-btn ${iotPrefix}--date-time-picker__menu-btn-reset`}
+              size="md"
+              {...others}
+              id={`clear-${others.id}`}
+              onClick={onClearClick}
+              onMouseDown={(e) => e.preventDefault()}
+              onKeyUp={handleSpecificKeyDown(['Enter', ' '], onClearClick)}
+            >
+              {mergedI18n.resetBtnLabel}
+            </Button>
+          ) : (
+            <Button
+              kind="secondary"
+              className={`${iotPrefix}--date-time-picker__menu-btn ${iotPrefix}--date-time-picker__menu-btn-cancel`}
+              onClick={onCancelClick}
+              size="md"
+              {...others}
+              id={`cancel-${others.id}`}
+              onKeyUp={handleSpecificKeyDown(['Enter', ' '], onCancelClick)}
+            >
+              {mergedI18n.cancelBtnLabel}
+            </Button>
+          )}
           <Button
-            kind="secondary"
-            className={`${iotPrefix}--date-time-picker__menu-btn ${iotPrefix}--date-time-picker__menu-btn-back`}
-            size="md"
+            kind="primary"
+            className={`${iotPrefix}--date-time-picker__menu-btn ${iotPrefix}--date-time-picker__menu-btn-apply`}
             {...others}
-            onClick={toggleIsCustomRange}
-            onKeyUp={handleSpecificKeyDown(['Enter', ' '], toggleIsCustomRange)}
-          >
-            {mergedI18n.backBtnLabel}
-            id={`back-${others.id}`}
-          </Button>
-        ) : isSingleSelect ? (
-          <Button
-            kind="secondary"
-            className={`${iotPrefix}--date-time-picker__menu-btn ${iotPrefix}--date-time-picker__menu-btn-reset`}
-            size="md"
-            {...others}
-            id={`clear-${others.id}`}
-            onClick={onClearClick}
+            id={`apply-${others.id}`}
+            onClick={onApplyClick}
+            onKeyUp={handleSpecificKeyDown(['Enter', ' '], onApplyClick)}
             onMouseDown={(e) => e.preventDefault()}
-            onKeyUp={handleSpecificKeyDown(['Enter', ' '], onClearClick)}
-          >
-            {mergedI18n.resetBtnLabel}
-          </Button>
-        ) : (
-          <Button
-            kind="secondary"
-            className={`${iotPrefix}--date-time-picker__menu-btn ${iotPrefix}--date-time-picker__menu-btn-cancel`}
-            onClick={onCancelClick}
             size="md"
-            {...others}
-            id={`cancel-${others.id}`}
-            onKeyUp={handleSpecificKeyDown(['Enter', ' '], onCancelClick)}
+            disabled={customRangeKind === PICKER_KINDS.SINGLE ? false : disableApply}
           >
-            {mergedI18n.cancelBtnLabel}
+            {mergedI18n.applyBtnLabel}
           </Button>
-        )}
-        <Button
-          kind="primary"
-          className={`${iotPrefix}--date-time-picker__menu-btn ${iotPrefix}--date-time-picker__menu-btn-apply`}
-          {...others}
-          id={`apply-${others.id}`}
-          onClick={onApplyClick}
-          onKeyUp={handleSpecificKeyDown(['Enter', ' '], onApplyClick)}
-          onMouseDown={(e) => e.preventDefault()}
-          size="md"
-          disabled={customRangeKind === PICKER_KINDS.SINGLE ? false : disableApply}
-        >
-          {mergedI18n.applyBtnLabel}
-        </Button>
+        </div>
       </div>
     );
   };
@@ -1124,7 +1129,8 @@ const DateTimePicker = ({
           (invalidRangeStartDate ? invalidDateWarningHeight : 0) -
           (!hasTimeInput ? timeInputHeight : 0),
       }}
-      role="presentation"
+      role="region"
+      aria-label={mergedI18n.datePickerContent}
       onClick={(event) => event.stopPropagation()} // need to stop the event so that it will not close the menu
       onKeyDown={(event) => event.stopPropagation()} // need to stop the event so that it will not close the menu
       tabIndex="-1"
@@ -1311,7 +1317,10 @@ const DateTimePicker = ({
             </>
           ) : (
             <div data-testid={`${testId}-datepicker`}>
-              <FormGroup className={`${iotPrefix}--date-time-picker__menu-formgroup`}>
+              <FormGroup
+                legendText={mergedI18n.startDateLabel}
+                className={`${iotPrefix}--date-time-picker__menu-formgroup`}
+              >
                 <Layer>
                   <DatePicker
                     datePickerType={datePickerType}
@@ -1331,7 +1340,7 @@ const DateTimePicker = ({
                   >
                     <DatePickerInput
                       labelText={mergedI18n.startDateLabel}
-                      aria-label={mergedI18n.startAriaLabel}
+                      aria-label={mergedI18n.startDateLabel}
                       id={`${id}-date-picker-input-start`}
                       invalid={invalidRangeStartDate}
                       invalidText={mergedI18n.invalidDateText}
@@ -1350,7 +1359,11 @@ const DateTimePicker = ({
               </FormGroup>
               {hasTimeInput ? (
                 <FormGroup
-                  legendText=""
+                  legendText={
+                    isSingleSelect
+                      ? mergedI18n.startTimeLabel
+                      : `${mergedI18n.startTimeLabel} ${mergedI18n.toLabel} ${mergedI18n.endTimeLabel}`
+                  }
                   className={`${iotPrefix}--date-time-picker__menu-formgroup`}
                 >
                   <Layer>
@@ -1484,34 +1497,36 @@ const DateTimePicker = ({
 
   return (
     <div className={`${iotPrefix}--date-time-pickerv2`} ref={containerRef}>
-      <div
-        ref={datePickerRef}
-        data-testid={testId}
-        id={`${id}-${iotPrefix}--date-time-pickerv2__wrapper`}
-        className={classnames(`${iotPrefix}--date-time-pickerv2__wrapper`, {
-          [`${iotPrefix}--date-time-pickerv2__wrapper--disabled`]: disabled,
-          [`${iotPrefix}--date-time-pickerv2__wrapper--invalid`]: invalidState,
-        })}
-        style={{ '--wrapper-width': hasIconOnly ? '3rem' : '20rem' }}
-        role="button"
-        onClick={onFieldClick}
-        onKeyDown={handleSpecificKeyDown(['Enter', ' ', 'Escape', 'ArrowDown'], (event) => {
-          // the onApplyClick event gets blocked when called via the keyboard from the flyout menu's
-          // custom footer. This is a catch to ensure the onApplyCLick is called correctly for preset
-          // ranges via the keyboard.
-          if (
-            (event.key === 'Enter' || event.key === ' ') &&
-            event.target.classList.contains(`${iotPrefix}--date-time-picker__menu-btn-apply`) &&
-            !isCustomRange
-          ) {
-            onApplyClick();
-          }
+      <div role="region" aria-label={mergedI18n.datePickerReference}>
+        <div
+          ref={datePickerRef}
+          data-testid={testId}
+          id={`${id}-${iotPrefix}--date-time-pickerv2__wrapper`}
+          className={classnames(`${iotPrefix}--date-time-pickerv2__wrapper`, {
+            [`${iotPrefix}--date-time-pickerv2__wrapper--disabled`]: disabled,
+            [`${iotPrefix}--date-time-pickerv2__wrapper--invalid`]: invalidState,
+          })}
+          style={{ '--wrapper-width': hasIconOnly ? '3rem' : '20rem' }}
+          role="button"
+          onClick={onFieldClick}
+          onKeyDown={handleSpecificKeyDown(['Enter', ' ', 'Escape', 'ArrowDown'], (event) => {
+            // the onApplyClick event gets blocked when called via the keyboard from the flyout menu's
+            // custom footer. This is a catch to ensure the onApplyCLick is called correctly for preset
+            // ranges via the keyboard.
+            if (
+              (event.key === 'Enter' || event.key === ' ') &&
+              event.target.classList.contains(`${iotPrefix}--date-time-picker__menu-btn-apply`) &&
+              !isCustomRange
+            ) {
+              onApplyClick();
+            }
 
-          onFieldInteraction(event);
-        })}
-        tabIndex={0}
-      >
-        {tooltipField}
+            onFieldInteraction(event);
+          })}
+          tabIndex={0}
+        >
+          {tooltipField}
+        </div>
       </div>
       {invalidState && !hasIconOnly ? (
         <p

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
@@ -1317,10 +1317,7 @@ const DateTimePicker = ({
             </>
           ) : (
             <div data-testid={`${testId}-datepicker`}>
-              <FormGroup
-                legendText={mergedI18n.startDateLabel}
-                className={`${iotPrefix}--date-time-picker__menu-formgroup`}
-              >
+              <FormGroup className={`${iotPrefix}--date-time-picker__menu-formgroup`}>
                 <Layer>
                   <DatePicker
                     datePickerType={datePickerType}
@@ -1350,7 +1347,6 @@ const DateTimePicker = ({
                     {datePickerType === 'range' ? (
                       <DatePickerInput
                         labelText={mergedI18n.endDateLabel}
-                        aria-label={mergedI18n.endAriaLabel}
                         id={`${id}-date-picker-input-end`}
                       />
                     ) : null}
@@ -1358,14 +1354,7 @@ const DateTimePicker = ({
                 </Layer>
               </FormGroup>
               {hasTimeInput ? (
-                <FormGroup
-                  legendText={
-                    isSingleSelect
-                      ? mergedI18n.startTimeLabel
-                      : `${mergedI18n.startTimeLabel} ${mergedI18n.toLabel} ${mergedI18n.endTimeLabel}`
-                  }
-                  className={`${iotPrefix}--date-time-picker__menu-formgroup`}
-                >
+                <FormGroup className={`${iotPrefix}--date-time-picker__menu-formgroup`}>
                   <Layer>
                     <TimePickerDropdown
                       className={`${iotPrefix}--time-picker-dropdown`}

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
@@ -1129,7 +1129,8 @@ const DateTimePicker = ({
           (invalidRangeStartDate ? invalidDateWarningHeight : 0) -
           (!hasTimeInput ? timeInputHeight : 0),
       }}
-      role="presentation"
+      role="region"
+      aria-label={mergedI18n.datePickerContent}
       onClick={(event) => event.stopPropagation()} // need to stop the event so that it will not close the menu
       onKeyDown={(event) => event.stopPropagation()} // need to stop the event so that it will not close the menu
       tabIndex="-1"

--- a/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePickerV2WithTimeSpinner.jsx
@@ -495,7 +495,6 @@ const DateTimePicker = ({
   closeOnSelect,
   ...others
 }) => {
-  console.log(renderInPortal);
   const id = useRef(others.id || uuidv4()).current;
 
   React.useEffect(() => {
@@ -1117,6 +1116,7 @@ const DateTimePicker = ({
   const datePlaceHolder = humanValue?.split(splitToken)[0];
 
   const datePickerContent = (
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
     <div
       ref={dropdownRef}
       className={`${iotPrefix}--date-time-picker__menu-scroll`}
@@ -1129,8 +1129,7 @@ const DateTimePicker = ({
           (invalidRangeStartDate ? invalidDateWarningHeight : 0) -
           (!hasTimeInput ? timeInputHeight : 0),
       }}
-      role="region"
-      aria-label={mergedI18n.datePickerContent}
+      role="presentation"
       onClick={(event) => event.stopPropagation()} // need to stop the event so that it will not close the menu
       onKeyDown={(event) => event.stopPropagation()} // need to stop the event so that it will not close the menu
       tabIndex="-1"


### PR DESCRIPTION
Closes : [MAXUIF-3057](https://jsw.ibm.com/browse/MAXUIF-3057)

**Summary**

This PR addresses accessibility violations identified by IBM Accessibility Checker in the `DateTimePickerV2WithTimeSpinner` component. The fixes ensure proper accessible names for form groups/fieldsets and align accessible names with visible label text.


**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

## Before :

<img width="1660" height="853" alt="image" src="https://github.com/user-attachments/assets/5696da8e-bbae-475a-aaff-50945c75bbd3" />


## After

<img width="1673" height="678" alt="image" src="https://github.com/user-attachments/assets/da0f3f4e-f206-4c1a-a32a-302480889fa6" />



<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
