### PR TITLE
feat: provide title to be in node

### DIFF
--- a/packages/react/src/components/TileCatalog/CatalogContent.jsx
+++ b/packages/react/src/components/TileCatalog/CatalogContent.jsx
@@ -8,7 +8,7 @@ const { iotPrefix } = settings;
 const propTypes = {
   /** optional icon to visually describe catalog item */
   icon: PropTypes.node,
-  title: PropTypes.string.isRequired,
+  title: PropTypes.node.isRequired,
   description: PropTypes.node,
 };
 
@@ -22,7 +22,7 @@ const CatalogContent = ({ icon, title, description }) => (
     {icon ? <div className={`${iotPrefix}--sample-tile-icon`}>{icon}</div> : null}
     <div className={`${iotPrefix}--sample-tile-contents`}>
       <div className={`${iotPrefix}--sample-tile-title`}>
-        <span title={title}>{title}</span>
+        <span title={typeof title === 'string' ? title : null}>{title}</span>
       </div>
       <div className={`${iotPrefix}--sample-tile-description`}>{description}</div>
     </div>


### PR DESCRIPTION
Closes #[MASMON-7142](https://jsw.ibm.com/browse/MASMON-7142)

**Summary**

- Add info tooltip in mist config tile

**Change List (commits, features, bugs, etc)**

- feat: provide title to be in node

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- tests here

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `iot` or `bx` class prefix is using the prefix variable
- [ ] (React) All major areas have a `data-testid` attribute. New test ids should have test written to ensure they are not changed or removed.
- [ ] UI should be checked in RTL mode to ensure the proper handling of layout and text.
- [ ] All strings should be translatable.
- [ ] The code should pass a11y scans (The storybook a11y knob should show no violations). New components should have a11y test written.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] All components should be passing visual regression test. For new styles or components either a visual regression test should be written for all permutations or the base image updated.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
