### PR TITLE
feat(progress-indicator): support passing pictogram as a component

### DIFF
--- a/packages/react/src/components/PageWizard/PageWizard.jsx
+++ b/packages/react/src/components/PageWizard/PageWizard.jsx
@@ -159,7 +159,7 @@ const PageWizard = ({
         subStep,
         disabled,
         invalid,
-        pictogramName,
+        pictogram,
         isComplete,
       }) => {
         if (!subStep) {
@@ -170,7 +170,7 @@ const PageWizard = ({
             ...(description && { description }),
             ...(disabled && { disabled }),
             ...(invalid && { invalid }),
-            ...(pictogramName && { pictogramName }),
+            ...(pictogram && { pictogram }),
             isComplete,
           });
         } else {
@@ -185,7 +185,7 @@ const PageWizard = ({
             ...(description && { description }),
             ...(disabled && { disabled }),
             ...(invalid && { invalid }),
-            ...(pictogramName && { pictogramName }),
+            ...(pictogram && { pictogram }),
             isComplete,
           });
         }

--- a/packages/react/src/components/PageWizard/PageWizard.story.jsx
+++ b/packages/react/src/components/PageWizard/PageWizard.story.jsx
@@ -26,7 +26,7 @@ export const content = (pictograms = [], isComplete) => [
     onSubmit={action('submit', () => {})}
     onNext={action('next', () => {})}
     onBack={action('back', () => {})}
-    pictogramName={pictograms.shift()}
+    pictogram={pictograms.shift()}
     isComplete={isComplete}
   >
     <PageWizardStepTitle>Step 1: Define the data</PageWizardStepTitle>
@@ -60,7 +60,7 @@ export const content = (pictograms = [], isComplete) => [
     onSubmit={action('submit', () => {})}
     onNext={action('next', () => {})}
     onBack={action('back', () => {})}
-    pictogramName={pictograms.shift()}
+    pictogram={pictograms.shift()}
   >
     <PageWizardStepTitle>Step 2: Pick the contents</PageWizardStepTitle>
     <PageWizardStepDescription>
@@ -102,7 +102,7 @@ export const content = (pictograms = [], isComplete) => [
     onSubmit={action('submit', () => {})}
     onNext={action('next', () => {})}
     onBack={action('back', () => {})}
-    pictogramName={pictograms.shift()}
+    pictogram={pictograms.shift()}
   >
     <PageWizardStepTitle>Step 2: Sub Step 1</PageWizardStepTitle>
     <PageWizardStepDescription>
@@ -125,7 +125,7 @@ export const content = (pictograms = [], isComplete) => [
     onSubmit={action('submit', () => {})}
     onNext={action('next', () => {})}
     onBack={action('back', () => {})}
-    pictogramName={pictograms.shift()}
+    pictogram={pictograms.shift()}
   >
     <PageWizardStepTitle>Step 2: Sub Step 2</PageWizardStepTitle>
     <PageWizardStepDescription>
@@ -148,7 +148,7 @@ export const content = (pictograms = [], isComplete) => [
     onSubmit={action('submit', () => {})}
     onNext={action('next', () => {})}
     onBack={action('back', () => {})}
-    pictogramName={pictograms.shift()}
+    pictogram={pictograms.shift()}
   >
     <PageWizardStepTitle>Step 2: Sub Step 3</PageWizardStepTitle>
     <PageWizardStepDescription>
@@ -172,7 +172,7 @@ export const content = (pictograms = [], isComplete) => [
     onSubmit={action('submit', () => {})}
     onNext={action('next', () => {})}
     onBack={action('back', () => {})}
-    pictogramName={pictograms.shift()}
+    pictogram={pictograms.shift()}
   >
     <PageWizardStepTitle>Step 2: Sub Step 4</PageWizardStepTitle>
     <PageWizardStepDescription>
@@ -195,7 +195,7 @@ export const content = (pictograms = [], isComplete) => [
     onSubmit={action('submit', () => {})}
     onNext={action('next', () => {})}
     onBack={action('back', () => {})}
-    pictogramName={pictograms.shift()}
+    pictogram={pictograms.shift()}
   >
     <PageWizardStepTitle>Step 3: Define your dashboard</PageWizardStepTitle>
     <PageWizardStepDescription>
@@ -217,7 +217,7 @@ export const content = (pictograms = [], isComplete) => [
     onSubmit={action('submit', () => {})}
     onNext={action('next', () => {})}
     onBack={action('back', () => {})}
-    pictogramName={pictograms.shift()}
+    pictogram={pictograms.shift()}
   >
     <PageWizardStepTitle>Step 4: Define your dashboard</PageWizardStepTitle>
     <PageWizardStepDescription>
@@ -238,7 +238,7 @@ export const content = (pictograms = [], isComplete) => [
     onSubmit={action('submit', () => {})}
     onNext={action('next', () => {})}
     onBack={action('back', () => {})}
-    pictogramName={pictograms.shift()}
+    pictogram={pictograms.shift()}
   >
     <PageWizardStepTitle>Step 5: Final Step</PageWizardStepTitle>
     <PageWizardStepDescription>

--- a/packages/react/src/components/PageWizard/PageWizard.story.jsx
+++ b/packages/react/src/components/PageWizard/PageWizard.story.jsx
@@ -4,6 +4,7 @@ import { action } from '@storybook/addon-actions';
 import { boolean, number, text } from '@storybook/addon-knobs';
 import { Button, Form, FormGroup, FormItem, Link, TextInput } from '@carbon/react';
 import { InformationFilled } from '@carbon/react/icons';
+import { Bee, Archive, Ai } from '@carbon/pictograms-react';
 
 import PageTitleBar from '../PageTitleBar/PageTitleBar';
 
@@ -602,7 +603,7 @@ export const StatefulWithPictograms = () => (
     setStep={action('step clicked', () => {})}
     isClickable
   >
-    {content(['Bee', 'Archive', null, null, 'Ai', 'Bee'])}
+    {content([Bee, Archive, null, null, Ai, Bee])}
   </StatefulPageWizard>
 );
 
@@ -620,7 +621,7 @@ export const WithHorizontalProgressIndicatorWithPictograms = () => (
     isProgressIndicatorVertical={boolean('Toggle Progress Indicator Alignment', false)}
     isClickable
   >
-    {content(['Bee', 'Archive', null, null, 'Ai', 'Bee'])}
+    {content([Bee, Archive, null, null, Ai, Bee])}
   </StatefulPageWizard>
 );
 
@@ -655,7 +656,7 @@ const StatefulWithSkippableStepsComp = () => {
           true
         )}
       >
-        {content(['Bee', 'Archive', null, null, 'Ai', 'Bee'], isComplete)}
+        {content([Bee, Archive, null, null, Ai, Bee], isComplete)}
       </StatefulPageWizard>
     </>
   );

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.jsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, isValidElement } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Enter, Space } from '@carbon/react/es/internal/keyboard/keys';
@@ -148,8 +148,7 @@ const ProgressStep = ({
     const dataTestIdLabel = label.replace(/\s/g, '-').toLowerCase();
     const type = mainStep ? 'main' : 'sub';
 
-    // get pictogram component from name passed in items array via pictogramName property
-    const PictogramComponent = pictogram || null;
+
     return (
       <>
         {
@@ -218,7 +217,7 @@ ProgressStep.propTypes = {
   subStep: PropTypes.bool,
   onClick: PropTypes.func,
   spaceEqually: PropTypes.bool,
-  pictogram: PropTypes.node,
+  PictogramComponent: PropTypes.node,
   hasPictogram: PropTypes.bool,
   /** When true, all connector lines are highlighted blue to show progress */
   highlightConnectorLinesToShowProgress: PropTypes.bool,
@@ -362,7 +361,7 @@ const ProgressIndicator = ({
             invalid={invalid}
             isClickable={isClickable}
             spaceEqually={spaceEqually}
-            pictogram={pictogram}
+            PictogramComponent={pictogram}
             hasPictogram={hasPictogram}
             highlightConnectorLinesToShowProgress={highlightConnectorLinesToShowProgress}
           />

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.jsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.jsx
@@ -31,7 +31,7 @@ const ProgressStep = ({
   mainStep,
   subStep,
   spaceEqually,
-  pictogramName,
+  pictogram,
   hasPictogram,
   highlightConnectorLinesToShowProgress,
 }) => {
@@ -149,7 +149,7 @@ const ProgressStep = ({
     const type = mainStep ? 'main' : 'sub';
 
     // get pictogram component from name passed in items array via pictogramName property
-    const PictogramComponent = pictogramName?.length ? Pictograms[pictogramName] : null;
+    const PictogramComponent = pictogram?.length ? Pictograms[pictogram] : null;
     return (
       <>
         {
@@ -218,7 +218,7 @@ ProgressStep.propTypes = {
   subStep: PropTypes.bool,
   onClick: PropTypes.func,
   spaceEqually: PropTypes.bool,
-  pictogramName: PropTypes.string,
+  pictogram: PropTypes.string,
   hasPictogram: PropTypes.bool,
   /** When true, all connector lines are highlighted blue to show progress */
   highlightConnectorLinesToShowProgress: PropTypes.bool,
@@ -243,7 +243,7 @@ ProgressStep.defaultProps = {
   subStep: false,
   onClick: null,
   spaceEqually: false,
-  pictogramName: null,
+  pictogram: null,
   hasPictogram: false,
   /** default false, all connector lines are highlighted grey to show progress */
   highlightConnectorLinesToShowProgress: true,
@@ -321,7 +321,7 @@ const ProgressIndicator = ({
 
   // check if any pictogram is to be shown, this will modify styling of all the steps
   const hasPictogram = newItems.some(
-    ({ pictogramName }) => pictogramName?.length && typeof Pictograms[pictogramName] !== 'undefined'
+    ({ pictogram }) => pictogram?.length && typeof Pictograms[pictogram] !== 'undefined'
   );
 
   return newItems.length > 1 ? (
@@ -337,7 +337,7 @@ const ProgressIndicator = ({
             invalid,
             stepNumber,
             level,
-            pictogramName,
+            pictogram,
             isComplete,
           },
           index
@@ -364,7 +364,7 @@ const ProgressIndicator = ({
             invalid={invalid}
             isClickable={isClickable}
             spaceEqually={spaceEqually}
-            pictogramName={pictogramName}
+            pictogram={pictogram}
             hasPictogram={hasPictogram}
             highlightConnectorLinesToShowProgress={highlightConnectorLinesToShowProgress}
           />
@@ -384,7 +384,7 @@ ProgressIndicator.propTypes = {
       description: PropTypes.string,
       disabled: PropTypes.bool,
       invalid: PropTypes.bool,
-      pictogramName: PropTypes.string,
+      pictogram: PropTypes.string,
     })
   ),
   currentItemId: IDPropTypes,

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.jsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.jsx
@@ -320,9 +320,7 @@ const ProgressIndicator = ({
   });
 
   // check if any pictogram is to be shown, this will modify styling of all the steps
-  const hasPictogram = newItems.some(
-    ({ pictogram }) => pictogram && (typeof pictogram === 'function' || isValidElement(pictogram))
-  );
+  const hasPictogram = newItems.some(({ pictogram }) => !!pictogram);
 
   return newItems.length > 1 ? (
     <ul className={classes} data-testid={testId}>

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.jsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.jsx
@@ -4,7 +4,6 @@ import classnames from 'classnames';
 import { Enter, Space } from '@carbon/react/es/internal/keyboard/keys';
 import { matches } from '@carbon/react/es/internal/keyboard/match';
 import { CheckmarkOutline, Warning, RadioButton, CircleFilled } from '@carbon/react/icons';
-import * as Pictograms from '@carbon/pictograms-react';
 
 import { settings } from '../../constants/Settings';
 

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.jsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Enter, Space } from '@carbon/react/es/internal/keyboard/keys';
@@ -149,7 +149,7 @@ const ProgressStep = ({
     const type = mainStep ? 'main' : 'sub';
 
     // get pictogram component from name passed in items array via pictogramName property
-    const PictogramComponent = pictogram?.length ? Pictograms[pictogram] : null;
+    const PictogramComponent = pictogram || null;
     return (
       <>
         {
@@ -218,7 +218,7 @@ ProgressStep.propTypes = {
   subStep: PropTypes.bool,
   onClick: PropTypes.func,
   spaceEqually: PropTypes.bool,
-  pictogram: PropTypes.string,
+  pictogram: PropTypes.node,
   hasPictogram: PropTypes.bool,
   /** When true, all connector lines are highlighted blue to show progress */
   highlightConnectorLinesToShowProgress: PropTypes.bool,
@@ -321,7 +321,7 @@ const ProgressIndicator = ({
 
   // check if any pictogram is to be shown, this will modify styling of all the steps
   const hasPictogram = newItems.some(
-    ({ pictogram }) => pictogram?.length && typeof Pictograms[pictogram] !== 'undefined'
+    ({ pictogram }) => pictogram && (typeof pictogram === 'function' || isValidElement(pictogram))
   );
 
   return newItems.length > 1 ? (
@@ -384,7 +384,7 @@ ProgressIndicator.propTypes = {
       description: PropTypes.string,
       disabled: PropTypes.bool,
       invalid: PropTypes.bool,
-      pictogram: PropTypes.string,
+      pictogram: PropTypes.node,
     })
   ),
   currentItemId: IDPropTypes,

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.jsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.jsx
@@ -148,7 +148,6 @@ const ProgressStep = ({
     const dataTestIdLabel = label.replace(/\s/g, '-').toLowerCase();
     const type = mainStep ? 'main' : 'sub';
 
-
     return (
       <>
         {

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.jsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.jsx
@@ -31,7 +31,7 @@ const ProgressStep = ({
   mainStep,
   subStep,
   spaceEqually,
-  pictogram,
+  PictogramComponent,
   hasPictogram,
   highlightConnectorLinesToShowProgress,
 }) => {
@@ -242,7 +242,7 @@ ProgressStep.defaultProps = {
   subStep: false,
   onClick: null,
   spaceEqually: false,
-  pictogram: null,
+  PictogramComponent: null,
   hasPictogram: false,
   /** default false, all connector lines are highlighted grey to show progress */
   highlightConnectorLinesToShowProgress: true,

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.story.jsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.story.jsx
@@ -211,7 +211,7 @@ const itemsWithPictograms = [
     label: 'First step is very, very long',
     secondaryLabel: 'Optional label is very, very long',
     description: 'This is displayed when step icon is hovered',
-    pictogramName: 'Bee',
+    pictogram: 'Bee',
   },
   {
     id: 'step2',
@@ -223,7 +223,7 @@ const itemsWithPictograms = [
         id: 'step2_substep2',
         label: 'Sub Step 2',
         secondaryLabel: 'Optional label',
-        pictogramName: 'Bee',
+        pictogram: 'Bee',
       },
       { id: 'step2_substep3', label: 'Sub Step 3', invalid: true },
       {
@@ -233,16 +233,16 @@ const itemsWithPictograms = [
         disabled: true,
       },
     ],
-    pictogramName: 'Archive',
+    pictogram: 'Archive',
   },
   {
     id: 'step3',
     label: 'Third Step',
     secondaryLabel: 'Optional label',
     disabled: true,
-    pictogramName: 'Ai',
+    pictogram: 'Ai',
   },
-  { id: 'step4', label: 'Fourth Step', invalid: true, pictogramName: 'Devops' },
+  { id: 'step4', label: 'Fourth Step', invalid: true, pictogram: 'Devops' },
   { id: 'step5', label: 'Fifth Step' },
 ];
 

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.story.jsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.story.jsx
@@ -5,6 +5,8 @@ import { action } from '@storybook/addon-actions';
 import { ProgressIndicatorSkeleton, Tooltip } from '@carbon/react';
 // import { settings } from 'carbon-components';
 
+import { Bee, Archive, Ai, Devops } from '@carbon/pictograms-react';
+
 import ProgressIndicator from './ProgressIndicator';
 
 import { CarbonProgressIndicator, CarbonProgressStep } from '.';
@@ -211,7 +213,7 @@ const itemsWithPictograms = [
     label: 'First step is very, very long',
     secondaryLabel: 'Optional label is very, very long',
     description: 'This is displayed when step icon is hovered',
-    pictogram: 'Bee',
+    pictogram: Bee,
   },
   {
     id: 'step2',
@@ -223,7 +225,7 @@ const itemsWithPictograms = [
         id: 'step2_substep2',
         label: 'Sub Step 2',
         secondaryLabel: 'Optional label',
-        pictogram: 'Bee',
+        pictogram: Bee,
       },
       { id: 'step2_substep3', label: 'Sub Step 3', invalid: true },
       {
@@ -233,16 +235,16 @@ const itemsWithPictograms = [
         disabled: true,
       },
     ],
-    pictogram: 'Archive',
+    pictogram: Archive,
   },
   {
     id: 'step3',
     label: 'Third Step',
     secondaryLabel: 'Optional label',
     disabled: true,
-    pictogram: 'Ai',
+    pictogram: Ai,
   },
-  { id: 'step4', label: 'Fourth Step', invalid: true, pictogram: 'Devops' },
+  { id: 'step4', label: 'Fourth Step', invalid: true, pictogram: Devops },
   { id: 'step5', label: 'Fifth Step' },
 ];
 

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.story.jsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.story.jsx
@@ -3,9 +3,9 @@ import React from 'react';
 import { boolean, number, select, text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { ProgressIndicatorSkeleton, Tooltip } from '@carbon/react';
+import { Bee, Archive, Ai, Devops } from '@carbon/pictograms-react';
 // import { settings } from 'carbon-components';
 
-import { Bee, Archive, Ai, Devops } from '@carbon/pictograms-react';
 
 import ProgressIndicator from './ProgressIndicator';
 

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.story.jsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.story.jsx
@@ -6,7 +6,6 @@ import { ProgressIndicatorSkeleton, Tooltip } from '@carbon/react';
 import { Bee, Archive, Ai, Devops } from '@carbon/pictograms-react';
 // import { settings } from 'carbon-components';
 
-
 import ProgressIndicator from './ProgressIndicator';
 
 import { CarbonProgressIndicator, CarbonProgressStep } from '.';


### PR DESCRIPTION
**Summary**

- This change is part of MAXUIF-3822, which adds support for custom pictograms in the progress wizard component.
- Accept pictogram React components directly via a new pictogram prop (type: PropTypes.node) instead of using string pictogramName.
- Remove the lookup-by-name behavior; components are used directly (no Pictograms[name] lookup).
- Update ProgressIndicator to consume pictogram prop, update its PropTypes and defaultProps accordingly.
- Change internal hasPictogram detection to check for a truthy pictogram value.
- Update PageWizard to forward pictogram to child step data instead of pictogramName.
- Update stories to import pictogram components from @carbon/pictograms-react and pass components (e.g., Bee, Archive, Ai, Devops) instead of string names.

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
