### PR TITLE
fix: added divider for expanded rows

### DIFF
--- a/packages/react/src/components/Table/Table.main.story.jsx
+++ b/packages/react/src/components/Table/Table.main.story.jsx
@@ -795,7 +795,7 @@ export const WithRowExpansion = () => {
 
   return (
     <>
-      <style>{`.iot--expanded-tablerow td[colspan="10"] { padding: 2rem !important;}`}</style>
+      <style>{`.iot--expanded-tablerow td[colspan="10"] { padding: 2rem !important; padding-left:4rem !important;}`}</style>
       <MyTable
         actions={getTableActions()}
         columns={columns}

--- a/packages/react/src/components/Table/_table.scss
+++ b/packages/react/src/components/Table/_table.scss
@@ -261,8 +261,21 @@ button.#{$prefix}--btn.#{$iot-prefix}--tooltip-svg-wrapper.#{$prefix}--btn--ghos
 
 .#{$iot-prefix}--expanded-tablerow {
   td {
-    padding: 0;
+    padding: $spacing-07;
+    padding-left: $spacing-10;
     font-weight: bold;
+    position: relative;
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: -1px;
+      left: 0;
+      height: calc(100% + 1px);
+      width: $spacing-09;
+      background-color: $layer-01;
+      border-right: solid 1px $layer-01;
+    }
   }
 }
 

--- a/packages/react/src/components/Table/_table.scss
+++ b/packages/react/src/components/Table/_table.scss
@@ -266,13 +266,14 @@ button.#{$prefix}--btn.#{$iot-prefix}--tooltip-svg-wrapper.#{$prefix}--btn--ghos
     font-weight: bold;
     position: relative;
 
+    // The divider starts after the expand column and extends to the right
     &::before {
       content: '';
       position: absolute;
       top: -1px;
       left: 0;
       height: calc(100% + 1px);
-      width: $spacing-09;
+      width: $spacing-09; // matches the expand column width
       background-color: $layer-01;
       border-right: solid 1px $layer-01;
     }


### PR DESCRIPTION
Closes : https://jsw.ibm.com/browse/MAXUIF-3482

## Describe your changes
Adds an indented divider for expanded table rows to match Carbon Design System. The divider starts after the expand column and extends to the right, with expanded content indented accordingly. Moved inline styles from the storybook to the external SCSS file.

## Screenshots
<!-- Please provide "before and after" screenshots if you changed css/styles. Otherwise, this section can be removed. -->

| Before | After |
| :----: | :---: |
| <img width="1360" height="301" alt="image" src="https://github.com/user-attachments/assets/3f5a5959-90da-4d63-8764-c15dc298e1b7" /> | <img width="1657" height="302" alt="image" src="https://github.com/user-attachments/assets/9fb65134-57bd-4b61-9f0f-b06eb88d5d40" />|





- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
