### PR TITLE
MAXUIF-2515 [Table] Multi-select row actions (blue bar) smart truncation of actions

### DIFF
--- a/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -890,7 +890,8 @@ const TableToolbar = ({
                         const focusableElements = batchActionsRef.current.querySelectorAll(
                           'button:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled])'
                         );
-                        const overflowButton = batchOverflowMenuRef.current?.querySelector('button');
+                        const overflowButton =
+                          batchOverflowMenuRef.current?.querySelector('button');
                         const currentIndex = Array.from(focusableElements).indexOf(overflowButton);
                         const prevElement = focusableElements[currentIndex - 1];
 
@@ -915,7 +916,8 @@ const TableToolbar = ({
                         const focusableElements = batchActionsRef.current.querySelectorAll(
                           'button:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled])'
                         );
-                        const overflowButton = batchOverflowMenuRef.current?.querySelector('button');
+                        const overflowButton =
+                          batchOverflowMenuRef.current?.querySelector('button');
                         const currentIndex = Array.from(focusableElements).indexOf(overflowButton);
                         const nextElement = focusableElements[currentIndex + 1];
 

--- a/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -32,6 +32,7 @@ import { tableTranslateWithId } from '../../../utils/componentUtilityFunctions';
 import { settings } from '../../../constants/Settings';
 import { RuleGroupPropType } from '../../RuleBuilder/RuleBuilderPropTypes';
 import useDynamicOverflowMenuItems from '../../../hooks/useDynamicOverflowMenuItems';
+import useResponsiveInlineCount from '../../../hooks/useResponsiveInlineCount';
 import { renderTableOverflowItemText } from '../tableUtilities';
 
 import TableToolbarAdvancedFilterFlyout from './TableToolbarAdvancedFilterFlyout';
@@ -255,10 +256,13 @@ const TableToolbar = ({
 }) => {
   const shouldShowBatchActions = hasRowSelection === 'multi' && totalSelected > 0;
   const langDir = useLangDirection();
+  const tableToolbarRef = useRef(null);
   const batchActionsRef = useRef(null);
   const previousFocusedElement = useRef(null);
   const toolbarContentRef = useRef(null);
   const batchOverflowMenuRef = useRef(null);
+  const batchActionsVisibleRef = useRef(null);
+  const batchActionsLayoutRef = useRef(null);
   const [isBatchOverflowOpen, setIsBatchOverflowOpen] = React.useState(false);
 
   // Function to restore focus to the previous element
@@ -468,16 +472,53 @@ const TableToolbar = ({
     };
   }, [customToolbarContent]);
 
-  const visibleBatchActions = batchActions.filter(
-    (action) => !action.isOverflow && action.hidden !== true
+  const visibleBatchActionCandidates = useMemo(
+    () => batchActions.filter((action) => !action.isOverflow && action.hidden !== true),
+    [batchActions]
   );
 
-  const visibleOverflowBatchActions = batchActions.filter(
-    (action) => action.isOverflow && action.hidden !== true
+  const staticOverflowBatchActions = useMemo(
+    () => batchActions.filter((action) => action.isOverflow && action.hidden !== true),
+    [batchActions]
   );
+
+  const batchActionExcludedWidthSelectors = useMemo(
+    () => ['.cds--batch-summary', '.cds--batch-summary__cancel'],
+    []
+  );
+
+  const responsiveBatchActionCount = useResponsiveInlineCount({
+    enabled:
+      hasBatchActionToolbar &&
+      (visibleBatchActionCandidates.length > 0 || staticOverflowBatchActions.length > 0),
+    items: visibleBatchActionCandidates,
+    containerRef: batchActionsVisibleRef,
+    overflowTriggerRef: batchOverflowMenuRef,
+    itemSelector: '[data-batch-action-visible="true"]',
+    staticOverflowCount: staticOverflowBatchActions.length,
+    layoutRef: tableToolbarRef,
+    excludedWidthSelector: batchActionExcludedWidthSelectors,
+  });
+  const visibleBatchActions =
+    responsiveBatchActionCount === null
+      ? visibleBatchActionCandidates
+      : visibleBatchActionCandidates.slice(0, responsiveBatchActionCount);
+
+  const visibleOverflowBatchActions = [
+    ...visibleBatchActionCandidates.slice(
+      responsiveBatchActionCount ?? visibleBatchActionCandidates.length
+    ),
+    ...staticOverflowBatchActions,
+  ];
 
   const hasVisibleBatchActions = visibleBatchActions.length > 0;
   const hasVisibleOverflowBatchActions = visibleOverflowBatchActions.length > 0;
+  const hasStaticOverflowBatchActions = staticOverflowBatchActions.length > 0;
+  const shouldRenderBatchOverflowTrigger =
+    hasStaticOverflowBatchActions ||
+    (responsiveBatchActionCount !== null &&
+      responsiveBatchActionCount < visibleBatchActionCandidates.length) ||
+    hasVisibleOverflowBatchActions;
 
   const totalSelectedText = useMemo(() => {
     if (totalSelected > 1) {
@@ -513,6 +554,7 @@ const TableToolbar = ({
 
   return (
     <CarbonTableToolbar
+      ref={tableToolbarRef}
       // TODO: remove deprecated 'testID' in v3
       data-testid={testID || testId}
       className={classnames(`${iotPrefix}--table-toolbar`, className)}
@@ -755,13 +797,23 @@ const TableToolbar = ({
       )}
       {hasBatchActionToolbar ? (
         <TableBatchActions
-          ref={batchActionsRef}
+          ref={(node) => {
+            batchActionsRef.current = node;
+            batchActionsLayoutRef.current = node;
+          }}
           role="region"
           aria-live="polite"
           aria-label={totalSelectedText}
           // TODO: remove deprecated 'testID' in v3
           data-testid={`${testID || testId}-batch-actions`}
+          id={`${tableId}-batch-actions-root`}
           className={`${iotPrefix}--table-batch-actions`}
+          style={{
+            width: '100%',
+            maxWidth: '100%',
+            minWidth: 0,
+            overflow: 'hidden',
+          }}
           onCancel={() => {
             if (onCancelBatchAction) {
               onCancelBatchAction();
@@ -772,129 +824,164 @@ const TableToolbar = ({
           totalSelected={totalSelected}
           translateWithId={(...args) => tableTranslateWithId(i18n, ...args)}
         >
-          {hasVisibleBatchActions &&
-            visibleBatchActions.map(({ id, labelText, disabled, ...others }) => (
-              <TableBatchAction
-                key={id}
-                onClick={() => {
-                  onApplyBatchAction(id);
-                  restoreFocus();
+          <div
+            id={`${tableId}-batch-actions-visible`}
+            ref={batchActionsVisibleRef}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'flex-end',
+              minWidth: 0,
+              flex: '1 1 auto',
+              overflow: 'visible',
+            }}
+          >
+            {visibleBatchActionCandidates.map(({ id, labelText, disabled, ...others }, index) => {
+              const isVisibleInline =
+                responsiveBatchActionCount === null || index < responsiveBatchActionCount;
+
+              return (
+                <TableBatchAction
+                  key={id}
+                  id={`${tableId}-batch-action-${id}`}
+                  data-batch-action-visible="true"
+                  onClick={() => {
+                    onApplyBatchAction(id);
+                    restoreFocus();
+                  }}
+                  tabIndex={isVisibleInline && shouldShowBatchActions ? 0 : -1}
+                  disabled={!shouldShowBatchActions || disabled}
+                  {...others}
+                  aria-hidden={!isVisibleInline}
+                  style={
+                    isVisibleInline
+                      ? {
+                          flex: '0 0 auto',
+                        }
+                      : {
+                          flex: '0 0 auto',
+                          position: 'absolute',
+                          visibility: 'hidden',
+                          pointerEvents: 'none',
+                        }
+                  }
+                >
+                  {labelText}
+                </TableBatchAction>
+              );
+            })}
+            {shouldRenderBatchOverflowTrigger ? (
+              <div
+                id={`${tableId}-batch-actions-overflow-trigger`}
+                role="presentation"
+                ref={batchOverflowMenuRef}
+                data-batch-overflow-visible="true"
+                style={{ display: 'inline-flex', flexShrink: 0 }}
+                onKeyDown={(e) => {
+                  if (!shouldShowBatchActions) return;
+
+                  // Handle Shift+Tab from within the batch overflow menu
+                  if (e.shiftKey && e.key === 'Tab') {
+                    const menuItems = batchOverflowMenuRef.current?.querySelectorAll(
+                      '[role="menuitem"]:not([disabled])'
+                    );
+                    const firstMenuItem = menuItems?.[0];
+
+                    // If we're on the first menu item, move focus to previous batch action
+                    if (firstMenuItem && document.activeElement === firstMenuItem) {
+                      e.preventDefault();
+                      // Find previous focusable element in batch actions
+                      if (batchActionsRef.current) {
+                        const focusableElements = batchActionsRef.current.querySelectorAll(
+                          'button:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled])'
+                        );
+                        const overflowButton = batchOverflowMenuRef.current?.querySelector('button');
+                        const currentIndex = Array.from(focusableElements).indexOf(overflowButton);
+                        const prevElement = focusableElements[currentIndex - 1];
+
+                        if (prevElement) {
+                          prevElement.focus();
+                        }
+                      }
+                    }
+                  }
+                  // Handle Tab from the last menu item
+                  else if (e.key === 'Tab' && !e.shiftKey) {
+                    const menuItems = batchOverflowMenuRef.current?.querySelectorAll(
+                      '[role="menuitem"]:not([disabled])'
+                    );
+                    const lastMenuItem = menuItems?.[menuItems.length - 1];
+
+                    // If we're on the last menu item, move to Clear selections button
+                    if (lastMenuItem && document.activeElement === lastMenuItem) {
+                      e.preventDefault();
+                      // Find the Clear selections button or next focusable element
+                      if (batchActionsRef.current) {
+                        const focusableElements = batchActionsRef.current.querySelectorAll(
+                          'button:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled])'
+                        );
+                        const overflowButton = batchOverflowMenuRef.current?.querySelector('button');
+                        const currentIndex = Array.from(focusableElements).indexOf(overflowButton);
+                        const nextElement = focusableElements[currentIndex + 1];
+
+                        if (nextElement) {
+                          nextElement.focus();
+                        }
+                      }
+                    }
+                  }
                 }}
-                tabIndex={shouldShowBatchActions ? 0 : -1}
-                disabled={!shouldShowBatchActions || disabled}
-                {...others}
               >
-                {labelText}
-              </TableBatchAction>
-            ))}
-          {hasVisibleOverflowBatchActions ? (
-            <div
-              role="presentation"
-              ref={batchOverflowMenuRef}
-              onKeyDown={(e) => {
-                if (!shouldShowBatchActions) return;
-
-                // Handle Shift+Tab from within the batch overflow menu
-                if (e.shiftKey && e.key === 'Tab') {
-                  const menuItems = batchOverflowMenuRef.current?.querySelectorAll(
-                    '[role="menuitem"]:not([disabled])'
-                  );
-                  const firstMenuItem = menuItems?.[0];
-
-                  // If we're on the first menu item, move focus to previous batch action
-                  if (firstMenuItem && document.activeElement === firstMenuItem) {
-                    e.preventDefault();
-                    // Find previous focusable element in batch actions
-                    if (batchActionsRef.current) {
-                      const focusableElements = batchActionsRef.current.querySelectorAll(
-                        'button:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled])'
-                      );
-                      const overflowButton = batchOverflowMenuRef.current?.querySelector('button');
-                      const currentIndex = Array.from(focusableElements).indexOf(overflowButton);
-                      const prevElement = focusableElements[currentIndex - 1];
-
-                      if (prevElement) {
-                        prevElement.focus();
-                      }
-                    }
-                  }
-                }
-                // Handle Tab from the last menu item
-                else if (e.key === 'Tab' && !e.shiftKey) {
-                  const menuItems = batchOverflowMenuRef.current?.querySelectorAll(
-                    '[role="menuitem"]:not([disabled])'
-                  );
-                  const lastMenuItem = menuItems?.[menuItems.length - 1];
-
-                  // If we're on the last menu item, move to Clear selections button
-                  if (lastMenuItem && document.activeElement === lastMenuItem) {
-                    e.preventDefault();
-                    // Find the Clear selections button or next focusable element
-                    if (batchActionsRef.current) {
-                      const focusableElements = batchActionsRef.current.querySelectorAll(
-                        'button:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled])'
-                      );
-                      const overflowButton = batchOverflowMenuRef.current?.querySelector('button');
-                      const currentIndex = Array.from(focusableElements).indexOf(overflowButton);
-                      const nextElement = focusableElements[currentIndex + 1];
-
-                      if (nextElement) {
-                        nextElement.focus();
-                      }
-                    }
-                  }
-                }
-              }}
-            >
-              <OverflowMenu
-                data-testid={`${testID || testId}-batch-actions-overflow-menu`}
-                className={`${iotPrefix}--table-overflow-batch-actions`}
-                flipped={langDir === 'ltr'}
-                direction="bottom"
-                onClick={(e) => e.stopPropagation()}
-                renderIcon={(props) => <OverflowMenuVertical size={16} {...props} />}
-                tabIndex={shouldShowBatchActions ? 0 : -1}
-                size="md"
-                menuOptionsClass={`${iotPrefix}--table-overflow-batch-actions__menu`}
-                withCarbonTooltip
-                tooltipPosition="bottom"
-                buttonLabel={i18n.batchActionsOverflowMenuText}
-                open={isBatchOverflowOpen}
-                onOpen={() => setIsBatchOverflowOpen(true)}
-                onClose={() => setIsBatchOverflowOpen(false)}
-              >
-                {visibleOverflowBatchActions.map(
-                  ({
-                    id,
-                    labelText,
-                    disabled,
-                    hasDivider,
-                    isDelete,
-                    renderIcon,
-                    iconDescription,
-                  }) => (
-                    <OverflowMenuItem
-                      data-testid={`${testID || testId}-batch-actions-overflow-menu-item-${id}`}
-                      itemText={renderTableOverflowItemText({
-                        action: { renderIcon, labelText: labelText || iconDescription },
-                        className: `${iotPrefix}--table-toolbar-aggregations__overflow-menu-content`,
-                      })}
-                      disabled={!shouldShowBatchActions || disabled}
-                      onClick={() => {
-                        onApplyBatchAction(id);
-                        restoreFocus();
-                      }}
-                      key={`table-batch-actions-overflow-menu-${id}`}
-                      requireTitle={!renderIcon}
-                      hasDivider={hasDivider}
-                      isDelete={isDelete}
-                      aria-label={labelText}
-                    />
-                  )
-                )}
-              </OverflowMenu>
-            </div>
-          ) : null}
+                <OverflowMenu
+                  data-testid={`${testID || testId}-batch-actions-overflow-menu`}
+                  className={`${iotPrefix}--table-overflow-batch-actions`}
+                  flipped={langDir === 'ltr'}
+                  direction="bottom"
+                  onClick={(e) => e.stopPropagation()}
+                  renderIcon={(props) => <OverflowMenuVertical size={16} {...props} />}
+                  tabIndex={shouldShowBatchActions ? 0 : -1}
+                  size="md"
+                  menuOptionsClass={`${iotPrefix}--table-overflow-batch-actions__menu`}
+                  withCarbonTooltip
+                  tooltipPosition="bottom"
+                  buttonLabel={i18n.batchActionsOverflowMenuText}
+                  open={isBatchOverflowOpen}
+                  onOpen={() => setIsBatchOverflowOpen(true)}
+                  onClose={() => setIsBatchOverflowOpen(false)}
+                >
+                  {visibleOverflowBatchActions.map(
+                    ({
+                      id,
+                      labelText,
+                      disabled,
+                      hasDivider,
+                      isDelete,
+                      renderIcon,
+                      iconDescription,
+                    }) => (
+                      <OverflowMenuItem
+                        data-testid={`${testID || testId}-batch-actions-overflow-menu-item-${id}`}
+                        itemText={renderTableOverflowItemText({
+                          action: { renderIcon, labelText: labelText || iconDescription },
+                          className: `${iotPrefix}--table-toolbar-aggregations__overflow-menu-content`,
+                        })}
+                        disabled={!shouldShowBatchActions || disabled}
+                        onClick={() => {
+                          onApplyBatchAction(id);
+                          restoreFocus();
+                        }}
+                        key={`table-batch-actions-overflow-menu-${id}`}
+                        requireTitle={!renderIcon}
+                        hasDivider={hasDivider}
+                        isDelete={isDelete}
+                        aria-label={labelText}
+                      />
+                    )
+                  )}
+                </OverflowMenu>
+              </div>
+            ) : null}
+          </div>
         </TableBatchActions>
       ) : null}
     </CarbonTableToolbar>

--- a/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -511,7 +511,6 @@ const TableToolbar = ({
     ...staticOverflowBatchActions,
   ];
 
-  const hasVisibleBatchActions = visibleBatchActions.length > 0;
   const hasVisibleOverflowBatchActions = visibleOverflowBatchActions.length > 0;
   const hasStaticOverflowBatchActions = staticOverflowBatchActions.length > 0;
   const shouldRenderBatchOverflowTrigger =

--- a/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/packages/react/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -499,10 +499,6 @@ const TableToolbar = ({
     layoutRef: tableToolbarRef,
     excludedWidthSelector: batchActionExcludedWidthSelectors,
   });
-  const visibleBatchActions =
-    responsiveBatchActionCount === null
-      ? visibleBatchActionCandidates
-      : visibleBatchActionCandidates.slice(0, responsiveBatchActionCount);
 
   const visibleOverflowBatchActions = [
     ...visibleBatchActionCandidates.slice(

--- a/packages/react/src/components/Table/TableToolbar/_table-toolbar.scss
+++ b/packages/react/src/components/Table/TableToolbar/_table-toolbar.scss
@@ -96,6 +96,13 @@ div.#{$prefix}--toolbar-action.#{$prefix}--toolbar-search-container-expandable {
 
 .#{$iot-prefix}--table-batch-actions {
   z-index: 3;
+  min-width: 0;
+
+  .#{$prefix}--action-list {
+    min-width: 0;
+    flex: 1 1 auto;
+    overflow: hidden;
+  }
 
   & + .#{$prefix}--toolbar-action {
     padding: 0;

--- a/packages/react/src/hooks/useResponsiveInlineCount.js
+++ b/packages/react/src/hooks/useResponsiveInlineCount.js
@@ -162,7 +162,6 @@ const useResponsiveInlineCount = ({
 
     const calculateInlineCount = () => {
       const container = containerRef.current;
-      const overflowTrigger = overflowTriggerRef.current;
 
       if (!container || !items.length) {
         setInlineCount(items.length);

--- a/packages/react/src/hooks/useResponsiveInlineCount.js
+++ b/packages/react/src/hooks/useResponsiveInlineCount.js
@@ -1,0 +1,271 @@
+import { useEffect, useState } from 'react';
+
+const RESIZE_DEBOUNCE_MS = 150;
+const POST_RESIZE_SETTLE_MS = 80;
+const INITIAL_SETTLE_MS = 80;
+
+/**
+ * Resolve the layout node that represents the full horizontal space available
+ * for inline actions. Prefer an explicit ref, but fall back to nearby parents
+ * so the hook still works when the caller does not provide one.
+ */
+const getLayoutNode = (layoutRef, container) =>
+  layoutRef?.current || container?.parentElement || container?.offsetParent || null;
+
+/**
+ * Normalize excluded-width input so the rest of the hook can always work with
+ * an array of selectors.
+ */
+const getExcludedSelectors = (excludedWidthSelector) =>
+  Array.isArray(excludedWidthSelector)
+    ? excludedWidthSelector
+    : [excludedWidthSelector].filter(Boolean);
+
+/**
+ * Sum the widths of sibling regions that permanently consume horizontal space,
+ * such as selection summary text or a cancel button.
+ */
+const getExcludedWidth = (layoutNode, selectors) =>
+  !layoutNode || !selectors.length
+    ? 0
+    : selectors.reduce((totalWidth, selector) => {
+        const element = layoutNode.querySelector(selector);
+        return totalWidth + (element?.offsetWidth || 0);
+      }, 0);
+
+/**
+ * Compute the width that is actually available for inline actions after fixed
+ * sibling regions have been removed.
+ */
+const getAvailableWidth = (layoutNode, excludedWidth) =>
+  layoutNode?.clientWidth ? Math.max(layoutNode.clientWidth - excludedWidth, 0) : 0;
+
+/**
+ * Measure all candidate inline action widths from the current DOM. The caller
+ * is responsible for keeping hidden items measurable in the DOM.
+ */
+const getItemWidths = (container, itemSelector) =>
+  Array.from(container.querySelectorAll(itemSelector)).map((element, index) => ({
+    index,
+    width: element.offsetWidth,
+  }));
+
+/**
+ * Calculate how many inline actions can fit when some width may need to be
+ * reserved for the overflow trigger itself.
+ */
+const calculateFittingInlineCount = ({
+  itemWidths,
+  containerWidth,
+  staticOverflowCount,
+  fallbackOverflowWidth,
+}) => {
+  const totalItemsWidth = itemWidths.reduce((total, item) => total + item.width, 0);
+
+  // Reserve overflow trigger width in either of these cases:
+  // - some actions are always forced into overflow
+  // - all visible candidates together do not fit inline
+  const shouldReserveOverflowSpace =
+    staticOverflowCount > 0 || totalItemsWidth + fallbackOverflowWidth > containerWidth;
+  const overflowWidth = shouldReserveOverflowSpace ? fallbackOverflowWidth : 0;
+
+  let nextInlineCount = 0;
+  let usedWidth = 0;
+
+  for (let index = 0; index < itemWidths.length; index += 1) {
+    const remainingItems = itemWidths.length - (index + 1);
+    const shouldReserveOverflowWidth =
+      staticOverflowCount > 0 || remainingItems > 0 || shouldReserveOverflowSpace;
+    const reservedWidth = shouldReserveOverflowWidth ? overflowWidth : 0;
+
+    if (usedWidth + itemWidths[index].width + reservedWidth > containerWidth) {
+      break;
+    }
+
+    usedWidth += itemWidths[index].width;
+    nextInlineCount = index + 1;
+  }
+
+  return nextInlineCount;
+};
+
+/**
+ * Calculate how many inline actions can remain visible before the remaining
+ * actions must move into overflow.
+ *
+ * Measurement strategy:
+ * - Use an explicit layout container when available.
+ * - Subtract any sibling regions that permanently occupy width
+ *   (for example selected-count summary / cancel button).
+ * - Measure the natural width of all candidate inline actions.
+ * - Reserve overflow trigger width when static overflow exists or when not all
+ *   actions can fit inline.
+ *
+ * Important implementation detail:
+ * Items are measured from already-rendered DOM nodes. Hidden inline actions
+ * should remain measurable in the DOM; otherwise width calculation will
+ * fluctuate between renders.
+ *
+ * @param {Object} params Hook parameters
+ * @param {boolean} params.enabled Whether measurement logic should run
+ * @param {Array} params.items Source items represented by rendered DOM nodes
+ * @param {React.RefObject<HTMLElement>} params.containerRef Ref to the inline items container
+ * @param {React.RefObject<HTMLElement>} params.overflowTriggerRef Ref to the visible overflow trigger container
+ * @param {string} params.itemSelector Selector used to find rendered inline item nodes inside the container
+ * @param {number} params.staticOverflowCount Count of items that are always rendered in overflow
+ * @param {React.RefObject<HTMLElement>} [params.layoutRef] Optional ref to the outer layout container
+ * @param {string|string[]} [params.excludedWidthSelector] Selector or selector list for sibling regions whose widths should be excluded from available inline space
+ * @param {number} [params.fallbackOverflowWidth=48] Width reserved for the overflow trigger when it is needed
+ * @returns {number|null} Number of items that should remain inline, or null when disabled
+ */
+const useResponsiveInlineCount = ({
+  enabled,
+  items,
+  containerRef,
+  overflowTriggerRef,
+  itemSelector,
+  staticOverflowCount = 0,
+  layoutRef = undefined,
+  excludedWidthSelector = '',
+  fallbackOverflowWidth = 48,
+}) => {
+  const [inlineCount, setInlineCount] = useState(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      setInlineCount(null);
+      return undefined;
+    }
+
+    let frameId = null;
+    let settleTimeoutId = null;
+    let resizeDebounceTimeoutId = null;
+    let postResizeSettleTimeoutId = null;
+    let resizeObserver = null;
+    const initialContainer = containerRef.current;
+    const layoutNode = getLayoutNode(layoutRef, initialContainer);
+
+    const cleanupScheduledWork = () => {
+      if (frameId) {
+        cancelAnimationFrame(frameId);
+      }
+      if (settleTimeoutId) {
+        window.clearTimeout(settleTimeoutId);
+      }
+      if (resizeDebounceTimeoutId) {
+        window.clearTimeout(resizeDebounceTimeoutId);
+      }
+      if (postResizeSettleTimeoutId) {
+        window.clearTimeout(postResizeSettleTimeoutId);
+      }
+    };
+
+    const calculateInlineCount = () => {
+      const container = containerRef.current;
+      const overflowTrigger = overflowTriggerRef.current;
+
+      if (!container || !items.length) {
+        setInlineCount(items.length);
+        return;
+      }
+
+      const itemWidths = getItemWidths(container, itemSelector);
+
+      if (!itemWidths.length) {
+        setInlineCount(0);
+        return;
+      }
+
+      const excludedSelectors = getExcludedSelectors(excludedWidthSelector);
+      const excludedWidth = getExcludedWidth(layoutNode, excludedSelectors);
+
+      // Available inline width comes from the outer layout width after removing
+      // regions that permanently consume horizontal space.
+      const containerWidth = getAvailableWidth(layoutNode, excludedWidth);
+
+      if (!containerWidth) {
+        setInlineCount(items.length);
+        return;
+      }
+
+      const nextInlineCount = calculateFittingInlineCount({
+        itemWidths,
+        containerWidth,
+        staticOverflowCount,
+        fallbackOverflowWidth,
+      });
+
+      setInlineCount((previousCount) =>
+        previousCount === nextInlineCount ? previousCount : nextInlineCount
+      );
+    };
+
+    const scheduleCalculation = () => {
+      if (frameId) {
+        cancelAnimationFrame(frameId);
+      }
+      frameId = requestAnimationFrame(calculateInlineCount);
+    };
+
+    scheduleCalculation();
+    settleTimeoutId = window.setTimeout(() => {
+      scheduleCalculation();
+    }, INITIAL_SETTLE_MS);
+
+    const debounceCalculation = () => {
+      if (resizeDebounceTimeoutId) {
+        window.clearTimeout(resizeDebounceTimeoutId);
+      }
+      if (postResizeSettleTimeoutId) {
+        window.clearTimeout(postResizeSettleTimeoutId);
+      }
+
+      resizeDebounceTimeoutId = window.setTimeout(() => {
+        scheduleCalculation();
+        postResizeSettleTimeoutId = window.setTimeout(() => {
+          scheduleCalculation();
+        }, POST_RESIZE_SETTLE_MS);
+      }, RESIZE_DEBOUNCE_MS);
+    };
+
+    const handleResize = () => {
+      debounceCalculation();
+    };
+
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(() => {
+        debounceCalculation();
+      });
+
+      if (layoutNode) {
+        resizeObserver.observe(layoutNode);
+      }
+    }
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      cleanupScheduledWork();
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [
+    containerRef,
+    enabled,
+    excludedWidthSelector,
+    fallbackOverflowWidth,
+    itemSelector,
+    items,
+    layoutRef,
+    overflowTriggerRef,
+    staticOverflowCount,
+  ]);
+
+  return inlineCount;
+};
+
+export default useResponsiveInlineCount;
+
+// Made with Bob


### PR DESCRIPTION

# Table Toolbar Batch Overflow Update

## Overview

This document describes the batch action overflow improvements made to [`TableToolbar.jsx`](../packages/react/src/components/Table/TableToolbar/TableToolbar.jsx) and the responsive measurement refactor in [`useResponsiveInlineCount.js`](../packages/react/src/hooks/useResponsiveInlineCount.js).

The purpose of this update is to ensure that batch actions behave correctly when the toolbar does not have enough horizontal space

## Problem Statement

The batch action toolbar previously showed several issues when many actions were available:

- batch actions could overflow outside the visible toolbar area
- the overflow menu sometimes appeared only after a manual resize
- selection and unselection could cause inconsistent overflow behavior
- the overflow menu could flicker because width measurements changed between renders
- the supporting hook logic had become harder to follow and maintain

## Root Cause

The behavior issues were mainly caused by unstable width measurement during rerenders.

Key causes included:

- width calculations depending on DOM states that changed between renders
- hidden inline actions no longer contributing to measurement when removed from layout flow
- overflow recalculation depending too heavily on resize timing
- a fragile fallback based on a hardcoded Carbon class selector

## Solution Summary

The implementation now calculates how many batch actions can remain inline and moves the remaining actions into an overflow menu when space is insufficient.

This behavior is now more stable because:

- actions marked with `isOverflow: true` always remain in overflow
- additional actions move into overflow dynamically when they no longer fit inline
- hidden inline actions remain measurable in the DOM
- layout measurement uses a more reliable layout node strategy
- recalculation behavior was stabilized during selection and resize transitions

## Functional Changes

### Batch action rendering

The batch action toolbar now supports two overflow scenarios:

1. **Forced overflow actions**
   - actions with `isOverflow: true` always render in the overflow menu

2. **Responsive overflow actions**
   - when inline space is limited, extra visible actions are moved into the overflow menu automatically

### Overflow trigger behavior

The overflow trigger is rendered when either of the following is true:

- there are static overflow actions
- the responsive inline count is lower than the total number of visible batch action candidates
- there are responsive overflow actions to display

### Selection behavior

The batch toolbar still appears only when row selection is active and rows are selected.

In multi-select nested row scenarios, the selected count can represent multiple selected row IDs when parent-child selection logic includes descendant rows.

## Refactoring Improvements

The responsive hook in [`useResponsiveInlineCount.js`](../packages/react/src/hooks/useResponsiveInlineCount.js) was refactored for clarity and maintainability.

- summary_here

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

https://github.com/user-attachments/assets/4730a051-1433-40ad-a876-6d60ffc2c8cc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
