### PR TITLE
feat: add optional translation support for card labels and titles - 4.x.x

### DIFF
--- a/packages/react/src/components/Card/Card.jsx
+++ b/packages/react/src/components/Card/Card.jsx
@@ -21,7 +21,11 @@ import {
 } from '../../constants/LayoutConstants';
 import { CardPropTypes } from '../../constants/CardPropTypes';
 import { getCardMinSize, filterValidAttributes } from '../../utils/componentUtilityFunctions';
-import { getUpdatedCardSize, useCardResizing } from '../../utils/cardUtilityFunctions';
+import {
+  getUpdatedCardSize,
+  useCardResizing,
+  getTranslatedLabel,
+} from '../../utils/cardUtilityFunctions';
 import { parseValue } from '../DateTimePicker/dateTimePickerUtils';
 import useSizeObserver from '../../hooks/useSizeObserver';
 import EmptyState from '../EmptyState/EmptyState';
@@ -273,6 +277,7 @@ export const defaultProps = {
   type: null,
   data: null,
   content: null,
+  shouldUseTranslatedLabels: false,
 };
 
 /** Dumb component that renders the card basics */
@@ -280,7 +285,7 @@ const Card = (props) => {
   const {
     size,
     children,
-    title,
+    title: titleProp,
     subtitle: subtitleProp,
     hasTitleWrap,
     layout,
@@ -320,8 +325,12 @@ const Card = (props) => {
     type,
     data,
     content,
+    shouldUseTranslatedLabels,
     ...others
   } = props;
+
+  // Get translated title if shouldUseTranslatedLabels is true
+  const title = getTranslatedLabel(titleProp, shouldUseTranslatedLabels, i18n);
 
   // TODO: remove once final version of range prop is supported
   useEffect(() => {

--- a/packages/react/src/components/Card/Card.jsx
+++ b/packages/react/src/components/Card/Card.jsx
@@ -299,7 +299,7 @@ const Card = (props) => {
     error,
     hideHeader,
     id,
-    tooltip,
+    tooltip: tooltipProp,
     titleTextTooltip,
     timeRange,
     timeRangeOptions,
@@ -331,6 +331,7 @@ const Card = (props) => {
 
   // Get translated title if shouldUseTranslatedLabels is true
   const title = getTranslatedLabel(titleProp, shouldUseTranslatedLabels, i18n);
+  const tooltip = getTranslatedLabel(tooltipProp, shouldUseTranslatedLabels, i18n);
 
   // TODO: remove once final version of range prop is supported
   useEffect(() => {

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditForm.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditForm.jsx
@@ -47,6 +47,8 @@ const propTypes = {
     modalHelpText: PropTypes.string,
     modalIconDescription: PropTypes.string,
   }),
+  /** whether to use translated labels in cards */
+  shouldUseTranslatedLabels: PropTypes.bool,
   /** if provided, returns an array of strings which are the dataItems to be allowed
    * on each card
    * getValidDataItems(card, selectedTimeRange)
@@ -110,6 +112,7 @@ const defaultProps = {
       'The JSON definition for this card is provided below.  You can modify this data directly to update the card configuration.',
     modalIconDescription: 'Close',
   },
+  shouldUseTranslatedLabels: false,
   getValidDataItems: null,
   getValidTimeRanges: null,
   dataItems: [],
@@ -145,6 +148,7 @@ const CardEditForm = ({
   dataSeriesItemLinks,
   // eslint-disable-next-line react/prop-types
   onFetchDynamicDemoHotspots,
+  shouldUseTranslatedLabels,
   actions,
 }) => {
   const mergedI18n = useMemo(() => ({ ...defaultProps.i18n, ...i18n }), [i18n]);
@@ -169,6 +173,7 @@ const CardEditForm = ({
               onChange={onChange}
               isSummaryDashboard={isSummaryDashboard}
               i18n={mergedI18n}
+              shouldUseTranslatedLabels={shouldUseTranslatedLabels}
               dataItems={dataItems}
               availableDimensions={availableDimensions}
               getValidDataItems={getValidDataItems}

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormContent.jsx
@@ -80,6 +80,8 @@ const propTypes = {
     thisQuarterLabel: PropTypes.string,
     thisYearLabel: PropTypes.string,
   }),
+  /** whether to use translated labels in cards */
+  shouldUseTranslatedLabels: PropTypes.bool,
   /** if provided, returns an array of strings which are the timeRanges to be allowed
    * on each card
    * getValidTimeRanges(card, selectedDataItems)
@@ -117,6 +119,7 @@ const propTypes = {
 const defaultProps = {
   cardConfig: {},
   i18n: {},
+  shouldUseTranslatedLabels: false,
   getValidDataItems: null,
   getValidTimeRanges: null,
   dataItems: [],
@@ -146,6 +149,7 @@ const CardEditFormContent = ({
   isSummaryDashboard,
   onChange,
   i18n,
+  shouldUseTranslatedLabels,
   dataItems,
   getValidDataItems,
   getValidTimeRanges,
@@ -174,6 +178,7 @@ const CardEditFormContent = ({
         key={`${cardConfig.id}-common`} // fix because I need to regenerate the form state when switching between cards
         onChange={onChange}
         i18n={mergedI18n}
+        shouldUseTranslatedLabels={shouldUseTranslatedLabels}
         getValidTimeRanges={getValidTimeRanges}
         currentBreakpoint={currentBreakpoint}
         selectedDataItems={selectedDataItems}
@@ -227,6 +232,7 @@ const CardEditFormContent = ({
           getValidDataItems={getValidDataItems}
           availableDimensions={availableDimensions}
           i18n={mergedI18n}
+          shouldUseTranslatedLabels={shouldUseTranslatedLabels}
           dataSeriesItemLinks={dataSeriesItemLinks}
           translateWithId={handleTranslation}
           actions={actions}

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
@@ -30,7 +30,10 @@ import {
 } from '../../../DashboardEditor/editorUtils';
 import ColorDropdown from '../../../ColorDropdown/ColorDropdown';
 import { CARD_TYPES } from '../../../../constants/LayoutConstants';
-import { isTimeBasedCard as isTimeBasedCardUtil } from '../../../../utils/cardUtilityFunctions';
+import {
+  isTimeBasedCard as isTimeBasedCardUtil,
+  getTranslatedLabel,
+} from '../../../../utils/cardUtilityFunctions';
 
 import ThresholdsFormItem from './ThresholdsFormItem';
 
@@ -139,6 +142,8 @@ const propTypes = {
     primaryButtonLabelText: PropTypes.string,
     secondaryButtonLabelText: PropTypes.string,
   }),
+  /** whether to use translated labels in cards */
+  shouldUseTranslatedLabels: PropTypes.bool,
   actions: DashboardEditorActionsPropTypes,
   /**
    * Used to override the default behaviour of handleDataItemEdit. if we dont pass any function then it uses handleDefaultDataItemEdit function by default
@@ -193,6 +198,7 @@ const defaultProps = {
     secondaryButtonLabelText: 'Cancel',
     decimalPlacesLabel: 'Decimal places',
   },
+  shouldUseTranslatedLabels: false,
   editDataSeries: [],
   showEditor: false,
   setShowEditor: null,
@@ -242,6 +248,7 @@ const DataSeriesFormItemModal = ({
   availableDimensions,
   onChange,
   i18n,
+  shouldUseTranslatedLabels,
   isLarge,
   actions: {
     dataSeriesFormActions: { hasAggregationsDropDown, hasGrainsDropDown, hasDataFilterDropdown },
@@ -417,7 +424,7 @@ const DataSeriesFormItemModal = ({
                   label: evt.target.value,
                 })
               }
-              value={editDataItem.label}
+              value={getTranslatedLabel(editDataItem.label, shouldUseTranslatedLabels, i18n)}
               helperText={mergedI18n.dataItemEditorDataItemHelperText(
                 mergedI18n.dataItemSource,
                 editDataItem.dataItemId
@@ -611,6 +618,7 @@ const DataSeriesFormItemModal = ({
       hasThresholds,
       hasTooltip,
       hasUnit,
+      i18n,
       id,
       initialAggregation,
       initialGrain,
@@ -619,6 +627,7 @@ const DataSeriesFormItemModal = ({
       mergedI18n,
       selectedDimensionFilter,
       setEditDataItem,
+      shouldUseTranslatedLabels,
       type,
     ]
   );

--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItems/DataSeriesFormContent.jsx
@@ -23,6 +23,7 @@ import ContentFormItemTitle from '../ContentFormItemTitle';
 import HierarchyDataFormItems, {
   isHierarchyDataItem,
 } from '../HierarchyDataFormItems/HierarchyDataFormItems';
+import { getTranslatedLabel } from '../../../../../utils/cardUtilityFunctions';
 
 import BarChartDataSeriesContent from './BarChartDataSeriesContent';
 
@@ -112,6 +113,8 @@ const propTypes = {
     incrementNumberText: PropTypes.string,
     decrementNumberText: PropTypes.string,
   }),
+  /** whether to use translated labels in cards */
+  shouldUseTranslatedLabels: PropTypes.bool,
   translateWithId: PropTypes.func.isRequired,
   actions: DashboardEditorActionsPropTypes,
 };
@@ -151,6 +154,7 @@ const defaultProps = {
     incrementNumberText: 'Increment number',
     decrementNumberText: 'Decrement number',
   },
+  shouldUseTranslatedLabels: false,
   getValidDataItems: null,
   dataItems: [],
   selectedDataItems: [],
@@ -256,6 +260,7 @@ const DataSeriesFormItem = ({
   selectedTimeRange,
   availableDimensions,
   i18n,
+  shouldUseTranslatedLabels,
   dataSeriesItemLinks,
   translateWithId,
   actions,
@@ -426,7 +431,11 @@ const DataSeriesFormItem = ({
           return {
             id: dataItem.dataSourceId,
             content: {
-              value: dataItem.label || dataItem.dataItemId,
+              value: getTranslatedLabel(
+                dataItem.label || dataItem.dataItemId,
+                shouldUseTranslatedLabels,
+                i18n
+              ),
               icon:
                 cardConfig.type === CARD_TYPES.TIMESERIES || cardConfig.type === CARD_TYPES.BAR ? (
                   <div
@@ -463,7 +472,15 @@ const DataSeriesFormItem = ({
             },
           };
         }) || [],
-    [cardConfig.type, handleEditButton, handleRemoveButton, mergedI18n.edit, mergedI18n.remove]
+    [
+      cardConfig.type,
+      handleEditButton,
+      handleRemoveButton,
+      i18n,
+      mergedI18n.edit,
+      mergedI18n.remove,
+      shouldUseTranslatedLabels,
+    ]
   );
 
   const dataItemListItems = useMemo(
@@ -492,6 +509,7 @@ const DataSeriesFormItem = ({
         dataSection={dataSection}
         onChange={onChange}
         i18n={mergedI18n}
+        shouldUseTranslatedLabels={shouldUseTranslatedLabels}
         actions={actions}
         options={{
           hasColorDropdown: type === CARD_TYPES.TIMESERIES || type === CARD_TYPES.BAR,

--- a/packages/react/src/components/CardEditor/CardEditForm/CommonCardEditFormFields.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CommonCardEditFormFields.jsx
@@ -11,6 +11,7 @@ import {
 import { settings } from '../../../constants/Settings';
 import { Dropdown } from '../../Dropdown';
 import { timeRangeToJSON } from '../../DashboardEditor/editorUtils';
+import { getTranslatedLabel } from '../../../utils/cardUtilityFunctions';
 
 const { iotPrefix } = settings;
 
@@ -75,6 +76,8 @@ const propTypes = {
     thisQuarterLabel: PropTypes.string,
     thisYearLabel: PropTypes.string,
   }),
+  /** whether to use translated labels in cards */
+  shouldUseTranslatedLabels: PropTypes.bool,
   /** if provided, returns an array of strings which are the timeRanges to be allowed
    * on each card
    * getValidTimeRanges(card, selectedDataItems)
@@ -109,6 +112,7 @@ const defaultProps = {
     thisQuarterLabel: 'This quarter',
     thisYearLabel: 'This year',
   },
+  shouldUseTranslatedLabels: false,
   selectedDataItems: [],
   getValidTimeRanges: null,
   currentBreakpoint: 'xl',
@@ -143,6 +147,7 @@ const CommonCardEditFormFields = ({
   cardConfig,
   onChange,
   i18n,
+  shouldUseTranslatedLabels,
   getValidTimeRanges,
   currentBreakpoint,
   selectedDataItems,
@@ -171,7 +176,7 @@ const CommonCardEditFormFields = ({
           labelText={mergedI18n.cardTitle}
           light
           onChange={(evt) => onChange({ ...cardConfig, title: evt.target.value })}
-          value={title}
+          value={getTranslatedLabel(title, shouldUseTranslatedLabels, mergedI18n)}
         />
       </div>
       <div className={`${baseClassName}--input`}>

--- a/packages/react/src/components/CardEditor/CardEditor.jsx
+++ b/packages/react/src/components/CardEditor/CardEditor.jsx
@@ -128,6 +128,8 @@ const propTypes = {
     searchPlaceHolderText: PropTypes.string,
     editDataItems: PropTypes.string,
   }),
+  /** whether to use translated labels in cards */
+  shouldUseTranslatedLabels: PropTypes.bool,
   currentBreakpoint: PropTypes.string,
   isSummaryDashboard: PropTypes.bool,
   /** Id that can be used for testing */
@@ -163,6 +165,7 @@ const defaultProps = {
       'The JSON definition for this card is provided below.  You can modify this data directly to update the card configuration.',
     modalIconDescription: 'Close',
   },
+  shouldUseTranslatedLabels: false,
   getValidDimensions: null,
   getValidDataItems: null,
   getValidTimeRanges: null,
@@ -298,6 +301,7 @@ const CardEditor = ({
   onRenderCardEditForm,
   icons,
   i18n,
+  shouldUseTranslatedLabels,
   currentBreakpoint,
   testId,
   dataSeriesItemLinks,
@@ -388,6 +392,7 @@ const CardEditor = ({
               getValidTimeRanges={getValidTimeRanges}
               availableDimensions={availableDimensions}
               i18n={mergedI18n}
+              shouldUseTranslatedLabels={shouldUseTranslatedLabels}
               currentBreakpoint={currentBreakpoint}
               dataSeriesItemLinks={dataSeriesItemLinks}
               onFetchDynamicDemoHotspots={onFetchDynamicDemoHotspots}

--- a/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditor.jsx
@@ -9,6 +9,7 @@ import { DASHBOARD_EDITOR_CARD_TYPES, CARD_TYPES } from '../../constants/LayoutC
 import DashboardGrid from '../Dashboard/DashboardGrid';
 import CardEditor from '../CardEditor/CardEditor';
 import ImageGalleryModal, { ImagePropTypes } from '../ImageGalleryModal/ImageGalleryModal';
+import { getTranslatedLabel } from '../../utils/cardUtilityFunctions';
 
 import DashboardEditorHeader from './DashboardEditorHeader/DashboardEditorHeader';
 import DashboardEditorCardRenderer from './DashboardEditorCardRenderer';
@@ -293,6 +294,8 @@ const propTypes = {
 
     editDataItems: PropTypes.string,
   }),
+  /** whether to use translated labels in cards */
+  shouldUseTranslatedLabels: PropTypes.bool,
   /** locale data */
   locale: PropTypes.string,
   /** optional link href's for each card type that will appear in a tooltip */
@@ -382,6 +385,7 @@ const defaultProps = {
     saveTitleButton: 'Save title',
     editDataItems: 'Edit data items',
   },
+  shouldUseTranslatedLabels: false,
   locale: 'en',
   dataSeriesItemLinks: null,
   onFetchDynamicDemoHotspots: () => Promise.resolve([{ x: 50, y: 50, type: 'fixed' }]),
@@ -434,6 +438,7 @@ const DashboardEditor = ({
   isSummaryDashboard,
   isLoading,
   i18n,
+  shouldUseTranslatedLabels,
   locale,
   dataSeriesItemLinks,
   isTitleEditable,
@@ -696,7 +701,9 @@ const DashboardEditor = ({
           renderHeader()
         ) : (
           <DashboardEditorHeader
-            title={dashboardJson?.title || title}
+            title={
+              getTranslatedLabel(dashboardJson?.title, shouldUseTranslatedLabels, i18n) || title
+            }
             breadcrumbs={headerBreadcrumbs}
             onImport={onImport}
             onExport={() => onExport(dashboardJson, imagesToUpload)}
@@ -799,6 +806,7 @@ const DashboardEditor = ({
                         key={cardConfig.id}
                         isResizable={isCardResizable}
                         i18n={mergedI18n}
+                        shouldUseTranslatedLabels={shouldUseTranslatedLabels}
                         isSelected={isSelected}
                         availableDimensions={availableDimensions}
                         onFetchDynamicDemoHotspots={onFetchDynamicDemoHotspots}
@@ -849,6 +857,7 @@ const DashboardEditor = ({
             getValidDimensions={getValidDimensions}
             availableDimensions={availableDimensions}
             i18n={mergedI18n}
+            shouldUseTranslatedLabels={shouldUseTranslatedLabels}
             currentBreakpoint={currentBreakpoint}
             dataSeriesItemLinks={dataSeriesItemLinks}
             onFetchDynamicDemoHotspots={onFetchDynamicDemoHotspots}

--- a/packages/react/src/components/DashboardEditor/DashboardEditorCardRenderer.jsx
+++ b/packages/react/src/components/DashboardEditor/DashboardEditorCardRenderer.jsx
@@ -75,6 +75,7 @@ const DashboardEditorCardRenderer = React.memo(
     baseClassName,
     renderCardPreview,
     style,
+    shouldUseTranslatedLabels,
     ...cardConfig
   }) => {
     // We have to keep track of our dynamic hotspots here
@@ -117,6 +118,7 @@ const DashboardEditorCardRenderer = React.memo(
         key: cardConfig.id,
         tooltip: cardConfig.description,
         i18n,
+        shouldUseTranslatedLabels,
         availableActions,
         onCardAction: handleOnCardAction,
         renderIconByName,
@@ -144,6 +146,7 @@ const DashboardEditorCardRenderer = React.memo(
         onShowImageGallery,
         onValidateUploadedImage,
         renderIconByName,
+        shouldUseTranslatedLabels,
         style,
       ]
     );

--- a/packages/react/src/components/ValueCard/Attribute.jsx
+++ b/packages/react/src/components/ValueCard/Attribute.jsx
@@ -10,6 +10,7 @@ import { CARD_LAYOUTS } from '../../constants/LayoutConstants';
 import CardIcon from '../ImageCard/CardIcon';
 import useMatchingThreshold from '../../hooks/useMatchingThreshold';
 import { Tooltip } from '../Tooltip/index';
+import { getTranslatedLabel } from '../../utils/cardUtilityFunctions';
 
 import ValueRenderer from './ValueRenderer';
 import UnitRenderer from './UnitRenderer';
@@ -37,7 +38,9 @@ const propTypes = {
   isEditable: PropTypes.bool,
   layout: PropTypes.oneOf(Object.values(CARD_LAYOUTS)),
   locale: PropTypes.string,
-
+  /** whether to use translated labels in cards */
+  shouldUseTranslatedLabels: PropTypes.bool,
+  i18n: PropTypes.objectOf(PropTypes.any),
   renderIconByName: PropTypes.func,
   /** Optional trend information */
   secondaryValue: PropTypes.shape({
@@ -66,6 +69,8 @@ const defaultProps = {
   locale: 'en',
   customFormatter: null,
   isEditable: false,
+  shouldUseTranslatedLabels: false,
+  i18n: {},
   testId: 'attribute',
   onValueClick: null,
 };
@@ -83,6 +88,8 @@ const Attribute = ({
   isEditable,
   layout,
   locale,
+  shouldUseTranslatedLabels,
+  i18n,
   renderIconByName,
   secondaryValue,
   value,
@@ -101,6 +108,10 @@ const Attribute = ({
 
   // need to reduce the width size to fit multiple attributes when card layout is horizontal
   const attributeWidthPercentage = layout === CARD_LAYOUTS.HORIZONTAL ? 100 / attributeCount : 100;
+
+  // Get translated label if shouldUseTranslatedLabels is true
+  const displayLabel = getTranslatedLabel(label, shouldUseTranslatedLabels, i18n);
+
   return (
     <div
       className={classnames(`${BEM_BASE}-wrapper`, {
@@ -125,11 +136,11 @@ const Attribute = ({
           />
         ) : null}
         {tooltip ? (
-          <Tooltip direction="right" showIcon={false} triggerText={label}>
+          <Tooltip direction="right" showIcon={false} triggerText={displayLabel}>
             <p>{tooltip}</p>
           </Tooltip>
         ) : (
-          <span data-testid={`${testId}-threshold-label`}>{label}</span>
+          <span data-testid={`${testId}-threshold-label`}>{displayLabel}</span>
         )}
       </div>
 

--- a/packages/react/src/components/ValueCard/ValueCard.jsx
+++ b/packages/react/src/components/ValueCard/ValueCard.jsx
@@ -39,6 +39,7 @@ const ValueCard = ({
   testId,
   onAttributeClick,
   className,
+  shouldUseTranslatedLabels,
   ...others
 }) => {
   const availableActions = {
@@ -71,6 +72,7 @@ const ValueCard = ({
       isResizable={isResizable}
       resizeHandles={resizeHandles}
       i18n={i18n}
+      shouldUseTranslatedLabels={shouldUseTranslatedLabels}
       locale={locale}
       id={id}
       className={classnames(className, {
@@ -97,6 +99,8 @@ const ValueCard = ({
         isEditable={isEditable}
         fontSize={fontSize}
         isNumberValueCompact={isNumberValueCompact}
+        i18n={i18n}
+        shouldUseTranslatedLabels={shouldUseTranslatedLabels}
         {...others}
       />
 
@@ -120,6 +124,7 @@ ValueCard.defaultProps = {
   // TODO: fix this default in V3, so that cards are unique not inherited from the base Card
   testId: 'Card',
   onAttributeClick: null,
+  shouldUseTranslatedLabels: false,
 };
 
 export default ValueCard;

--- a/packages/react/src/components/ValueCard/ValueContent.jsx
+++ b/packages/react/src/components/ValueCard/ValueContent.jsx
@@ -16,6 +16,8 @@ const propTypes = {
   layout: PropTypes.oneOf(['HORIZONTAL', 'VERTICAL']),
   locale: PropTypes.string,
   isEditable: PropTypes.bool,
+  /** whether to use translated labels in cards */
+  shouldUseTranslatedLabels: PropTypes.bool,
   ...ValueContentPropTypes,
 };
 
@@ -25,6 +27,7 @@ const defaultProps = {
   layout: 'VERTICAL',
   locale: 'en',
   isEditable: false,
+  shouldUseTranslatedLabels: false,
   dataState: null,
   values: null,
   fontSize: DEFAULT_FONT_SIZE,
@@ -44,6 +47,7 @@ const ValueContent = ({
   dataState,
   locale,
   isEditable,
+  shouldUseTranslatedLabels,
   customFormatter,
   fontSize,
   isNumberValueCompact,
@@ -70,6 +74,8 @@ const ValueContent = ({
             locale={locale}
             isEditable={isEditable}
             title={title}
+            shouldUseTranslatedLabels={shouldUseTranslatedLabels}
+            i18n={others.i18n}
             renderIconByName={others.renderIconByName}
             value={determineValue(attribute.dataSourceId, values, attribute.dataFilter)}
             secondaryValue={

--- a/packages/react/src/constants/CardPropTypes.js
+++ b/packages/react/src/constants/CardPropTypes.js
@@ -227,6 +227,8 @@ export const TableCardPropTypes = {
     defaultFilterStringPlaceholdText: PropTypes.string,
     downloadIconDescription: PropTypes.string,
   }),
+  /** whether to use translated labels in cards */
+  shouldUseTranslatedLabels: PropTypes.bool,
   cardVariables: PropTypes.objectOf(
     PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.number, PropTypes.bool])
   ),

--- a/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/packages/react/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -14658,6 +14658,7 @@ Map {
       "renderCardPreview": [Function],
       "renderHeader": null,
       "renderIconByName": [Function],
+      "shouldUseTranslatedLabels": false,
       "supportedCardTypes": Array [
         "VALUE",
         "TIMESERIES",
@@ -15307,6 +15308,9 @@ Map {
       "renderIconByName": Object {
         "type": "func",
       },
+      "shouldUseTranslatedLabels": Object {
+        "type": "bool",
+      },
       "supportedCardTypes": Object {
         "args": Array [
           Object {
@@ -15402,6 +15406,7 @@ Map {
       "onEditDataItems": null,
       "onRenderCardEditForm": null,
       "onValidateCardJson": null,
+      "shouldUseTranslatedLabels": false,
       "supportedCardTypes": Array [
         "VALUE",
         "TIMESERIES",
@@ -15643,6 +15648,9 @@ Map {
       },
       "onValidateCardJson": Object {
         "type": "func",
+      },
+      "shouldUseTranslatedLabels": Object {
+        "type": "bool",
       },
       "supportedCardTypes": Object {
         "args": Array [
@@ -16193,6 +16201,7 @@ Map {
         "xl": 144,
         "xs": 144,
       },
+      "shouldUseTranslatedLabels": false,
       "size": "MEDIUM",
       "subtitle": undefined,
       "tabIndex": undefined,
@@ -18459,6 +18468,7 @@ Map {
       "isNumberValueCompact": false,
       "locale": "en",
       "onAttributeClick": null,
+      "shouldUseTranslatedLabels": false,
       "size": "MEDIUM",
       "testId": "Card",
       "values": null,
@@ -23255,6 +23265,9 @@ Map {
         ],
         "type": "shape",
       },
+      "shouldUseTranslatedLabels": Object {
+        "type": "bool",
+      },
       "showOverflow": [Function],
       "size": Object {
         "args": Array [
@@ -24782,6 +24795,7 @@ Map {
       "layout": "VERTICAL",
       "locale": "en",
       "onAttributeClick": null,
+      "shouldUseTranslatedLabels": false,
       "size": "MEDIUM",
       "testId": "ValueContent",
       "title": "",
@@ -24995,6 +25009,9 @@ Map {
       },
       "onAttributeClick": Object {
         "type": "func",
+      },
+      "shouldUseTranslatedLabels": Object {
+        "type": "bool",
       },
       "title": Object {
         "type": "string",

--- a/packages/react/src/utils/cardUtilityFunctions.js
+++ b/packages/react/src/utils/cardUtilityFunctions.js
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import warning from 'warning';
-import { isNil, mapValues } from 'lodash-es';
+import { isEmpty, isNil, mapValues } from 'lodash-es';
 
 import { BAR_CHART_TYPES, CARD_SIZES, CARD_TYPES } from '../constants/LayoutConstants';
 
@@ -552,3 +552,17 @@ export const isTimeBasedCard = (card) =>
     card.content?.columns?.find((column) => column.type === 'TIMESTAMP')) ||
   (card.content?.type === BAR_CHART_TYPES.SIMPLE && card.content?.timeDataSourceId) ||
   (card.content?.type === BAR_CHART_TYPES.STACKED && card.content?.timeDataSourceId);
+
+/**
+ * Get translated label or title from i18n object, fallback to original if not found
+ * @param {string} label - The label or title key to translate
+ * @param {boolean} shouldUseTranslatedLabels - Flag to determine if translation should be used
+ * @param {Object} i18n - The i18n object containing translations
+ * @returns {string} - The translated label or original label if translation not found
+ */
+export const getTranslatedLabel = (label, shouldUseTranslatedLabels, i18n) => {
+  if (!isEmpty(label) && shouldUseTranslatedLabels && i18n && i18n[label]) {
+    return i18n[label];
+  }
+  return label;
+};


### PR DESCRIPTION
Closes # [MASMON-6065](https://jsw.ibm.com/browse/MASMON-6065)

Cherypick: #4079 

**Summary**

- feat: add optional translation support for card labels and titles

**Change List (commits, features, bugs, etc)**

- feat: add optional translation support for card labels and titles

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
