### PR TITLE
fix: EmptyState a11y props support

### DIFF
--- a/packages/react/src/components/EmptyState/EmptyState.jsx
+++ b/packages/react/src/components/EmptyState/EmptyState.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/require-default-props */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -70,16 +72,10 @@ const props = {
   size: PropTypes.oneOf([DEFAULT_SIZE, SMALL_SIZE]),
   /** Arrangement of the empty state */
   arrangement: PropTypes.oneOf(['stacked', 'inline']),
-};
-
-const defaultProps = {
-  action: null,
-  secondaryAction: null,
-  icon: '',
-  className: '',
-  testId: 'EmptyState',
-  size: 'default',
-  arrangement: 'stacked',
+  /** aria-labe to be passed to the empty state icon */
+  iconAriaLabel: PropTypes.string,
+  /** aria-hidden to be passed to the empty state icon */
+  iconAriaHidden: PropTypes.bool,
 };
 
 /**
@@ -88,15 +84,17 @@ const defaultProps = {
  */
 const EmptyState = ({
   title,
-  icon,
+  icon = '',
   body,
-  action,
-  secondaryAction,
-  className,
-  testId,
+  action = null,
+  secondaryAction = null,
+  className = '',
+  testId = 'EmptyState',
   testID,
-  size,
-  arrangement,
+  size = 'default',
+  arrangement = 'stacked',
+  iconAriaLabel,
+  iconAriaHidden,
 }) => {
   const isSmall = size === SMALL_SIZE;
   return (
@@ -119,6 +117,8 @@ const EmptyState = ({
             }),
             alt: '',
             'data-testid': `${testID || testId}-icon`,
+            'aria-label': iconAriaLabel,
+            'aria-hidden': iconAriaHidden,
             ...(isSmall && smallIconProps),
           })}
         <h3
@@ -170,6 +170,5 @@ const EmptyState = ({
 };
 
 EmptyState.propTypes = props;
-EmptyState.defaultProps = defaultProps;
 
 export default EmptyState;


### PR DESCRIPTION
Relates to: [MAXUIF-3055](https://jsw.ibm.com/browse/MAXUIF-3055)

**Summary**
Adding the following A11Y props to EmptyState component:
- `iconAriaLabel`
- `iconAriaHidden`

**Acceptance Test (how to verify the PR)**
- Check if the new props passed to the component work as expected

**Regression Test (how to make sure this PR doesn't break old functionality)**
- Check if the component continues to work as it did before with no issues

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
