### PR TITLE
fix(dashboard-grid): add card sizes, large wide tall, large wide extra tall

### DIFF
--- a/packages/react/src/components/Dashboard/DashboardGrid.story.jsx
+++ b/packages/react/src/components/Dashboard/DashboardGrid.story.jsx
@@ -289,6 +289,28 @@ export const DashboardAllCardSizes = () => {
     />,
     <Card
       titleTextTooltip={titleTextTooltip}
+      title="Large Wide Tall"
+      id="Large Wide Tall"
+      key="Large Wide Tall"
+      size={CARD_SIZES.LARGE_WIDE_TALL}
+      type={CARD_TYPES.VALUE}
+      availableActions={{
+        delete: true,
+      }}
+    />,
+    <Card
+      titleTextTooltip={titleTextTooltip}
+      title="Large Wide Extra Tall"
+      id="Large Wide Extra Tall"
+      key="Large Wide Extra Tall"
+      size={CARD_SIZES.LARGE_WIDE_XTALL}
+      type={CARD_TYPES.VALUE}
+      availableActions={{
+        delete: true,
+      }}
+    />,
+    <Card
+      titleTextTooltip={titleTextTooltip}
       title="Full"
       id="Full"
       key="Full"

--- a/packages/react/src/components/Dashboard/DashboardGrid.test.jsx
+++ b/packages/react/src/components/Dashboard/DashboardGrid.test.jsx
@@ -229,6 +229,20 @@ describe('DashboardGrid', () => {
         }}
         values={[]}
       />,
+      <Card
+        testId="test-card-tall"
+        title="Large Wide Tall"
+        id="Large Wide Tall"
+        key="Large Wide Tall"
+        size={CARD_SIZES.LARGE_WIDE_TALL}
+      />,
+      <Card
+        testId="test-card-xtall"
+        title="Large Wide Extra Tall"
+        id="Large Wide Extra Tall"
+        key="Large Wide Extra Tall"
+        size={CARD_SIZES.LARGE_WIDE_XTALL}
+      />,
     ];
 
     it('adds resize handles for all cards with isResizable: true', () => {

--- a/packages/react/src/constants/LayoutConstants.js
+++ b/packages/react/src/constants/LayoutConstants.js
@@ -22,6 +22,8 @@ export const CARD_SIZES = {
   LARGE: 'LARGE',
   LARGETHICK: 'LARGETHICK',
   LARGEWIDE: 'LARGEWIDE',
+  LARGE_WIDE_TALL: 'LARGE_WIDE_TALL',
+  LARGE_WIDE_XTALL: 'LARGE_WIDE_XTALL',
   FULL: 'FULL',
 };
 
@@ -263,6 +265,22 @@ export const CARD_DIMENSIONS = {
     md: { w: 8, h: 11 },
     sm: { w: 8, h: 11 },
     xs: { w: 4, h: 11 },
+  },
+  LARGE_WIDE_TALL: {
+    max: { w: 16, h: 6 },
+    xl: { w: 16, h: 6 },
+    lg: { w: 16, h: 6 },
+    md: { w: 8, h: 6 },
+    sm: { w: 4, h: 4 },
+    xs: { w: 4, h: 4 },
+  },
+  LARGE_WIDE_XTALL: {
+    max: { w: 16, h: 8 },
+    xl: { w: 16, h: 8 },
+    lg: { w: 16, h: 8 },
+    md: { w: 8, h: 8 },
+    sm: { w: 4, h: 4 },
+    xs: { w: 4, h: 4 },
   },
 };
 


### PR DESCRIPTION
Closes https://jsw.ibm.com/browse/MAXUIF-4057

**Summary**
- Dashboard grid
  - Added 2 new card sizes
  - Large wide tall - Width 16, height 6
  - Large wide extra tall, Width 16, height 8

These are added 2 have some size between large wide and full

**Screenshots**
<img width="1728" height="889" alt="Screenshot 2026-07-09 at 1 44 09 PM" src="https://github.com/user-attachments/assets/2b2c7405-ea1a-42d4-b5d5-08b3499ea619" />
<img width="1728" height="889" alt="Screenshot 2026-07-09 at 1 44 20 PM" src="https://github.com/user-attachments/assets/3da9f691-f52e-407c-944a-a473922d1602" />
<img width="1728" height="889" alt="Screenshot 2026-07-09 at 1 44 25 PM" src="https://github.com/user-attachments/assets/0d96127b-bef4-433e-a741-a43ef1e0aac0" />


**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
