### PR TITLE
Fix: MAXUIF-4041: [Tooltips] Overflow menu tooltips getting cut off

### DIFF
--- a/packages/react/src/components/Card/CardToolbar.jsx
+++ b/packages/react/src/components/Card/CardToolbar.jsx
@@ -189,8 +189,8 @@ const CardToolbar = ({
         <OverflowMenu
           menuOptionsClass={`${iotPrefix}--card--toolbar__overflow-menu`}
           flipped={overflowMenuPosition}
-          title={extraActions.iconDescription || mergedI18n.overflowMenuDescription}
           iconDescription={extraActions.iconDescription || mergedI18n.overflowMenuDescription}
+          autoAlign
           {...(extraActions.icon ? { renderIcon: extraActions.icon } : {})}
         >
           {extraActions.children.map((child, i) =>
@@ -229,8 +229,8 @@ const CardToolbar = ({
       {(availableActions.clone || availableActions.delete) && (
         <OverflowMenu
           flipped={overflowMenuPosition}
-          title={mergedI18n.overflowMenuDescription}
           iconDescription={mergedI18n.overflowMenuDescription}
+          autoAlign
         >
           {availableActions.clone && (
             <OverflowMenuItem


### PR DESCRIPTION
Closes # MAXUIF-4041

**Summary**
- Fixes duplicate tooltips on CardToolbar OverflowMenu components
- Prevents tooltip cutoff at viewport edges by enabling auto-positioning

**Change List (commits, features, bugs, etc)**

- Removed duplicate `title` prop from both OverflowMenu components in CardToolbar (lines 192 and 232)
- Added `autoAlign` prop to both OverflowMenu components to enable Carbon's auto-positioning feature
- This fixes two issues:
  1. Duplicate tooltips appearing (native browser tooltip from `title` + Carbon's styled tooltip from `iconDescription`)
  2. Tooltips being cut off when OverflowMenu is positioned near viewport edges

**Acceptance Test (how to verify the PR)**
- Open a Card component with toolbar actions (e.g., GaugeCard, ValueCard) in Storybook
- Hover over the overflow menu icon (three dots)
- Verify only ONE tooltip appears (not two)
- Position the card near the right edge of the viewport
- Hover over the overflow menu icon again
- Verify the tooltip auto-positions itself to stay visible (not cut off)

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

**Screenshots**
| Before | After |
| ------ | ------ |
| <img width="909" height="415" alt="Tooltip_Before" src="https://github.com/user-attachments/assets/ea28f144-6380-4972-a190-73b5a8173d45" /> | <img width="833" height="464" alt="Tooltip_After" src="https://github.com/user-attachments/assets/332a2309-e894-486c-a68a-320eedb0d8bc" /> |

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
