### PR TITLE
feat: update thresholds icon position for value card

### DIFF
--- a/packages/react/src/components/ValueCard/Attribute.jsx
+++ b/packages/react/src/components/ValueCard/Attribute.jsx
@@ -32,6 +32,8 @@ const propTypes = {
       })
     ),
     tooltip: PropTypes.string,
+    // Position of threshold icon: 'label' (inline with label) or 'unit' (above unit)
+    thresholdsIconPosition: PropTypes.oneOf(['label', 'unit']),
   }).isRequired,
   customFormatter: PropTypes.func,
   formatter: PropTypes.func,
@@ -79,7 +81,16 @@ const BEM_BASE = `${BASE_CLASS_NAME}__attribute`;
  * He also determines which threshold applies to a given attribute (perhaps that should be moved)
  */
 const Attribute = ({
-  attribute: { label, unit, thresholds, precision, dataSourceId, measurementUnitLabel, tooltip },
+  attribute: {
+    label,
+    unit,
+    thresholds,
+    precision,
+    dataSourceId,
+    measurementUnitLabel,
+    tooltip,
+    thresholdsIconPosition = 'unit', // Default to 'unit' for backward compatibility
+  },
   attributeCount,
   customFormatter,
   formatter,
@@ -104,6 +115,29 @@ const Attribute = ({
 
   // need to reduce the width size to fit multiple attributes when card layout is horizontal
   const attributeWidthPercentage = layout === CARD_LAYOUTS.HORIZONTAL ? 100 / attributeCount : 100;
+
+  // Render threshold icon component
+  const renderThresholdIcon = () => {
+    if (!matchingThreshold?.icon) return null;
+
+    return (
+      <CardIcon
+        fill={matchingThreshold.color}
+        color={matchingThreshold.color}
+        width={16}
+        height={16}
+        title={`${matchingThreshold.comparison} ${matchingThreshold.value}`}
+        renderIconByName={renderIconByName}
+        icon={matchingThreshold.icon}
+        testId={`${testId}-threshold-icon`}
+        className={classnames({
+          [`${BEM_BASE}-threshold-icon`]: thresholdsIconPosition === 'unit',
+          [`${BEM_BASE}-label-icon`]: thresholdsIconPosition === 'label',
+        })}
+      />
+    );
+  };
+
   return (
     <div
       className={classnames(`${BEM_BASE}-wrapper`, {
@@ -114,19 +148,13 @@ const Attribute = ({
         '--value-card-attribute-width': `${attributeWidthPercentage}%`,
       }}
     >
-      <div className={`${BEM_BASE}-label`}>
-        {matchingThreshold?.icon ? (
-          <CardIcon
-            fill={matchingThreshold.color}
-            color={matchingThreshold.color}
-            width={16}
-            height={16}
-            title={`${matchingThreshold.comparison} ${matchingThreshold.value}`}
-            renderIconByName={renderIconByName}
-            icon={matchingThreshold.icon}
-            testId={`${testId}-threshold-icon`}
-          />
-        ) : null}
+      <div
+        className={classnames(`${BEM_BASE}-label`, {
+          [`${BEM_BASE}-label--with-icon`]:
+            thresholdsIconPosition === 'label' && matchingThreshold?.icon,
+        })}
+      >
+        {thresholdsIconPosition === 'label' && renderThresholdIcon()}
         {tooltip ? (
           <Tooltip direction="right" showIcon={false} triggerText={label}>
             <p>{tooltip}</p>
@@ -150,10 +178,12 @@ const Attribute = ({
           isNumberValueCompact={isNumberValueCompact}
           testId={`${testId}-value`}
           dataSourceId={dataSourceId}
-          measurementUnitLabel={measurementUnitLabel}
           onClick={onValueClick}
         />
-        <UnitRenderer unit={unit} testId={`${testId}-unit`} />
+        <div className={`${BEM_BASE}-unit-with-icon`}>
+          {thresholdsIconPosition === 'unit' && renderThresholdIcon()}
+          <UnitRenderer unit={measurementUnitLabel || unit} testId={`${testId}-unit`} />
+        </div>
       </div>
       {!isNil(secondaryValue) ? (
         <div

--- a/packages/react/src/components/ValueCard/ValueCard.story.jsx
+++ b/packages/react/src/components/ValueCard/ValueCard.story.jsx
@@ -151,8 +151,12 @@ export const WithLinkAndMeasurementUnit = () => {
             {
               dataSourceId: 'peakUsage',
               label: text('content.attributes[0].label', 'Peak usage'),
-              tooltip: text('content.attributes[0].tooltip', 'Peak usage tooltip'),
               measurementUnitLabel: text('content.attributes[0].measurementUnitLabel', 'AppPoints'),
+              thresholdsIconPosition: select(
+                'content.attributes[0].thresholdsIconPosition',
+                ['label', 'unit'],
+                'unit'
+              ),
               thresholds: [
                 {
                   comparison: '>',
@@ -321,6 +325,116 @@ export const SmallWideThresholdsString = () => {
 };
 
 SmallWideThresholdsString.storyName = 'with thresholds (string)';
+export const WithIconPositions = () => {
+  const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMWIDE);
+  const breakpoint = select('breakpoint', ['lg', 'md', 'sm', 'xs'], 'lg');
+  return (
+    <div
+      style={{
+        width: text('cardWidth', `${getCardMinSize(breakpoint, size).x}px`),
+        margin: '5px',
+      }}
+    >
+      <ValueCard
+        title={text('title', 'Threshold Icon Positions')}
+        id="thresholdsIconPositionCard"
+        renderIconByName={(name, props = {}) =>
+          name === 'checkmark' ? (
+            <Checkmark {...props}>
+              <title>{props.title}</title>
+            </Checkmark>
+          ) : name === 'warning' ? (
+            <WarningFilled {...props}>
+              <title>{props.title}</title>
+            </WarningFilled>
+          ) : (
+            <span>Unknown</span>
+          )
+        }
+        content={{
+          attributes: [
+            {
+              dataSourceId: 'pumpsStopped',
+              label: 'Pumps Currently Stopped',
+              thresholdsIconPosition: select(
+                'content.attributes[0].thresholdsIconPosition',
+                ['label', 'unit'],
+                'label'
+              ),
+              thresholds: [
+                {
+                  comparison: '<',
+                  value: 20,
+                  icon: 'checkmark',
+                  color: 'green',
+                },
+              ],
+            },
+            {
+              dataSourceId: 'temperature',
+              label: 'Temperature',
+              unit: '°C',
+              thresholdsIconPosition: select(
+                'content.attributes[1].thresholdsIconPosition',
+                ['label', 'unit'],
+                'unit'
+              ),
+              thresholds: [
+                {
+                  comparison: '>',
+                  value: 80,
+                  icon: 'warning',
+                  color: '#f1c21b',
+                },
+              ],
+            },
+            {
+              dataSourceId: 'pressure',
+              label: 'Pressure',
+              unit: 'PSI',
+              thresholdsIconPosition: select(
+                'content.attributes[2].thresholdsIconPosition',
+                ['label', 'unit'],
+                'label'
+              ),
+              thresholds: [
+                {
+                  comparison: '>',
+                  value: 100,
+                  icon: 'warning',
+                  color: 'red',
+                },
+              ],
+            },
+          ],
+        }}
+        breakpoint={breakpoint}
+        size={size}
+        values={{
+          pumpsStopped: number('values.pumpsStopped', 1),
+          temperature: number('values.temperature', 85),
+          pressure: number('values.pressure', 120),
+        }}
+        isNumberValueCompact={boolean('isNumberValueCompact', false)}
+        locale={select('locale', ['de', 'fr', 'en', 'ja'], 'en')}
+        fontSize={number('fontSize', 42)}
+        onAttributeClick={action('onAttributeClick')}
+      />
+    </div>
+  );
+};
+
+WithIconPositions.storyName = 'with configurable icon positions (label vs unit)';
+
+WithIconPositions.parameters = {
+  info: {
+    text: `This story demonstrates the new thresholdsIconPosition property that allows you to control where threshold icons appear:
+    - 'label': Icon appears inline with the attribute label (original behavior)
+    - 'unit': Icon appears above the unit text (current default behavior)
+    
+    Each attribute can have its own thresholdsIconPosition setting, allowing for flexible layouts within the same card.`,
+  },
+};
 
 export const MediumThin3 = () => {
   const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);

--- a/packages/react/src/components/ValueCard/_attribute.scss
+++ b/packages/react/src/components/ValueCard/_attribute.scss
@@ -11,6 +11,29 @@
   align-items: baseline;
   padding-right: $spacing-05;
 
+  &-unit-with-icon {
+    position: relative;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
+    margin-left: $spacing-02;
+    min-height: 1.25rem; // Match unit font size to maintain consistent height
+  }
+
+  &-threshold-icon {
+    position: absolute;
+    top: -15px;
+    left: 0;
+    z-index: 1;
+  }
+
+  &-label-icon {
+    display: inline-flex;
+    margin-right: $spacing-02;
+    vertical-align: middle;
+    flex-shrink: 0;
+  }
+
   &-wrapper {
     width: var(--value-card-attribute-width);
 
@@ -52,6 +75,12 @@
 
     & > svg {
       margin-right: $spacing-02;
+    }
+
+    &--with-icon {
+      display: flex;
+      align-items: center;
+      gap: $spacing-02;
     }
   }
 

--- a/packages/react/src/components/ValueCard/_unit-renderer.scss
+++ b/packages/react/src/components/ValueCard/_unit-renderer.scss
@@ -3,7 +3,8 @@
 @use '@carbon/react/scss/type' as *;
 .#{$iot-prefix}--value-card__attribute-unit {
   @include type-style('heading-03');
-  padding-left: $spacing-02;
-  padding-bottom: $spacing-02;
+  display: inline-block;
+  padding-left: 0;
   white-space: nowrap;
+  min-height: 1.25rem; // Maintain height even when empty to keep icon position stable
 }


### PR DESCRIPTION
Closes #

**Summary**

-[MAXUIF-3435](https://jsw.ibm.com/browse/MAXUIF-3435)  [KPI Value] Reduce user confusion on values that are below caution & not on target


**Change List (commits, features, bugs, etc)**

- Currently, a KPI value that is not at a caution state yet is displayed with a green check mark.
The text next to it signifies that it is above or below target
This can be confusing for a new user that does not understand the KPI Manager's configuration limitations. The two elements are not related.

    Example 1: 
    KPI Value = 3
    KPI Target = 1
    Caution at: 5
    
<img width="214" height="137" alt="image" src="https://github.com/user-attachments/assets/9f914ad9-3d65-452c-86b6-1b2808f5f18e" />
This is confusing as being over target by 2 does not seem to be a "good/green" thing, conceptually.  

Example 2:

"Target" is an exact value that the KPI can be compared against, but has nothing to do with "Caution" or "Alert".    The KPI can be configured to have an alert state and target state that are identical.  It is very hard to know if this would be a "bad configuration" 100% of the time or is actually a valid usage of the feature. 
<img width="421" height="182" alt="image" src="https://github.com/user-attachments/assets/8f21aa95-645c-48f3-813f-47c0dea8a10d" />
<img width="1260" height="473" alt="image" src="https://github.com/user-attachments/assets/7eec9515-2300-4c9d-8231-2cdd582d72d9" />

Update:
The best we can do, due to the behavior of KPI Manager, is to simply move the threshold icon (check mark/warning/error) to a different location: 

<img width="698" height="366" alt="image" src="https://github.com/user-attachments/assets/433b3fbb-e8a8-4275-9c52-223c7642e25f" />

Current implementation for [PAL Value card](https://carbon-design-system.github.io/carbon-addons-iot-react/?path=/story/1-watson-iot-card-valuecard--with-link-and-measurement-unit&knob-breakpoint=lg&knob-cardWidth=252px&knob-content.attributes%5B0%5D.label=Walkers&knob-content.attributes%5B0%5D.measurementUnitLabel=AppPoints&knob-content.attributes%5B0%5D.secondaryValue.color=red&knob-content.attributes%5B0%5D.secondaryValue.trend=down&knob-content.attributes%5B0%5D.thresholds%5B0%5D.color=#f1c21b&knob-content.attributes%5B0%5D.thresholds%5B0%5D.icon=warning&knob-content.attributes%5B0%5D.tooltip=Peak%2520usage%2520tooltip&knob-content.attributes%5B1%5D.label=Target&knob-content.attributes%5B1%5D.measurementUnitLabel=AppPoints&knob-fontSize=42&knob-isNumberValueCompact=true&knob-locale=en&knob-size=SMALL&knob-title=Foot%2520Traffic%2520-%2520%7Ba-variable%7D&knob-values.adjustTarget=Adjust%2520target&knob-values.footTraffic=13572&knob-values.peakUsage=1045&knob-values.target=1000&knob-values.trend=22%25&knob-variables=%7B%2522a-variable%2522:%2522working%2522%7D) or if we can just do it [in Graphite](https://pages.github.ibm.com/maximo-app-framework/graphite/main/react/storybook/?path=/story/2-components-%F0%9F%96%A5-dashboard--maximo-kpi-tile-story)

Current PAL changes looks as below:
<img width="3244" height="1415" alt="image" src="https://github.com/user-attachments/assets/051d0e1a-446d-4386-b0d7-28c226aa5ef2" />

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
