### PR TITLE
fix: apply translation to unit and description fields - 4.x.x

### DIFF
--- a/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CardEditFormItems/DataSeriesFormItemModal.jsx
@@ -488,7 +488,7 @@ const DataSeriesFormItemModal = ({
                       unit: evt.target.value,
                     })
                   }
-                  value={editDataItem.unit}
+                  value={getTranslatedLabel(editDataItem.unit, shouldUseTranslatedLabels, i18n)}
                 />
               </div>
             )}

--- a/packages/react/src/components/CardEditor/CardEditForm/CommonCardEditFormFields.jsx
+++ b/packages/react/src/components/CardEditor/CardEditForm/CommonCardEditFormFields.jsx
@@ -185,7 +185,7 @@ const CommonCardEditFormFields = ({
           labelText={mergedI18n.description}
           light
           onChange={(evt) => onChange({ ...cardConfig, description: evt.target.value })}
-          value={description}
+          value={getTranslatedLabel(description, shouldUseTranslatedLabels, mergedI18n)}
         />
       </div>
       <div className={`${baseClassName}--input`}>

--- a/packages/react/src/components/ValueCard/Attribute.jsx
+++ b/packages/react/src/components/ValueCard/Attribute.jsx
@@ -111,6 +111,7 @@ const Attribute = ({
 
   // Get translated label if shouldUseTranslatedLabels is true
   const displayLabel = getTranslatedLabel(label, shouldUseTranslatedLabels, i18n);
+  const displayUnitLabel = getTranslatedLabel(unit, shouldUseTranslatedLabels, i18n);
 
   return (
     <div
@@ -159,7 +160,7 @@ const Attribute = ({
           measurementUnitLabel={measurementUnitLabel}
           onClick={onValueClick}
         />
-        <UnitRenderer unit={unit} testId={`${testId}-unit`} />
+        <UnitRenderer unit={displayUnitLabel} testId={`${testId}-unit`} />
       </div>
       {!isNil(secondaryValue) ? (
         <div


### PR DESCRIPTION
Closes # [MASMON-6065](https://jsw.ibm.com/browse/MASMON-6065)

**Summary**

- summary_here

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
