### PR TITLE
fix: remove X of Y pages when the dropdown is active PAL

### DIFF
--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -549,7 +549,7 @@ export const defaultProps = (baseProps) => ({
     pageNumberAria: 'Page Number',
     itemsPerPage: 'Items per page:',
     itemsRangeWithTotal: (min, max, total) => `${min}–${max} of ${total} items`,
-    pageRange: (current, total) => `${current} of ${total} pages`,
+    pageRange: (current, total) => `of ${total} pages`,
     /** table body */
     overflowMenuAria: 'More actions',
     clickToExpandAria: 'Click to expand content',

--- a/packages/react/src/components/Table/TablePropTypes.js
+++ b/packages/react/src/components/Table/TablePropTypes.js
@@ -249,7 +249,7 @@ export const defaultI18NPropTypes = {
   pageNumberAria: 'Page Number',
   itemsPerPage: 'Items per page:',
   itemsRangeWithTotal: (min, max, total) => `${min}–${max} of ${total} items`,
-  pageRange: (current, total) => `${current} of ${total} pages`,
+  pageRange: (current, total) => `of ${total} pages`,
   /** table body */
   overflowMenuAria: 'More actions',
   clickToExpandAria: 'Click to expand content',


### PR DESCRIPTION
Closes #
https://jsw.ibm.com/browse/MAXUIF-153

**Summary**
Updated the default pageRange prop type to match the new format and the documentation to reflect the new pageRange function signature.

Result: Pagination now shows the page number dropdown followed by "of X pages" text, eliminating the duplicate that appeared before.

# Screenshots
| Before | After |
| ------ | ----- |
| <img width="1558" height="625" alt="image" src="https://github.com/user-attachments/assets/9512748c-3fb9-415f-a666-8869a9b03015" />|<img width="1556" height="622" alt="image" src="https://github.com/user-attachments/assets/74eabf4b-c3fe-408f-97f6-751811f1891d" />|
**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
