### PR TITLE
chore: exposed width & backgroundColor as props

### DIFF
--- a/packages/react/src/components/SidePanel/SidePanel.jsx
+++ b/packages/react/src/components/SidePanel/SidePanel.jsx
@@ -56,6 +56,10 @@ const propTypes = {
   isBusy: PropTypes.bool,
   /** should the footer primary button be disabled */
   isPrimaryButtonDisabled: PropTypes.bool,
+  /** Custom width in pixels for the side panel (e.g., 400, '400px', or '25rem') */
+  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /** Custom background color for the side panel (e.g., '#f4f4f4', 'gray', or any valid CSS color) */
+  backgroundColor: PropTypes.string,
 };
 
 const defaultProps = {
@@ -79,6 +83,8 @@ const defaultProps = {
   onSecondaryButtonClick: undefined,
   isBusy: false,
   isPrimaryButtonDisabled: false,
+  width: undefined,
+  backgroundColor: undefined,
 };
 
 const baseClass = `${iotPrefix}--sidepanel`;
@@ -103,6 +109,8 @@ const SidePanel = ({
   style,
   isBusy,
   isPrimaryButtonDisabled,
+  width,
+  backgroundColor,
 }) => {
   const titleRef = useRef();
   const subtitleRef = useRef();
@@ -189,6 +197,20 @@ const SidePanel = ({
     }
     return `${str.substring(0, length)}...`;
   };
+  const panelWidth = useMemo(() => {
+    if (width !== undefined) {
+      return typeof width === 'number' ? `${width}px` : width;
+    }
+    return undefined;
+  }, [width]);
+
+  const panelStyle = useMemo(() => {
+    return {
+      ...style,
+      ...(panelWidth && { width: panelWidth }),
+      ...(backgroundColor && { backgroundColor }),
+    };
+  }, [style, panelWidth, backgroundColor]);
 
   return (
     <div
@@ -202,7 +224,7 @@ const SidePanel = ({
         [`${baseClass}--slide-over`]: type === 'over',
         [`${baseClass}--condensed`]: isCondensed || isScrolled,
       })}
-      style={style}
+      style={panelStyle}
     >
       {onToggle && (isOpen || type === 'inline') ? (
         <Button

--- a/packages/react/src/components/SidePanel/SidePanel.story.jsx
+++ b/packages/react/src/components/SidePanel/SidePanel.story.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withKnobs, select, boolean, text } from '@storybook/addon-knobs';
+import { withKnobs, select, boolean, text, number } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { Edit, Information, SendAlt } from '@carbon/react/icons';
 
@@ -67,17 +67,21 @@ const InPage = ({
   onSecondaryButtonClick,
   isBusy,
   isPrimaryButtonDisabled,
+  width,
+  backgroundColor,
 }) => {
   // Padding would normally be done in app scss file off of classes
+  const panelWidth = width || 320;
+  const paddingValue = panelWidth + 16;
   let padding;
   if (type === 'over') {
     padding = '1rem 1rem 1rem 1rem';
   } else if (isOpen === true) {
     if (direction === 'right') {
-      padding = '1rem 336px 1rem 1rem';
+      padding = `1rem ${paddingValue}px 1rem 1rem`;
     } else {
       // direction is left
-      padding = '1rem 1rem 1rem 336px';
+      padding = `1rem 1rem 1rem ${paddingValue}px`;
     }
   } else if (type === 'inline' && direction === 'right') {
     padding = '1rem 4rem 1rem 1rem';
@@ -135,6 +139,8 @@ const InPage = ({
         onSecondaryButtonClick={options.onSecondaryButtonClick}
         isBusy={isBusy}
         isPrimaryButtonDisabled={isPrimaryButtonDisabled}
+        width={width}
+        backgroundColor={backgroundColor}
       >
         <Content />
       </SidePanel>
@@ -188,6 +194,34 @@ export const Default = () => (
     )}
     isBusy={boolean('isBusy', false)}
     isPrimaryButtonDisabled={boolean('Footer primary button disabled', false)}
+    width={number('Width (px)', undefined, {
+      range: true,
+      min: 200,
+      max: 800,
+      step: 10,
+    })}
+    backgroundColor={select(
+      'Background Color',
+      {
+        'Default (White)': '',
+        'Light Gray': '#f4f4f4',
+        Gray: '#e0e0e0',
+        'Dark Gray': '#d0d0d0',
+        'Carbon Layer 01': '#f4f4f4',
+        'Carbon Layer 02': '#ffffff',
+        'Warm Gray': '#e8e8e8',
+        'Cool Gray': '#dfe3e6',
+        'Blue Gray': '#d8dce6',
+        Beige: '#f5f5dc',
+        'Light Blue': '#e3f2fd',
+        'Light Green': '#e8f5e9',
+        'Light Yellow': '#fffde7',
+        'Light Pink': '#fce4ec',
+        'Light Purple': '#f3e5f5',
+        'Light Orange': '#fff3e0',
+      },
+      ''
+    )}
   >
     <Content />
   </SidePanel>
@@ -218,6 +252,34 @@ export const InPageExample = () => (
     onSecondaryButtonClick={select('Secondary footer button', ['yes', 'no'], 'yes')}
     isBusy={boolean('isBusy', false)}
     isPrimaryButtonDisabled={boolean('Footer primary button disabled', false)}
+    width={number('Width (px)', undefined, {
+      range: true,
+      min: 200,
+      max: 800,
+      step: 10,
+    })}
+    backgroundColor={select(
+      'Background Color',
+      {
+        'Default (White)': '',
+        'Light Gray': '#f4f4f4',
+        Gray: '#e0e0e0',
+        'Dark Gray': '#d0d0d0',
+        'Carbon Layer 01': '#f4f4f4',
+        'Carbon Layer 02': '#ffffff',
+        'Warm Gray': '#e8e8e8',
+        'Cool Gray': '#dfe3e6',
+        'Blue Gray': '#d8dce6',
+        Beige: '#f5f5dc',
+        'Light Blue': '#e3f2fd',
+        'Light Green': '#e8f5e9',
+        'Light Yellow': '#fffde7',
+        'Light Pink': '#fce4ec',
+        'Light Purple': '#f3e5f5',
+        'Light Orange': '#fff3e0',
+      },
+      ''
+    )}
   />
 );
 


### PR DESCRIPTION
Closes #
https://jsw.ibm.com/browse/MAXUIF-3522
**Summary**
Minor enhancement: width and backgroundColor are now exposed as props so consuming apps can control layout and styling without overrides. No functional impact on existing usage.
- summary_here

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
