### PR TITLE
feat: pagination fixes of max pages MAXUIF-1417

### DIFF
--- a/packages/react/src/components/Table/Pagination.jsx
+++ b/packages/react/src/components/Table/Pagination.jsx
@@ -37,6 +37,7 @@ const SizedPagination = ({
           [`${iotPrefix}--pagination--hide-select`]: preventInteraction,
           [`${iotPrefix}--pagination--narrow`]: width > 500 && width < 608,
           [`${iotPrefix}--pagination--compact`]: width < 500,
+          [`${iotPrefix}--pagination--hide-goto-page`]: rest.maxPagesConditionalStyle,
         })}
         style={{
           '--pagination-text-display': width < 500 ? 'none' : 'flex',

--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -15,7 +15,7 @@ import FilterTags from '../FilterTags/FilterTags';
 import { RuleGroupPropType } from '../RuleBuilder/RuleBuilderPropTypes';
 import experimental from '../../internal/experimental';
 import deprecate from '../../internal/deprecate';
-import SimplePagination from '../SimplePagination/SimplePagination';
+// import SimplePagination from '../SimplePagination/SimplePagination';
 
 import {
   TableColumnsPropTypes,
@@ -1292,42 +1292,44 @@ const Table = (props) => {
         </CarbonTable>
       </div>
       {options.hasPagination && !view.table.loadingState.isLoading && visibleData?.length ? ( // don't show pagination row while loading
-        paginationProps.totalItems > Math.ceil(maxPages * paginationProps.pageSize) ? (
-          <SimplePagination
-            prevPageText={i18n.pageBackwardAria}
-            nextPageText={i18n.pageForwardAria}
-            totalItems={paginationProps.totalItems}
-            page={paginationProps.page}
-            maxPage={Math.ceil(paginationProps.totalItems / paginationProps.pageSize)}
-            onPage={(page) =>
-              actions.pagination.onChangePage({ page, pageSize: paginationProps.pageSize })
-            }
-            testId={`${id || testId}-table-pagination`}
-            size={size}
-          />
-        ) : (
-          <Pagination
-            pageSize={paginationProps.pageSize}
-            pageSizes={paginationProps.pageSizes}
-            page={paginationProps.page}
-            isItemPerPageHidden={paginationProps.isItemPerPageHidden}
-            totalItems={
-              paginationProps.totalItems < Math.ceil(maxPages * paginationProps.pageSize)
-                ? paginationProps.totalItems
-                : Math.ceil(maxPages * paginationProps.pageSize)
-            }
-            onChange={actions.pagination.onChangePage}
-            backwardText={i18n.pageBackwardAria}
-            forwardText={i18n.pageForwardAria}
-            pageNumberText={i18n.pageNumberAria}
-            itemsPerPageText={i18n.itemsPerPage}
-            itemRangeText={i18n.itemsRangeWithTotal}
-            pageRangeText={i18n.pageRange}
-            preventInteraction={rowEditMode || singleRowEditMode}
-            testId={`${id || testId}-table-pagination`}
-            size={paginationProps.size}
-          />
-        )
+        // paginationProps.totalItems > Math.ceil(maxPages * paginationProps.pageSize) ? (
+        //   <SimplePagination
+        //     prevPageText={i18n.pageBackwardAria}
+        //     nextPageText={i18n.pageForwardAria}
+        //     totalItems={paginationProps.totalItems}
+        //     page={paginationProps.page}
+        //     maxPage={Math.ceil(paginationProps.totalItems / paginationProps.pageSize)}
+        //     onPage={(page) =>
+        //       actions.pagination.onChangePage({ page, pageSize: paginationProps.pageSize })
+        //     }
+        //     testId={`${id || testId}-table-pagination`}
+        //     size={size}
+        //   />
+        // ) :
+        <Pagination
+          pageSize={paginationProps.pageSize}
+          pageSizes={paginationProps.pageSizes}
+          page={paginationProps.page}
+          isItemPerPageHidden={paginationProps.isItemPerPageHidden}
+          totalItems={
+            paginationProps.totalItems < Math.ceil(maxPages * paginationProps.pageSize)
+              ? paginationProps.totalItems
+              : Math.ceil(maxPages * paginationProps.pageSize)
+          }
+          onChange={actions.pagination.onChangePage}
+          backwardText={i18n.pageBackwardAria}
+          forwardText={i18n.pageForwardAria}
+          pageNumberText={i18n.pageNumberAria}
+          itemsPerPageText={i18n.itemsPerPage}
+          itemRangeText={i18n.itemsRangeWithTotal}
+          pageRangeText={i18n.pageRange}
+          preventInteraction={rowEditMode || singleRowEditMode}
+          testId={`${id || testId}-table-pagination`}
+          size={paginationProps.size}
+          maxPagesConditionalStyle={
+            paginationProps.totalItems > Math.ceil(maxPages * paginationProps.pageSize)
+          }
+        />
       ) : null}
       {options.hasMultiSort && (
         <TableMultiSortModal

--- a/packages/react/src/components/Table/_pagination.scss
+++ b/packages/react/src/components/Table/_pagination.scss
@@ -64,6 +64,14 @@
     margin-left: 0rem;
   }
 }
+.#{$iot-prefix}--pagination--hide-goto-page {
+  .#{$prefix}--pagination__right .#{$prefix}--select__page-number {
+    display: none;
+  }
+  .#{$prefix}--pagination__right {
+    border-left-style: none;
+  }
+}
 // This is a workaround to hide the select controls since the
 // page size select can't be disabled.
 .#{$iot-prefix}--pagination--hide-select .#{$prefix}--select {


### PR DESCRIPTION
Closes #
https://jsw.ibm.com/browse/MAXUIF-1417

**Summary**
ISSUE: MaxPages removes items per page ddropdown also,
Requirment: items Per Page should be visible, go to pages should be hidden
Solution: pagination was getting switched from pagination(from Carbon) to Simple pagination(Manualy created)
removed the check to always render carbon pagination, ussed css to hide 'go to page' dropdown

BEFORE:
<img width="1517" height="912" alt="image" src="https://github.com/user-attachments/assets/d47b0de9-6d61-4aea-a196-3febf6023c9b" />

AFTER:
<img width="1446" height="922" alt="image" src="https://github.com/user-attachments/assets/ba874425-ce7c-4580-8d44-5b5011b65477" />

when maxPages is greater than pages:
<img width="1444" height="885" alt="image" src="https://github.com/user-attachments/assets/b4d55918-0125-4d3f-9c0d-163c3eecdc9c" />


**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
