### PR TITLE
Fix: Table column widths reset to 150px on first resize in percentage…

### DIFF
--- a/packages/react/src/components/Table/TableHead/TableHead.jsx
+++ b/packages/react/src/components/Table/TableHead/TableHead.jsx
@@ -302,22 +302,30 @@ const TableHead = ({
 
   const onManualColumnResize = (modifiedColumnWidths) => {
     if (percentageMode) {
-      const modifiedColumns = [...columns];
-      Object.keys(modifiedColumns).forEach((key) => {
-        if (modifiedColumns[key].hasOwnProperty('width')) {
-          delete modifiedColumns[key].width;
-        }
+      // Measure current rendered widths BEFORE switching to pixel mode
+      // This prevents unused space by preserving actual column widths
+      const measuredWidths = measureColumnWidths();
+
+      // Convert measured widths directly to column format with pixel values
+      // This preserves the actual rendered widths instead of using defaults
+      const columnsWithMeasuredWidths = columns.map((col) => {
+        const measured = measuredWidths.find((m) => m.id === col.id);
+        return {
+          ...col,
+          width: measured ? `${measured.width}px` : col.width,
+        };
       });
 
-      // while Resizing setting all column width to default DEFAULT_COLUMN_WIDTH 150px
-      const columnPropInlcudingWidths = addMissingColumnWidths({
+      // Create width map from columns with measured values, then apply user's resize
+      const newColumnWidths = createNewWidthsMap(
         ordering,
-        columns: modifiedColumns,
-        currentColumnWidths: {},
-      });
+        columnsWithMeasuredWidths,
+        modifiedColumnWidths
+      );
 
-      const newColumnWidths = createNewWidthsMap(ordering, columnPropInlcudingWidths);
-      setCurrentColumnWidths(newColumnWidths);
+      // Update both state and notify parent component
+      // This ensures horizontal scrollbar appears if total width exceeds container
+      updateColumnWidths(newColumnWidths);
       setPercentageMode(false);
     } else {
       const newColumnWidths = createNewWidthsMap(


### PR DESCRIPTION
Problem
When resizing table columns in components with enablePercentageColumnWidth={true} (e.g., Lookup dialogs), all columns would reset to 150px width on the first resize attempt instead of maintaining their proportional sizes. Additionally, the horizontal scrollbar would not appear when column widths exceeded the container, making some columns inaccessible.

## Root Cause
The onManualColumnResize function in TableHead.jsx had a flawed percentage-to-pixel mode transition:

1. It measured current column widths correctly
2. But then deleted all column widths from the columns array
3. Called addMissingColumnWidths which assigned DEFAULT_COLUMN_WIDTH (150px) to all columns
4. The measured widths were completely ignored
5. Didn't call updateColumnWidths() to notify parent component

## Solution

1. Modified the percentage mode handling in onManualColumnResize to:
2. Measure current rendered column widths before mode transition
3. Map measured widths directly to columns (preserving actual rendered sizes)
4. Apply user's resize operation on top of measured widths
5. Call updateColumnWidths() to notify parent component and enable horizontal scrollbar

Closes #

**Summary**

- summary_here

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
