### PR TITLE
feat(button): add light theme (tertiary--light) for dark background

### DIFF
--- a/packages/react/src/components/Button/Button.jsx
+++ b/packages/react/src/components/Button/Button.jsx
@@ -10,6 +10,7 @@ const ButtonKinds = [
   'primary',
   'secondary',
   'tertiary',
+  'tertiary--light',
   'ghost',
   'danger',
   'danger--primary',

--- a/packages/react/src/components/Button/Button.story.jsx
+++ b/packages/react/src/components/Button/Button.story.jsx
@@ -29,6 +29,7 @@ const kinds = {
   'Primary button (primary)': 'primary',
   'Secondary button (secondary)': 'secondary',
   'Tertiary button (tertiary)': 'tertiary',
+  'Tertiary Light button (tertiary--light)': 'tertiary--light',
   'Danger button (danger)': 'danger',
   'Danger ghost button (danger--ghost)': 'danger--ghost',
   'Danger tertiary button (danger--tertiary)': 'danger--tertiary',
@@ -64,6 +65,7 @@ const props = {
           'Primary button (primary)': 'primary',
           'Secondary button (secondary)': 'secondary',
           'Tertiary button (tertiary)': 'tertiary',
+          'Tertiary Light button (tertiary--light)': 'tertiary--light',
           'Ghost button (ghost)': 'ghost',
         },
         'primary'
@@ -168,6 +170,10 @@ export const _Default = () => {
         display: 'flex',
         alignItems: 'center',
         flexWrap: 'wrap',
+        background: regularProps.kind === 'tertiary--light' ? 'black' : 'white',
+        width: '100%',
+        height: '100%',
+        padding: '1rem',
       }}
     >
       <Button {...regularProps} className="some-class">
@@ -218,9 +224,19 @@ _Default.parameters = {
   },
 };
 
-export const IconOnlyButtons = () => (
-  <Button {...props.iconOnly()} hasIconOnly /> // eslint-disable-line react/destructuring-assignment
-);
+export const IconOnlyButtons = () => {
+  const iconOnly = props.iconOnly(); // eslint-disable-line react/destructuring-assignment
+  return (
+    <div
+      style={{
+        background: iconOnly.kind === 'tertiary--light' ? 'black' : 'white',
+        padding: '1rem',
+      }}
+    >
+      <Button {...iconOnly} hasIconOnly />
+    </div>
+  );
+};
 
 IconOnlyButtons.storyName = 'Icon-only buttons';
 

--- a/packages/react/src/components/Button/_button.scss
+++ b/packages/react/src/components/Button/_button.scss
@@ -5,6 +5,7 @@
 @use '@carbon/react/scss/components/button' as *;
 @use '@carbon/react/scss/utilities/convert';
 @use '../../globals/vars' as *;
+@use '@carbon/styles/scss/components/button/mixins' as *;
 
 .#{$iot-prefix}--btn {
   .#{$prefix}--loading {
@@ -93,5 +94,22 @@
 
   .#{$prefix}--btn-set .#{$prefix}--btn:last-of-type:not(:focus) {
     box-shadow: convert.to-rem(1px) 0 0 0 $button-separator;
+  }
+}
+
+// light colored button, to be used on dark backgrounds
+.cds--btn--tertiary--light {
+  @include button-theme(transparent, $white, $white, $background-hover, $white, $background-active);
+
+  &:focus {
+    border-color: $white;
+    box-shadow: inset 0 0 0 $button-outline-width $white,
+      inset 0 0 0 $button-border-width $background-active;
+  }
+
+  &:hover,
+  &:active {
+    background-color: $background-active;
+    border-color: $white;
   }
 }


### PR DESCRIPTION
Part of https://jsw.ibm.com/browse/MAXUIF-4011

**Summary**
- Button
  - Added a new kind `tertiary--light` as light themed button for dark background
  - It shows white fonts, icons and border

## Screenshots

### Without icon  
<img width="854" height="285" alt="Screenshot 2026-06-05 at 2 55 14 PM" src="https://github.com/user-attachments/assets/735b5c68-821e-4f01-a26a-36500ad84afd" />

### With icon
<img width="854" height="285" alt="Screenshot 2026-06-05 at 2 55 42 PM" src="https://github.com/user-attachments/assets/5f4a1124-715c-473b-b59e-1dc1653ad64b" />

### Icon only
<img width="205" height="175" alt="Screenshot 2026-06-05 at 3 13 17 PM" src="https://github.com/user-attachments/assets/cd0e94ce-5198-4a64-83d3-8eccbb84db26" />


### Hover
<img width="854" height="285" alt="Screenshot 2026-06-05 at 2 55 18 PM" src="https://github.com/user-attachments/assets/8caed9ca-5149-4cf3-994f-6622724be6a6" />

### Focus
<img width="854" height="285" alt="Screenshot 2026-06-05 at 2 55 22 PM" src="https://github.com/user-attachments/assets/0fbf17c2-e579-4c28-8bf4-a463aac33d99" />

### Loading state
<img width="854" height="285" alt="Screenshot 2026-06-05 at 2 55 28 PM" src="https://github.com/user-attachments/assets/b07a50a8-2fa7-45e7-bbf4-0c02b085ad04" />

### Disabled
<img width="854" height="285" alt="Screenshot 2026-06-05 at 2 55 35 PM" src="https://github.com/user-attachments/assets/fcbfc1a3-240e-4492-96c9-aa5e9ec7d72e" />

 
<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
