### PR TITLE
feat: add highlightConnectorLinesToShowProgress option for step connector highlighting

### DIFF
--- a/packages/react/src/components/PageWizard/PageWizard.jsx
+++ b/packages/react/src/components/PageWizard/PageWizard.jsx
@@ -89,7 +89,7 @@ export const defaultProps = {
   testId: 'page-wizard',
   spaceEqually: false,
   stepWidth: null,
-  highlightConnectorLinesToShowProgress: false,
+  highlightConnectorLinesToShowProgress: true,
 };
 
 const PageWizard = ({

--- a/packages/react/src/components/PageWizard/PageWizard.jsx
+++ b/packages/react/src/components/PageWizard/PageWizard.jsx
@@ -61,6 +61,8 @@ export const PageWizardPropTypes = {
   /** Specify whether the progress steps should be split equally in size in the div */
   spaceEqually: PropTypes.bool,
   stepWidth: PropTypes.number,
+  /** When true, all connector lines are highlighted blue to show progress */
+  highlightConnectorLinesToShowProgress: PropTypes.bool,
 };
 
 export const defaultProps = {
@@ -87,6 +89,7 @@ export const defaultProps = {
   testId: 'page-wizard',
   spaceEqually: false,
   stepWidth: null,
+  highlightConnectorLinesToShowProgress: false,
 };
 
 const PageWizard = ({
@@ -111,6 +114,7 @@ const PageWizard = ({
   testId,
   spaceEqually,
   stepWidth,
+  highlightConnectorLinesToShowProgress,
 }) => {
   const children = ch.length ? ch : [ch];
   const steps = React.Children.map(children, (step) => step.props);
@@ -215,6 +219,7 @@ const PageWizard = ({
             isClickable={isClickable}
             spaceEqually={spaceEqually}
             stepWidth={stepWidth}
+            highlightConnectorLinesToShowProgress={highlightConnectorLinesToShowProgress}
             // TODO: pass down the testId in v3 instead of falling back to the
             // default.
             // testId={`${testId}-progress-indicator`}

--- a/packages/react/src/components/PageWizard/PageWizard.story.jsx
+++ b/packages/react/src/components/PageWizard/PageWizard.story.jsx
@@ -426,6 +426,26 @@ export const WithHorizontalProgressIndicator = () => (
 
 WithHorizontalProgressIndicator.storyName = 'With Horizontal ProgressIndicator';
 
+export const WithHorizontalProgressIndicatorAndHighlightedConnectorLines = () => (
+  <PageWizard
+    currentStepId="step1"
+    onClose={action('closed', () => {})}
+    onSubmit={action('submit', () => {})}
+    onNext={action('next', () => {})}
+    onBack={action('back', () => {})}
+    setStep={action('step clicked', () => {})}
+    onClearError={action('Clear error', () => {})}
+    isProgressIndicatorVertical={boolean('Toggle Progress Indicator Alignment', false)}
+    highlightConnectorLinesToShowProgress={boolean('highlightConnectorLinesToShowProgress', true)}
+    isClickable
+  >
+    {content()}
+  </PageWizard>
+);
+
+WithHorizontalProgressIndicatorAndHighlightedConnectorLines.storyName =
+  'With Horizontal ProgressIndicator and highlighted connector lines';
+
 export const OnlyOneStepInPageTitleBar = () => (
   <PageTitleBar
     {...commonProps}

--- a/packages/react/src/components/PageWizard/PageWizard.story.jsx
+++ b/packages/react/src/components/PageWizard/PageWizard.story.jsx
@@ -426,26 +426,6 @@ export const WithHorizontalProgressIndicator = () => (
 
 WithHorizontalProgressIndicator.storyName = 'With Horizontal ProgressIndicator';
 
-export const WithHorizontalProgressIndicatorAndHighlightedConnectorLines = () => (
-  <PageWizard
-    currentStepId="step1"
-    onClose={action('closed', () => {})}
-    onSubmit={action('submit', () => {})}
-    onNext={action('next', () => {})}
-    onBack={action('back', () => {})}
-    setStep={action('step clicked', () => {})}
-    onClearError={action('Clear error', () => {})}
-    isProgressIndicatorVertical={boolean('Toggle Progress Indicator Alignment', false)}
-    highlightConnectorLinesToShowProgress={boolean('highlightConnectorLinesToShowProgress', true)}
-    isClickable
-  >
-    {content()}
-  </PageWizard>
-);
-
-WithHorizontalProgressIndicatorAndHighlightedConnectorLines.storyName =
-  'With Horizontal ProgressIndicator and highlighted connector lines';
-
 export const OnlyOneStepInPageTitleBar = () => (
   <PageTitleBar
     {...commonProps}
@@ -670,6 +650,10 @@ const StatefulWithSkippableStepsComp = () => {
           console.log('t', t, isComplete);
         }}
         isClickable
+        highlightConnectorLinesToShowProgress={boolean(
+          'highlightConnectorLinesToShowProgress',
+          true
+        )}
       >
         {content(['Bee', 'Archive', null, null, 'Ai', 'Bee'], isComplete)}
       </StatefulPageWizard>

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.jsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.jsx
@@ -104,10 +104,14 @@ const ProgressStep = ({
 
   const StepLine = () => {
     const classes = classnames({
-      [`${iotPrefix}--progress-step-line`]: !complete && !subStep && !highlightConnectorLinesToShowProgress,
-      [`${iotPrefix}--progress-step-line--sub`]: !complete && subStep && !highlightConnectorLinesToShowProgress,
-      [`${iotPrefix}--progress-step-line--complete`]: !subStep && (complete || highlightConnectorLinesToShowProgress),
-      [`${iotPrefix}--progress-step-line--sub-complete`]: subStep && (complete || highlightConnectorLinesToShowProgress),
+      [`${iotPrefix}--progress-step-line`]:
+        !subStep && !(complete && highlightConnectorLinesToShowProgress),
+      [`${iotPrefix}--progress-step-line--sub`]:
+        subStep && !(complete && highlightConnectorLinesToShowProgress),
+      [`${iotPrefix}--progress-step-line--complete`]:
+        !subStep && complete && highlightConnectorLinesToShowProgress,
+      [`${iotPrefix}--progress-step-line--sub-complete`]:
+        subStep && complete && highlightConnectorLinesToShowProgress,
     });
 
     return !lastItem ? <div className={classes} /> : null;
@@ -244,7 +248,7 @@ ProgressStep.defaultProps = {
   pictogramName: null,
   hasPictogram: false,
   /** default false, all connector lines are highlighted grey to show progress */
-  highlightConnectorLinesToShowProgress: false,
+  highlightConnectorLinesToShowProgress: true,
 };
 
 const ProgressIndicator = ({
@@ -394,7 +398,7 @@ ProgressIndicator.propTypes = {
   testId: PropTypes.string,
   /** Specify whether the progress steps should be split equally in size in the div */
   spaceEqually: PropTypes.bool,
-    /** When true, all connector lines are highlighted blue to show progress */
+  /** When true, all connector lines are highlighted blue to show progress */
   highlightConnectorLinesToShowProgress: PropTypes.bool,
 };
 
@@ -410,7 +414,7 @@ ProgressIndicator.defaultProps = {
   testId: `${iotPrefix}--progress-indicator-testid`,
   spaceEqually: false,
   /** default false, all connector lines are highlighted grey to show progress */
-  highlightConnectorLinesToShowProgress: false,
+  highlightConnectorLinesToShowProgress: true,
 };
 
 export default ProgressIndicator;

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.jsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.jsx
@@ -103,15 +103,13 @@ const ProgressStep = ({
   };
 
   const StepLine = () => {
+    const showComplete = complete && highlightConnectorLinesToShowProgress;
+
     const classes = classnames({
-      [`${iotPrefix}--progress-step-line`]:
-        !subStep && !(complete && highlightConnectorLinesToShowProgress),
-      [`${iotPrefix}--progress-step-line--sub`]:
-        subStep && !(complete && highlightConnectorLinesToShowProgress),
-      [`${iotPrefix}--progress-step-line--complete`]:
-        !subStep && complete && highlightConnectorLinesToShowProgress,
-      [`${iotPrefix}--progress-step-line--sub-complete`]:
-        subStep && complete && highlightConnectorLinesToShowProgress,
+      [`${iotPrefix}--progress-step-line`]: !subStep && !showComplete,
+      [`${iotPrefix}--progress-step-line--sub`]: subStep && !showComplete,
+      [`${iotPrefix}--progress-step-line--complete`]: !subStep && showComplete,
+      [`${iotPrefix}--progress-step-line--sub-complete`]: subStep && showComplete,
     });
 
     return !lastItem ? <div className={classes} /> : null;

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.jsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.jsx
@@ -33,6 +33,7 @@ const ProgressStep = ({
   spaceEqually,
   pictogramName,
   hasPictogram,
+  highlightConnectorLinesToShowProgress,
 }) => {
   const accessible = isClickable && !disabled && !current;
 
@@ -103,10 +104,10 @@ const ProgressStep = ({
 
   const StepLine = () => {
     const classes = classnames({
-      [`${iotPrefix}--progress-step-line`]: !complete && !subStep,
-      [`${iotPrefix}--progress-step-line--sub`]: !complete && subStep,
-      [`${iotPrefix}--progress-step-line--complete`]: complete && !subStep,
-      [`${iotPrefix}--progress-step-line--sub-complete`]: complete && subStep,
+      [`${iotPrefix}--progress-step-line`]: !complete && !subStep && !highlightConnectorLinesToShowProgress,
+      [`${iotPrefix}--progress-step-line--sub`]: !complete && subStep && !highlightConnectorLinesToShowProgress,
+      [`${iotPrefix}--progress-step-line--complete`]: !subStep && (complete || highlightConnectorLinesToShowProgress),
+      [`${iotPrefix}--progress-step-line--sub-complete`]: subStep && (complete || highlightConnectorLinesToShowProgress),
     });
 
     return !lastItem ? <div className={classes} /> : null;
@@ -217,6 +218,8 @@ ProgressStep.propTypes = {
   spaceEqually: PropTypes.bool,
   pictogramName: PropTypes.string,
   hasPictogram: PropTypes.bool,
+  /** When true, all connector lines are highlighted blue to show progress */
+  highlightConnectorLinesToShowProgress: PropTypes.bool,
 };
 
 ProgressStep.defaultProps = {
@@ -240,6 +243,8 @@ ProgressStep.defaultProps = {
   spaceEqually: false,
   pictogramName: null,
   hasPictogram: false,
+  /** default false, all connector lines are highlighted grey to show progress */
+  highlightConnectorLinesToShowProgress: false,
 };
 
 const ProgressIndicator = ({
@@ -253,6 +258,7 @@ const ProgressIndicator = ({
   onClickItem,
   testId,
   spaceEqually,
+  highlightConnectorLinesToShowProgress,
 }) => {
   const [currentStep, setCurrentStep] = useState(currentItemId || items[0].id);
 
@@ -358,6 +364,7 @@ const ProgressIndicator = ({
             spaceEqually={spaceEqually}
             pictogramName={pictogramName}
             hasPictogram={hasPictogram}
+            highlightConnectorLinesToShowProgress={highlightConnectorLinesToShowProgress}
           />
         )
       )}
@@ -387,6 +394,8 @@ ProgressIndicator.propTypes = {
   testId: PropTypes.string,
   /** Specify whether the progress steps should be split equally in size in the div */
   spaceEqually: PropTypes.bool,
+    /** When true, all connector lines are highlighted blue to show progress */
+  highlightConnectorLinesToShowProgress: PropTypes.bool,
 };
 
 ProgressIndicator.defaultProps = {
@@ -400,6 +409,8 @@ ProgressIndicator.defaultProps = {
   onClickItem: null,
   testId: `${iotPrefix}--progress-indicator-testid`,
   spaceEqually: false,
+  /** default false, all connector lines are highlighted grey to show progress */
+  highlightConnectorLinesToShowProgress: false,
 };
 
 export default ProgressIndicator;

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.story.jsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.story.jsx
@@ -69,6 +69,21 @@ export const Stateful = () => (
 
 Stateful.storyName = 'stateful';
 
+
+export const StatefulWithHighlightedConnectorLines = () => (
+  <ProgressIndicator
+    items={items}
+    currentItemId="step2_substep2"
+    stepWidth={number('stepWidth', 6)}
+    showLabels={boolean('showlabels', true)}
+    isVerticalMode={boolean('isVerticalMode', false)}
+    isClickable={boolean('isClickable', true)}
+    highlightConnectorLinesToShowProgress={boolean('highlightConnectorLinesToShowProgress', true)}
+  />
+);
+
+StatefulWithHighlightedConnectorLines.storyName = 'stateful with highlighted connector lines';
+
 export const Presentation = () => {
   const spaceEquallyFlag = boolean('spaceEqually', false);
   return (

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.story.jsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.story.jsx
@@ -69,21 +69,6 @@ export const Stateful = () => (
 
 Stateful.storyName = 'stateful';
 
-
-export const StatefulWithHighlightedConnectorLines = () => (
-  <ProgressIndicator
-    items={items}
-    currentItemId="step2_substep2"
-    stepWidth={number('stepWidth', 6)}
-    showLabels={boolean('showlabels', true)}
-    isVerticalMode={boolean('isVerticalMode', false)}
-    isClickable={boolean('isClickable', true)}
-    highlightConnectorLinesToShowProgress={boolean('highlightConnectorLinesToShowProgress', true)}
-  />
-);
-
-StatefulWithHighlightedConnectorLines.storyName = 'stateful with highlighted connector lines';
-
 export const Presentation = () => {
   const spaceEquallyFlag = boolean('spaceEqually', false);
   return (
@@ -305,6 +290,7 @@ export const StatefulWithSkip = () => (
     showLabels={boolean('showlabels', true)}
     isVerticalMode={boolean('isVerticalMode', false)}
     isClickable={boolean('isClickable', true)}
+    highlightConnectorLinesToShowProgress={boolean('highlightConnectorLinesToShowProgress', true)}
   />
 );
 


### PR DESCRIPTION
Closes : https://jsw.ibm.com/browse/MAXUIF-4455

**Summary**

- Adds a new `highlightConnectorLinesToShowProgress` boolean prop to `ProgressIndicator` and `PageWizard`, allowing consumers to suppress the blue "complete" styling on connector lines between progress steps. When `true` (default), behavior is unchanged from today — completed steps show a blue connector line. When `false`, connector lines remain grey regardless of step completion, matching the updated design spec.


**Change List (commits, features, bugs, etc)**

- `packages/react/src/components/ProgressIndicator/ProgressIndicator.jsx`
  - Added `highlightConnectorLinesToShowProgress` prop to `ProgressStep` (propTypes, defaultProps, and `StepLine` class logic)
  - Added `highlightConnectorLinesToShowProgress` prop to `ProgressIndicator` (propTypes, defaultProps) and passed through to `ProgressStep`
  - Default value is `true` to preserve backward compatibility
- `packages/react/src/components/PageWizard/PageWizard.jsx`
  - Added `highlightConnectorLinesToShowProgress` prop (propTypes, defaultProps) and passed through to `ProgressIndicator`
- `packages/react/src/components/ProgressIndicator/ProgressIndicator.story.jsx`
  - Added `highlightConnectorLinesToShowProgress` knob to `Stateful` and `StatefulWithSkip` stories
- `packages/react/src/components/PageWizard/PageWizard.story.jsx`
  - Added `highlightConnectorLinesToShowProgress` knob to `StatefulWithSkippableSteps` story
- `PageWizardStep.jsx` intentionally not modified — this prop is only relevant at the `PageWizard`/`ProgressIndicator` level

**Acceptance Test (how to verify the PR)**

1. Run `yarn storybook` in `packages/react`
2. Navigate → stateful with skippable step**
3. Toggle the `highlightConnectorLinesToShowProgress` knob:
   - `true` (default): connector lines for completed steps render **blue**
   - `false`: connector lines render **grey**, even for completed steps
4. Navigate → stateful with skippable steps**
5. Toggle the `highlightConnectorLinesToShowProgress` knob and confirm the same grey/blue behavior holds across main steps and sub-steps


https://github.com/user-attachments/assets/a39c9baa-77f6-453c-9624-b82cd1ee09bf


https://github.com/user-attachments/assets/c1f88699-3a0b-45c5-bace-b670286d19ed



**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
