### PR TITLE
current page number is missing from pagination text issue fixed

### DIFF
--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -1334,7 +1334,9 @@ const Table = (props) => {
           testId={`${id || testId}-table-pagination`}
           size={paginationProps.size}
           maxPagesConditionalStyle={
-            paginationProps.totalItems > Math.ceil(maxPages * paginationProps.pageSize)
+            Math.ceil(maxPages * paginationProps.pageSize) < paginationProps.totalItems ? false :
+            paginationProps.totalItems > Math.ceil(maxPages * paginationProps.pageSize) 
+
           }
         />
       ) : null}

--- a/packages/react/src/components/Table/Table.jsx
+++ b/packages/react/src/components/Table/Table.jsx
@@ -1334,9 +1334,9 @@ const Table = (props) => {
           testId={`${id || testId}-table-pagination`}
           size={paginationProps.size}
           maxPagesConditionalStyle={
-            Math.ceil(maxPages * paginationProps.pageSize) < paginationProps.totalItems ? false :
-            paginationProps.totalItems > Math.ceil(maxPages * paginationProps.pageSize) 
-
+            Math.ceil(maxPages * paginationProps.pageSize) < paginationProps.totalItems
+              ? false
+              : paginationProps.totalItems > Math.ceil(maxPages * paginationProps.pageSize)
           }
         />
       ) : null}


### PR DESCRIPTION
Closes #

MAXUIF-4318

if you have:

totalItems: 1000
pageSize: 10
maxPages: 5
Result: Pagination will show only 5 pages (50 items max), even though there are 1000 total items.

The calculation: maxPages * pageSize = 5 * 10 = 50 items

Use Cases
Performance: Limit pagination for very large datasets
UX: Prevent users from navigating too far into results
API Limits: Match backend pagination limits
Encourage Filtering: Force users to filter/search instead of browsing all pages

**Summary**

- summary_here

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
