### PR TITLE
fix: thresold value breaks if value is equal to zero 4.x.x

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ThresholdsFormItem.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ThresholdsFormItem.jsx
@@ -275,13 +275,11 @@ const ThresholdsFormItem = ({
                     invalid={false} // don't allow invalid state
                     value={threshold.value?.toString() || 0}
                     onChange={(event, { value }) => {
+                      const parsedValue = Number(value ?? event.imaginaryTarget.value);
                       const updatedThresholds = [...thresholds];
                       updatedThresholds[i] = {
                         ...updatedThresholds[i],
-                        value:
-                          Number(value ?? event.imaginaryTarget.value) ||
-                          value ||
-                          event.imaginaryTarget.value,
+                        value: parsedValue,
                       };
                       onChange(updatedThresholds.map((item) => omit(item, 'id')));
                       setThresholds(updatedThresholds);

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ThresholdsFormItem.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/ThresholdsFormItem.jsx
@@ -274,12 +274,11 @@ const ThresholdsFormItem = ({
                     translateWithId={translateWithId}
                     invalid={false} // don't allow invalid state
                     value={threshold.value?.toString() || 0}
-                    onChange={(event, { value }) => {
-                      const parsedValue = Number(value ?? event.imaginaryTarget.value);
+                    onChange={({ value }) => {
                       const updatedThresholds = [...thresholds];
                       updatedThresholds[i] = {
                         ...updatedThresholds[i],
-                        value: parsedValue,
+                        value,
                       };
                       onChange(updatedThresholds.map((item) => omit(item, 'id')));
                       setThresholds(updatedThresholds);


### PR DESCRIPTION
Closes #

**Summary**

- Issue: The threshold value input field was breaking when users entered a value of 0 or values starting with 0. The  component was treating 0 as a falsy value, causing the input to display incorrectly or lose the value.
- fix: Zero values are properly parsed and stored. Values starting with 0 (like 0.5, 01) are correctly handled.

**Change List (commits, features, bugs, etc)**

- Thresold value breaks if value is equal to zero.

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

closes: https://jsw.ibm.com/browse/MASMON-5626

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
