### PR TITLE
fix(valuecard): maxuif-3647 secondary value text outside card

### DIFF
--- a/packages/react/src/components/ValueCard/_attribute.scss
+++ b/packages/react/src/components/ValueCard/_attribute.scss
@@ -6,7 +6,7 @@
 .#{$iot-prefix}--value-card__attribute {
   display: flex;
   // need a set height to determine truncation vs wrapping. This is the max font size allowed
-  height: 54px;
+  height: 44px;
   // line up the value and unit
   align-items: baseline;
   padding-right: $spacing-05;


### PR DESCRIPTION
Closes #

**Summary**

-[MAXUIF-3647](https://jsw.ibm.com/browse/MAXUIF-3647)
Value card secondary value text outside the card

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
